### PR TITLE
[SPEC] Add GitHub MCP Owner Mismatch Debugging Guideline

### DIFF
--- a/.opencode/guidelines/126-github-mcp-debugging.md
+++ b/.opencode/guidelines/126-github-mcp-debugging.md
@@ -1,0 +1,144 @@
+# GitHub MCP Debugging: Owner Mismatch Protocol
+
+## Overview
+
+When GitHub MCP operations fail due to owner/repo mismatch, the agent MUST document the error on the associated issue with complete debugging information.
+
+---
+
+## Mandatory Documentation Protocol
+
+### When to Document
+
+**ALWAYS document GitHub MCP errors when ANY of these occur:**
+
+| Error Type | Example |
+|------------|---------|
+| 404 Not Found | `GET https://api.github.com/repos/muksihs/snea-shoebox-editor/issues/47` → 404 |
+| Permission Denied | `403 Forbidden` when accessing repo |
+| Resource Not Found | Issue, PR, or file not found in expected location |
+| Unexpected Empty Results | `github_issue_read` returns empty when issue should exist |
+
+### What to Document
+
+**Post a comment on the associated issue containing:**
+
+1. **Error Details**
+   - The exact GitHub API error message (if any)
+   - The `owner` and `repo` values used in the failing call
+   - The tool name and parameters that caused the error
+
+2. **Session Context**
+   - The `GIT_OWNER` and `GIT_REPO` values from session init
+   - The `git remote -v` output
+   - The `git config --get remote.origin.url` output
+
+3. **Evidence of Correct Values**
+   - Full `uv run python ai_bin/session_init.py` output
+   - Any environment variables that might override
+
+4. **Agent Context (if applicable)**
+   - Whether this is a fresh session or continuation
+   - Any previous session context that might have stale values
+
+---
+
+## Example Debug Comment
+
+```markdown
+## GitHub MCP Owner Mismatch Debug
+
+### Error Details
+- **Tool:** `github_issue_read`
+- **Parameters:** `owner=muksihs, repo=snea-shoebox-editor, issue_number=47`
+- **Error:** `404 Not Found - resource not found`
+
+### Session Context
+```
+$ uv run python ai_bin/session_init.py
+# Session Init - Git Context
+GIT_USER_NAME=Michael Conrad
+GIT_USER_EMAIL=m.conrad.202@gmail.com
+GIT_OWNER=Brothertown-Language
+GIT_REPO=snea-shoebox-editor
+GIT_HOOKS_PATH=
+GIT_REMOTE_URL=git@github.com:Brothertown-Language/snea-shoebox-editor.git
+
+$ git remote -v
+origin  git@mconrad-github:Brothertown-Language/snea-shoebox-editor.git (fetch)
+origin  git@mconrad-github:Brothertown-Language/snea-shoebox-editor.git (push)
+
+$ git config --get remote.origin.url
+git@github.com:Brothertown-Language/snea-shoebox-editor.git
+```
+
+### Analysis
+- Session init correctly returns `Brothertown-Language` as owner
+- Agent tool call used `muksihs` as owner
+- Root cause: [to be investigated]
+
+### Session Info
+- Fresh session: Yes/No
+- Previous context: [describe if this is a continuation]
+
+🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* 🔍 Debug Report
+```
+
+---
+
+## Root Cause Checklist
+
+When documenting owner mismatch errors, check for:
+
+| Potential Cause | How to Verify |
+|-----------------|---------------|
+| Session not run | Verify `session_init.py` was executed first |
+| Cached/stale values | Check if this is a continuation from a previous session |
+| Agent context injection | Check agent prompts for hardcoded owner values |
+| Environment variables | Run `env | grep -iE "(owner|git|github)"` |
+| Git config overrides | Run `git config --list | grep -E "(user|remote)"` |
+| SSH alias confusion | Run `git remote -v` and `git config --get remote.origin.url` |
+
+---
+
+## Never Assume Owner Values
+
+**🚫 FORBIDDEN:**
+- Assuming owner from git username (e.g., `muksihs` from `$USER`)
+- Guessing owner from file paths (`/home/muksihs/...`)
+- Using hardcoded owner values from previous sessions
+- Proceeding with GitHub MCP calls without running session init first
+
+**✅ REQUIRED:**
+- Run `uv run python ai_bin/session_init.py` at session start
+- Use `GIT_OWNER` and `GIT_REPO` from session init output for ALL GitHub MCP calls
+- Document any discrepancies between expected and actual values
+- When in doubt, run session init again and verify output
+
+---
+
+## Session Init is Authoritative
+
+The `ai_bin/session_init.py` script is the SINGLE SOURCE OF TRUTH for:
+
+| Value | Usage |
+|-------|-------|
+| `GIT_OWNER` | `owner` parameter in all GitHub MCP tools |
+| `GIT_REPO` | `repo` parameter in all GitHub MCP tools |
+| `GIT_USER_NAME` | Commit trailer `on behalf of <name>` |
+| `GIT_USER_EMAIL` | Commit author email |
+| `GIT_REMOTE_URL` | Verification of remote configuration |
+
+**If session init produces unexpected values:**
+1. STOP immediately
+2. Do NOT proceed with GitHub operations
+3. Document the discrepancy on the issue
+4. Wait for human intervention
+
+---
+
+## Related
+
+- `000-session-init.md` — Session initialization protocol
+- `122-github-mcp-operations.md` — GitHub MCP tool usage
+- `120-github-issue-first.md` — Issue-first workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ OpenCode loads guidelines from:
 | 000-099 | Core | Session init, critical rules, approval |
 | 100-109 | MCP/Scope | Tool usage, scope autonomy |
 | 110-119 | Git | Branch, commit, merge, PR, cleanup |
