### PR TITLE
[SPEC] Prohibit sed for file operations

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -284,6 +284,33 @@ See `142-planning-archive-workflow.md` → "Investigation Completion Criteria" f
 
 ---
 
+## Critical Violation: Using sed for File Operations
+
+**⚠️ Using `sed`, `awk`, `tr`, or shell redirects for file operations is a CRITICAL GUIDELINE VIOLATION.**
+
+These tools are too fragile and can corrupt files in unexpected ways:
+- `sed` mangles line endings (CRLF vs LF)
+- `sed` corrupts binary-like content
+- `sed` fails silently on edge cases
+- `sed` behaves differently across platforms (BSD vs GNU sed)
+- Shell redirects (`> file`, `>> file`) corrupt notebook files (`.ipynb`)
+
+**🚫 FORBIDDEN:**
+- Use `sed` for file content operations
+- Use `awk` or `tr` for file transformations
+- Use shell redirect patterns (`> file`, `>> file`) for notebook files
+- Use any shell text-processing tool on files
+
+**✅ REQUIRED:**
+- Use `edit` tool for targeted string replacements in text files
+- Use `write` tool for complete file rewrites
+- Use `the-notebook-mcp` tools (e.g., `the-notebook-mcp_notebook_read`, `the-notebook-mcp_notebook_edit_cell`) for `.ipynb` files
+- Use PyCharm MCP tools (`pycharm_replace_text_in_file`, `pycharm_create_new_file`) when available
+
+**See:** `060-tool-usage.md` for complete file operation guidelines.
+
+---
+
 ## Critical Violation: Implementing Stale or Superseded Specs
 
 **⚠️ Implementing a stale or superseded spec without revision is a CRITICAL GUIDELINE VIOLATION.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,7 @@ Key areas:
 - **RUN NOTEBOOKS WITH PRODUCTION DATA** — `the-notebook-mcp_notebook_execute_cell`, `pycharm_runNotebookCell`, and ANY execution method on production notebooks (see `061-notebook-rules.md`) is FORBIDDEN without explicit per-execution user authorization
 - **IMPLEMENT SCOPE CREEP** — Only implement what the spec explicitly requests. Never refactor "nearby" code, add "helper" functions, or fix "similar issues" not in the spec
 - **USE PROPER NOTEBOOK TOOLING** — Always use `the-notebook-mcp` tools (e.g., `the-notebook-mcp_notebook_read`, `the-notebook-mcp_notebook_edit_cell`). Never use shell redirects (`sed`, `>`, `cat`) on notebook content — this causes edit failures and corrupted state.
+- **USE `sed`, `awk`, `tr`, OR SHELL REDIRECTS FOR FILE OPERATIONS** — These tools mangle line endings, corrupt binary content, and fail silently. Use `edit` tool for text files, `the-notebook-mcp` tools for notebooks, and PyCharm MCP tools when available.
 - **USE GIT RESTORE ON EXTERNAL CHANGES** — `git restore` on externally-modified files destroys changes permanently. Always `git stash` first.
 - **RUN STREAMLIT AS FOREGROUND APP** — Background only via `nohup`. Any blocking `streamlit run` call is a CRITICAL VIOLATION.
 - **DELETE/RESET LOCAL DATABASE** — NEVER delete `tmp/local_db` or `tmp/junie_db` without explicit "reset" or "wipe" instruction.


### PR DESCRIPTION
## Summary

Added critical violation prohibition for `sed`, `awk`, `tr`, and shell redirects for file operations.

## Motivation

These tools are too fragile and corrupt files in unexpected ways:
- `sed` mangles line endings (CRLF vs LF)
- `sed` corrupts binary-like content
- `sed` fails silently on edge cases
- `sed` behaves differently across platforms (BSD vs GNU sed)
- Shell redirects (`> file`, `>> file`) corrupt notebook files (`.ipynb`)

## Changes

**`.opencode/guidelines/000-critical-rules.md`:**
- New "Critical Violation: Using sed for File Operations" section
- Explicit forbidden list: `sed`, `awk`, `tr`, shell redirects on files
- Required alternatives: `edit` tool, `write` tool, `the-notebook-mcp` tools, PyCharm MCP tools

**`AGENTS.md`:**
- Added sed prohibition to NEVER list
- Cross-reference to `060-tool-usage.md` for complete guidelines

## Testing

- Verified guideline updates are complete
- Confirmed cross-references are accurate

Fixes #40

🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✨ Created