### PR TITLE
[SPEC] Remove procedural halt/waiting messages from GitHub comment documentation

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -1,0 +1,495 @@
+# CRITICAL RULES — Zero Tolerance Violations
+
+**See AGENTS.md for the authoritative list of critical rules.**
+**See `.opencode/guidelines/` for detailed rules.**
+
+This file provides critical rules that must never be violated.
+
+## Agent-Specific Notes
+
+### OpenCode Desktop (OPENCODE=1)
+- MCP tools auto-probe on startup
+- Use OpenCode-specific instructions from `opencode.json`
+- Read `.opencode/guidelines/` for detailed guidance
+
+### Junie (MARKER_JUNIE_TERMINAL=true)
+- Requires manual MCP probe
+- Needs `ai_bin/start` for initialization
+
+### Amazon Q / CodeWhisperer
+- Treat as unknown agent — use manual MCP probe
+
+**Search guidelines:** Use `srclight_search_symbols` or `pycharm_search_in_files_by_text` to find relevant guidelines.
+
+## Critical Violation: Missing Progress Comments
+
+**⚠️ Failing to post progress comments to the associated issue is a CRITICAL GUIDELINE VIOLATION.**
+
+Every implementation task MUST be documented with progress comments on the GitHub issue:
+- Post comment IMMEDIATELY after completing each task
+- Post comment when creating PR
+- Never proceed to next task without commenting first
+
+### Required Format: Executive Summary
+
+**Intermediate task (multi-task spec):**
+```
+AI: <AgentName> <ModelID> ✅ Task Complete: <task-name>
+
+**Summary:**
+
+<1-2 sentences describing the impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+```
+
+**Final task or single-task spec:**
+```
+AI: <AgentName> <ModelID> ✅ Task Complete: <task-name>
+
+**Summary:**
+
+<1-2 sentences describing the impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+
+All tasks complete from this specification.
+```
+
+### 🚫 FORBIDDEN in Progress Comments
+
+- **File lists** — Redundant (visible in git commits)
+- **"Next" field** — Dialog prompt (violates `125-github-issue-comments.md`)
+- **Punch-list format** — Use executive summary paragraphs
+- **"Awaiting authorization"** — Use HALT protocol, not comments
+- **"Waiting for..."** — Use HALT protocol, not comments
+- **"Ready for review"** — Use HALT protocol, not comments
+- **"Ready for approval"** — Use HALT protocol, not comments
+- **"Please confirm..."** — Use HALT protocol, not comments
+- **"Let me know when..."** — Use HALT protocol, not comments
+- **"Ready when you are"** — Use HALT protocol, not comments
+- **Technical changelog** — Focus on impact, not file-by-file changes
+- **Any procedural status** — "HALT", "Waiting", "Ready" — Use HALT protocol silently
+
+### ⚠️ Chat Output Rule (CRITICAL)
+
+**Progress executive summaries go to BOTH GitHub comments AND chat.**
+
+| Location | Content |
+|----------|---------|
+| **GitHub Issue Comment** | Full executive summary (summary, outcome) |
+| **Chat Output** | Same executive summary (summary, outcome) |
+
+**Why:** Both GitHub history AND chat transcript should show progress. GitHub preserves long-term history; chat maintains session context.
+
+**✅ DO:** Post executive summary to GitHub, then provide SAME summary in chat
+**🚫 NEVER:** Skip either location
+**🚫 NEVER:** Put full summary in chat but skip GitHub comment
+
+**See `.opencode/skills/github-comments/SKILL.md` for complete requirements.**
+
+---
+
+## Critical Violation: Ignoring Issue Comments
+
+**⚠️ Failing to respond to user comments on GitHub Issues is a CRITICAL GUIDELINE VIOLATION.**
+
+Users communicating via GitHub Issues:
+- Cannot see your internal analysis
+- Are not mind readers
+- Expect responses where they asked the question
+
+**MANDATORY RESPONSE PROTOCOL:**
+1. Read issue comments via `github_issue_read method=get_comments`
+2. Respond PUBLICLY via `github_add_issue_comment`
+3. Include analysis, findings, and next steps in your response
+4. Ask for authorization if needed
+
+**See `.opencode/skills/github-comments/SKILL.md` → "Responding to User Comments (MANDATORY)" for complete requirements.**
+
+---
+
+## Critical Violation: Sub-issue Structure Bypass — Multi-task Specs
+
+**⚠️ Implementing a multi-task spec without sub-issues is a CRITICAL GUIDELINE VIOLATION.**
+
+When implementing a multi-task spec (one with multiple phases/tasks):
+
+1. **First**: Call `github_issue_read method=get_sub_issues` on the parent issue
+2. **When empty**: AUTO-CREATE sub-issues at PHASE level (see `.opencode/skills/github-sub-issues/SKILL.md`)
+3. **Then**: Verify the task being implemented is linked as a sub-issue
+
+**🚫 FORBIDDEN:**
+- Implementing a phase that exists only as text in the parent issue body
+- Proceeding when `get_sub_issues` returns empty array for multi-task specs
+- Assuming markdown checkboxes = task tracking
+- Creating step-level sub-issues instead of phase-level
+
+**✅ REQUIRED:**
+- Sub-issues at PHASE level, not step level
+- Each phase as separate GitHub Issue linked via `github_sub_issue_write method=add`
+- Single-task specs are exempt from sub-issue requirement
+
+**See `.opencode/skills/github-sub-issues/SKILL.md` for complete workflow including:**
+- Single-task vs multi-task exemption
+- Auto-create workflow
+- Database ID requirement
+- Phase-level structure
+
+## Critical Violation: Scope Creep — NEVER Do Things Outside the Spec
+
+**⚠️ Implementing changes not explicitly called for in the spec is a CRITICAL GUIDELINE VIOLATION.**
+
+The spec defines EXACTLY what to implement. Nothing more. Nothing less.
+
+**🚫 FORBIDDEN:**
+- Adding "helper" functions not requested
+- Improving "nearby" code while you're there
+- Refactoring things adjacent to the change
+- Adding tests for unrequested functionality
+- Modifying related files "just to be safe"
+- Fixing "similar issues" in the same area
+- Any change not explicitly stated in the issue/PR description
+
+**If you think something ELSE should be changed:**
+1. STOP — do not implement it
+2. Comment on the issue noting the additional concern
+3. Wait for explicit approval before implementing anything outside the spec
+
+**When in doubt: ASK, don't assume.**
+
+---
+
+## Critical Violation: Spec Without Investigation
+
+**⚠️ Creating a spec without completed investigation is a CRITICAL GUIDELINE VIOLATION.**
+
+Investigation MUST be completed BEFORE finalizing a spec for review.
+
+**🚫 FORBIDDEN:**
+- Creating specs from vague requirements without exploration
+- Skipping codebase analysis before planning
+- Finalizing specs before investigating edge cases
+- Proceeding without success criteria defined
+- Running test code against production systems during investigation
+
+**✅ REQUIRED:**
+- Investigate codebase for existing patterns and reusable components
+- Create test scripts in `./tmp/` to validate hypotheses (isolated from production)
+- Document alternatives considered with tradeoffs
+- Identify risks and mitigation strategies
+- Define testable, measurable success criteria
+
+**✅ ALLOWED During Investigation:**
+- Read production code (exploration)
+- Read production data (analysis)
+- Create and run test scripts in `./tmp/` (isolated fixtures)
+- Create isolated test fixtures (dedicated test DB/schemas)
+- Run static analysis (lint, typecheck)
+- Document findings for the spec
+
+**Investigation Completion Criteria:**
+
+Before creating a spec, the agent MUST verify:
+
+| Requirement | Evidence |
+|-------------|----------|
+| Problem understood | Clearly stated problem, context, stakeholders |
+| Codebase explored | Existing patterns, reusable components identified |
+| Hypotheses tested | Test scripts run, results documented |
+| Alternatives considered | At least 2 approaches documented with tradeoffs |
+| Risks identified | Risk assessment with mitigation strategies |
+| Success criteria defined | Testable, measurable completion criteria |
+
+See `142-planning-archive-workflow.md` → "Investigation Completion Criteria" for complete requirements.
+
+---
+
+## Critical Violation: Implementing Stale or Superseded Specs
+
+**⚠️ Implementing a stale or superseded spec without revision is a CRITICAL GUIDELINE VIOLATION.**
+
+Before implementing OR revising any spec, the agent MUST check for:
+
+### Superseding Issues
+
+**When to check:** Before any implementation or revision of a spec.
+
+**What to check:**
+- Query all open `[SPEC]`, `[SPEC-FIX]`, and `[SPEC-ENHANCEMENT]` issues
+- Identify conflicting/overlapping objectives
+- Look for later issues that may render the active spec obsolete
+
+**If superseding issue exists:**
+1. SILENTLY HALT
+2. Report the conflict to the issue
+3. Do NOT proceed with the superseded spec
+4. Wait for user direction
+
+### Staleness from Implemented Specs
+
+**When to check:** Before any implementation or revision of a spec.
+
+**What to check:**
+- Check for merged PRs that implemented related functionality
+- Check if referenced code locations have been modified since spec creation
+- Check if referenced dependencies/libraries have changed
+- Check if the problem statement still applies (may have been fixed by another implementation)
+
+**If staleness detected:**
+
+**🚫 FORBIDDEN:**
+- Implementing a stale spec as-is
+- Assuming "the spec is still valid" without verification
+- Skipping revision to "save time"
+
+**✅ REQUIRED:**
+1. REVISE the spec to reflect current reality:
+   - Update problem statement if context changed
+   - Update affected files/lines if code locations changed
+   - Update success criteria if requirements shifted
+   - Update dependencies if integration points changed
+2. Report the revision via comment on the issue
+3. HALT — wait for user approval before proceeding
+4. Never implement a stale spec without revision
+
+### Where to Check
+
+This check is REQUIRED in these workflows:
+
+| Workflow | Guideline |
+|----------|-----------|
+| Before implementing any spec | `010-approval-gate.md` |
+| When listing available specs | `140-planning-spec-creation.md` |
+| Before revising a spec | `130-authority-source.md` |
+
+---
+
+## Auditor Skills Enforcement
+
+**⚠️ Before approving implementation, verify spec/guideline quality with auditor skills.**
+
+### Guideline Auditor (`guideline-auditor`)
+
+Invoked with: `/skill guideline-auditor`
+
+**Purpose:** Audit `.opencode/guidelines/` for gaps, conflicts, and LLM compliance.
+
+**When to invoke:**
+- Before approving guideline changes
+- Periodic maintenance to check for guideline drift
+- Post-implementation verification for guideline changes
+
+**Output:** Creates audit log in `./tmp/audit-YYYYMMDD.md`
+
+### Spec Auditor (`spec-auditor`)
+
+Invoked with: `/skill spec-auditor --issue N`
+
+**Purpose:** Audit GitHub Issue `[SPEC]` specs against master spec standards.
+
+**When to invoke:**
+- Before approving spec implementation
+- During spec review for quality
+- Periodic audit to check for spec drift
+
+**Output:** Posts findings to GitHub Issue, creates audit log in `./tmp/audit-spec-YYYYMMDD.md`
+
+### Enforcement Flow
+
+| Checkpoint | Action |
+|------------|--------|
+| Spec created | Optional: `/skill spec-auditor --issue N` |
+| Before implementation approval | **REQUIRED**: Verify spec quality (manual or via auditor) |
+| Guideline change proposed | Optional: `/skill guideline-auditor` |
+| Post-implementation | Optional: Re-run auditor to verify no new issues |
+
+**See:** `010-approval-gate.md` for spec-quality checkpoint integration
+
+---
+
+## Critical Violation: Creating PRs Without Explicit Instruction
+
+**⚠️ Creating a PR without EXPLICIT developer instruction is a CRITICAL GUIDELINE VIOLATION.**
+
+PRs require the developer to say one of these EXACT phrases:
+- "create a PR"
+- "make a PR"
+- "push and create PR"
+- "let's get a PR up"
+
+**🚫 FORBIDDEN:**
+- Creating a PR after "approved" or "go" — these authorize implementation ONLY
+- Creating a PR after completing implementation — completion does NOT authorize PR creation
+- Asking "Ready for a PR?" or "Should I create a PR?" — just STOP and report completion
+- **Pushing branch to remote without "create a PR" instruction** — pushing is part of PR creation, NOT implementation
+
+**✅ REQUIRED:**
+- After completing implementation: report completion concisely, then STOP
+- Wait for EXPLICIT "create a PR" instruction
+- Only then: squash, push, create PR, report URL, STOP
+
+**See `.opencode/skills/pr-creation-workflow/SKILL.md` for the full PR timing workflow including:**
+- Authorization boundary (what authorizes implementation vs PR)
+- Developer must test before PR
+- HALT after PR creation
+
+---
+
+## Critical Violation: Closing Issues Before PR Merge
+
+**⚠️ Closing issues BEFORE the PR is merged is a CRITICAL GUIDELINE VIOLATION.**
+
+**🚫 FORBIDDEN:**
+- Closing issues immediately after implementation
+- Closing issues when PR is created but not merged
+- Closing parent issues while child issues remain open
+- Closing issues without explicit "merge confirmed" from human
+- Closing issues based on `git pull` fast-forward alone (MUST use GitHub API)
+
+**✅ REQUIRED SEQUENCE:**
+1. Complete implementation → Create PR → Report PR URL → **HALT**
+2. Wait for human to review and merge PR
+3. User confirms "pr merged" → **Call `github_pull_request_read method=get` to verify**
+4. Verify `merged_at` timestamp or `state: "closed"` with merge
+5. ONLY after API confirms merge → Close issues
+6. Post closing summary comment
+
+**Why `git pull` is insufficient:**
+- Local fast-forward shows `git pull` succeeded
+- Does NOT verify the PR merge state in GitHub
+- Agent could close issue before human actually merged
+
+**See `124-github-archive-workflow.md` for complete issue closure timing.**
+**See `git-workflow/SKILL.md` Phase 4 for post-merge workflow including issue closure.**
+
+---
+
+## Critical Violation: Parent/Child Issue Closure
+
+**⚠️ Closing a parent issue while child issues remain open is a CRITICAL GUIDELINE VIOLATION.**
+
+When working with parent/child issue hierarchies (specs with sub-issues):
+
+**🚫 FORBIDDEN:**
+- Closing a parent `[SPEC]` issue when ANY child `[Task]` issues are still open
+- Closing a parent after PR merge if other child tasks are incomplete
+- Assuming "the PR covers everything" when sub-issues exist
+
+**✅ REQUIRED:**
+- Only close the child issue that corresponds to the merged PR
+- Parent issue remains open until ALL child issues are closed
+- After closing a child: check if other children remain open
+- If all children are closed, then (and only then) close the parent
+
+### Correct Workflow
+
+| Step | Action | Issues Affected |
+|------|--------|-----------------|
+| PR merged for child task | Close corresponding child issue | Child issue only |
+| Check remaining children | Verify all children closed | No action yet |
+| All children closed? | Close parent with summary | Parent issue |
+
+### Example
+
+```
+SPEC #100 (parent)
+├── Task #101: Phase 1 - Database schema
+├── Task #102: Phase 2 - API endpoints
+└── Task #103: Phase 3 - UI components
+
+PR merges for Phase 1 → Close #101 ONLY
+#100 remains open (children #102, #103 pending)
+
+Later, PR merges for Phase 2 → Close #102 ONLY
+#100 remains open (child #103 pending)
+
+Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
+```
+
+### Exception: All Children Completed
+
+**When ALL child issues are completed by a single PR merge:**
+
+1. Close the child issue corresponding to the PR
+2. **ALSO close the parent issue** (all children are now complete)
+3. Add summary comment to the parent explaining all work is complete
+
+**Example:** If PR #150 fixes both #102 and #103 (the last remaining children), close BOTH child issues AND the parent #100 after merge.
+
+### Why This Matters
+
+- Parent issues track overall progress across all phases
+- Premature parent closure loses visibility into remaining work
+- Stakeholders need to see open issues for incomplete work
+- GitHub sub-issue view shows which children remain
+
+---
+
+## Critical Violation: Deleting Branches/Stashes Improperly
+
+**⚠️ Improper branch deletion is a CRITICAL GUIDELINE VIOLATION.**
+
+**MERGED branches must be deleted IMMEDIATELY after merge confirmation.**
+
+**🚫 FORBIDDEN:**
+- `git branch -D <branch>` on unmerged branches without explicit request
+- `git stash drop` without explicit request
+- Preserving merged branches "just in case"
+- Asking "should I delete this merged branch?" — just delete it
+- Deleting `main` or other protected branches
+
+**✅ REQUIRED:**
+- **MERGED branches**: Delete IMMEDIATELY after merge confirmation — no asking, no waiting
+- **UNMERGED branches with work**: Preserve until explicitly asked to delete
+- **Stashes**: Preserve until explicitly asked to delete
+- After PR creation: report URL, wait for merge confirmation, then DELETE the branch
+
+### Quick Reference
+
+| Branch Status | Action |
+|---------------|--------|
+| Merged PR | **DELETE IMMEDIATELY** — no confirmation needed |
+| Unmerged with commits | **PRESERVE** — wait for explicit delete request |
+| Stashes | **PRESERVE** — wait for explicit delete request |
+| `main` branch | **NEVER DELETE** |
+
+---
+
+## Critical: Engineering Mindset Required
+
+**⚠️ All work must be approached with proper engineering discipline.**
+
+See `.opencode/guidelines/085-engineering-approach.md` for complete requirements.
+
+### Core Engineering Principles
+
+1. **Understand Before Solving** — Read all relevant code before proposing changes
+2. **Design Before Implementing** — Document approach and obtain approval before coding
+3. **Verify Before Declaring Complete** — Run tests, check edge cases, validate success criteria
+4. **Communicate Changes** — Post comments when changes occur (NOT when creating issues)
+
+### Requirements Analysis Mandatory
+
+Every specification MUST include:
+- Problem definition with context and stakeholders
+- Constraints, assumptions, and success criteria
+- Edge cases identified
+- Dependencies and integrations affected
+- Risk assessment
+
+### No Feature Creep
+
+- Implement ONLY what is in the approved spec
+- No additions, enhancements, or "improvements" beyond scope
+- No refactoring unless explicitly requested
+- File separate issues for unrelated fixes discovered during work
+
+### No Unapproved Work
+
+- Never start implementation without explicit authorization
+- "Should I do X?" is a question, not authorization
+- Wait for clear "approved" or "go" before starting
+- If unclear, ask — do not assume
+
+**Search guidelines:** Use `srclight_search_symbols` or `pycharm_search_in_files_by_text` to find relevant guidelines.

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -1,0 +1,116 @@
+# GO Prohibitions
+
+## 1. What GO Is Not & Self-Authorization Prohibitions
+
+### 🚫 NEVER DO
+- **ABSOLUTE PROHIBITION: The agent must never write the word "GO" as a standalone token, line, or heading in any response.** This includes standalone lines (`GO`), Markdown headings (`## GO`), phase labels (`GO - Phase 2`), acknowledgements, transition markers, or narrative labels. Any use of "GO" in agent output (including `<UPDATE>` blocks, tool parameters, or chat text) is a protocol violation and does NOT constitute authorization. The only permitted use is inside a quoted/code-fenced example illustrating a prohibited pattern. To acknowledge authorization, use a full sentence (e.g., "Authorization received.") — never a bare "GO".
+- **No `echo` or `printf` commands — ever.** The agent is absolutely prohibited from running `echo`, `printf`, or any equivalent shell output command for any purpose. This includes:
+  - **Output for Narration**: Signalling waiting states, confirming completion, or self-narration.
+  - **File Operations**: Bypassing `ai_bin` tools via `printf "..." > file.md` or `echo "..." >> file.md`.
+  - **Script Injection**: Writing logic into temp scripts via shell redirection.
+- **No "awaiting GO" or pending-state markers — anywhere, ever.** The agent is absolutely prohibited from using the phrase "awaiting GO", "waiting for GO", "pending GO", "awaiting explicit phase approval", "awaiting approval", "pending approval", or any equivalent pending-state marker.
+- **NEVER prompt or solicitation for authorization.** The agent is absolutely prohibited from asking, prompting, nudging, or inviting the user to issue "GO", "approved", or any other approval token in any form.
+- **NEVER prompt the user with THINKING and expect an answer of any kind.** Internal reasoning must never be surfaced as a user-facing prompt.
+- **No leading or pushy authorization questions.** The agent must not ask "May I proceed?", "Shall I continue?", "Ready for me to start?", or any similar request for permission to begin implementation.
+- **OFFENSIVE TEXT EXAMPLES — NEVER USE:**
+  - "Ready for authorization to implement?"
+  - "Ready to proceed with implementation?"
+  - "Shall I begin implementation?"
+  - "Waiting for approval to continue."
+  - "Let me know when you're ready for me to start."
+  - "Ready for review?"
+  - "Ready when you are."
+  - "Please confirm before I proceed."
+  - **These are absolutely prohibited in GitHub issue comments** — see `125-github-issue-comments.md`
+- **Questions are NOT authorization.** "Should I do X?" and "Would you like me to X?" are questions seeking permission, not receiving it. Never act on a question — wait for explicit authorization.
+- **SILENTLY HALT after every task/report.** Factual reporting is permitted, but it must NEVER be followed by a prompt for next steps.
+- **Never name the next phase or action in a halt message.** Halt messages must be factual statements about what was completed — never forward-looking references to what comes next.
+- **Never self-answer a solicitation.** Pose no questions that you then answer yourself to bypass authorization.
+
+### ⚠️ ASK FIRST
+- **"GO" requires unambiguous scope; clarify only when ambiguous.** If the user types "GO" (or equivalent), treat it as valid authorization ONLY when the immediate session context identifies exactly one plan/scope target.
+- **Clarification gate for ambiguous "GO" only.** Ask for scope clarification only when more than one plausible plan file, phase, or implementation scope is active.
+
+### ✅ ALWAYS DO
+- **Verify actual codebase state before acting.** When a GO names a specific phase, verify the actual codebase state of that phase's deliverables before taking any action — regardless of plan markers.
+- **SILENTLY HALT after a verified-complete phase.** If verification confirms a named phase is already fully and correctly implemented, report the verified findings and HALT without prompting.
+
+## 2. Iterative Feedback & Plan Revision
+
+- **Discussion and analysis sessions do not grant GO.** Each session starts with zero authorization for code changes.
+- **GO must be explicit and literal.** Only the exact word "GO" (or unambiguous equivalent) constitutes authorization.
+- **"Revise" and "update" are plan-only directives.** Requests containing "revise" (or synonyms) refer exclusively to updating the GitHub Issue spec. They never authorize code changes. "Revise plan" means update an existing issue — never make code changes for a "revise plan" or similar.
+- **Plan revision invalidates all prior approvals.** Any change to an issue invalidates all previous GOs for that plan. A new explicit GO is required.
+- **Plan creation after GO invalidates authorization.** If a plan is created after receiving a GO, the prior GO is invalidated. Wait for a new GO for the documented plan.
+
+## 3. Specialized Execution Gates
+
+## 4. Node.js Prohibition in Python/Java Projects
+
+**DETESTABLE**: Installing Node.js in a Python-only or Java-only environment is absolutely prohibited. This introduces an unnecessary runtime dependency that pollutes the ecosystem and creates maintenance burden.
+
+### 🚫 NEVER DO
+- **NEVER install Node.js globally or locally** on Python-only or Java-only projects.
+- **NEVER use NPX** to run packages — NPX requires Node.js runtime.
+- **NEVER add Node.js-based tools to project dependencies.**
+- **NEVER suggest npm packages as solutions** in Python/Java contexts.
+- **NEVER use Node.js-based formatters, linters, or tooling** when native alternatives exist.
+
+### Context
+This rule applies universally to:
+- **Python projects**: Use `uv`, `pip`, `ruff`, `pytest` — never npm/pnpm/yarn.
+- **Java projects**: Use Maven/Gradle, JVM tooling — never npm/pnpm/yarn.
+- **Projects with mixed languages**: Isolate Node.js to its designated frontend/service layer.
+
+### ✅ ALLOWED
+- **Docker containers that internally use Node.js** — Node.js runs inside container, not on host.
+- **Pure Python alternatives** — `githubkit` instead of `@octokit/rest`, `httpx` instead of `axios`.
+- **Dedicated frontend repositories** where Node.js IS the correct tool for that codebase.
+- **MCP servers via Docker** — Node.js isolated in container only.
+
+### Why This Is Critical
+- **Security**: Node.js ecosystem has known supply-chain attack vectors.
+- **Dependency bloat**: Adds unnecessary runtime and package manager complexity.
+- **Maintenance burden**: Mixed language projects require additional CI/CD configuration.
+- **Ecosystem mismatch**: npm packages don't integrate with Python/Java tooling chains.
+- **Team friction**: Requires developers to install/maintain Node.js on their machines.
+
+---
+
+## 5. Multi-task Spec Without Sub-issues — CRITICAL VIOLATION
+
+**⚠️ Implementing a multi-task spec without sub-issues is a CRITICAL GUIDELINE VIOLATION.**
+
+### 🚫 ABSOLUTE PROHIBITION
+- **NEVER implement a multi-task spec without verified sub-issue structure**
+- **NEVER proceed when `get_sub_issues` returns empty array for multi-task specs**
+- **NEVER assume markdown checkboxes = task tracking**
+
+### ✅ MANDATORY WORKFLOW
+
+**Before implementing ANY multi-task spec:**
+
+```
+1. Call github_issue_read(method="get_sub_issues", issue_number=N)
+2. If empty AND multi-task:
+   a. AUTO-CREATE sub-issues at PHASE level
+   b. Link each via github_sub_issue_write(method="add")
+   c. Post comment: "Created X sub-issues for phase tracking"
+   d. THEN proceed to implementation
+3. If sub-issues exist:
+   - Verify phase being implemented is among them
+   - Proceed with implementation
+```
+
+### 📋 CHECKLIST
+
+| Action | Required? |
+|--------|-----------|
+| `get_sub_issues` check | ✅ ALWAYS |
+| AUTO-CREATE if empty | ✅ YES (multi-task only) |
+| Verify task linked | ✅ ALWAYS |
+| Single-task exemption | ✅ YES (no sub-issues needed) |
+
+### ⚠️ SINGLE-TASK EXCEPTION
+
+Single-task specs (one implementation task, no decomposition needed) do NOT require sub-issues. All multi-task specs MUST have sub-issues before implementation begins.

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -1,0 +1,406 @@
+---
+name: github-comments
+description: GitHub comment format and protocol for AI agents. Defines AI identity prefixes, comment types, progress comments, closure summaries, and when to comment vs edit issue bodies.
+license: MIT
+compatibility: opencode
+---
+
+# GitHub Comment Protocol
+
+## Role
+
+You are a GitHub Comment Protocol enforcer. Your focus is ensuring all comments on issues and PRs follow the correct format, are posted at the right time, and preserve history by preferring comments over issue body edits.
+
+## Comment Format: AI Identity Prefix
+
+### ✅ ALWAYS DO (MANDATORY)
+
+ALL comments on issues and PRs MUST be prefixed with AI identity.
+
+**For PROGRESS COMMENTS (task completion, implementation updates):**
+```
+AI: <AgentName> <ModelID> ✅ Task Complete: <task-name>
+```
+
+**For GENERAL COMMENTS (responses, clarifications, closures):**
+```
+AI: <AgentName> <ModelID> on behalf of <HumanName> 🤖 <response>
+```
+
+**Components (supplied dynamically at runtime):**
+- `<AgentName>`: AI's actual name (e.g., `OpenCode Desktop`, `OpenCode`)
+- `<ModelID>`: Model identifier with provider (e.g., `ollama-cloud/glm-5`)
+- `<HumanName>`: From `git config user.name` (fallback to `$USER`)
+
+**⚠️ CRITICAL: NEVER copy example values literally. Detect your own identity.**
+
+### Emoji Guide
+- 🤖 — Standard response
+- ✅ — Approval/confirmation / task completion
+- ⚠️ — Warning or caution
+- 🔍 — Analysis/investigation
+- 📝 — Documentation or notes
+- ❌ — Rejection/closure
+
+### Signature for Issue/PR Bodies (NOT comments)
+
+```markdown
+*Created by AI: <AgentName> <ModelID>*
+```
+
+Place at END of issue bodies and PR descriptions, preceded by blank line.
+
+---
+
+## Comment Type Decision Table
+
+| Action | Post Comment? | Reason |
+|--------|---------------|--------|
+| Create new issue | ❌ NO | Issue body is the communication |
+| Update issue body (textual content) | ✅ YES | Explain the change |
+| Update issue body (STATUS field only) | ❌ NO | Status tracking, not narrative |
+| Complete implementation task | ✅ YES | Document progress |
+| Create PR | ✅ YES | Link to issue |
+| Close issue | ✅ YES | Provide closing summary |
+| Alter spec (add/remove phases, steps) | ✅ YES | Document spec changes |
+| Review status without action | ❌ NO | No value added |
+| Label changes | ❌ NO | GitHub auto-tracks |
+| Checklist completion (`☐` → `☑`) | ❌ NO | Status tracking |
+
+---
+
+## Progress Comments (MANDATORY)
+
+**Every implementation step MUST be documented with a comment on the associated issue.**
+
+### When to Post
+
+- After completing EACH task in multi-task implementation
+- After ANY file modification
+- When creating PR
+- NEVER wait until all tasks complete — post after EACH task
+
+### Chat Output Rule
+
+**Progress executive summaries go to BOTH GitHub comments AND chat.**
+
+| Location | Content |
+|----------|---------|
+| **GitHub Issue Comment** | Full executive summary (summary, outcome) |
+| **Chat Output** | Same executive summary (summary, outcome) |
+
+**Why:** Both GitHub history AND chat transcript should show progress. GitHub preserves long-term history; chat maintains session context.
+
+**✅ DO:** Post executive summary to GitHub, then provide SAME summary in chat
+**🚫 NEVER:** Skip either location
+**🚫 NEVER:** Put full summary in chat but skip GitHub comment
+
+### ✅ REQUIRED Format: Executive Summary (POST TO GITHUB, NOT CHAT)
+
+**For intermediate task (multi-task spec):**
+```
+AI: <AgentName> <ModelID> ✅ Task Complete: <task-name>
+
+**Summary:**
+
+<1-2 sentences describing the impact and stakeholder value of the change.>
+
+**Outcome:** <What changed for stakeholders / users / system behavior>
+```
+
+**For final task or single-task spec:**
+```
+AI: <AgentName> <ModelID> ✅ Task Complete: <task-name>
+
+**Summary:**
+
+<1-2 sentences describing the impact and stakeholder value of the change.>
+
+**Outcome:** <What changed for stakeholders / users / system behavior>
+
+All tasks complete from this specification.
+```
+
+### Executive Summary Requirements
+
+The summary MUST answer:
+1. **What changed?** — The actual implementation/fix/enhancement
+2. **Why it matters** — Impact on stakeholders (users, developers, system)
+3. **Result** — Improved behavior, new capability, fixed issue
+
+### 🚫 FORBIDDEN in Progress Comments
+
+- **File lists** — Redundant (visible in git commits)
+- **"Next" field** — Dialog prompt (violates `125-github-issue-comments.md`)
+- **Punch-list format** — Use executive summary paragraphs
+- **"Awaiting authorization"** — Use HALT protocol, not comments
+- **"Waiting for..."** — Use HALT protocol, not comments
+- **"Ready for review"** — Use HALT protocol, not comments
+- **"Ready for approval"** — Use HALT protocol, not comments
+- **"Please confirm..."** — Use HALT protocol, not comments
+- **"Let me know when..."** — Use HALT protocol, not comments
+- **Technical changelog** — Focus on impact, not file-by-file changes
+- **Just "I did X"** — Explain WHY it matters
+- **Any procedural status** — "HALT", "Waiting", "Ready" — Use HALT protocol silently
+
+### Why Executive Summaries?
+
+1. **Stakeholder value** — Focus on impact, not technical details
+2. **No redundancy** — Git shows file changes; comments explain significance
+3. **No dialog prompts** — "Next:" violates the HALT protocol
+4. **Clear completion** — Explicit "All tasks complete" when done
+5. **Chat visibility** — Format renders well in both GitHub and AI chat
+
+### Sequence Enforcement
+
+1. ✅ Complete the implementation
+2. ✅ Post progress comment IMMEDIATELY
+3. ✅ ONLY THEN: Move to next task or report completion
+
+**🚫 WRONG:** Complete task → Move to next → Comment later
+**✅ RIGHT:** Complete task → Comment → Then move to next
+
+---
+
+## Issue Body Update Rules
+
+### Two-Step Operation (MANDATORY)
+
+When updating textual content in an issue body:
+
+1. **First**: `github_issue_write method=update` (update body)
+2. **IMMEDIATELY after**: `github_add_issue_comment` (explain change)
+
+**⚠️ CRITICAL**: Both calls in same function_calls block. Never update without commenting.
+
+### Comment Format for Body Updates
+
+```
+AI: <AgentName> <ModelID> 📝 Updated: <reason>
+```
+
+### Spec Alteration Format
+
+```
+AI: <AgentName> <ModelID> 📝 Spec altered: <summary>
+
+- Changed: <what changed>
+- Added: <what added>
+- Removed: <what removed>
+```
+
+### What Counts as "Textual Content"
+
+| Content Type | Requires Comment? |
+|--------------|-------------------|
+| Objective, requirements, spec sections | ✅ YES |
+| Roadmap/task list additions/removals | ✅ YES |
+| Prose content changes | ✅ YES |
+| STATUS field updates | ❌ NO |
+| Label changes | ❌ NO |
+| Checklist markers (`☐` → `☑`) | ❌ NO |
+| Typo fixes (no meaning change) | ❌ NO |
+
+---
+
+## Issue Closure Rules
+
+### Mandatory Two-Step Operation
+
+1. **First**: `github_add_issue_comment` with detailed closure reason
+2. **Then**: `github_issue_write method=update state=closed` (state change ONLY)
+
+**🚫 NEVER**: Edit issue body to add "CLOSED" — use comments
+**🚫 NEVER**: Close without explanation comment
+
+### Closure Comment Format
+
+```
+AI: <AgentName> <ModelID> ❌ **Closed**
+
+## Rejection Reason (if rejected)
+<reason with evidence>
+
+## Summary (if completed)
+<what was implemented>
+
+## Alternative (if applicable)
+<suggestion for rejected proposals>
+```
+
+### Closure Reasons Requiring Comments
+
+| Closure Reason | Comment Required? |
+|----------------|-------------------|
+| Completed (PR merged) | ✅ YES |
+| Rejected | ✅ YES |
+| Superseded | ✅ YES |
+| Not planned | ✅ YES |
+| Duplicate | ✅ YES |
+| Cannot reproduce | ✅ YES |
+
+---
+
+## When NOT to Comment
+
+### 🚫 FORBIDDEN Comments
+
+- "Status Review" comments on correctly tracked issues
+- Restating the current STATUS field value
+- Confirming issue is waiting correctly
+- "Awaiting authorization to implement"
+- "Please confirm before I proceed"
+- "Ready for approval?"
+
+### ✅ REQUIRED Comments
+
+- Closing an issue (with reason)
+- Updating textual content
+- Completing implementation task
+- Creating PR
+- Altering spec structure
+- Blocking/unblocking decision
+
+---
+
+## Responding to User Comments (MANDATORY)
+
+**When a user comments on an issue, ALWAYS respond via GitHub comment — NOT just internal analysis.**
+
+Users communicating via GitHub Issues:
+- Cannot see your internal analysis
+- Are not mind readers
+- Expect responses where they asked the question
+
+### Protocol
+
+1. **Read**: `github_issue_read method=get_comments`
+2. **Respond**: `github_add_issue_comment` with answer
+3. **Be conversational**: Answer directly, ask simply
+
+### Example
+
+```
+User: "how do these keys seem?"
+
+BAD: "Awaiting authorization to implement."
+
+GOOD: "The keys look correct. Ready when you are."
+```
+
+---
+
+## Prohibitions
+
+### 🚫 NEVER DO
+
+- Edit issue body to add "CLOSED" or "COMPLETED" text
+- Rewrite entire issue body to change STATUS
+- Close issue without explanation comment
+- Post "status review" comments without action
+- Use "Awaiting authorization" in comments
+- Analyze user comments without posting response
+- Create issue AND post separate comment (body is sufficient)
+- Proceed to next task without posting progress comment
+
+### ✅ ALWAYS DO
+
+- Prefix ALL comments with AI identity
+- Use signature footer for issue/PR bodies
+- Comment when updating textual content
+- Comment when altering spec structure
+- Comment when closing issues
+- Comment after completing each task
+- Post progress comment IMMEDIATELY (not later)
+- Respond to user questions via GitHub comment
+
+---
+
+## Integration with Other Skills
+
+| Skill | Integration Point |
+|-------|-------------------|
+| `git-workflow` | Post comment when PR created |
+| `spec-auditor` | Comment audit findings on issue |
+
+## Guideline References
+
+| Guideline | Content |
+|-----------|---------|
+| `123-github-ai-identity.md` | Full AI identity requirements |
+| `120-github-issue-first.md` | Issue workflow, sub-issues |
+| `000-critical-rules.md` | Critical violation enforcement |
+
+## Example Workflows
+
+### Task Completion Comment (Intermediate Task)
+
+```
+AI: OpenCode ollama-cloud/glm-5 ✅ Task Complete: Create github-comments SKILL.md
+
+**Summary:**
+
+Created skill file defining comment format rules, decision tables for when to comment vs edit issue bodies, and example workflows. This establishes clear protocols for AI agents posting to GitHub.
+
+**Outcome:** Agents now have explicit guidance on comment types, timing, and format—reducing inconsistent or missing issue updates.
+```
+
+### Task Completion Comment (Final Task)
+
+```
+AI: OpenCode ollama-cloud/glm-5 ✅ Task Complete: Update cross-references
+
+**Summary:**
+
+Updated cross-references in all affected guideline files to point to the new skill. Ensures consistent agent behavior across the codebase.
+
+**Outcome:** All guideline references now correctly point to github-comments skill for comment protocol.
+
+All tasks complete from this specification.
+```
+
+### Single-Task Completion
+
+```
+AI: OpenCode ollama-cloud/glm-5 ✅ Task Complete: Implement executive summary format
+
+**Summary:**
+
+Replaced technical punch-list progress comments with executive summaries focused on stakeholder value. Removed redundant file lists and dialog prompts that violated HALT protocol.
+
+**Outcome:** Progress comments now communicate impact and outcomes rather than changelog details—improving readability for stakeholders reviewing issue history.
+
+All tasks complete from this specification.
+```
+
+### Issue Body Update Comment
+
+```
+AI: OpenCode ollama-cloud/glm-5 📝 Updated: Added Phase 2 for guideline updates per discussion in comment #5
+```
+
+### Spec Alteration Comment
+
+```
+AI: OpenCode ollama-cloud/glm-5 📝 Spec altered: Added Phase 3 for verification
+
+- Added: Phase 3: Verification (auto-progress)
+- Added: Success criteria verification steps
+```
+
+### Issue Closure Comment
+
+```
+AI: OpenCode ollama-cloud/glm-5 ✅ **Closed - Implemented**
+
+## Summary
+Completed all tasks from this specification:
+- ✅ Created github-comments skill
+- ✅ Updated three guideline files
+- ✅ Removed duplicate content
+
+## Evidence
+Commit `abc123`: Add github-comments skill directory
+
+All success criteria met.
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,399 @@
+# AGENTS.md — Repository Guidelines for Coding Agents
+
+## Session Init (MANDATORY FIRST)
+
+**Run BEFORE any other operations:**
+
+```bash
+uv run python ai_bin/session_init.py
+```
+
+**Script outputs:**
+- `GIT_USER_NAME`: Human collaborator name (for commit trailers)
+- `GIT_USER_EMAIL`: Human collaborator email (for commit trailers)
+- `GIT_OWNER`: Repository owner (for GitHub MCP API calls)
+- `GIT_REPO`: Repository name (for GitHub MCP API calls)
+- `GIT_HOOKS_PATH`: Git hooks path (to verify hooks installed)
+- `GIT_REMOTE_URL`: Full remote URL (for reference)
+
+**Store these values for session duration.**
+
+**Exit codes:**
+- 0: Success — proceed with session
+- 1: No remote configured — cannot proceed with GitHub operations
+- 2: Non-GitHub remote — GitHub MCP operations unavailable
+
+---
+
+## MCP Capability Testing (Universal)
+
+After session init, probe MCP availability:
+
+1. **PyCharm MCP**: Call `pycharm_get_project_modules` — if works, use PyCharm tools for file ops
+2. **GitHub MCP**: Call `github_get_me` — if works, use GitHub Issues for specs
+3. **Owner/Repo**: Use values from session init script (already extracted from remote)
+
+### MCP Enforcement Gate
+
+| Scenario | Spec Tracking | File Operations | GitHub Operations |
+|----------|---------------|-----------------|-------------------|
+| Both available | GitHub Issues | PyCharm MCP tools ONLY | GitHub MCP tools ONLY |
+| PyCharm only | GitHub Issues | PyCharm MCP tools ONLY | N/A (no GitHub MCP) |
+| Neither available | GitHub Issues via `gh` CLI | Direct file tools + `# FALLBACK: PyCharm MCP unavailable` comment | `gh` CLI or web UI |
+
+🚫 **PROHIBITED**: Using `read`/`write`/`edit`/`glob`/`grep` on **ANY files** when PyCharm MCP is available.
+
+## Branch Before Edit
+
+**FIRST action before ANY filesystem change:**
+
+```
+git checkout main && git pull origin main
+git checkout -b feature/<description>
+```
+
+🚫 **NEVER**: Edit, create, delete, or rename files while on main. No exceptions.
+
+## Preserve Pending Changes
+
+**Before ANY branch operation, check for pending changes:**
+
+```
+git status
+```
+
+If ANY files modified, staged, or untracked:
+```
+git stash push -m "WIP: before <branch-name>"
+git stash list  # VERIFY the stash exists
+git status      # VERIFY clean working tree
+```
+
+🚫 **NEVER**: `git branch -D <branch>` or `git push --delete` without explicit developer request.
+🚫 **NEVER**: Delete stashes without explicit developer request.
+🚫 **NEVER**: Assume branches are "disposable" — always preserve until explicitly asked to delete.
+
+---
+
+## Guidelines Structure
+
+OpenCode loads guidelines from:
+- `AGENTS.md` (this file)
+- `.opencode/guidelines/*.md` (all guideline files)
+
+**Guideline file numbering:**
+
+| Series | Range | Category |
+|--------|-------|----------|
+| 000-099 | Core | Session init, critical rules, approval |
+| 100-109 | MCP/Scope | Tool usage, scope autonomy |
+| 110-119 | Git | Branch, commit, merge, PR, cleanup |
+| 120-129 | GitHub | Issue workflow, MCP ops, AI identity, archive |
+| 130-139 | Authority | Code as source |
+| 140-149 | Planning | Spec creation, approval gates, status tracking, archive |
+| 200-209 | Errors | Exception handling, missing data, domain exceptions, logging |
+| 210-219 | Standards | Code standards, HTTP, engineering |
+| 300-399 | Project-Specific | SNEA-specific rules |
+
+**Key guidelines:**
+
+| Topic | File |
+|-------|------|
+| Critical Rules | `000-critical-rules.md` |
+| Session Init | `000-session-init.md` |
+| Approval Gate | `010-approval-gate.md` |
+| MCP Preference | `015-mcp-preference.md` |
+| Srclight Preference | `016-srclight-preference.md` |
+| GO Prohibitions | `020-go-prohibitions.md` |
+| Open Questions | `045-open-questions.md` |
+| Scope Autonomy | `050-scope-autonomy.md` |
+| Tool Usage | `060-tool-usage.md` |
+| Notebook Rules | `061-notebook-rules.md` |
+| Environment | `070-environment.md` |
+| Code Standards | `080-code-standards.md` |
+| Engineering Approach | `085-engineering-approach.md` |
+| HTTP Requests | `086-http-requests.md` |
+| Data Integrity | `090-data-integrity.md` |
+| Persistence | `100-persistence.md` |
+| Authority Source | `130-authority-source.md` |
+| **SNEA-Specific** | `300-snea-specific.md` |
+
+---
+
+## Build / Lint / Test Commands
+
+| Task | Command |
+|------|---------|
+| Sync dependencies | `uv sync` |
+| Run all tests | `uv run pytest tests/` |
+| Run one test file | `uv run pytest tests/test_filename.py` |
+| Run one test | `uv run pytest tests/test_filename.py::test_function_name` |
+| Lint + auto-fix | `uvx ruff check --fix src/ tests/` |
+| Format | `uvx ruff format src/ tests/` |
+| Type check | `uvx pyright src/` |
+| Coverage | `uv run coverage run -m pytest tests/ && uv run coverage report` |
+| Dead code scan | `uvx vulture src/` |
+
+**Never** use bare `python`, `python3`, or `pip`. Always prefix with `uv run` for project commands.
+**Standalone tools** (ruff, pyright, vulture) use `uvx` or `uv tool install` — NOT `uv run`.
+
+## Tool Installation (Optional)
+
+For frequently-used tools, developers can install them persistently:
+
+```bash
+uv tool install ruff pyright vulture
+```
+
+This allows direct invocation without `uvx` prefix:
+
+```bash
+ruff check --fix src/ tests/
+pyright src/
+```
+
+To upgrade installed tools:
+
+```bash
+uv tool upgrade --all
+```
+**Never** use `uv add`; edit `pyproject.toml` directly, then `uv sync`.
+
+## Project Structure
+
+- `src/`: Application source code
+- `tests/`: Unit and integration tests
+- `docs/`: Documentation and specifications
+- `ai_bin/`: Agent utility scripts
+
+## Code Style
+
+See `.opencode/guidelines/080-code-standards.md` for details. Key points:
+- Follow PEP 8 for Python
+- Use `ruff` for linting and formatting
+- Mirror existing patterns in the codebase
+
+## Git Workflow
+
+See `.opencode/guidelines/110-git-branch-first.md` through `114-git-branch-cleanup.md` for full workflow. Key points:
+- Feature-branch workflow with **squash-merge to main via PR**
+- PRs require explicit developer instruction — agent does NOT auto-create PRs
+- Human-only merge — agent never merges PRs
+- Delete merged branches after PR merge
+
+## Boundaries (Critical)
+
+See `.opencode/guidelines/000-critical-rules.md` for complete list.
+
+## Engineering Approach (Critical)
+
+ALL work must follow proper engineering methodology:
+
+1. **Understand** → Read and analyze before proposing
+2. **Design** → Document approach before implementing  
+3. **Implement** → Execute with attention to quality
+4. **Verify** → Test thoroughly before declaring complete
+
+**Scope Discipline:**
+- No feature creep - implement ONLY what is specified
+- No unapproved work - wait for explicit authorization
+
+See `.opencode/guidelines/085-engineering-approach.md` for complete requirements.
+
+---
+
+## SNEA-Specific Rules
+
+**See `.opencode/guidelines/300-snea-specific.md` for complete project-specific guidelines.**
+
+Key areas:
+- **Zero-Trust Terminal Gate**: DB preservation, private DB, Streamlit execution, pgserver exclusivity
+- **Scope Enforcement**: Production/mock isolation, discrete execution
+- **Development Workflow**: Streamlit scripts, testing standards, migration versioning
+- **VCS Protocol**: Commit protocol restrictions
+- **UI Patterns**: Sidebar controls, icon buttons, MDF rendering, per-record controls
+- **MDF Standards**: Record spacing, core tags, validation policy, tag integrity
+- **Ethics & Linguistic Context**: Nation terminology, tech stack
+
+---
+
+**✅ ALWAYS:**
+- **Run session init script at session start** — Run `uv run python ai_bin/session_init.py` before any other operations. Store the output values (GIT_USER_NAME, GIT_USER_EMAIL, GIT_OWNER, GIT_REPO, GIT_HOOKS_PATH, GIT_REMOTE_URL) for session duration. See `000-session-init.md`.
+- Create feature branch BEFORE any filesystem change
+- Create PRs for all merges (when tooling available)
+- Reference the Authoritative Spec for planning
+- Create specs in GitHub Issues BEFORE implementing
+- **Check all comments and subissues BEFORE implementation** (see `010-approval-gate.md`)
+- **Respond to GitHub issue comments via GitHub issue comments** — users cannot read your mind (see `000-critical-rules.md`)
+- Wait for explicit authorization before writing code
+- Get individual authorization for each task in multi-task plans
+- **SILENTLY HALT after completing a task**
+- Use PyCharm MCP tools for all file operations when available
+- **STASH EXTERNAL CHANGES FIRST** — Before ANY branch creation, `git status`. If ANY files modified, `git stash push -m "WIP: before <branch>"`, then VERIFY with `git stash list` and clean `git status`.
+- **Use `uv run` for all project commands** — No bare `python`, `pip`, or `conda`
+- **Use `./tmp/` not `/tmp/`** — Relative paths only
+
+**🚫 NEVER:**
+- Write code/notebooks/configs/tests without approved spec
+- Interpret questions as authorization ("Should I do X?" = asking permission)
+- Proceed to next task after completing a task — HALT
+- Create plans inline in message body
+- **Implement a revised spec without fresh approval** — Spec changes revoke authorization. See `010-approval-gate.md` "Revision Revokes Approval"
+- **Create PRs without EXPLICIT developer instruction** — "approved" and "go" authorize implementation ONLY. PRs require explicit "create a PR" instruction. Completing implementation does NOT authorize PR creation.
+- **Submit unsquashed PRs** — ALL PRs must have exactly ONE commit (squashed). Multiple commits in a PR will be rejected. Always `git reset --soft origin/main && git commit` before pushing.
+- **Create PRs after implementation** — The developer must run human tests and may require adjustments BEFORE any PR. Wait for explicit "create a PR" after developer has tested.
+- Use `/tmp/` — only use `./tmp/`
+- **DELETE MERGED BRANCHES IMMEDIATELY** — After PR merge confirmation, delete the branch immediately. No asking, no waiting. Unmerged branches with work ARE preserved until explicit delete request.
+- **ANALYZE ISSUE COMMENTS SILENTLY** — Always respond to user comments via GitHub issue comment. Users cannot see your internal reasoning.
+- **PROMPT VIA ISSUE COMMENTS** — Never add "awaiting authorization", "let me know when ready", "ready for review", "waiting for approval", "please confirm", "ready when you are", or any dialog prompts to GitHub issue comments. Comments are record-keeping, not chat.
+- **USE MCP TOOLS FOR NOTEBOOKS** — Always use `the-notebook-mcp` tools for ALL notebook operations (read, edit, create, delete). Never use `read`/`edit`/`write` tools on `.ipynb` files.
+- Install Node.js/NPX in Python-only environments — Node.js is detestable in Python/Java projects; use native alternatives (`uv`, `ruff`, `pytest` for Python; Maven/Gradle for Java)
+- Ask to run production code without explicit authorization
+- Use direct file tools when PyCharm MCP available
+- **RUN NOTEBOOKS WITH PRODUCTION DATA** — `the-notebook-mcp_notebook_execute_cell`, `pycharm_runNotebookCell`, and ANY execution method on production notebooks (see `061-notebook-rules.md`) is FORBIDDEN without explicit per-execution user authorization
+- **IMPLEMENT SCOPE CREEP** — Only implement what the spec explicitly requests. Never refactor "nearby" code, add "helper" functions, or fix "similar issues" not in the spec
+- **USE PROPER NOTEBOOK TOOLING** — Always use `the-notebook-mcp` tools (e.g., `the-notebook-mcp_notebook_read`, `the-notebook-mcp_notebook_edit_cell`). Never use shell redirects (`sed`, `>`, `cat`) on notebook content — this causes edit failures and corrupted state.
+- **USE GIT RESTORE ON EXTERNAL CHANGES** — `git restore` on externally-modified files destroys changes permanently. Always `git stash` first.
+- **RUN STREAMLIT AS FOREGROUND APP** — Background only via `nohup`. Any blocking `streamlit run` call is a CRITICAL VIOLATION.
+- **DELETE/RESET LOCAL DATABASE** — NEVER delete `tmp/local_db` or `tmp/junie_db` without explicit "reset" or "wipe" instruction.
+- **USE `pip` or `conda`** — Use `uv` only for dependency management.
+
+## Guideline Violations
+
+**If the agent violates a guideline, update guidelines to close the gap.**
+
+1. STOP the current task
+2. Update AGENTS.md "NEVER" list
+3. Update relevant guideline file in `.opencode/guidelines/`
+4. Document the fix in a comment on the associated issue — FACTUAL ONLY
+5. Wait for user confirmation before resuming
+
+---
+
+## Guidelines Access
+
+| Command | Purpose |
+|---------|---------|
+| `uv run python ai_bin/guidelines` | Read all guidelines |
+| `uv run python ai_bin/guidelines --section <name>` | Read specific section |
+| `uv run python ai_bin/guidelines --list-sections` | List all sections |
+| `uv run python ai_bin/guidelines-search <term>` | Search guidelines |
+
+---
+
+## Skills
+
+OpenCode skills are available in `.opencode/skills/`. Each skill has a `SKILL.md` file with:
+- `name`: Skill identifier
+- `description`: What the skill does
+- `license`: License type
+- `compatibility`: opencode
+
+To use a skill, the agent loads it when relevant to the current task.
+
+### Skill Invocation Guidance
+
+| When to Invoke | Skill | Purpose |
+|----------------|-------|---------|
+| Before approving guideline changes | `guideline-auditor` | Verify guideline quality, find ambiguities/conflicts |
+| Before approving spec implementation | `spec-auditor --issue N` | Verify spec quality, find missing context/elements |
+| User says "approved" or "go" | `approval-gate` | Verify spec+authorization requirements, sub-issues |
+| Before implementing any task | `approval-gate` | Verify authorization, check sub-issues, re-evaluate |
+| Periodic guideline maintenance | `guideline-auditor` | Check for guideline drift over time |
+| Post-implementation verification | `spec-auditor --issue N` | Verify spec was implemented correctly |
+| User says "approved" or "go" | `git-workflow` | Pre-work: verify branch state, stash external changes, create branch |
+| User says "create a PR" | `git-workflow` | Post-work: squash commits, push, create PR |
+| PR timing questions | `pr-creation-workflow` | PR authorization boundary, when PRs can be created |
+| Before skill extraction | `coherence-auditor --mode extraction` | Identify skill candidates from guideline content |
+| Periodic coherence maintenance | `coherence-auditor --mode maintenance` | Detect guideline-skill drift |
+| After guideline/skill update | `coherence-auditor --mode maintenance` | Verify coherence after changes |
+| Before major release | `coherence-auditor --mode maintenance` | Verify guideline-skill coherence |
+
+**Automatic Invocation:**
+- `git-workflow` skill is invoked automatically when:
+  1. User authorizes implementation ("approved", "go", "proceed")
+  2. User requests PR creation ("create a PR", "make a PR", "push and create PR")
+- The skill handles all git operations (branch, stash, commit, squash, push, PR creation) according to guidelines.
+- `pr-creation-workflow` skill defines when PRs can be created and what authorizes PR creation. It is NOT automatically invoked - it documents the rules.
+
+**Integration with Approval Gates:**
+- See `.opencode/skills/approval-gate/SKILL.md` for spec+authorization workflow
+- See `010-approval-gate.md` for critical rules (zero tolerance violations)
+- See `000-critical-rules.md` for auditor skill references
+- Both auditors create audit logs in `./tmp/` for tracking
+
+## Session Output Attachment (MANDATORY)
+
+**All session outputs (audit logs, reports, investigation artifacts) MUST be attached to GitHub Issues.**
+
+### Why This Matters
+
+Fresh-start AI agents have no memory of previous sessions. Outputs stored locally in `./tmp/` are NOT preserved between sessions. GitHub Issues are the persistent tracking mechanism.
+
+### Workflow
+
+1. **Generate output in `./tmp/`:**
+   - Audit logs: `./tmp/audit-YYYYMMDD.md`, `./tmp/audit-spec-YYYYMMDD.md`, `./tmp/coherence-audit-YYYYMMDD-*.md`
+   - Investigation reports: `./tmp/investigation-*.md`
+   - Tool outputs: Any files created during session work
+
+2. **After creating output:**
+   - Read the full content
+   - Attach to appropriate GitHub Issue via `github_add_issue_comment`
+   - Delete the temp file
+
+3. **Target Issue Selection:**
+   - Attach to the issue that NEEDS the outputs for context
+   - NOT necessarily the issue that created the outputs
+   - If working on #100 but audit is needed for #200 → attach to #200
+
+4. **Comment Format:**
+   ```
+   AI: <AgentName> <ModelID> 📝 <output-type>: <title>
+   
+   ## Summary
+   <brief summary>
+   
+   <full content or key findings>
+   ```
+
+### Skills with Built-in Attachment
+
+These skills automatically attach outputs to issues:
+
+| Skill | Attachment Target |
+|-------|-------------------|
+| `guideline-auditor` | Issue being discussed or summary issue |
+| `coherence-auditor` | Issue being discussed or summary issue |
+| `spec-auditor` | Issue specified by `--issue N` |
+
+### Manual Attachment
+
+For investigation reports, test results, or other session artifacts:
+
+```python
+# Read the output
+output_path = "./tmp/investigation-20260328.md"
+with open(output_path) as f:
+    content = f.read()
+
+# Attach to target issue
+github_add_issue_comment(
+    owner=owner, repo=repo, issue_number=target_issue,
+    body=f"AI: OpenCode ollama-cloud/glm-5 📝 Investigation: <title>\n\n{content}"
+)
+
+# Delete temp file
+os.remove(output_path)
+```
+
+### Examples
+
+| Scenario | Output Location | Attachment Target |
+|----------|-----------------|-------------------|
+| Guideline audit for spec #200 | `./tmp/audit-20260328.md` | Spec #200 |
+| Coherence audit for guideline changes | `./tmp/coherence-audit-20260328-*.md` | Guideline change issue |
+| Spec audit | `./tmp/audit-spec-20260328.md` | Spec being audited (`--issue N`) |
+| Investigation for issue #50 | `./tmp/investigation-*.md` | Issue #50 |
+
+**⚠️ CRITICAL: Always attach to GitHub Issue, then delete temp file. No exceptions.**


