### PR TITLE
Fix git-workflow skill: Add mandatory compare URL + HALT protocol

### DIFF
--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -52,6 +52,51 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
    - Phase 5: PR Creation (user-initiated) → `pr-creation` task
    - Phase 6: Branch Cleanup (after merge) → `cleanup` task
 
+## Critical Workflow Sequence
+
+**🚫 CRITICAL: Skipping phases or HALT points is a CRITICAL GUIDELINE VIOLATION.**
+
+### Mandatory Sequence (NO EXCEPTIONS)
+
+```
+Implementation complete
+    ↓
+review-prep invoked AUTOMATICALLY (Phase 3)
+    ↓
+Push branch → Generate compare URL → HALT
+    ↓
+(DEVELOPER REVIEWS VIA GITHUB DIFF)
+    ↓
+Developer says "create a PR"
+    ↓
+pr-creation: Squash → Push → Create PR → HALT
+    ↓
+(DEVELOPER MERGES PR)
+    ↓
+Developer confirms "PR merged"
+    ↓
+cleanup: Verify merge via GitHub API → Close issues
+```
+
+### What HALT Means
+
+**HALT = Stop all further action and wait for explicit instruction.**
+
+| HALT Point | What Agent Does | What Agent WAITS For |
+|------------|----------------|----------------------|
+| After review-prep | Post compare URL + completion comment | "create a PR" instruction |
+| After pr-creation | Post PR URL | "PR merged" confirmation |
+| After PR merged | Close issues | Next explicit instruction |
+
+### 🚫 CRITICAL VIOLATIONS
+
+| Violation | Consequence |
+|-----------|-------------|
+| Skip review-prep | No developer visibility, premature PR |
+| Skip HALT after push | Issues closed without PR |
+| Close issues without PR merge | Lost tracking, audit trail broken |
+| Skip GitHub API verification | Closing issues on unmerged PRs |
+
 ## Critical Rules
 
 ### 🚫 NEVER DO

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -25,19 +25,31 @@ Delete merged branches after PR merge, clean stale references, and verify reposi
 
 ## Procedure
 
-### Step 1: Verify PR Merge
+### Step 1: Verify PR Merge (CRITICAL - NO EXCEPTIONS)
 
-**DO NOT trust `git pull` alone.**
+**🚫 CRITICAL VIOLATION: Closing issues without PR merge verification is a CRITICAL GUIDELINE VIOLATION.**
+
+**DO NOT trust `git pull` or local fast-forward. You MUST verify via GitHub API.**
 
 ```python
 # MUST use GitHub API to verify merge
-github_pull_request_read(method="get", owner=..., repo=..., pullNumber=...)
+pr = github_pull_request_read(method="get", owner=..., repo=..., pullNumber=...)
 
 # Verify merged_at timestamp exists
-if merged_at is None:
+if pr.get("merged_at") is None:
     # PR is not merged, STOP
-    return "PR not yet merged, cannot close issue"
+    report = f"PR #{pullNumber} is not yet merged. Cannot close issues."
+    return report
+
+# ONLY after verified merge:
+proceed_to_close_issues()
 ```
+
+**Why API verification is mandatory:**
+- `git pull` shows local fast-forward success
+- Does NOT verify PR was merged (could be closed/rejected)
+- GitHub API `merged_at` field is the ONLY reliable merge indicator
+- Closing issues without merged PR loses tracking and audit trail
 
 ### Step 2: Switch to Main
 
@@ -231,3 +243,46 @@ github_list_pull_requests(state="merged", perPage=50)
 - Stale remote references clutter `git branch -a`
 - Clean repository state required for next work session
 - Prevents confusion from stale branch references
+- **Issues ONLY closed after VERIFIED PR merge**
+
+## Correct vs Incorrect Workflow
+
+### ✅ CORRECT Workflow (Issue Closure)
+
+```
+PR created
+    ↓
+Developer reviews and merges PR
+    ↓
+Developer confirms "PR merged"
+    ↓
+cleanup task invoked
+    ↓
+Verify merge via GitHub API (merged_at field)
+    ↓
+API confirms merge → Proceed
+    ↓
+Close child issues addressed by PR
+    ↓
+Check parent for remaining sub-issues
+    ↓
+If all children closed → Close parent with summary
+```
+
+### 🚫 INCORRECT Workflow (CRITICAL VIOLATION)
+
+```
+PR created (or just branch pushed)
+    ↓
+Immediately close issues (NO MERGE)
+    ↓
+NO GitHub API verification
+NO PR merge status check
+NO parent/child structure check
+```
+
+**This incorrect workflow VIOLATES critical rules and causes:**
+- Issues closed without PR tracking
+- No merge verification
+- Potential reopen of closed issues if PR rejected
+- Lost audit trail

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -105,10 +105,11 @@ Using session values (GIT_OWNER, GIT_REPO):
 https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 ```
 
-### Step 3: Report Completion
+### Step 3: Report Completion (BOTH Issue AND Chat)
 
-Format for issue and chat:
+**⚠️ CRITICAL: Completion comment MUST be posted to BOTH the GitHub issue AND chat.**
 
+Post to GitHub issue:
 ```markdown
 **Summary:**
 
