### PR TITLE
feat: add git hooks to prevent commits to main branch

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,34 @@
+#!/bin/bash
+# post-commit hook: Warn after commits to main branch
+# This catches commits that bypassed pre-commit
+
+set -e
+
+# Get the current branch
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# Only warn for commits to main
+if [ "$branch" = "main" ]; then
+    echo ""
+    echo "⚠️  WARNING: A commit was just made to 'main' branch."
+    echo ""
+    echo "GUIDELINE VIOLATION: Branch Before Edit"
+    echo ""
+    echo "This commit should have been on a feature branch."
+    echo ""
+    echo "RECOVERY OPTIONS:"
+    echo "  1. Create a recovery branch from this commit:"
+    echo "     git branch feature/recovery HEAD"
+    echo ""
+    echo "  2. Reset main to match remote:"
+    echo "     git checkout main"
+    echo "     git reset --hard origin/main"
+    echo ""
+    echo "  3. Switch to the recovery branch:"
+    echo "     git checkout feature/recovery"
+    echo ""
+    echo "See AGENTS.md 'Enforcement Mechanisms' section for details."
+    echo ""
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/bash
+# pre-commit hook: Block commits to main branch
+# This enforces the branch-first workflow from AGENTS.md
+
+set -e
+
+# Get the current branch
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# Only block commits to main
+if [ "$branch" = "main" ]; then
+    echo "ERROR: Direct commits to 'main' branch are prohibited."
+    echo ""
+    echo "CRITICAL GUIDELINE VIOLATION: Branch Before Edit"
+    echo ""
+    echo "The FIRST action before ANY filesystem change is:"
+    echo "  git checkout main && git pull origin main"
+    echo "  git checkout -b feature/<description>"
+    echo ""
+    echo "Then make your changes and commit to the feature branch."
+    echo ""
+    echo "See AGENTS.md 'Branch Before Edit' section for details."
+    exit 1
+fi
+
+exit 0

--- a/ai_bin/session_init.py
+++ b/ai_bin/session_init.py
@@ -136,6 +136,18 @@ def main() -> int:
     print(f"GIT_HOOKS_PATH={hooks_path}")
     print(f"GIT_REMOTE_URL={remote_url}")
 
+    # Verify hooks are installed
+    if hooks_path:
+        pre_commit = os.path.join(hooks_path, "pre-commit")
+        if os.path.exists(pre_commit):
+            print("# Hooks: ✅ pre-commit hook installed")
+        else:
+            print("# Hooks: ⚠️ hooks path set but pre-commit hook missing", file=sys.stderr)
+    else:
+        print("# Hooks: ⚠️ No hooks path configured", file=sys.stderr)
+        print("# Run: git config core.hooksPath .githooks", file=sys.stderr)
+        print("# Then: ./scripts/install-hooks.sh", file=sys.stderr)
+
     return 0
 
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Install git hooks to prevent commits to main branch
+#
+# This script sets up pre-commit and post-commit hooks that enforce
+# the branch-first workflow from AGENTS.md.
+#
+# Usage: ./scripts/install-hooks.sh
+#
+# After running:
+#   git config core.hooksPath .githooks
+#
+# To verify:
+#   git config core.hooksPath  # Should show ".githooks"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$PROJECT_ROOT/.githooks"
+
+echo "Installing git hooks..."
+
+# Create hooks directory if needed
+mkdir -p "$HOOKS_DIR"
+
+# Copy hooks
+cp "$SCRIPT_DIR/../.githooks/pre-commit" "$HOOKS_DIR/pre-commit" 2>/dev/null || true
+cp "$SCRIPT_DIR/../.githooks/post-commit" "$HOOKS_DIR/post-commit" 2>/dev/null || true
+
+# Make executable
+chmod +x "$HOOKS_DIR/pre-commit" "$HOOKS_DIR/post-commit"
+
+# Configure git
+cd "$PROJECT_ROOT"
+git config core.hooksPath .githooks
+
+echo ""
+echo "✅ Git hooks installed successfully."
+echo ""
+echo "Hooks configured:"
+echo "  - pre-commit: Blocks commits to main branch"
+echo "  - post-commit: Warns after commits to main branch"
+echo ""
+echo "To verify: git config core.hooksPath"
+echo "  Expected output: .githooks"


### PR DESCRIPTION
## Summary

CRITICAL GUIDELINE VIOLATION FIX

Fixes #79

This addresses the violation where AI agents close issues before PR merge. The root cause is committing directly to main instead of using feature branches.

**Problem:**
- AI agents close issues before PR merge verification
- This violates `124-github-archive-workflow.md` critical rule
- Related to #72 where I incorrectly closed issues before PR

**Solution:**
Add git hooks that enforce branch-first workflow:

1. **pre-commit hook**: Blocks commits to main branch
   - Detects if current branch is `main`
   - Blocks commit with clear error message
   - Directs user to create feature branch first

2. **post-commit hook**: Warns after commits to main
   - Backup warning if commit reaches main
   - Provides recovery instructions

3. **install-hooks.sh**: Installation script for hooks

4. **session_init.py**: Verifies hooks installed on startup
   - Reports hook status in session init output

**Testing:**
- ✅ Pre-commit hook blocks commits to main
- ✅ Hooks configured: `core.hooksPath = .githooks`
- ✅ Session init reports: `# Hooks: ✅ pre-commit hook installed`

**Enforcement:**
- Local pre-commit hook blocks the commit
- Developer must create feature branch first
- Aligns with AGENTS.md "Branch Before Edit" section

---

🤖 ✅ Completed by OpenCode (ollama-cloud/glm-5)