### PR TITLE
Standardize placeholder patterns for project-specific values

### DIFF
--- a/.opencode/guidelines/061-notebook-rules.md
+++ b/.opencode/guidelines/061-notebook-rules.md
@@ -36,7 +36,7 @@ ALL code standards in `080-code-standards.md` apply to notebook cells. Key limit
 
 **Production notebook execution is ABSOLUTELY FORBIDDEN without EXPLICIT USER INSTRUCTION.**
 
-- Production notebooks: `pubmed_data_3/`, imports from `commons/`, API calls, database connections
+- Production notebooks: `<project-db>/`, imports from `commons/`, API calls, database connections
 - Authorization: Required PER SESSION, PER EXECUTION — no carryover
 - When in doubt: DO NOT RUN IT
 

--- a/.opencode/guidelines/070-environment.md
+++ b/.opencode/guidelines/070-environment.md
@@ -153,7 +153,7 @@ This rule applies universally to:
   3. STOP — do not run the script against production to verify
   4. Ask user if they want to test/verify (they may provide a test fixture)
 - **NEVER run any script, notebook, or command that connects to, reads from, or writes to a production data path**
-  (e.g. `pubmed_data_3/db/`, any path outside `./tmp/`) without explicit user authorization in the current session.
+  (e.g. `<project-db>/db/`, any path outside `./tmp/`) without explicit user authorization in the current session.
 - This includes verification steps: do NOT run `pgserver_start.py`, `pgserver_stop.py`, or any script that starts,
   stops, or force-kills a PostgreSQL server process unless the user explicitly says to do so.
 - Verification of script correctness must use static analysis (lint, grep, code review) or a dedicated test fixture

--- a/.opencode/guidelines/090-data-integrity.md
+++ b/.opencode/guidelines/090-data-integrity.md
@@ -34,7 +34,7 @@
 - **Robust Sampling Required**: When analyzing or remediating data formats, behavior, or patterns, you MUST compare
   across multiple samples (minimum 5-10 distinct records) from different categories/topics. Never assume a single
   example is representative of a set or format.
-- **Exhaustive Automated Analysis**: When a large archived dataset is available (e.g., `pubmed_data_2`), you MUST
+- **Exhaustive Automated Analysis**: When a large archived dataset is available (e.g., `<archived-db>`), you MUST
   generate and run an automated script to scan the ENTIRE archive for frequency analysis of headers, fields, and
   formatting patterns. Relying on manual sampling for large datasets is strictly prohibited. A dataset is considered
   **large** for this rule if it contains more than 1,000 records or files.
@@ -42,7 +42,7 @@
   automated analysis or robust multi-sample sets.
 - **NO UNAUTHORIZED FORMAT CHANGES**: You are strictly prohibited from adding, removing, or altering data fields,
   headers, or formatting styles (e.g., Markdown structure) without explicit, documented authorization. Any deviation
-  from the established "Ground Truth" (e.g., archived datasets like `pubmed_data_2`) is a data integrity violation.
+  from the established "Ground Truth" (e.g., archived datasets like `<archived-db>`) is a data integrity violation.
   Authorization is established by an explicit user instruction in the current session (chat or approved plan). A GO on
   a plan that includes the format change constitutes documented authorization.
 - **MANDATORY AUDIT LOGGING**: Any proposed change to a data format MUST be accompanied by an automated audit report

--- a/.opencode/guidelines/100-persistence.md
+++ b/.opencode/guidelines/100-persistence.md
@@ -1,6 +1,6 @@
 # PostgreSQL & SQLAlchemy Standards
 
-Applies to `pubmed_data_3` and all new persistence code.
+Applies to `<project-db>` and all new persistence code.
 
 ## Repository Usage (MANDATORY)
 
@@ -99,5 +99,5 @@ def initialize_schema(engine: Engine) -> None:
 
 ## Backward Compatibility
 
-- `sqlbind` and existing SQLite repository classes remain untouched until the `pubmed_data_3` migration to `pgserver` is
+- `sqlbind` and existing SQLite repository classes remain untouched until the `<project-db>` migration to `pgserver` is
   complete. Do not refactor, remove, or replace SQLite-based repositories without explicit instruction.

--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -216,7 +216,7 @@ A different AI agent (or the same agent after a context reset) may pick up this 
 
 3. **Cross-references with context**
    - When referencing other issues/specs: include issue number AND brief summary
-   - Include URLs: `https://github.com/owner/repo/issues/123`
+   - Include URLs: `https://github.com/<owner>/<repo>/issues/123`
    - State WHY the reference matters
 
 4. **Decision rationale documented**

--- a/.opencode/guidelines/143-planning-spec-templates.md
+++ b/.opencode/guidelines/143-planning-spec-templates.md
@@ -110,7 +110,7 @@ CREATED: YYYY-MM-DD
 
 | Issue | Summary | Relevance |
 |-------|---------|-----------|
