### PR TITLE
[SPEC] Guidelines: Preserve user prompt context in spec creation/revision

### DIFF
--- a/.opencode/guidelines/120-github-issue-first.md
+++ b/.opencode/guidelines/120-github-issue-first.md
@@ -124,6 +124,30 @@ Titles that describe specific concerns or features:
 
 **See `github-comments` skill for complete progress comment requirements.**
 
+### Prompt Preservation (MANDATORY)
+
+**When creating or revising a spec, capture the user's original prompt as a comment.**
+
+The user's prompt contains nuanced context about:
+- WHY the change is needed
+- Specific constraints or preferences
+- Background information that informed decisions
+- Edge cases the user cares about
+
+**Prompt Preservation Workflow:**
+
+1. **After creating a new spec issue:**
+   - Immediately post a comment capturing the user's original prompt
+   - Use the format specified in `github-comments` skill → "User Prompt Comment Format"
+
+2. **After revising an existing spec:**
+   - Post a comment with the revision prompt
+   - Include both the new prompt and any additional context
+
+3. **See `140-planning-spec-creation.md` §1.2 for complete requirements.**
+
+---
+
 ### Quick Reference
 
 **Post progress comments after EACH task completion:**

--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -124,7 +124,72 @@ Before any implementation, every spec must document:
 
 ---
 
-## 1.2. Fresh-Start Context Requirements
+## 1.2. User Prompt Preservation (MANDATORY)
+
+**When creating or revising a spec, the agent MUST preserve the user's original prompt as context.**
+
+### Why Prompt Preservation Matters
+
+The user's original prompt contains:
+- The initial intent and motivation behind the request
+- Nuanced context that may not be captured in the spec body
+- Specific constraints, preferences, or edge cases the user mentioned
+- Background information that informed the decision
+
+Without the original prompt context:
+- Future agents lose critical information about the user's intent
+- Decision rationale may be unclear
+- Subtle requirements may be missed in implementation
+
+### Prompt Capture Requirement
+
+**ALWAYS capture the user prompt as a comment on the spec issue:**
+
+1. **When creating a new spec:**
+   - After creating the GitHub Issue, immediately post a comment with the user prompt
+   - Format: See "User Prompt Comment Format" in `github-comments` skill
+
+2. **When revising an existing spec:**
+   - After updating the issue body, post a comment with the revision prompt
+   - Include both the new prompt and any additional context provided
+
+3. **Multiple prompts:**
+   - If the user provides multiple messages before spec creation, capture the triggering prompt
+   - Optionally capture key context messages as separate comments
+
+### What to Capture
+
+| Prompt Element | Capture? | Format |
+|----------------|----------|--------|
+| Exact user prompt text | ✅ YES | Verbatim or minimal editing |
+| Key context from conversation | ✅ YES | Summarized in separate section |
+| Decision to create spec | ✅ YES | Brief note on why spec was created |
+| Code snippets in prompt | ✅ YES | Include verbatim |
+
+### Edge Cases
+
+| Scenario | Action |
+|----------|--------|
+| Prompt is very long | Summarize key points, link to full conversation if available |
+| User provides clarifications | Add clarification comments separately |
+| Confidential/sensitive info | Allow user to redact before posting |
+
+### Integration with Fresh-Start Context
+
+User prompt preservation COMPLEMENTS the fresh-start context rules:
+
+| Context Type | Location |
+|--------------|----------|
+| User's original prompt | First comment on issue |
+| Detailed analysis | Issue body (Problem Statement, Context, etc.) |
+| Related issues | Issue body (Related Issues section) |
+| User clarifications | Follow-up comments |
+
+**The prompt comment provides the "WHY" — the issue body provides the "WHAT" and "HOW".**
+
+---
+
+## 1.3. Fresh-Start Context Requirements
 
 **All specs, bug reports, and issues MUST be self-contained for agents with NO memory context.**
 

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -118,6 +118,102 @@ You are a GitHub Comment Protocol enforcer. Your focus is ensuring all comments 
 
 ______________________________________________________________________
 
+## User Prompt Comment Format
+
+**When creating or revising a spec, capture the user's original prompt as a comment on the issue.**
+
+### Why This Matters
+
+The user's prompt contains nuanced context that may not be captured in the spec body:
+- WHY the change is needed
+- Specific constraints or preferences
+- Background information that informed decisions
+- Edge cases the user cares about
+
+Without the original prompt context, future agents lose critical information about intent.
+
+### Format
+
+```markdown
+**User Prompt:**
+
+> <verbatim user prompt text>
+
+[Optional: Additional context summary if multiple messages]
+
+**Why This Spec:**
+<Brief note on why the spec was created from this prompt>
+
+---
+🤖 ✨ Created by <AgentName> (<ModelID>): Issue #N
+```
+
+### Examples
+
+**Single Prompt:**
+
+```markdown
+**User Prompt:**
+
+> "when creating a spec or revising a spec - it is important to include the user prompt as an added comment to the spec so that context about the spec is properly maintained to prevent loss of information - especially nuance"
+
+**Why This Spec:**
+Establishes requirement to preserve user prompts for context continuity across sessions.
+
+---
+🤖 ✨ Created by OpenCode (ollama-cloud/glm-5): Issue #113
+```
+
+**Multiple Messages:**
+
+```markdown
+**User Prompt:**
+
+> "Add rate limiting to the PubMed API client"
+
+**Additional Context:**
+- User mentioned issues with API throttling during testing
+- Concerned about retry behavior during high-load periods
+- Wants graceful degradation, not hard failures
+
+**Why This Spec:**
+Addresses production stability by implementing rate limiting with configurable thresholds.
+
+---
+🤖 ✨ Created by <AgentName> (<ModelID>): Issue #N
+```
+
+**Revision Prompt:**
+
+```markdown
+**Revision Prompt:**
+
+> "Add edge case handling for concurrent rate limit scenarios"
+
+**Context:**
+This updates the original rate limiting spec to handle concurrent requests more robustly.
+
+---
+🤖 📝 Updated by <AgentName> (<ModelID>)
+```
+
+### Edge Cases
+
+| Scenario | Action |
+|----------|--------|
+| Prompt is very long | Summarize key points, link to full conversation |
+| User provides clarifications | Add clarification comments separately |
+| Confidential/sensitive info | Allow user to redact before posting |
+
+### Integration Points
+
+| Guideline | Connection |
+|-----------|------------|
+| `140-planning-spec-creation.md` §1.2 | Full prompt preservation requirements |
+| `120-github-issue-first.md` §5 | Prompt preservation workflow |
+
+______________________________________________________________________
+
 ## Comment Type Decision Table
 
 | Action | Post Comment? | Reason |


### PR DESCRIPTION
## Summary

Added mandatory user prompt preservation requirements to the guidelines ecosystem, ensuring user prompts are captured as comments on specs for context continuity across sessions.

## Changes

- Add "§1.2 User Prompt Preservation (MANDATORY)" section to `140-planning-spec-creation.md`
- Add "Prompt Preservation (MANDATORY)" workflow to `120-github-issue-first.md`
- Add "User Prompt Comment Format" section to `github-comments` skill
- Cross-references established between all three files

## Why This Matters

User prompts contain nuanced context about WHY changes are needed, specific constraints, and background information that may not be fully captured in the spec body. Preserving prompts ensures future agents have access to the original intent.

Fixes #113