### PR TITLE
Fix byline format: italicize attribution only, status plain

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -49,7 +49,7 @@ Every implementation task MUST be documented with progress comments on the GitHu
 
 **Outcome:** <What changed for stakeholders>
 
-*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ✅ Task Complete: <task-name>*
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✅ Task Complete: <task-name>
 ```
 
 **Final task or single-task spec:**
@@ -62,35 +62,49 @@ Every implementation task MUST be documented with progress comments on the GitHu
 
 All tasks complete from this specification.
 
-*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ✅ Task Complete: <task-name>*
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✅ Task Complete: <task-name>
 ```
 
 ### Required Byline Format Table (MANDATORY)
 
 **ALL comments AND issue body signatures MUST include "on behalf of <HumanName>".**
 
-**Bylines are ALWAYS at the END of content, wrapped in italics.**
+**Structure: Attribution italicized; status plain.**
 
 | Type | Required Format |
 |------|-----------------|
-| Progress (task completion) | `<content>\n\n*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ✅ Task Complete: <task-name>*` |
-| Body update | `<content>\n\n*[🤖 AI: <AgentBrand>] on behalf of <HumanName> 📝 Updated: <reason>*` |
-| Spec alteration | `<content>\n\n*[🤖 AI: <AgentBrand>] on behalf of <HumanName> 📝 Spec altered: <summary>*` |
-| Closure | `<content>\n\n*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ❌ Closed - <reason>*` |
-| General response | `<content>\n\n*[🤖 AI: <AgentBrand>] on behalf of <HumanName> 🤖*` |
-| Issue body signature | `<issue content>\n\n*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ✨ Created*` |
-| PR body signature | `<pr content>\n\n*[🤖 AI: <AgentBrand>] on behalf of <HumanName> 🚀 Launched*` |
+| Progress (task completion) | `<content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✅ Task Complete: <task-name>` |
+| Body update | `<content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName>* 📝 Updated: <reason>` |
+| Spec alteration | `<content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName>* 📝 Spec altered: <summary>` |
+| Closure | `<content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName>* ❌ Closed - <reason>` |
+| General response | `<content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName>* 🤖` |
+| Issue body signature | `<issue content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✨ Created` |
+| PR body signature | `<pr content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✨ Created` |
 
-**Position Breakdown:**
+**Structure Breakdown:**
 
-| Position | Component | Description |
-|----------|-----------|-------------|
-| 1 | `<AgentIcon>` | Agent iconography (🤖, 🟣, 💙) — ALWAYS before `AI:` |
-| 2 | `AI:` | Fixed AI label |
-| 3 | `<AgentBrand>` | Agent brand (OpenCode/glm-5, Claude/sonnet-4) |
-| 4 | `on behalf of <HumanName>` | Human attribution |
-| 5 | `<ContextEmoji>` | Comment type indicator — ALWAYS after human name |
-| 6 | `<TypeText>` | Context-specific text |
+```
+<AgentIcon> *AI: <AgentBrand> on behalf of <HumanName>* <ContextEmoji> <TypeText>
+```
+
+| Part | Content | Format |
+|------|---------|--------|
+| Agent icon | `🤖` | Plain (outside italics) |
+| Attribution | `AI: OpenCode/glm-5 on behalf of Michael Conrad` | Italicized |
+| Context emoji | `✅` | Plain (outside italics) |
+| Type text | `Task Complete: schema` | Plain (outside italics) |
+
+**Examples:**
+
+| Type | Full Byline |
+|------|-------------|
+| Task complete | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✅ Task Complete: schema` |
+| General response | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* 🤖` |
+| Body update | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* 📝 Updated: added field` |
+| Spec alteration | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* 📝 Spec altered: Phase 2` |
+| Issue closure | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ❌ Closed - Implemented` |
+| Issue creation | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✨ Created` |
+| PR creation | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✨ Created` |
 
 **Agent Icon Registry:**
 
@@ -113,7 +127,6 @@ All tasks complete from this specification.
 | 🔍 | `Analysis` | Investigation findings |
 | ⚠️ | `Warning` | Cautions |
 | ✨ | `Created` | Issue/PR creation |
-| 🚀 | `Launched` | PR creation |
 
 **Dynamic Components:**
 - `<AgentIcon>`: Agent iconography (🤖 for OpenCode)

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -19,11 +19,11 @@ ALL comments on issues and PRs MUST end with AI byline.
 
 **ALL bylines AND issue body signatures MUST include "on behalf of <HumanName>".**
 
-**Bylines are ALWAYS at the END of content, wrapped in italics.**
+**Structure: Attribution italicized; status plain.**
 
 **Format:**
 ```