-| [#123](https://github.com/owner/repo/issues/123) | [Brief summary] | [Why it matters to this spec] |
+| [#123](https://github.com/<owner>/<repo>/issues/123) | [Brief summary] | [Why it matters to this spec] |
 
 ---
 
@@ -277,7 +277,7 @@ def broken_function():
 
 | Issue | Summary | Relevance |
 |-------|---------|-----------|
-| [#123](https://github.com/owner/repo/issues/123) | [Related bug or feature] | [Connection to this fix] |
+| [#123](https://github.com/<owner>/<repo>/issues/123) | [Related bug or feature] | [Connection to this fix] |
 
 ---
 

--- a/.opencode/guidelines/144-planning-spec-examples.md
+++ b/.opencode/guidelines/144-planning-spec-examples.md
@@ -61,8 +61,8 @@ This is BAD because:
 > **Related Issues:**
 > | Issue | Summary | Relevance |
 > |-------|---------|-----------|
-> | [#100](https://github.com/owner/repo/issues/100) | Persistent sessions | Credential storage implementation |
-> | [#150](https://github.com/owner/repo/issues/150) | Token rotation | Future improvement for longer sessions |
+> | [#100](https://github.com/<owner>/<repo>/issues/100) | Persistent sessions | Credential storage implementation |
+> | [#150](https://github.com/<owner>/<repo>/issues/150) | Token rotation | Future improvement for longer sessions |
 >
 > **Success Criteria:**
 > 1. ✅ Users with expired refresh tokens are automatically re-authenticated
@@ -179,8 +179,8 @@ This is BAD because:
 > **Related Issues:**
 > | Issue | Summary | Relevance |
 > |-------|---------|-----------|
-> | [#50](https://github.com/owner/repo/issues/50) | Performance audit | Original performance report |
-> | [#200](https://github.com/owner/repo/pull/200) | Redis infra setup | Infrastructure PR |
+> | [#50](https://github.com/<owner>/<repo>/issues/50) | Performance audit | Original performance report |
+> | [#200](https://github.com/<owner>/<repo>/pull/200) | Redis infra setup | Infrastructure PR |
 
 This is GOOD because:
 - ✅ Problem statement with measurable impact

--- a/.opencode/skills/notebook-operations/SKILL.md
+++ b/.opencode/skills/notebook-operations/SKILL.md
@@ -153,7 +153,7 @@ The following are **STRICTLY FORBIDDEN** on notebooks that interact with product
 
 ### What Counts as Production Data
 
-- **ALL notebooks in `pubmed_data_3/`** — connects to PubMed API and production databases
+- **ALL notebooks in `<project-db>/`** — connects to PubMed API and production databases
 - **ANY notebook that imports from `commons/`** — likely uses production database connections
 - **ANY notebook with `send_html_email`, `SMTP`, or email functionality** — sends real emails
 - **ANY notebook with API calls** (`requests`, `Entrez`, `PubMedClient`) — production services

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -302,7 +302,7 @@ Agent:
 → Adds co-author trailers
 → Pushes to remote
 → Creates PR via GitHub MCP
-→ Reports: "PR created: https://github.com/owner/repo/pull/123"
+→ Reports: "PR created: https://github.com/<owner>/<repo>/pull/123"
 → HALTS (waits for merge)
 ```
 

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -118,7 +118,7 @@ Per `045-open-questions.md` and `140-planning-spec-creation.md`, specs MUST be s
 1. **Cross-references with context**
 
    - When referencing other issues/specs: include issue number AND brief summary
-   - Include URLs: `https://github.com/owner/repo/issues/123`
+   - Include URLs: `https://github.com/<owner>/<repo>/issues/123`
    - State WHY the reference matters
 
 1. **Decision rationale documented**

--- a/.opencode/skills/sync-guidelines/SKILL.md
+++ b/.opencode/skills/sync-guidelines/SKILL.md
@@ -64,7 +64,7 @@ A file is **project-specific** if it:
 
 Examples of project-specific content:
 
-- `pubmed_data_3/` - project database path
+- `<project-db>/` - project database path
 - `<repo>` - project name (from session_init.py)
 - `project_root /` - project-specific path handling
 - Project-specific table names or schemas
@@ -278,7 +278,7 @@ Classification: ✅ Core (sync bidirectionally)
 File: .opencode/guidelines/070-environment.md
 
 Analysis:
-- Contains "pubmed_data_3" (project-specific database)
+- Contains "<project-db>" (project-specific database)
 - Contains "project_root" handling (project-specific)
 - Contains project-specific configuration
 - Would break in another project


### PR DESCRIPTION
Fixes #99

## Summary

Replaced all project-specific database placeholders with generic placeholders in guidelines and skills:
- `pubmed_data_3` → `<project-db>` (8 instances)
- `pubmed_data_2` → `<archived-db>` (2 instances)
- `github.com/owner/repo` → `github.com/<owner>/<repo>` (consistent format, 9 instances)

## Outcome

Documentation now uses portable generic placeholders, improving reusability across projects.

---
🤖 ✅ Completed by OpenCode (ollama-cloud/glm-5)