### PR TITLE
Rename GIT_USER_* to DEV_* for clarity

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -56,8 +56,8 @@ This file provides critical rules that must never be violated.
 ### ✅ REQUIRED SEQUENCE
 1. Run session init: `uv run python ai_bin/session_init.py`
 2. Store ALL output values for session duration:
-   - `GIT_USER_NAME` (human name for commit trailers)
-   - `GIT_USER_EMAIL` (human email for commit trailers)
+   - `DEV_NAME` (human name for commit trailers)
+   - `DEV_EMAIL` (human email for commit trailers)
    - `GIT_OWNER` (repository owner for GitHub API calls)
    - `GIT_REPO` (repository name for GitHub API calls)
    - `GIT_HOOKS_PATH` (git hooks path)

--- a/.opencode/guidelines/000-session-init.md
+++ b/.opencode/guidelines/000-session-init.md
@@ -13,8 +13,8 @@ uv run python ai_bin/session_init.py
 ```
 
 **Script outputs:**
-- `GIT_USER_NAME`: Human collaborator name (for commit trailers)
-- `GIT_USER_EMAIL`: Human collaborator email (for commit trailers)
+- `DEV_NAME`: Human collaborator name (for commit trailers)
+- `DEV_EMAIL`: Human collaborator email (for commit trailers)
 - `GIT_OWNER`: Repository owner (for GitHub MCP API calls)
 - `GIT_REPO`: Repository name (for GitHub MCP API calls)
 - `GIT_HOOKS_PATH`: Git hooks path (to verify hooks installed)
@@ -64,8 +64,8 @@ uv run python ai_bin/session_init.py
 uv run python ai_bin/session_init.py
 
 # Expected output format:
-# GIT_USER_NAME=<human-name>        # For commit trailers
-# GIT_USER_EMAIL=<human-email>     # For commit trailers
+# DEV_NAME=<human-name>        # For commit trailers
+# DEV_EMAIL=<human-email>     # For commit trailers
 # GIT_OWNER=<github-owner>          # For GitHub MCP API calls
 # GIT_REPO=<github-repo>            # For GitHub MCP API calls
 # GIT_HOOKS_PATH=<hooks-path>        # Git hooks location
@@ -74,7 +74,7 @@ uv run python ai_bin/session_init.py
 
 **Use these values for SESSION DURATION:**
 - `GIT_OWNER` and `GIT_REPO` for ALL `github_*` MCP calls
-- `GIT_USER_NAME` and `GIT_USER_EMAIL` for commit trailers
+- `DEV_NAME` and `DEV_EMAIL` for commit trailers
 - DO NOT re-run `git config` or derive values from other sources
 
 ### Why This Matters

--- a/.opencode/guidelines/111-git-commit-workflow.md
+++ b/.opencode/guidelines/111-git-commit-workflow.md
@@ -21,7 +21,7 @@ The developer will say "commit" or "create a PR" when they want git operations. 
 ### ✅ ALWAYS DO
 - **Include co-author trailers for both AI and human collaborator.** Every implementation commit MUST include TWO trailers:
   - AI author: Use the AI's actual identity dynamically (the AI knows its own name)
-  - Human collaborator: Use session-cached values from `000-session-init.md` §0.1 (`GIT_USER_NAME`, `GIT_USER_EMAIL`)
+  - Human collaborator: Use session-cached values from `000-session-init.md` §0.1 (`DEV_NAME`, `DEV_EMAIL`)
 - Re-run discovery (`git status`, `git diff`) before any commit workflow.
 - If `pyproject.toml` changed, include `uv.lock`.
 
@@ -42,8 +42,8 @@ The AI must use its **own identity**, not the example name. Examples show placeh
 
 **Step 2: Use cached human identity from session start:**
 - Human collaborator values are cached at session start via `000-session-init.md` §0.1
-- `GIT_USER_NAME`: Human's name (or `$USER` fallback)
-- `GIT_USER_EMAIL`: Human's email (or `$USER@$HOSTNAME` fallback)
+- `DEV_NAME`: Human's name (or `$USER` fallback)
+- `DEV_EMAIL`: Human's email (or `$USER@$HOSTNAME` fallback)
 - **Do NOT re-run `git config`** — use stored session values
 
 **Step 3: Include BOTH trailers (MANDATORY):**

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -217,4 +217,4 @@ pre-work → implementation → review-prep → [commit-prep] → pr-creation �
 
 - Related skills: `approval-gate` (authorization), `pr-creation-workflow` (PR timing)
 - Related guidelines: `110-git-branch-first.md`, `111-git-commit-workflow.md`, `113-git-pr-workflow.md`, `114-git-branch-cleanup.md`, `124-github-archive-workflow.md`
-- Session init: `000-session-init.md` (for GIT_OWNER, GIT_REPO, GIT_USER_NAME, GIT_USER_EMAIL)
+- Session init: `000-session-init.md` (for GIT_OWNER, GIT_REPO, DEV_NAME, DEV_EMAIL)

--- a/.opencode/skills/git-workflow/tasks/commit-prep.md
+++ b/.opencode/skills/git-workflow/tasks/commit-prep.md
@@ -82,14 +82,14 @@ Every implementation commit MUST include:
 
 1. **Human Collaborator**: Use session values from `000-session-init.md`
 
-   - `GIT_USER_NAME`: Human's name
-   - `GIT_USER_EMAIL`: Human's email
+   - `DEV_NAME`: Human's name
+   - `DEV_EMAIL`: Human's email
 
 Example:
 
 ```
 Co-authored-by: OpenCode (ollama-cloud/glm-5) <noreply@opencode.ai>
