### PR TITLE
guidelines: add AI authorship attribution rules

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -30,6 +30,21 @@ Every implementation task MUST be documented with progress comments on the GitHu
 - Post comment when creating PR
 - Never proceed to next task without commenting first
 
+### AI Authorship Attribution
+
+**AI bylines are MANDATORY for AI-GENERATED content.**
+
+**Content copied from ANY source does NOT get AI attribution** — the original source holds the copyright.
+
+| Scenario | Byline Required? |
+|----------|-------------------|
+| AI writes original content | ✅ YES |
+| AI copies Stack Overflow | ❌ NO (cite original) |
+| AI quotes documentation | ❌ NO (cite original) |
+| AI paraphrases external content | ✅ Partial (cite + AI byline) |
+
+**See `088-ai-authorship.md` for complete rules.**
+
 ### Required Format: Executive Summary
 
 **ALL bylines MUST include "on behalf of <HumanName>".**

--- a/.opencode/guidelines/088-ai-authorship.md
+++ b/.opencode/guidelines/088-ai-authorship.md
@@ -1,0 +1,186 @@
+# AI Authorship Attribution
+
+## Scope
+
+This guideline governs AI authorship attribution for content CREATED by AI agents.
+
+**Applies to:**
+- Code written by AI (implementation, refactoring)
+- Documentation written by AI (guidelines, SKILL.md files, README)
+- Comments authored by AI (GitHub issue comments, PR comments)
+- Specs written by AI (GitHub issue bodies)
+- Commit messages written by AI
+
+**Does NOT apply to:**
+- Copy-pasted content (retains original source copyright)
+- Minimally edited human content (human remains primary author)
+- Quoted/cited content (attribution to original source)
+
+---
+
+## Mandatory AI Co-Authorship for AI-Generated Content
+
+### When AI Co-Authorship is REQUIRED
+
+**MANDATORY for all AI-Generated Content:**
+
+1. **Commit trailers** — All commits from AI sessions MUST include co-author trailers
+2. **GitHub issue comments** — All AI-generated comments MUST end with AI byline
+3. **GitHub issue bodies** — Specs created by AI MUST end with creation signature
+4. **PR descriptions** — PR descriptions written by AI MUST end with creation signature
+5. **Guideline files** — New guidelines authored by AI MUST include attribution
+6. **SKILL.md files** — Skills authored by AI MUST include attribution
+
+### AI Co-Authorship Format
+
+**Commits:**
+```
+Co-authored-by: <AI-Name> (<model-id>) <ai-email>
+Co-authored-by: <Human-Name> <human-email>
+```
+
+**Issue Comments/PR Comments:**
+```
+<content>
+
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* <ContextEmoji> <TypeText>
+```
+
+**Issue/PR Bodies (Creation):**
+```
+<content>
+
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✨ Created
+```
+
+**Guideline/Skill Files:**
+```markdown
+<!--
+AI-Authored: <AI-Name> (<model-id>)
+Created: <YYYY-MM-DD>
+On-Behalf-Of: <Human-Name>
+-->
+```
+
+---
+
+## When AI Co-Authorship is NOT Applicable
+
+### Copy-Pasted Content Rule
+
+**CRITICAL CLARIFICATION:** Content copied from ANY source does NOT receive AI co-authorship.
+
+The original source holds the copyright. AI is merely reproducing existing content.
+
+| Source | Correct Attribution |
+|--------|---------------------|
+| Stack Overflow answer | Link to original answer in comment, NO AI co-authorship |
+| Documentation from another project | Quote with citation, NO AI co-authorship |
+| Code from tutorial/blog | Cite source in comment, NO AI co-authorship |
+| AI-generated original code | AI co-authorship REQUIRED |
+| AI-modified existing human code | AI co-authorship for modification, human as primary author |
+
+### Examples
+
+**❌ WRONG: Copying Stack Overflow**
+```python
+# AI copies Stack Overflow answer verbatim
+def parse_json(data):
+    return json.loads(data)
+# AI should NOT add co-authorship - Stack Overflow holds copyright
+```
+
+**✅ CORRECT: Original AI Code**
+```python
+# AI writes original implementation
+def parse_json_safe(data: str) -> dict:
+    """Parse JSON with error handling."""
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError:
+        return {}
+# AI MUST add co-authorship in commit
+```
+
+**✅ CORRECT: AI Modifying Human Code**
+```python
+# Human wrote original function
+# AI adds type hints and error handling
+# Commit: "Add type hints and error handling to parse_json"
+# Co-authored-by: AI-Name (model-id) <ai-email>
+# Co-authored-by: Human-Name <human-email>
+```
+
+---
+
+## Determination Rules
+
+### Apply this decision tree:
+
+```
+Is content AI-generated?
+├─ YES → Is it copied from another source?
+│        ├─ YES → NO AI co-authorship (cite original source)
+│        └─ NO → AI co-authorship REQUIRED
+└─ NO → Human author only
+```
+
+### Edge Cases
+
+| Scenario | Attribution |
+|----------|-------------|
+| AI paraphrases Stack Overflow | Cite SO, optional AI co-authorship for paraphrase creativity |
+| AI writes code based on SO concepts | AI co-authorship (concepts transformed to original implementation) |
+| AI fixes typo in human code | Minimal change - no co-authorship needed |
+| AI refactors human code significantly | AI co-authorship REQUIRED |
+| AI generates docstring for human code | AI co-authorship for docstring portion |
+| AI translates code to different language | AI co-authorship (creative transformation) |
+
+---
+
+## Integration with Existing Workflows
+
+### Git Commit Workflow (111-git-commit-workflow.md)
+
+When AI generates implementation:
+1. AI determines its own identity dynamically
+2. AI uses cached human identity from session init
+3. Commit includes BOTH co-author trailers
+
+### GitHub Comments (github-comments/SKILL.md)
+
+All AI-generated comments must include byline:
+- Progress comments end with byline
+- Body updates end with byline
+- Issue/PR creation ends with creation signature
+
+### Spec Creation (140-planning-spec-creation.md)
+
+Specs authored by AI:
+- Issue body ends with creation signature
+- Any edits to spec body end with update signature
+
+---
+
+## Why This Matters
+
+1. **Transparency:** Users can distinguish AI-generated content from human content
+2. **Accountability:** Clear attribution for debugging and review
+3. **Legal:** Proper copyright attribution for AI-assisted work
+4. **Context:** Future readers understand how content was created
+
+---
+
+## Related Guidelines
+
+| Guideline | Section |
+|-----------|---------|
+| `000-critical-rules.md` | Critical Violation sections |
+| `111-git-commit-workflow.md` | Co-Author Trailer Workflow |
+| `123-github-ai-identity.md` | AI identity format |
+| `github-comments/SKILL.md` | Comment byline format |
+| `git-workflow/SKILL.md` | Squash commit trailers |
+
+---
+
+*Content attribution ensures intellectual property and creative work are properly credited.*