-| 120-129 | GitHub | Issue workflow, MCP ops, AI identity, archive |
+| 120-129 | GitHub | Issue workflow, MCP ops, AI identity, archive, debugging |
 | 130-139 | Authority | Code as source |
 | 140-149 | Planning | Spec creation, approval gates, status tracking, archive |
 | 200-209 | Errors | Exception handling, missing data, domain exceptions, logging |
@@ -123,6 +123,7 @@ OpenCode loads guidelines from:
 | Planning: Spec Examples | `144-planning-spec-examples.md` |
 | Planning: Exec Summary | `145-planning-exec-summary.md` |
 | **SNEA-Specific** | `300-snea-specific.md` |
+| GitHub MCP Debugging | `126-github-mcp-debugging.md` |
 
 ---
 
@@ -237,6 +238,7 @@ Key areas:
 - **SILENTLY HALT after completing a task**
 - Use PyCharm MCP tools for all file operations when available
 - **STASH EXTERNAL CHANGES FIRST** — Before ANY branch creation, `git status`. If ANY files modified, `git stash push -m "WIP: before <branch>"`, then VERIFY with `git stash list` and clean `git status`.
+- **Document GitHub MCP errors** — When GitHub MCP operations fail with owner/repo mismatch, post a debug comment on the associated issue with full session context. See `126-github-mcp-debugging.md`.
 - **Use `uv run` for all project commands** — No bare `python`, `pip`, or `conda`
 - **Use `./tmp/` not `/tmp/`** — Relative paths only
 
@@ -247,7 +249,6 @@ Key areas:
 - Create plans inline in message body
 - **Implement a revised spec without fresh approval** — Spec changes revoke authorization. See `010-approval-gate.md` "Revision Revokes Approval"
 - **Post comments OR issue bodies without branded byline at END** — All comments and issue bodies must have byline at END with format: `🤖 *AI: <Brand>] on behalf of <Name> <emoji> <type>*`. See `000-critical-rules.md` for complete format table.
-- **Implement a revised spec without fresh approval** — Spec changes revoke authorization. See `010-approval-gate.md` "Revision Revokes Approval"
 - **Create PRs without EXPLICIT developer instruction** — "approved" and "go" authorize implementation ONLY. PRs require explicit "create a PR" instruction. Completing implementation does NOT authorize PR creation.
 - **Create issues without assignees** — Always assign at least one stakeholder. Use requesting user from session init or default to project maintainer.
 - **Submit unsquashed PRs** — ALL PRs must have exactly ONE commit (squashed). Multiple commits in a PR will be rejected. Always `git reset --soft origin/main && git commit` before pushing.


### PR DESCRIPTION
## Summary

Add mandatory documentation protocol for GitHub MCP owner mismatch errors. When GitHub MCP operations fail due to incorrect owner/repo values, the agent must document full session context on the associated issue.

## Changes

| File | Change |
|------|--------|
| `.opencode/guidelines/126-github-mcp-debugging.md` | New guideline with debug protocol |
| `AGENTS.md` | Reference new guideline, add to ALWAYS list |

## Protocol Requirements

When GitHub MCP errors occur:
- Post debug comment with error details, session context, git configuration
- Document expected vs actual owner values
- Analyze root cause using provided checklist

## Related

- Fixes #49
- References #47 (original investigation)
- References #16 (previous SSH alias fix)

🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✨ Created