### PR TITLE
guidelines: add critical rule for owner inference from paths

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -598,6 +598,33 @@ Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
 
 ---
 
+## Critical Violation: Inferring Owner from File Paths or Usernames
+
+**⚠️ Using file paths or usernames to infer GitHub owner is a CRITICAL GUIDELINE VIOLATION.**
+
+The session init script is the SINGLE SOURCE OF TRUTH for owner/repo values.
+
+**🚫 FORBIDDEN:**
+- Inferring `owner=muksihs` from file path `/home/muksihs/git/...`
+- Inferring owner from `$USER` environment variable
+- Inferring owner from git username (`git config user.name`)
+- Using cached/stale owner values from previous sessions
+- Making ANY GitHub MCP call without first running session init
+
+**✅ REQUIRED:**
+1. Run `uv run python ai_bin/session_init.py` FIRST (before any other operations)
+2. Store ALL output values for session duration
+3. Use `GIT_OWNER` and `GIT_REPO` for EVERY GitHub MCP call
+4. Never proceed with GitHub operations if session init fails
+
+**Why this is critical:**
+- Incorrect owner causes GitHub API 404 errors
+- Wastes tokens on failed API calls
+- Breaks workflow for issue/PR operations
+- Demonstrates failure to follow documented procedure
+
+---
+
 ## Critical: Engineering Mindset Required
 
 **⚠️ All work must be approached with proper engineering discipline.**

--- a/.opencode/guidelines/126-github-mcp-debugging.md
+++ b/.opencode/guidelines/126-github-mcp-debugging.md
@@ -101,9 +101,9 @@ When documenting owner mismatch errors, check for:
 
 ---
 
-## Never Assume Owner Values
+## Never Assume Owner Values (Zero Tolerance)
 
-**🚫 FORBIDDEN:**
+**🚫 FORBIDDEN (Zero Tolerance — See `000-critical-rules.md`):**
 - Assuming owner from git username (e.g., `muksihs` from `$USER`)
 - Guessing owner from file paths (`/home/muksihs/...`)
 - Using hardcoded owner values from previous sessions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,7 @@ Key areas:
 - **Use `./tmp/` not `/tmp/`** — Relative paths only
 
 **🚫 NEVER:**
+- **INFER GITHUB OWNER FROM FILE PATHS OR USERNAMES** — Session init output (`GIT_OWNER`, `GIT_REPO`) is the ONLY source of truth. Inferring `muksihs` from `/home/muksihs/...` is a CRITICAL VIOLATION. See `000-critical-rules.md`.
 - Write code/notebooks/configs/tests without approved spec
 - Interpret questions as authorization ("Should I do X?" = asking permission)
 - Proceed to next task after completing a task — HALT


### PR DESCRIPTION
## Summary

Elevates the prohibition against inferring GitHub owner from file paths/username to a **critical rule** with zero-tolerance enforcement.

## Problem

The agent incorrectly inferred `owner=muksihs` from the file path `/home/muksihs/git/...` despite the session init script correctly outputting `GIT_OWNER=Brothertown-Language`. This caused GitHub API 404 errors.

While the procedure was documented in `126-github-mcp-debugging.md`, it was not enforced strongly enough as a critical rule.

## Changes

| File | Change |
|------|--------|
| `000-critical-rules.md` | Added new critical violation section |
| `126-github-mcp-debugging.md` | Cross-referenced critical rule |
| `AGENTS.md` | Added to NEVER list |

## New Critical Rule

```markdown
## Critical Violation: Inferring Owner from File Paths or Usernames

**🚫 FORBIDDEN:**
- Inferring `owner=muksihs` from file path `/home/muksihs/git/...`
- Inferring owner from `$USER` environment variable
- Inferring owner from git username (`git config user.name`)
- Using cached/stale owner values from previous sessions
- Making ANY GitHub MCP call without first running session init

**✅ REQUIRED:**
1. Run session init script FIRST
2. Store ALL output values for session duration
3. Use `GIT_OWNER` and `GIT_REPO` for EVERY GitHub MCP call
```

Fixes #47

🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✨ Created