@@ -118,22 +119,37 @@ Format for issue and chat:
 
 **Ready for Review:**
 
-https://github.com/NewsRx/newsrx-genai-python/compare/main...<branch-name>
+https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 ```
 
-### Step 4: HALT
+Post to chat (same content):
+- Same executive summary + compare URL
+- Ensures visibility in BOTH GitHub history AND current session
+
+### Step 4: HALT (MANDATORY - NO EXCEPTIONS)
+
+**🚫 CRITICAL VIOLATION: Proceeding past this point without explicit "create a PR" is a CRITICAL GUIDELINE VIOLATION.**
 
 **DO NOT:**
 - Squash commits (happens at PR creation)
 - Create PR (requires explicit "create a PR" instruction)
 - Push again (push happens once)
+- Close issues (requires PR merge verification)
+- Proceed to any next step (HALT means STOP)
 
-**WAIT for:**
+**WAIT for EXPLICIT instruction:**
 - Developer reviews changes via GitHub diff viewer
 - Developer says "create a PR" to proceed
+- NO assumptions, NO auto-progression
+
+**What HALT means:**
+- Report completion (issue + chat)
+- STOP all further action
+- Wait for developer's next explicit instruction
+- If developer says "approved" or "go" again → STILL WAIT for "create a PR"
 
 ### ⚠️ CRITICAL: PR Request Before Review-Prep
 
@@ -170,6 +186,50 @@ https://github.com/NewsRx/newsrx-genai-python/compare/main...<branch-name>
 - GitHub diff viewer is superior to local review
 - Prevents premature PR creation
 - Clear separation between "done implementing" and "create PR"
+
+## Correct vs Incorrect Workflow
+
+### ✅ CORRECT Workflow
+
+```
+Implementation complete
+    ↓
+review-prep invoked AUTOMATICALLY
+    ↓
+Push branch to remote
+    ↓
+Generate compare URL
+    ↓
+Post compare URL to issue + chat
+    ↓
+HALT - Wait for "create a PR"
+    ↓
+Developer reviews via GitHub diff
+    ↓
+Developer says "create a PR"
+    ↓
+pr-creation workflow begins
+```
+
+### 🚫 INCORRECT Workflow (CRITICAL VIOLATION)
+
+```
+Implementation complete
+    ↓
+Push branch to remote
+    ↓
+Close issues IMMEDIATELY (SKIPPED HALT)
+    ↓
+NO compare URL posted
+NO PR created
+NO merge verification
+```
+
+**This incorrect workflow VIOLATES critical rules and causes:**
+- Issues closed without PR tracking
+- No developer visibility via compare URL
+- No review before closure
+- Lost audit trail
 
 ## Example
 


### PR DESCRIPTION
## Summary

Fixes critical workflow violation where agent closed issues #65-68 without:
- Posting GitHub compare URL for review
- Waiting for "create a PR" instruction
- Creating a PR
- Verifying PR merge

## Changes

### `review-prep.md`
- Step 3: Completion comment MUST be posted to BOTH issue AND chat
- Step 4: HALT marked as MANDATORY with CRITICAL VIOLATION warning
- Added Correct vs Incorrect workflow section with consequences

### `cleanup.md`
- Step 1: PR merge verification marked as CRITICAL with explicit GitHub API requirement
- Added "Why API verification is mandatory" section
- Added Correct vs Incorrect workflow section

### `SKILL.md`
- Added Critical Workflow Sequence section with mandatory flow
- HALT meaning table explains agent actions at each stop point
- Critical violations table maps violations to consequences

## Test Plan

1. Verify skill files load correctly
2. Verify review-prep HALT enforcement is explicit
3. Verify cleanup requires GitHub API verification before issue closure

Fixes #69