### PR TITLE
Enforce mandatory review-prep invocation after implementation

### DIFF
--- a/.opencode/guidelines/113-git-pr-workflow.md
+++ b/.opencode/guidelines/113-git-pr-workflow.md
@@ -9,6 +9,8 @@
 
 ## Review Phase (Mandatory)
 
+**⚠️ This phase is MANDATORY and AUTOMATIC — there is NO choice to skip it.**
+
 After implementation completes and BEFORE PR creation authorization:
 
 1. **Agent pushes feature branch** to remote:
@@ -86,6 +88,18 @@ git checkout feature/recovery
 # Push and create PR
 git push origin feature/recovery
 ```
+
+---
+
+## Enforcement Reference
+
+**The git-workflow skill automatically enforces the review phase.**
+
+- **After implementation completes** → `git-workflow` skill → `review-prep` task is invoked AUTOMATICALLY
+- **Mandatory actions** → Push branch, generate compare URL, HALT
+- **NO decision point** → Review-prep runs regardless of "minor changes" or "already reviewed"
+
+**See `git-workflow` skill → `review-prep` task for the complete workflow.**
 
 ---
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -69,6 +69,28 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 
 **Enforcement:** Do NOT proceed with edits, implementation, or comments without first loading this skill and verifying authorization.
 
+### ⚠️ MANDATORY: Post-Implementation Review-Prep Invocation
+
+**After implementation completes, the agent MUST invoke review-prep from the git-workflow skill — this is AUTOMATIC.**
+
+The sequence is FIXED:
+
+1. `approval-gate` verifies authorization → implementation begins
+2. Implementation task finishes all file changes
+3. Implementation task commits AND pushes the branch
+4. Implementation task reports completion
+5. **git-workflow review-prep task is invoked AUTOMATICALLY**
+6. review-prep generates compare URL → HALTs
+
+**DO NOT:**
+- Return to chat after implementation without invoking review-prep
+- Report completion and HALT without pushing branch first
+- Skip compare URL generation because "no changes needed"
+
+**The review-prep task provides MANDATORY developer visibility before PR creation.**
+
+See `git-workflow` skill → `review-prep` task for the complete workflow.
+
 ## Authorization Requirements
 
 ### Mandatory Before ANY Code Change

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -64,6 +64,25 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
 
 **Enforcement:** Do NOT proceed with git operations at these trigger points without first loading this skill and verifying workflow compliance.
 
+### ⚠️ MANDATORY: review-prep Is Automatic (No Decision Point)
+
+**After implementation completes, the agent MUST automatically invoke review-prep — there is NO choice.**
+
+The sequence is FIXED:
+
+1. Implementation task finishes all file changes
+2. Implementation task commits AND pushes the branch
+3. Implementation task reports completion
+4. **review-prep is invoked AUTOMATICALLY** → generates compare URL → HALTs
+
+**DO NOT:**
+- Skip review-prep because "changes are trivial"
+- Skip review-prep because "developer can review via git log"
+- Skip review-prep and proceed directly to PR creation
+- Ask developer "do you want to review?" — just do it
+
+**The compare URL is MANDATORY visibility for developers before PR creation.**
+
 ## Critical Workflow Sequence
 
 **🚫 CRITICAL: Skipping phases or HALT points is a CRITICAL GUIDELINE VIOLATION.**


### PR DESCRIPTION
## Summary

- Added explicit enforcement in `git-workflow/SKILL.md` clarifying review-prep is automatic with no decision point
- Added post-implementation hook reference in `approval-gate/SKILL.md` mandating review-prep invocation after implementation completes
- Added mandatory enforcement notice in `113-git-pr-workflow.md` reinforcing review phase is automatic
- Documented that review-prep runs regardless of "minor changes" or "already reviewed" claims

## Changes

**`.opencode/skills/git-workflow/SKILL.md`:**
- Added new section "⚠️ MANDATORY: review-prep Is Automatic (No Decision Point)"
- Clarifies the fixed sequence: implementation → commit → push → review-prep (automatic) → compare URL → HALT
- Explicitly prohibits skipping review-prep for any reason

**`.opencode/skills/approval-gate/SKILL.md`:**
- Added new section "⚠️ MANDATORY: Post-Implementation Review-Prep Invocation"
- Added enforcement reference to git-workflow review-prep task
- Clarifies that review-prep invocation is automatic, not optional

**`.opencode/guidelines/113-git-pr-workflow.md`:**
- Added explicit mandatory notice to Review Phase section
- Added Enforcement Reference section pointing to git-workflow skill
- Reinforces that review-prep runs regardless of "minor changes" or "already reviewed"

## Test Plan

1. Verify modified files load correctly with `ai_bin/guidelines search review-prep`
2. Verify search finds new enforcement content
3. Markdown linter passes (line length warnings acceptable for skill files)

Fixes #134