### PR TITLE
[SPEC] Fix AI Agent Icon Placement in Issue Bylines

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -94,6 +94,25 @@ All tasks complete from this specification.
 | Context emoji | `✅` | Plain (outside italics) |
 | Type text | `Task Complete: schema` | Plain (outside italics) |
 
+**⚠️ CRITICAL: Icon Placement (Most Common Mistake)**
+
+The agent icon (🤖) must be **OUTSIDE the asterisks** — never inside them.
+
+| Incorrect (icon italicized) | Correct (icon plain) |
+|----------------------------|---------------------|
+| `*🤖 AI: OpenCode/glm-5 on behalf of Michael Conrad*` ❌ | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad*` ✓ |
+
+**Why it matters:** Markdown italicizes everything between `*` characters. When the icon is inside asterisks:
+- The icon may not render at all (some renderers fail to display emoji in italic context)
+- The icon becomes italicized along with the text (where it does render)
+- Inconsistent rendering across GitHub, IDEs, and markdown viewers
+
+The icon must remain plain to ensure consistent rendering everywhere.
+
+**Visual rendering:**
+- ❌ Incorrect: `*🤖 AI: ...*` → *(icon may not render or is italicized)*
+- ✓ Correct: `🤖 *AI: ...*` → 🤖 followed by italicized text
+
 **Examples:**
 
 | Type | Full Byline |

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -26,6 +26,21 @@ ALL comments on issues and PRs MUST end with AI byline.
 <AgentIcon> *AI: <AgentBrand> on behalf of <HumanName>* <ContextEmoji> <TypeText>
 ```
 
+**⚠️ CRITICAL: Icon Placement**
+
+The agent icon (🤖) must be **OUTSIDE the asterisks** — never inside them.
+
+| Incorrect (icon italicized) | Correct (icon plain) |
+|----------------------------|---------------------|
+| `*🤖 AI: OpenCode/glm-5 on behalf of Michael Conrad*` ❌ | `🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad*` ✓ |
+
+**Why it matters:** Markdown italicizes everything between `*` characters. When the icon is inside asterisks:
+- The icon may not render at all (some renderers fail to display emoji in italic context)
+- The icon becomes italicized along with the text (where it does render)
+- Inconsistent rendering across GitHub, IDEs, and markdown viewers
+
+The icon must remain plain to ensure consistent rendering everywhere.
+
 **For PROGRESS COMMENTS (task completion, implementation updates):**
 ```
 **Summary:**


### PR DESCRIPTION
## Summary

Fixed the icon placement bug in agent byline format where the agent icon (🤖) was being incorrectly italicized. Added explicit warnings with visual examples showing `❌ *🤖 AI:...*` vs `✓ 🤖 *AI:...*` format.

## Changes

- Added "Icon Placement (Most Common Mistake)" section to `000-critical-rules.md`
- Added "Icon Placement" warning to `github-comments/SKILL.md`
- Included incorrect/correct comparison tables
- Added visual rendering explanations

Fixes #52

🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✨ Created