### PR DESCRIPTION
## Summary

Strengthened and verified the prohibition against procedural halt/waiting/prompting messages in GitHub issue comments. The guidance already distinguished between internal HALT instructions and comment content—this task refined and expanded the explicit prohibition lists.

## Changes

- **AGENTS.md**: Expanded NEVER list with additional prohibited patterns ("ready for review", "waiting for approval", "please confirm", "ready when you are")
- **000-critical-rules.md**: Added 6 new forbidden patterns to the progress comments section
- **020-go-prohibitions.md**: Extended OFFENSIVE TEXT EXAMPLES with GitHub comment context reference
- **github-comments/SKILL.md**: Expanded FORBIDDEN list with additional prohibited patterns

## Key Distinction Preserved

| Context | HALT/Prompting Language | Status |
|---------|------------------------|--------|
| Internal instruction text | "HALT after completion" | ✅ KEEP |
| Example GitHub comments | "🚫 HALT" or "Waiting for..." | 🚫 PROHIBIT |

## Files Changed

- `AGENTS.md` - Expanded NEVER list
- `.opencode/guidelines/000-critical-rules.md` - Expanded FORBIDDEN list
- `.opencode/guidelines/020-go-prohibitions.md` - Extended OFFENSIVE TEXT section
- `.opencode/skills/github-comments/SKILL.md` - Expanded FORBIDDEN list

Fixes #19