### PR TITLE
[SPEC-FIX] Git Workflow: Ensure Commit Before Push

### DIFF
--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -107,7 +107,7 @@ cleanup: Verify merge via GitHub API → Close issues
 - Merge PRs (HUMAN-ONLY)
 - Use `--no-verify` flag
 - Ask "Ready to commit?" or "Create a PR?"
-- Push without explicit "create a PR" instruction
+- Close issues without PR merge verification
 - **Use hardcoded model IDs** (e.g., `ollama-cloud/glm-5`) - MUST dynamically detect runtime identity
 
 ### ✅ ALWAYS DO
@@ -115,8 +115,9 @@ cleanup: Verify merge via GitHub API → Close issues
 - Stash ALL modifications before branch creation
 - Verify stash exists (`git stash list`)
 - Verify working tree is clean (`git status`)
+- **Commit ALL changes before pushing** (`git add -A && git commit`)
+- **Push after committing** - ensures GitHub compare works correctly
 - **Clean temp files before review** (`rm ./tmp/temp_*.py ./tmp/*.json 2>/dev/null`)
-- Push branch AFTER implementation complete
 - Squash to single commit before PR
 - Include co-author trailers in squash commit
 - **Dynamically detect model ID at runtime** - NEVER copy example IDs from skills/guidelines

--- a/.opencode/skills/git-workflow/tasks/implementation.md
+++ b/.opencode/skills/git-workflow/tasks/implementation.md
@@ -35,6 +35,32 @@ git commit -m "WIP: <descriptive message>"
 
 **No co-author trailers required** during implementation commits - those are added during squash at PR time.
 
+### ⚠️ CRITICAL: Commit Before Push
+
+**The most common workflow failure is pushing without committing.**
+
+**Correct sequence:**
+```
+1. Make file changes (edit tool, etc.)
+2. git status (verify changes exist)
+3. git add -A (stage changes)
+4. git commit (commit changes)
+5. git push (push committed branch)
+```
+
+**Incorrect sequence (CRITICAL VIOLATION):**
+```
+1. Make file changes
+2. git push (WRONG - uncommitted changes)
+   Result: Empty branch on remote
+   Result: GitHub compare shows "nothing to compare"
+```
+
+**Verification before push:**
+- `git status` MUST show "nothing to commit, working tree clean"
+- Local branch MUST have at least one commit ahead of remote
+- If `git status` shows uncommitted changes → COMMIT FIRST
+
 ## Multiple Commits Are Acceptable
 
 | Commit Type | When | Message | Trailers |
@@ -45,8 +71,8 @@ git commit -m "WIP: <descriptive message>"
 ## Important Rules
 
 - **DO NOT squash until PR creation** - Multiple implementation commits are expected
-- **DO NOT push without explicit instruction** - Push happens at PR creation only
 - **DO NOT create PR without explicit instruction** - PR requires explicit "create a PR"
+- **ALWAYS push after committing** - Push ensures GitHub compare works correctly
 
 ## Context Required
 
@@ -64,8 +90,10 @@ Commit when:
 
 ## After Implementation Completes
 
-1. **Report completion** (executive summary to issue AND chat)
-2. **HALT** — do NOT push, do NOT create PR
-3. **WAIT** for explicit "create a PR" instruction
+1. **Commit all changes** (`git add -A && git commit`)
+2. **Push to remote** (`git push -u origin <branch-name>`)
+3. **Report completion** (executive summary to issue AND chat)
+4. **HALT** — do NOT create PR
+5. **WAIT** for explicit "create a PR" instruction
 
 **See:** `pr-creation-workflow` skill for complete PR workflow.

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -2,18 +2,45 @@
 
 ## Purpose
 
-Push feature branch to remote and generate GitHub compare URL for developer review. This provides the developer with visibility into changes BEFORE deciding to create a PR.
+Generate GitHub compare URL for developer review AFTER the implementation task has already pushed the branch. This provides the developer with visibility into changes BEFORE deciding to create a PR.
 
 ## ⚠️ MANDATORY INVOCATION
 
 **This task is ALWAYS invoked automatically after implementation completes. There is NO decision point.**
 
 The sequence is:
-1. Implementation complete → **review-prep invoked automatically**
-2. Branch pushed, compare URL generated → HALT
+1. Implementation complete → commit → push → **review-prep invoked automatically**
+2. Compare URL generated → HALT
 3. Wait for developer to say "create a PR"
 
-**DO NOT skip this task after implementation. DO NOT ask the developer if they want review. Just push the branch.**
+**DO NOT skip this task after implementation. DO NOT ask the developer if they want review. Just generate the compare URL.**
+
+### ⚠️ CRITICAL: Branch Must Be Pushed Before This Task
+
+**The `implementation` task is responsible for pushing the branch.**
+
+**Correct sequence:**
+```
+Implementation task:
+  1. Make changes
+  2. git status (verify)
+  3. git add -A (stage)
+  4. git commit (commit)
+  5. git push -u origin <branch> (push)
+  6. Report completion
+  7. Invoke review-prep
+
+Review-prep task:
+  1. Verify branch is pushed
+  2. Generate compare URL
+  3. Post completion comment
+  4. HALT
+```
+
+**If this task is invoked and branch is NOT pushed:**
+1. Inform user: "Implementation task must push before review-prep"
+2. Push the branch: `git push -u origin <branch-name>`
+3. Continue to generate compare URL
 
 ### ⚠️ CRITICAL: NO EXCEPTIONS
 
@@ -49,15 +76,14 @@ When implementation determines "no file changes needed":
 
 ## Entry Criteria
 
-- All implementation work complete
-- Feature branch exists (not main)
+- All implementation work complete AND pushed to remote
+- Feature branch pushed (done by implementation task)
 - No explicit "create a PR" instruction yet
 - Temp files cleaned up (see Step 0)
 
 ## Exit Criteria
 
-- Feature branch pushed to remote
-- GitHub compare URL generated
+- Compare URL generated and posted
 - Developer can review changes via GitHub diff viewer
 
 ## Procedure
@@ -82,20 +108,22 @@ ls ./tmp/
 - `./tmp/*.log` (log files)
 - `./tmp/.*` (hidden files like `.output.txt`)
 
-### Step 1: Push Feature Branch (ALWAYS EXECUTE)
+### Step 1: Verify Branch Is Pushed
+
+**Before generating compare URL, verify branch is on remote.**
 
 ```bash
+git branch -vv
+```
+
+**If branch is NOT pushed to remote:**
+
+```bash
+# Push branch
 git push -u origin <branch-name>
 ```
 
-**This pushes the branch to remote WITHOUT creating a PR.**
-
-**CRITICAL:** This step is ALWAYS executed, even if:
-- Git reports "Everything up-to-date"
-- No file changes were made during implementation
-- Branch already exists on remote
-
-The push establishes remote tracking and ensures the compare URL will work correctly.
+**This ensures compare URL will work correctly.**
 
 ### Step 2: Generate Compare URL
 
