### PR TITLE
[SPEC] Require Assignees on All Issues

### DIFF
--- a/.opencode/guidelines/120-github-issue-first.md
+++ b/.opencode/guidelines/120-github-issue-first.md
@@ -118,6 +118,42 @@ All tasks complete from this specification.
 
 ---
 
+## 5.5. Assignee Requirement (MANDATORY)
+
+**All issues created or managed by AI agents MUST have assignees.**
+
+### Requirements
+
+1. **New issues**: Assign the requesting user (from session init `GIT_USER_NAME`/`GIT_USER_EMAIL`)
+2. **Spec issues**: Assign the spec author and relevant stakeholders
+3. **Bug reports**: Assign the code area owner or project maintainer
+4. **If unclear who to assign**: Use the default from session init or project maintainer
+
+### Rationale
+
+Assignees ensure:
+- Stakeholders receive notifications
+- Clear ownership for follow-up
+- Issues don't become orphaned
+
+### Implementation
+
+When using `github_issue_write method="create"`:
+```python
+github_issue_write(
+    method="create",
+    owner=owner,
+    repo=repo,
+    title="Issue Title",
+    body="Issue body",
+    assignees=["username"]  # REQUIRED - never empty
+)
+```
+
+**⚠️ FAILURE TO ASSIGN ISSUES IS A CRITICAL GUIDELINE VIOLATION.**
+
+---
+
 ## 6. Responding to Issue Comments (MANDATORY)
 
 **When a user comments on an issue, ALWAYS respond via GitHub issue comment - NOT just internal analysis.**

--- a/.opencode/skills/github-sub-issues/SKILL.md
+++ b/.opencode/skills/github-sub-issues/SKILL.md
@@ -70,7 +70,8 @@ If multi-task: Sub-issues are MANDATORY.
 ```
 For each PHASE in spec:
   1. Create issue: github_issue_write(method="create",
-     title="[Task: #N] <phase-description>")
+     title="[Task: #N] <phase-description>",
+     assignees=["<username>"])  # REQUIRED: inherit from parent or use default
   2. Get database ID from response (.id field)
   3. Link: github_sub_issue_write(method="add",
      issue_number=N, sub_issue_id=db_id)
@@ -78,6 +79,11 @@ For each PHASE in spec:
 Post comment: "Created X sub-issues for phase tracking"
 Proceed to implement first phase
 ```
+
+**⚠️ ASSIGNMENT REQUIREMENT:**
+- Sub-issues MUST inherit assignees from parent issue
+- If parent has no assignees, use session init user or default maintainer
+- NEVER create unassigned sub-issues
 
 **⚠️ DATABASE ID REQUIREMENT:**
 - Use `.id` field from response (e.g., `4129879155`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,7 @@ Key areas:
 - Create plans inline in message body
 - **Implement a revised spec without fresh approval** — Spec changes revoke authorization. See `010-approval-gate.md` "Revision Revokes Approval"
 - **Create PRs without EXPLICIT developer instruction** — "approved" and "go" authorize implementation ONLY. PRs require explicit "create a PR" instruction. Completing implementation does NOT authorize PR creation.
+- **Create issues without assignees** — Always assign at least one stakeholder. Use requesting user from session init or default to project maintainer.
 - **Submit unsquashed PRs** — ALL PRs must have exactly ONE commit (squashed). Multiple commits in a PR will be rejected. Always `git reset --soft origin/main && git commit` before pushing.
 - **Create PRs after implementation** — The developer must run human tests and may require adjustments BEFORE any PR. Wait for explicit "create a PR" after developer has tested.
 - Use `/tmp/` — only use `./tmp/`


### PR DESCRIPTION
## Summary

Updates repository guidelines to require assignees on all issues created or managed by AI agents.

**Changes:**
- `AGENTS.md`: Added to NEVER section — "Create issues without assignees"
- `120-github-issue-first.md`: Added Section 5.5 with assignee requirements and implementation guidance
- `github-sub-issues/SKILL.md`: Added assignment requirement for sub-issue creation workflow

**Rationale:**
- Stakeholders receive notifications
- Clear ownership for follow-up
- Issues don't become orphaned

Fixes #24