--- a/.opencode/guidelines/111-git-commit-workflow.md
+++ b/.opencode/guidelines/111-git-commit-workflow.md
@@ -19,9 +19,10 @@ The developer will say "commit" or "create a PR" when they want git operations. 
 3. **Do NOT automatically create PRs**: PR creation requires the same explicit instruction as commits
 
 ### ✅ ALWAYS DO
-- **Include co-author trailers for both AI and human collaborator.** Every implementation commit MUST include TWO trailers:
+- **Include co-author trailers for AI-GENERATED content.** For AI-generated commits, include co-author trailers for both AI and human collaborator:
   - AI author: Use the AI's actual identity dynamically (the AI knows its own name)
   - Human collaborator: Use session-cached values from `000-session-init.md` §0.1 (`GIT_USER_NAME`, `GIT_USER_EMAIL`)
+- **NO co-authorship for copied content.** Content copied from ANY source retains original copyright - see `088-ai-authorship.md`
 - Re-run discovery (`git status`, `git diff`) before any commit workflow.
 - If `pyproject.toml` changed, include `uv.lock`.
 

--- a/.opencode/guidelines/123-github-ai-identity.md
+++ b/.opencode/guidelines/123-github-ai-identity.md
@@ -2,38 +2,43 @@
 
 **See `.opencode/skills/github-comments/SKILL.md` for complete comment protocol.**
 
-## 🤖 MANDATORY: AI Identity Prefix
+## 🤖 MANDATORY: AI Identity for AI-Generated Content
 
-ALL comments on issues and PRs MUST be prefixed with AI identity:
+ALL AI-GENERATED comments on issues and PRs MUST end with AI byline:
 
 ```
-AI: <AgentName> <ModelID> on behalf of <HumanName> 🤖 <response>
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* <ContextEmoji> <TypeText>
 ```
 
-**Dynamic Components:**
-- `<AgentName>`: AI's actual name (e.g., `OpenCode Desktop`, `OpenCode`)
-- `<ModelID>`: Model identifier with provider (e.g., `ollama-cloud/glm-5`)
-- `<HumanName>`: From `git config user.name` (fallback to `$USER`)
+**⚠️ Clarification: Copied content does NOT get AI byline.**
 
-**⚠️ CRITICAL: NEVER copy example values literally. Detect your own identity at runtime.**
+Content copied from ANY source (Stack Overflow, documentation, external sources) retains original copyright. AI bylines apply ONLY to genuinely AI-generated content.
+
+**See `088-ai-authorship.md` for complete attribution rules.**
+
+---
 
 ## Required Byline Format Table (MANDATORY)
 
 **ALL bylines AND issue body signatures MUST include "on behalf of <HumanName>".**
 
+**ALL bylines AND issue body signatures MUST include "on behalf of <HumanName>".**
+
 | Type | Required Format |
 |------|-----------------|
