### PR TITLE
[SPEC] Fix Missing review-prep Steps in Implementation Workflow

### DIFF
--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -15,6 +15,25 @@ The sequence is:
 
 **DO NOT skip this task after implementation. DO NOT ask the developer if they want review. Just push the branch.**
 
+### ⚠️ CRITICAL: NO EXCEPTIONS
+
+**Review prep is MANDATORY regardless of:**
+- Whether file changes were made
+- Whether "no changes needed" was determined
+- Whether branch is already up-to-date
+- Whether implementation made zero modifications
+
+**The review prep workflow provides developer visibility - it must NEVER be skipped.**
+
+**"No File Changes" Edge Case:**
+When implementation determines "no file changes needed":
+1. **STILL push branch** - git will report "up-to-date", which is acceptable
+2. **STILL generate compare URL** - developer can see branch state
+3. **STILL post completion comment** - clear signal that work is done
+4. **NEVER skip review prep** - visibility is mandatory
+
+**Why this matters:** Developer needs visibility into what was checked, even if no changes were made.
+
 ## Operating Protocol
 
 1. **After implementation:** This task runs AFTER all implementation is complete - NO EXCEPTIONS
@@ -56,13 +75,20 @@ ls ./tmp/
 - `./tmp/*.log` (log files)
 - `./tmp/.*` (hidden files like `.output.txt`)
 
-### Step 1: Push Feature Branch
+### Step 1: Push Feature Branch (ALWAYS EXECUTE)
 
 ```bash
 git push -u origin <branch-name>
 ```
 
-This pushes the branch to remote WITHOUT creating a PR.
+**This pushes the branch to remote WITHOUT creating a PR.**
+
+**CRITICAL:** This step is ALWAYS executed, even if:
+- Git reports "Everything up-to-date"
+- No file changes were made during implementation
+- Branch already exists on remote
+
+The push establishes remote tracking and ensures the compare URL will work correctly.
 
 ### Step 2: Generate Compare URL
 


### PR DESCRIPTION
Adds explicit enforcement to the review-prep task clarifying that the workflow is MANDATORY with no exceptions.

**Changes:**
- Added "CRITICAL: NO EXCEPTIONS" section to `review-prep.md`
- Added "No File Changes" edge case handling
- Clarified that "git push --up-to-date" is acceptable
- Emphasized developer visibility requirement

**Why:** Prevents agents from skipping review-prep steps (push branch, generate compare URL, post completion comment) when they determine "no file changes needed".

Fixes #60