### PR TITLE
[SPEC] Clarify issue closure timing: allow GitHub auto-close

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -369,14 +369,31 @@ PRs require the developer to say one of these EXACT phrases:
 
 **⚠️ Closing issues BEFORE the PR is merged is a CRITICAL GUIDELINE VIOLATION.**
 
+**Two closure paths exist — auto-close (GitHub) and manual closure (AI agent):**
+
+### Path 1: GitHub Auto-Close (Acceptable)
+
+If the PR body contains `fixes #N`, `closes #N`, or similar closing keyword:
+- GitHub automatically closes the linked issue upon PR merge
+- **No AI action required** — this is correct GitHub behavior
+- The issue closes automatically when the PR merges
+
+### Path 2: Manual Closure (AI Agent)
+
+If the PR body does NOT contain a closing keyword:
+- Issue remains open after PR merge
+- AI agent MUST receive explicit `"pr merged"` instruction
+- AI MUST verify merge via GitHub API before closing
+- AI posts closing summary comment after closure
+
 **🚫 FORBIDDEN:**
 - Closing issues immediately after implementation
 - Closing issues when PR is created but not merged
 - Closing parent issues while child issues remain open
-- Closing issues without explicit "merge confirmed" from human
-- Closing issues based on `git pull` fast-forward alone (MUST use GitHub API)
+- Closing issues without explicit "pr merged" instruction (for manual closure path)
+- Closing issues based on `git pull` alone (MUST use GitHub API)
 
-**✅ REQUIRED SEQUENCE:**
+**✅ REQUIRED SEQUENCE (Manual Closure Path):**
 1. Complete implementation → Create PR → Report PR URL → **HALT**
 2. Wait for human to review and merge PR
 3. User confirms "pr merged" → **Call `github_pull_request_read method=get` to verify**

--- a/.opencode/guidelines/124-github-archive-workflow.md
+++ b/.opencode/guidelines/124-github-archive-workflow.md
@@ -27,22 +27,49 @@ Archive a spec **immediately** after the final phase is approved and the PR is m
 
 **Issues are closed ONLY AFTER the PR is merged — NEVER before.**
 
+### Two Closure Paths
+
+**Path 1: GitHub Auto-Close (Acceptable)**
+
+If the PR body contains `fixes #N`, `closes #N`, or similar closing keyword:
+- GitHub automatically closes the linked issue upon PR merge
+- **No AI action required** — this is correct GitHub behavior
+- The issue closes automatically when the PR merges
+
+**Path 2: Manual Closure (AI Agent)**
+
+If the PR body does NOT contain a closing keyword:
+- Issue remains open after PR merge
+- AI agent MUST receive explicit `"pr merged"` instruction
+- AI MUST verify merge via GitHub API before closing
+- AI posts closing summary comment after closure
+
 ### 🚫 PROHIBITED
 
 1. **NEVER close an issue immediately after implementation**
 2. **NEVER close an issue when PR is created but not merged**
 3. **NEVER close an issue when PR is submitted for review**
 4. **NEVER close an issue based on `git pull` alone** — MUST verify via GitHub API
+5. **NEVER close an issue manually if PR already contains closing keyword** — let GitHub handle it
 
-### ✅ REQUIRED SEQUENCE
+### ✅ REQUIRED SEQUENCE (Manual Closure Path)
 
 | Step | Action | Agent Role |
 |------|--------|------------|
-| Implementation complete | Create PR with `Fixes #123` | ✅ Agent creates PR |
+| Implementation complete | Create PR with or without `Fixes #123` | ✅ Agent creates PR |
 | PR created | Report URL, HALT | ✅ Agent waits |
 | Human merges PR | Merge happens | 🚫 Human ONLY |
 | User confirms merge | Call `github_pull_request_read method=get` | ✅ Agent verifies |
-| PR state = merged | Close issue | ✅ Agent closes |
+| PR state = merged | Close issue (if not auto-closed) | ✅ Agent closes |
+
+### ✅ REQUIRED SEQUENCE (Auto-Close Path)
+
+| Step | Action | Agent Role |
+|------|--------|------------|
+| Implementation complete | Create PR with `Fixes #123` or `Closes #123` | ✅ Agent creates PR |
+| PR created | Report URL, HALT | ✅ Agent waits |
+| Human merges PR | Merge happens, GitHub auto-closes issue | 🚫 Human ONLY |
+| Issue auto-closed | No agent action needed | ✅ None (GitHub handled it) |
 
 ### ⚠️ MANDATORY: API-Based Merge Verification
 

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -170,18 +170,40 @@ When user says "create a PR" or similar:
 
 **Issues are closed ONLY AFTER the PR is merged — NEVER before.**
 
+**Two closure paths exist — auto-close (GitHub) and manual closure (AI agent):**
+
+### Path 1: GitHub Auto-Close (Acceptable)
+
+If the PR body contains `fixes #N`, `closes #N`, or similar closing keyword:
+- GitHub automatically closes the linked issue upon PR merge
+- **No AI action required** — this is correct GitHub behavior
+- The issue closes automatically when the PR merges
+
+### Path 2: Manual Closure (AI Agent)
+
+If the PR body does NOT contain a closing keyword:
+- Issue remains open after PR merge
+- AI agent MUST receive explicit `"pr merged"` instruction
+- AI MUST verify merge via GitHub API before closing
+- AI posts closing summary comment after closure
+
 **🚫 FORBIDDEN:**
 - Closing issues when PR is created but not merged
 - Closing issues immediately after implementation
 - Closing issues based on `git pull` alone (MUST use GitHub API)
 - Closing parent issues while child issues remain open
 
-**✅ REQUIRED SEQUENCE:**
+**✅ REQUIRED SEQUENCE (Manual Closure Path):**
 1. User confirms "pr merged" or similar
 2. **VERIFY via GitHub API:** `github_pull_request_read method=get`
 3. Check `merged_at` timestamp exists
 4. **Only after API confirms merge:** Close child issues, then parent if all children done
 5. Post closing summary comment
+
+**✅ REQUIRED SEQUENCE (Auto-Close Path):**
+1. No agent action needed after PR merge
+2. GitHub automatically closes the linked issue
+3. Issue shows as closed (agent does nothing)
 
 ### Why `git pull` is Insufficient
 


### PR DESCRIPTION
## Summary

Updated guidelines to clarify two issue closure paths:

- **Path 1: GitHub Auto-Close** — When PR body contains `fixes #N` or `closes #N`, GitHub automatically closes the linked issue upon merge. No AI action required.
- **Path 2: Manual Closure** — When PR body has no closing keyword, issues remain open after merge. AI agent requires explicit `"pr merged"` instruction and must verify merge via GitHub API before closing.

## Files Updated

- `.opencode/guidelines/000-critical-rules.md` — Added auto-close path explanation to Critical Violation section
- `.opencode/guidelines/124-github-archive-workflow.md` — Added two-path closure tables for both auto-close and manual paths
- `.opencode/skills/git-workflow/SKILL.md` — Added auto-close path section to Post-Merge Workflow

## Success Criteria

- [x] Guidelines acknowledge GitHub auto-close as acceptable
- [x] Guidelines distinguish between auto-close and manual closure
- [x] Manual closure requires `"pr merged"` instruction + API verification
- [x] Auto-close requires no AI action

Fixes #31