@@ -105,7 +133,7 @@ Using session values (GIT_OWNER, GIT_REPO):
 https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 ```
 
-### Step 3: Report Completion (BOTH Issue AND Chat)
+### Step 2: Report Completion (BOTH Issue AND Chat)
 
 **⚠️ CRITICAL: Completion comment MUST be posted to BOTH the GitHub issue AND chat.**
 
@@ -129,14 +157,14 @@ Post to chat (same content):
 - Same executive summary + compare URL
 - Ensures visibility in BOTH GitHub history AND current session
 
-### Step 4: HALT (MANDATORY - NO EXCEPTIONS)
+### Step 3: HALT (MANDATORY - NO EXCEPTIONS)
 
 **🚫 CRITICAL VIOLATION: Proceeding past this point without explicit "create a PR" is a CRITICAL GUIDELINE VIOLATION.**
 
 **DO NOT:**
 - Squash commits (happens at PR creation)
 - Create PR (requires explicit "create a PR" instruction)
-- Push again (push happens once)
+- Push again (already pushed in implementation)
 - Close issues (requires PR merge verification)
 - Proceed to any next step (HALT means STOP)
 
@@ -151,28 +179,16 @@ Post to chat (same content):
 - Wait for developer's next explicit instruction
 - If developer says "approved" or "go" again → STILL WAIT for "create a PR"
 
-### ⚠️ CRITICAL: PR Request Before Review-Prep
+### ⚠️ CRITICAL: Implementation Must Push Before Review-Prep
 
-**If user requests "create a PR" but review-prep was NOT completed:**
+**If review-prep is invoked but branch is NOT pushed:**
 
-1. **Detect skipped review-prep:**
-   - Branch not pushed to remote, OR
-   - No compare URL was provided, OR
-   - No completion comment posted
+1. **Detect missed push:** `git branch -vv` shows no upstream
+2. **Inform user:** "Implementation task must commit and push. Fixing now."
+3. **Fix and continue:** `git push -u origin <branch-name>`
+4. **Continue:** Generate compare URL, post completion comment
 
-2. **Inform user:** "Review step must be completed first"
-
-3. **Complete review-prep now:**
-   - Commit any uncommitted changes
-   - Push feature branch: `git push -u origin <branch-name>`
-   - Generate GitHub compare URL
-   - Post completion comment
-
-4. **HALT:** Wait for developer to review via diff URL
-
-5. **After developer reviews:** User says "create a PR" again → proceed with PR creation workflow
-
-**Why:** Developer must have visibility BEFORE PR creation decision.
+**Why:** Commit without push = empty compare URL. Push is mandatory after commit.
 
 ## Context Required
 
@@ -192,11 +208,23 @@ Post to chat (same content):
 ### ✅ CORRECT Workflow
 
 ```
-Implementation complete
+Implementation task:
+    ↓
+Make file changes
+    ↓
+git status (verify changes)
+    ↓
+git add -A (stage)
+    ↓
+git commit (commit)
+    ↓
+git push -u origin <branch> (push)
+    ↓
+Report completion
     ↓
 review-prep invoked AUTOMATICALLY
     ↓
-Push branch to remote
+Verify branch is pushed
     ↓
 Generate compare URL
     ↓
@@ -216,6 +244,9 @@ pr-creation workflow begins
 ```
 Implementation complete
     ↓
+[SKIPPED: commit]
+[SKIPPED: push]
+    ↓
 Push branch to remote
     ↓
 Close issues IMMEDIATELY (SKIPPED HALT)
@@ -230,6 +261,30 @@ NO merge verification
 - No developer visibility via compare URL
 - No review before closure
 - Lost audit trail
+
+### 🚫 CRITICAL VIOLATION: Commit Without Push
+
+```
+Implementation complete
+    ↓
+git commit (commit made)
+    ↓
+[SKIPPED: git push]
+    ↓
+review-prep invoked
+    ↓
+Generate compare URL
+    ↓
+Result: "nothing to compare"
+Result: Developer CANNOT review changes
+Result: Workflow STALLS
+```
+
+**Why this fails:**
+- Compare URL requires pushed commits
+- Unpushed commits are local only
+- Remote branch has NO commits
+- Compare URL shows empty diff
 
 ## Example
 


### PR DESCRIPTION
## Summary

Fixed the git-workflow skill to ensure changes are committed before pushing, preventing "nothing to compare" errors on GitHub.

## Changes

- **SKILL.md**: Added "ALWAYS push after committing" to ALWAYS DO section
- **implementation.md**: Added push step after commit in workflow
- **implementation.md**: Added "Commit Before Push" section with correct sequence
- **review-prep.md**: Simplified to generate compare URL (push done by implementation)
- **review-prep.md**: Added fallback if branch not pushed

## Root Cause

The agent pushed branches without committing, causing:
- Empty branch on remote
- GitHub compare shows "nothing to compare"
- Developer cannot review changes

## Fix

The workflow now clearly specifies:
1. Commit all changes (`git add -A && git commit`)
2. Push to remote (`git push -u origin <branch>`)
3. Compare URL will work correctly

Fixes #85