-Co-authored-by: <Human Name> <human@email.com>  # From GIT_USER_NAME and GIT_USER_EMAIL
+Co-authored-by: <Human Name> <human@email.com>  # From DEV_NAME and DEV_EMAIL
 ```
 
 ## Why This Task Is Separate from PR Creation

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -16,9 +16,9 @@ The sequence is:
 
 **DO NOT skip this task after implementation. DO NOT ask the developer if they want review. Just generate the compare URL.**
 
-### ⚠️ CRITICAL: Branch Must Be Pushed Before This Task
+### ⚠️ CRITICAL: Implementation MUST Push Branch
 
-**The `implementation` task is responsible for pushing the branch.**
+**The implementation task is responsible for committing AND pushing the branch BEFORE invoking review-prep.**
 
 **Correct sequence:**
 
@@ -28,7 +28,7 @@ Implementation task:
   2. git status (verify)
   3. git add -A (stage)
   4. git commit (commit)
-  5. git push -u origin <branch> (push)
+  5. git push -u origin <branch> (push) ← MANDATORY
   6. Report completion
   7. Invoke review-prep
 
@@ -41,9 +41,10 @@ Review-prep task:
 
 **If this task is invoked and branch is NOT pushed:**
 
-1. Inform user: "Implementation task must push before review-prep"
-1. Push the branch: `git push -u origin <branch-name>`
-1. Continue to generate compare URL
+1. **STOP and report the violation:** "Implementation task failed to push branch - fixing now"
+2. **Push the branch:** `git push -u origin <branch-name>`
+3. **Continue to generate compare URL**
+4. **Document the gap in the completion comment**
 
 ### ⚠️ CRITICAL: NO EXCEPTIONS
 
@@ -123,10 +124,19 @@ ls ./tmp/
 git branch -vv
 ```
 
+**Expected output:**
+```
+* spec/my-branch  abc123 [origin/spec/my-branch] Commit message
+```
+
+**If branch shows `[origin/<branch>]` with upstream tracking → ✅ Branch is pushed**
+
+**If branch shows NO upstream or "gone" → 🚫 Branch NOT pushed**
+
 **If branch is NOT pushed to remote:**
 
 ```bash
-# Push branch
+# Push branch immediately
 git push -u origin <branch-name>
 ```
 

--- a/.opencode/skills/mcp-tool-usage/SKILL.md
+++ b/.opencode/skills/mcp-tool-usage/SKILL.md
@@ -35,8 +35,8 @@ uv run python ai_bin/session_init.py
 # Use these values for SESSION DURATION:
 # - GIT_OWNER for all github_* MCP calls
 # - GIT_REPO for all github_* MCP calls