-*[<AgentIcon> AI: <AgentBrand>] on behalf of <HumanName> <ContextEmoji> <TypeText>*
+<AgentIcon> *AI: <AgentBrand> on behalf of <HumanName>* <ContextEmoji> <TypeText>
 ```
 
 **For PROGRESS COMMENTS (task completion, implementation updates):**
@@ -34,14 +34,14 @@ ALL comments on issues and PRs MUST end with AI byline.
 
 **Outcome:** <What changed for stakeholders>
 
-*[🤖 AI: OpenCode/glm-5] on behalf of <HumanName> ✅ Task Complete: <task-name>*
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✅ Task Complete: <task-name>
 ```
 
 **For GENERAL COMMENTS (responses, clarifications):**
 ```
 <response content>
 
-*[🤖 AI: OpenCode/glm-5] on behalf of <HumanName> 🤖*
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* 🤖
 ```
 
 **Components (supplied dynamically at runtime):**
@@ -72,14 +72,13 @@ ALL comments on issues and PRs MUST end with AI byline.
 | 🔍 | `Analysis` | Investigation findings |
 | ⚠️ | `Warning` | Cautions |
 | ✨ | `Created` | Issue/PR creation |
-| 🚀 | `Launched` | PR creation |
 
 ### Signature for Issue/PR Bodies (NOT comments)
 
 ```markdown
 <issue content>
 
-*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ✨ Created*
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✨ Created
 ```
 
 Place at END of issue bodies and PR descriptions, preceded by blank line.
@@ -139,7 +138,7 @@ Place at END of issue bodies and PR descriptions, preceded by blank line.
 
 **Outcome:** <What changed for stakeholders / users / system behavior>
 
-*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ✅ Task Complete: <task-name>*
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✅ Task Complete: <task-name>*
 ```
 
 **For final task or single-task spec:**
@@ -152,7 +151,7 @@ Place at END of issue bodies and PR descriptions, preceded by blank line.
 
 All tasks complete from this specification.
 
-*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ✅ Task Complete: <task-name>*
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✅ Task Complete: <task-name>*
 ```
 
 ### Executive Summary Requirements
@@ -212,7 +211,7 @@ When updating textual content in an issue body:
 ```
 <summary of changes>
 
-*[🤖 AI: <AgentBrand>] on behalf of <HumanName> 📝 Updated: <reason>*
+🤖 *AI: <AgentBrand> on behalf of <HumanName> 📝 Updated: <reason>*
 ```
 
 ### Spec Alteration Format
@@ -222,7 +221,7 @@ When updating textual content in an issue body:
 - Added: <what added>
 - Removed: <what removed>
 
-*[🤖 AI: <AgentBrand>] on behalf of <HumanName> 📝 Spec altered: <summary>*
+🤖 *AI: <AgentBrand> on behalf of <HumanName> 📝 Spec altered: <summary>*
 ```
 
 ### What Counts as "Textual Content"
@@ -262,7 +261,7 @@ Commit `<sha>`: <commit message>
 
 All success criteria met.
 
-*[🤖 AI: <AgentBrand>] on behalf of <HumanName> ❌ Closed - Implemented*
+🤖 *AI: <AgentBrand> on behalf of <HumanName> ❌ Closed - Implemented*
 ```
 
 ### Closure Reasons Requiring Comments
@@ -379,7 +378,7 @@ Created skill file defining comment format rules, decision tables for when to co
 
 **Outcome:** Agents now have explicit guidance on comment types, timing, and format—reducing inconsistent or missing issue updates.
 
-*[🤖 AI: OpenCode/glm-5] on behalf of Michael Conrad ✅ Task Complete: Create github-comments SKILL.md*
+🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad ✅ Task Complete: Create github-comments SKILL.md*
 ```
 
 ### Task Completion Comment (Final Task)
@@ -393,7 +392,7 @@ Updated cross-references in all affected guideline files to point to the new ski
 
 All tasks complete from this specification.
 
-*[🤖 AI: OpenCode/glm-5] on behalf of Michael Conrad ✅ Task Complete: Update cross-references*
+🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad ✅ Task Complete: Update cross-references*
 ```
 
 ### Single-Task Completion
@@ -407,7 +406,7 @@ Replaced technical punch-list progress comments with executive summaries focused
 
 All tasks complete from this specification.
 
-*[🤖 AI: OpenCode/glm-5] on behalf of Michael Conrad ✅ Task Complete: Implement executive summary format*
+🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad ✅ Task Complete: Implement executive summary format*
 ```
 
 ### Issue Body Update Comment
@@ -415,7 +414,7 @@ All tasks complete from this specification.
 ```
 Added Phase 2 for guideline updates per discussion in comment #5
 
