### PR TITLE
[SPEC] Strengthen PR workflow enforcement in skill files

### DIFF
--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -104,6 +104,7 @@ cleanup: Verify merge via GitHub API → Close issues
 - Edit files on `main` branch
 - `git restore` on externally-modified files
 - Create PR without explicit user instruction
+- Create PR without squashing to SINGLE COMMIT first
 - Merge PRs (HUMAN-ONLY)
 - Use `--no-verify` flag
 - Ask "Ready to commit?" or "Create a PR?"
@@ -115,15 +116,37 @@ cleanup: Verify merge via GitHub API → Close issues
 - Stash ALL modifications before branch creation
 - Verify stash exists (`git stash list`)
 - Verify working tree is clean (`git status`)
+- **SQUASH TO SINGLE COMMIT BEFORE ANY PR** — See `pr-creation-workflow` skill for pre-PR checklist
 - **Commit ALL changes before pushing** (`git add -A && git commit`)
 - **Push after committing** - ensures GitHub compare works correctly
 - **Clean temp files before review** (`rm ./tmp/temp_*.py ./tmp/*.json 2>/dev/null`)
-- Squash to single commit before PR
 - Include co-author trailers in squash commit
 - **Dynamically detect model ID at runtime** - NEVER copy example IDs from skills/guidelines
 - Wait for human to merge PR
 - Delete merged branches immediately (local AND remote)
 - Report completion and HALT after each phase
+
+### ⚠️ SQUASH IS MANDATORY — NO EXCEPTIONS
+
+**Every PR must have EXACTLY ONE commit. No exceptions.**
+
+**Before creating ANY PR:**
+
+```bash
+# Step 1: Verify commit count
+git log origin/main..HEAD --oneline
+
+# Step 2: If MORE THAN ONE commit shown, SQUASH NOW
+git reset --soft origin/main
+git commit -m "<descriptive message>" \
+    --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
+    --trailer "Co-authored-by: <Human-Name> <human-email>"
+
+# Step 3: Force push the single commit
+git push --force-with-lease origin <branch>
+```
+
+**See `pr-creation-workflow` skill for the complete pre-PR checklist.**
 
 ### ⚠️ Edge Case: Already Implemented (No Changes)
 

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -83,12 +83,34 @@ Fixes #<child2>
 
 ### Step 5: Report PR URL and HALT
 
-Report:
-- PR URL
-- Brief summary
-- "Wait for human to merge"
+### ⚠️ CRITICAL: PR URL Reporting is MANDATORY
 
-**DO NOT merge the PR.**
+**You MUST report the PR URL in chat:**
+
+1. **Chat Output:**
+   ```
+   PR created: https://github.com/<owner>/<repo>/pull/<number>
+   
+   <Brief implementation summary>
+   
+   Wait for human to merge.
+   ```
+
+### What If PR Creation Fails?
+
+| Failure Reason | Response |
+|----------------|----------|
+| No commits between branches | Report: "Branch has no commits to main. Changes may already be merged. Verify and HALT." |
+| Branch conflicts | Report: "Branch conflicts with main. Rebase and push, then create PR." |
+| GitHub API error | Report error details and HALT |
+
+### Post-PR Creation Checklist
+
+- [ ] PR URL reported in chat
+- [ ] Brief implementation summary included
+- [ ] HALT — waiting for human merge
+
+**🚫 NEVER:** Skip reporting PR URL, merge PR, or proceed without developer confirmation.
 
 ## Context Required
 

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -54,6 +54,68 @@ instruction, HALTing after PR creation, and NEVER merging PRs.
 
 ### When Developer Says "create a PR"
 
+#### ⚠️ MANDATORY: Pre-PR Creation Checklist
+
+**Before creating ANY PR, you MUST verify ALL of the following:**
+
+```markdown
+## Pre-PR Creation Checklist (MANDATORY)
+
+☐ **Squash Verification**
+  - Run: `git log origin/main..HEAD --oneline`
+  - Verify: EXACTLY ONE commit on branch
+  - If multiple commits: Run `git reset --soft origin/main && git commit`
+  - NEVER proceed with multiple commits
+
+☐ **Branch State**
+  - Run: `git status`
+  - Verify: Working tree clean (no uncommitted changes)
+  - If dirty: Commit or stash before proceeding
+
+☐ **Push Verification**
+  - Run: `git log origin/<branch>..HEAD --oneline`
+  - Verify: No unpushed commits
+  - If unpushed: Run `git push --force-with-lease origin <branch>`
+
+☐ **Co-Author Trailers**
+  - Verify: Commit message includes BOTH trailers:
+    - AI Author: `Co-authored-by: <AI-Name> (<model-id>) <ai-email>`
+    - Human Collaborator: `Co-authored-by: <Human-Name> <human-email>`
+
+☐ **Issue References**
+  - For single-task: Include `Fixes #<parent>` in PR body
+  - For multi-task: Include `Fixes #<parent>` AND `Fixes #<child>` for EACH sub-issue
+```
+
+**🚫 CRITICAL VIOLATION: Creating PR with multiple commits is FORBIDDEN.**
+
+| Violation | Consequence |
+|-----------|-------------|
+| Multiple commits in PR | PR REJECTED — squash required |
+| Missing PR URL report | CRITICAL — communication failure |
+| Premature merge attempt | CRITICAL — HUMAN-ONLY operation |
+
+### Violation Warning
+
+**Creating a PR with multiple commits is a CRITICAL GUIDELINE VIOLATION.**
+
+If you accidentally create a PR with multiple commits:
+
+1. **DO NOT ask user to fix it** — Fix it yourself immediately:
+   ```bash
+   git reset --soft origin/main
+   git commit -m "<descriptive message>" \
+       --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
+       --trailer "Co-authored-by: <Human-Name> <human-email>"
+   git push --force-with-lease origin <branch>
+   ```
+
+2. **Close the bad PR** and create a new one if necessary.
+
+3. **Report the violation** in the GitHub issue comment.
+
+**User intervention should NEVER be required to fix squash violations.**
+
 1. **Collect sub-issues** (for multi-task specs):
    ```python
    # Fetch all sub-issues for the parent issue


### PR DESCRIPTION
## Summary

Updated skill files to prevent PR workflow violations:

- **git-workflow/tasks/pr-creation.md**: Added mandatory PR URL reporting in chat with clear failure handling
- **pr-creation-workflow/SKILL.md**: Added pre-PR creation checklist with squash verification and violation self-fix procedure
- **git-workflow/SKILL.md**: Strengthened squash requirement with explicit verification commands

Fixes #70
Fixes #82
Fixes #91
Fixes #92
Fixes #93
Fixes #94
Fixes #95
Fixes #96