-# - GIT_USER_NAME for commit trailers
-# - GIT_USER_EMAIL for commit trailers
+# - DEV_NAME for commit trailers
+# - DEV_EMAIL for commit trailers
 ```
 
 ### ✅ CORRECT Usage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ uv run python ai_bin/session_init.py
 ```
 
 **Script outputs:**
-- `GIT_USER_NAME`: Human collaborator name (for commit trailers)
-- `GIT_USER_EMAIL`: Human collaborator email (for commit trailers)
+- `DEV_NAME`: Human collaborator name (for commit trailers)
+- `DEV_EMAIL`: Human collaborator email (for commit trailers)
 - `GIT_OWNER`: Repository owner (for GitHub MCP API calls)
 - `GIT_REPO`: Repository name (for GitHub MCP API calls)
 - `GIT_HOOKS_PATH`: Git hooks path (to verify hooks installed)
@@ -206,7 +206,7 @@ ALL work must follow proper engineering methodology:
 See `.opencode/guidelines/085-engineering-approach.md` for complete requirements.
 
 **✅ ALWAYS:**
-- **Run session init script at session start** — Run `uv run python ai_bin/session_init.py` before any other operations. Store the output values (GIT_USER_NAME, GIT_USER_EMAIL, GIT_OWNER, GIT_REPO, GIT_HOOKS_PATH, GIT_REMOTE_URL) for session duration. See `000-session-init.md`.
+- **Run session init script at session start** — Run `uv run python ai_bin/session_init.py` before any other operations. Store the output values (DEV_NAME, DEV_EMAIL, GIT_OWNER, GIT_REPO, GIT_HOOKS_PATH, GIT_REMOTE_URL) for session duration. See `000-session-init.md`.
 - Create feature branch BEFORE any filesystem change
 - Create PRs for all merges (when tooling available)
 - Reference the Authoritative Spec for planning

--- a/ai_bin/session_init.py
+++ b/ai_bin/session_init.py
@@ -2,8 +2,8 @@
 """Session initialization script for AI agents.
 
 Extracts git context needed for agent startup:
-- GIT_USER_NAME: Human collaborator name (for commit trailers)
-- GIT_USER_EMAIL: Human collaborator email (for commit trailers)
+- DEV_NAME: Human collaborator name (for commit trailers)
+- DEV_EMAIL: Human collaborator email (for commit trailers)
 - GIT_OWNER: Repository owner (for GitHub MCP API calls)
 - GIT_REPO: Repository name (for GitHub MCP API calls)
 - GIT_HOOKS_PATH: Git hooks path (to verify hooks installed)
@@ -129,8 +129,8 @@ def main() -> int:
 
     # Output in the specified format
     print("# Session Init - Git Context")
-    print(f"GIT_USER_NAME={user_name}")
-    print(f"GIT_USER_EMAIL={user_email}")
+    print(f"DEV_NAME={user_name}")
+    print(f"DEV_EMAIL={user_email}")
     print(f"GIT_OWNER={owner}")
     print(f"GIT_REPO={repo}")
     print(f"GIT_HOOKS_PATH={hooks_path}")


### PR DESCRIPTION
## Summary

Renames session init output variables from `GIT_USER_NAME`/`GIT_USER_EMAIL` to `DEV_NAME`/`DEV_EMAIL` to clarify these values represent the developer's identity, not Git system configuration.

Also fixes a critical gap in the `review-prep` skill to prevent future "commit without push" violations.

## Changes

**Variable rename:**
- `ai_bin/session_init.py`: Output variables and docstring updated
- Guidelines updated: `000-session-init.md`, `111-git-commit-workflow.md`, `000-critical-rules.md`, `AGENTS.md`
- Skills updated: `git-workflow/SKILL.md`, `git-workflow/tasks/commit-prep.md`, `mcp-tool-usage/SKILL.md`, `git-workflow/tasks/review-prep.md`

**Skill fix:**
- `review-prep.md`: Strengthened push verification and violation handling

## Verification

- ✅ Session init outputs `DEV_NAME` and `DEV_EMAIL`
- ✅ Zero remaining `GIT_USER_NAME` or `GIT_USER_EMAIL` references
- ✅ All guidelines and skills updated

Fixes #114