-*[🤖 AI: OpenCode/glm-5] on behalf of Michael Conrad 📝 Updated: Added Phase 2 for guideline updates*
+🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad 📝 Updated: Added Phase 2 for guideline updates*
 ```
 
 ### Spec Alteration Comment
@@ -424,7 +423,7 @@ Added Phase 2 for guideline updates per discussion in comment #5
 - Added: Phase 3: Verification (auto-progress)
 - Added: Success criteria verification steps
 
-*[🤖 AI: OpenCode/glm-5] on behalf of Michael Conrad 📝 Spec altered: Added Phase 3 for verification*
+🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad 📝 Spec altered: Added Phase 3 for verification*
 ```
 
 ### Issue Closure Comment
@@ -441,5 +440,5 @@ Commit `abc123`: Add github-comments skill directory
 
 All success criteria met.
 
-*[🤖 AI: OpenCode/glm-5] on behalf of Michael Conrad ❌ Closed - Implemented*
+🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad ❌ Closed - Implemented*
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ Key areas:
 
 **✅ ALWAYS:**
 - **Run session init script at session start** — Run `uv run python ai_bin/session_init.py` before any other operations. Store the output values (GIT_USER_NAME, GIT_USER_EMAIL, GIT_OWNER, GIT_REPO, GIT_HOOKS_PATH, GIT_REMOTE_URL) for session duration. See `000-session-init.md`.
-- **Post bylines at END with branded AI marker** — Use format: `<content>\n\n*[🤖 AI: <AgentBrand>] on behalf of <HumanName> <emoji> <type-text>*`. Agent icon (🤖) BEFORE `AI:`, context emoji AFTER human name. See `000-critical-rules.md` for complete format table.
+- **Post bylines at END with branded AI marker** — Use format: `<content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName> <emoji> <type-text>*`. Agent icon (🤖) BEFORE `AI:`, context emoji AFTER human name. See `000-critical-rules.md` for complete format table.
 - Create feature branch BEFORE any filesystem change
 - Create PRs for all merges (when tooling available)
 - Reference the Authoritative Spec for planning
@@ -246,7 +246,7 @@ Key areas:
 - Proceed to next task after completing a task — HALT
 - Create plans inline in message body
 - **Implement a revised spec without fresh approval** — Spec changes revoke authorization. See `010-approval-gate.md` "Revision Revokes Approval"
-- **Post comments OR issue bodies without branded byline at END** — All comments and issue bodies must have byline at END with format: `*[🤖 AI: <Brand>] on behalf of <Name> <emoji> <type>*`. See `000-critical-rules.md` for complete format table.
+- **Post comments OR issue bodies without branded byline at END** — All comments and issue bodies must have byline at END with format: `🤖 *AI: <Brand>] on behalf of <Name> <emoji> <type>*`. See `000-critical-rules.md` for complete format table.
 - **Implement a revised spec without fresh approval** — Spec changes revoke authorization. See `010-approval-gate.md` "Revision Revokes Approval"
 - **Create PRs without EXPLICIT developer instruction** — "approved" and "go" authorize implementation ONLY. PRs require explicit "create a PR" instruction. Completing implementation does NOT authorize PR creation.
 - **Create issues without assignees** — Always assign at least one stakeholder. Use requesting user from session init or default to project maintainer.
@@ -364,7 +364,7 @@ Fresh-start AI agents have no memory of previous sessions. Outputs stored locall
    
    <full content or key findings>
    
-   *[🤖 AI: OpenCode/glm-5] on behalf of Michael Conrad 📝 <output-type>: <title>*
+   🤖 *AI: OpenCode/glm-5] on behalf of Michael Conrad 📝 <output-type>: <title>*
    ```
 
 ### Skills with Built-in Attachment


### PR DESCRIPTION
## Summary

Fixes the byline format to properly separate attribution from status.

**Problem:** Emojis and status text inside italics markdown (`*...*`) don't visually render as italicized. The format was backwards.

**New format:**
```
🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✅ Task Complete: schema
```

**Structure:**
- `🤖` — Agent icon (plain, outside italics)
- `*AI: OpenCode/glm-5 on behalf of Michael Conrad*` — Attribution (italicized)
- `✅ Task Complete: schema` — Status (plain, outside italics)

**Changes:**
- `.opencode/guidelines/000-critical-rules.md` — Updated format table and examples
- `.opencode/skills/github-comments/SKILL.md` — Updated all byline examples
- `AGENTS.md` — Updated ALWAYS section

**Removed:**
- `🚀 Launched` for PR signatures — now uses `✨ Created` consistently

🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✨ Created