### PR TITLE
Add "Already Implemented" edge case handling to git workflow skills

### DIFF
--- a/.opencode/skills/approval-gate/tasks/post-implementation.md
+++ b/.opencode/skills/approval-gate/tasks/post-implementation.md
@@ -30,6 +30,55 @@ The sequence is:
 
 ## Procedure
 
+### Step 0: Determine Implementation Outcome
+
+**Check if any changes were made:**
+
+```bash
+git status --porcelain
+```
+
+**If EMPTY (no file changes):**
+- Skip to "No-Changes Path" below
+- This means implementation was already complete or no changes needed
+
+**If NOT EMPTY (file changes exist):**
+- Continue to Step 1 (Push Feature Branch)
+
+---
+
+### No-Changes Path (Already Implemented)
+
+**When implementation determined no changes were needed:**
+
+1. **Close issue directly:**
+   - Post verification comment explaining what was checked
+   - Use `github_issue_write(method="update", state="closed", state_reason="completed")`
+
+2. **Comment format:**
+```markdown
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+
+**Summary:**
+
+Verified all proposed changes were already implemented. No modifications needed.
+
+**Verification Results:**
+
+- [List what was checked with file:line references]
+- [Confirm each requirement from spec is present]
+
+**Outcome:** <What the verification confirmed>
+```
+
+3. **HALT after closing:**
+   - No branch push
+   - No compare URL
+   - No PR needed
+   - Report completion in chat
+
+---
+
 ### Step 1: Push Feature Branch
 
 ```bash

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -79,6 +79,37 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
 - Delete merged branches immediately (local AND remote)
 - Report completion and HALT after each phase
 
+### ⚠️ Edge Case: Already Implemented (No Changes)
+
+**When spec investigation reveals all changes are already present:**
+
+1. **Skip branch creation entirely:**
+   - Do NOT create feature branch
+   - Do NOT push anything
+   - Do NOT create PR
+
+2. **Close issue directly with verification comment:**
+   ```markdown
+   🤖 ✅ Completed by <AgentName> (<ModelID>)
+
+   **Summary:**
+   
+   Verified all proposed changes were already implemented. No modifications needed.
+   
+   **Verification Results:**
+   
+   - [File:line references for existing content]
+   - [Confirmation of each spec requirement]
+   
+   **Outcome:** Spec verified complete without additional changes.
+   ```
+
+3. **Use `state_reason: "completed"` when closing:**
+   - Indicates successful completion (not cancellation)
+
+4. **Report completion in chat and HALT:**
+   - No further workflow steps needed
+
 ## Task Dependencies
 
 ```

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -61,6 +61,45 @@ git checkout -b spec/<short-name>  # or feature/<description>
 
 Report: "Ready for implementation on branch: <branch-name>"
 
+## ⚠️ Edge Case: Already Implemented (No Changes Needed)
+
+**When investigation reveals spec is already implemented:**
+
+1. **Detect before branch creation:**
+   - After reading files, verify all proposed changes are already present
+   - Confirm no modifications needed
+   - Document verification in issue comment
+
+2. **Skip branch creation entirely:**
+   - Do NOT create feature branch
+   - Do NOT push anything
+   - Do NOT create PR
+
+3. **Close issue directly:**
+   - Post verification comment explaining what was checked
+   - Close issue with `state_reason: "completed"`
+   - Report completion in chat
+
+**Example Comment:**
+```markdown
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+
+**Summary:**
+
+Verified all proposed changes were already implemented. No modifications needed.
+
+**Verification Results:**
+
+- [List what was checked and confirmed present]
+- [File:line references for existing content]
+
+**Outcome:** Spec requirements verified complete without additional changes.
+```
+
+4. **HALT after closing:**
+   - No further steps needed
+   - No branch cleanup (no branch was created)
+
 ## Context Required
 
 - Guidelines: `110-git-branch-first.md`, `114-git-branch-cleanup.md`


### PR DESCRIPTION
Add "Already Implemented" edge case handling to git workflow skills.

**Changes:**
- `git-workflow/SKILL.md`: Add edge case section for specs already implemented with no changes needed
- `git-workflow/tasks/pre-work.md`: Add detection and handling before branch creation, close issue directly with verification comment
- `approval-gate/tasks/post-implementation.md`: Add Step 0 to check for no-changes outcome, skip branch/PR when spec already complete

**Why:**
When investigation reveals spec requirements are already present in the codebase, the workflow should skip unnecessary branch creation and PR, closing the issue directly with a verification comment instead of creating "nothing to compare" PRs.

Fixes #58