-| Progress (task completion) | `AI: <AgentName> <ModelID> on behalf of <HumanName> ✅ Task Complete: <task-name>` |
-| Body update | `AI: <AgentName> <ModelID> on behalf of <HumanName> 📝 Updated: <reason>` |
-| Spec alteration | `AI: <AgentName> <ModelID> on behalf of <HumanName> 📝 Spec altered: <summary>` |
-| Closure | `AI: <AgentName> <ModelID> on behalf of <HumanName> ✅ **Closed - Implemented**` |
-| General response | `AI: <AgentName> <ModelID> on behalf of <HumanName> 🤖 <response>` |
-| Issue body signature | `*Created by AI: <AgentName> <ModelID> on behalf of <HumanName>*` |
+| Progress (task completion) | `🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✅ Task Complete: <task-name>` |
+| Body update | `🤖 *AI: <AgentBrand> on behalf of <HumanName>* 📝 Updated: <reason>` |
+| Spec alteration | `🤖 *AI: <AgentBrand> on behalf of <HumanName>* 📝 Spec altered: <summary>` |
+| Closure | `🤖 *AI: <AgentBrand> on behalf of <HumanName>* ❌ Closed - <reason>` |
+| General response | `🤖 *AI: <AgentBrand> on behalf of <HumanName>* 🤖` |
+| Issue body signature | `<content>\n\n🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✨ Created` |
 
 ### Signature for Issue/PR Bodies (NOT comments)
 
 ```markdown
-*Created by AI: <AgentName> <ModelID> on behalf of <HumanName>*
+<issue content>
+
+🤖 *AI: <AgentBrand> on behalf of <HumanName>* ✨ Created
 ```
 
 Place at END of issue bodies and PR descriptions, preceded by blank line.

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -354,6 +354,7 @@ Co-authored-by: Michael Conrad <michael@example.com>
 - Delete merged branches immediately (local AND remote)
 - Report completion and HALT after each phase
 - Let user decide when/where to restore stash
+- **NO co-authorship for copied content** — Content copied from any source (Stack Overflow, documentation) retains original copyright. See `088-ai-authorship.md`
 
 ## Failure Recovery
 
@@ -400,6 +401,7 @@ This skill enforces:
 | `124-github-archive-workflow.md` | Issue closure timing |
 | `pr-creation-workflow/SKILL.md` | PR creation timing, issue closure |
 | `000-critical-rules.md` | PR without instruction violation |
+| `088-ai-authorship.md` | AI authorship attribution |
 | `AGENTS.md` | Branch Before Edit, Preserve Pending Changes |
 
 ## Example Workflows

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -66,6 +66,20 @@ The icon must remain plain to ensure consistent rendering everywhere.
 
 **⚠️ CRITICAL: NEVER copy example values literally. Detect your own identity.**
 
+### Copyright Clarification: Copied Content Does NOT Get AI Byline
+
+**Content copied from ANY source retains original copyright.** AI bylines apply ONLY to genuinely AI-generated content.
+
+| Scenario | Byline? |
+|----------|---------|
+| AI writes original comment/reply | ✅ YES - AI byline required |
+| AI copies Stack Overflow answer | ❌ NO - Cite original, no AI byline |
+| AI quotes documentation | ❌ NO - Quote with citation only |
+| AI paraphrases external content | ✅ Partial - Cite source, AI byline for creative paraphrase |
+| AI posts status update | ✅ YES - AI byline required |
+
+**See `088-ai-authorship.md` for complete attribution rules.**
+
 ### Agent Icon Registry
 
 | Agent | Icon | Brand |
@@ -379,6 +393,7 @@ GOOD: "The keys look correct. Ready when you are."
 | Guideline | Content |
 |-----------|---------|
 | `123-github-ai-identity.md` | Full AI identity requirements |
+| `088-ai-authorship.md` | AI authorship attribution rules |
 | `120-github-issue-first.md` | Issue workflow, sub-issues |
 | `000-critical-rules.md` | Critical violation enforcement |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ OpenCode loads guidelines from:
 | Code Standards | `080-code-standards.md` |
 | Engineering Approach | `085-engineering-approach.md` |
 | HTTP Requests | `086-http-requests.md` |
+| AI Authorship | `088-ai-authorship.md` |
 | Data Integrity | `090-data-integrity.md` |
 | Persistence | `100-persistence.md` |
 | Authority Source | `130-authority-source.md` |


### PR DESCRIPTION
## Summary

Adds new guideline `088-ai-authorship.md` clarifying when AI co-authorship is MANDATORY and when it does NOT apply.

**Key clarifications:**
- AI-generated content REQUIRES co-author trailers/bylines
- **Copied content does NOT get AI byline** — original source holds copyright
- Original AI-created content gets full AI attribution

## Outcome

Guidelines now explicitly define:
1. What content requires AI co-authorship (commits, comments, specs, docs)
2. What content does NOT (Stack Overflow, documentation, external sources)
3. Decision tree for determining attribution

Updated 6 files with cross-references and clarifications.

🤖 *AI: OpenCode/glm-5 on behalf of Michael Conrad* ✨ Created