### PR TITLE
[SPEC] Enhance PR Creation Workflow with Changelog Skill Integration

### DIFF
--- a/.opencode/skills/changelog-generator/SKILL.md
+++ b/.opencode/skills/changelog-generator/SKILL.md
@@ -106,14 +106,15 @@ guidelines from CHANGELOG_STYLE.md
 | Task | Purpose | Words |
 |------|---------|-------|
 | `overview` | Full skill content for changelog generation | ~400 |
+| `write` | Write generated entries to CHANGELOG.md | ~300 |
 
 ## Tips
 
 - Run from your git repository root
 - Specify date ranges for focused changelogs
 - Use your CHANGELOG_STYLE.md for consistent formatting
-- Review and adjust the generated changelog before publishing
-- Save output directly to CHANGELOG.md
+- **Write to CHANGELOG.md before creating PRs** - Use `write` task to update the file
+- Follow Keep a Changelog format for industry-standard changelogs
 
 ## Related Use Cases
 

--- a/.opencode/skills/changelog-generator/tasks/write.md
+++ b/.opencode/skills/changelog-generator/tasks/write.md
@@ -1,0 +1,183 @@
+# Task: write
+
+## Purpose
+
+Write generated changelog entries to CHANGELOG.md file.
+
+## Operating Protocol
+
+1. **After generate task:** Run after `overview` task generates entries
+2. **Prepend entries:** Add new entries to `[Unreleased]` section
+3. **Create if missing:** Initialize CHANGELOG.md if it doesn't exist
+4. **Atomic write:** Use file operations, not shell redirects
+
+## Entry Criteria
+
+- Changelog entries generated from `overview` task
+- Repository has git history to analyze
+- Working directory is clean or changes are acceptable to include
+
+## Exit Criteria
+
+- CHANGELOG.md updated with new entries
+- File formatted per Keep a Changelog standard
+- Entries in correct `[Unreleased]` section
+
+## Procedure
+
+### Step 1: Generate Changelog Entries
+
+Invoke the `overview` task to generate changelog entries from commits:
+
+```
+Create a changelog from commits since branching from main
+```
+
+### Step 2: Locate CHANGELOG.md
+
+Check if CHANGELOG.md exists at repository root.
+
+**Path:** `<repo-root>/CHANGELOG.md`
+
+**If file doesn't exist:**
+- Create with standard Keep a Changelog header
+- Include `[Unreleased]` section
+- Include format reference links
+
+### Step 3: Read Existing Content
+
+Read current CHANGELOG.md content:
+
+```python
+content = pycharm_get_file_text_by_path(
+    pathInProject="CHANGELOG.md",
+    projectPath=<project-root>
+)
+```
+
+### Step 4: Parse Sections
+
+Parse existing changelog into sections:
+
+```
+## [Unreleased]
+### Added
+### Changed
+### Fixed
+...
+
+## [1.0.0] - YYYY-MM-DD
+...
+```
+
+### Step 5: Merge New Entries
+
+For each category in generated entries:
+1. Find matching section in `[Unreleased]`
+2. Prepend new entries to that section
+3. Preserve existing entries below
+
+**Category Mapping:**
+- `New Features` → `### Added`
+- `Improvements` → `### Changed`
+- `Bug Fixes` → `### Fixed`
+- `Breaking Changes` → `### Changed` (with breaking note)
+- `Security` → `### Security` (or `### Fixed` with security note)
+
+### Step 6: Write Updated Content
+
+Write merged content back to CHANGELOG.md:
+
+```python
+pycharm_replace_text_in_file(
+    pathInProject="CHANGELOG.md",
+    projectPath=<project-root>,
+    oldText=<existing-content>,
+    newText=<merged-content>
+)
+```
+
+### Step 7: Verify Write
+
+Read back content to verify:
+- Entries are in correct sections
+- Formatting is preserved
+- No duplicate entries
+
+## File Format Template
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- <entry-1>
+- <entry-2>
+
+### Changed
+- <entry-1>
+
+### Fixed
+- <entry-1>
+
+## [0.1.0] - 2026-04-03
+
+### Added
+- Initial release
+```
+
+## Entry Insertion Example
+
+**Generated entries:**
+```
+### Added
+- New feature A
+- New feature B
+
+### Fixed
+- Bug fix for X
+```
+
+**Existing CHANGELOG.md:**
+```
+## [Unreleased]
+
+### Added
+- Previous feature
+
+### Fixed
+```
+
+**Merged result:**
+```
+## [Unreleased]
+
+### Added
+- New feature A
+- New feature B
+- Previous feature
+
+### Fixed
+- Bug fix for X
+```
+
+## Context Required
+
+- Repository root path
+- Git history (commits since last release or branch point)
+- Keep a Changelog format specification
+
+## Common Issues
+
+| Issue | Resolution |
+|-------|------------|
+| File doesn't exist | Create with standard header and `[Unreleased]` section |
+| No `[Unreleased]` section | Add section after header, before versioned sections |
+| Duplicate entries | Skip entries that already exist in file |
+| Wrong category | Map to closest matching category in Keep a Changelog |

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -24,7 +24,7 @@ Git Workflow Enforcer ensuring all git operations follow the repository's strict
 | `implementation` | Handle WIP commits during implementation | ~400 |
 | `review-prep` | Push branch, generate compare URL for review | ~560 |
 | `commit-prep` | Prepare squash commit message (read-only) | ~480 |
-| `pr-creation` | Squash, push, create PR via GitHub MCP | ~640 |
+| `pr-creation` | Squash, push, create PR with changelog via GitHub MCP | ~700 |
 | `cleanup` | Delete merged branches, clean stale refs | ~800 |
 
 ## Invocation
@@ -238,6 +238,6 @@ pre-work → implementation → review-prep → [commit-prep] → pr-creation �
 
 ## Cross-References
 
-- Related skills: `approval-gate` (authorization), `pr-creation-workflow` (PR timing)
+- Related skills: `approval-gate` (authorization), `pr-creation-workflow` (PR timing), `changelog-generator` (PR body)
 - Related guidelines: `110-git-branch-first.md`, `111-git-commit-workflow.md`, `113-git-pr-workflow.md`, `114-git-branch-cleanup.md`, `124-github-archive-workflow.md`
 - Session init: `000-session-init.md` (for GIT_OWNER, GIT_REPO, DEV_NAME, DEV_EMAIL)

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -24,24 +24,30 @@ Create pull request after explicit user instruction. Squash commits to single co
 
 ## Procedure
 
-### Step 1: Squash to Single Commit
+### Step 0: Check PR State
 
-**MANDATORY:** All PRs must have exactly ONE commit.
-
-```bash
-git reset --soft origin/main
-git commit -m "<descriptive message>" \
-    --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
-    --trailer "Co-authored-by: <Human-Name> <human-email>"
-```
-
-### Step 2: Push to Remote
+**Before creating PR, check if branch already has a merged PR:**
 
 ```bash
-git push --force-with-lease origin <branch>
+# Get current branch name
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Check for existing PRs on this branch
+gh pr list --head "$CURRENT_BRANCH" --state merged --json number,url,mergedAt
 ```
 
-### Step 3: Collect Sub-Issues (Multi-Task Specs)
+**If merged PR exists:**
+1. Get current main state: `git fetch origin && git checkout main && git pull origin main`
+2. Create new branch: `git checkout -b <new-branch-name>`
+3. Cherry-pick or reapply changes
+4. Continue with PR creation
+
+**Report to user:**
+```
+⚠️ Branch <name> has a merged PR. Creating new PR against current main.
+```
+
+### Step 1: Collect Sub-Issues (Multi-Task Specs)
 
 **For specs with sub-issues:**
 
@@ -57,14 +63,84 @@ autoclose_issues = [<parent>] + [sub["number"] for sub in sub_issues]
 
 No sub-issues needed. Include only parent issue.
 
-### Step 4: Create PR via GitHub MCP
+### Step 2: Generate Changelog via Skill
+
+**⚠️ CRITICAL: Use skill invocation to prevent context contamination.**
+
+Invoke changelog-generator skill as a sub-task:
+
+```
+/skill changelog-generator --task overview
+```
+
+Then generate entries from commits since branching from main.
+
+**Skill Invocation Response:**
+- User-facing changelog with categorized changes
+- Executive summary of changes
+- Clear, professional formatting
+
+**If changelog invocation returns empty/no entries:**
+
+Skip changelog step. PR body will use fallback format.
+
+### Step 3: Write to CHANGELOG.md
+
+**⚠️ CRITICAL: Update CHANGELOG.md BEFORE squash commit.**
+
+Invoke changelog-generator write task:
+
+```
+/skill changelog-generator --task write
+```
+
+**Write task performs:**
+1. Generate changelog entries from commits
+2. Read existing CHANGELOG.md (or create if missing)
+3. Prepend entries to `[Unreleased]` section
+4. Write updated content to file
+
+**After write:**
+```bash
+git add CHANGELOG.md
+git status  # Verify CHANGELOG.md is staged
+```
+
+### Step 4: Squash to Single Commit
+
+**MANDATORY:** All PRs must have exactly ONE commit, including CHANGELOG.md changes.
+
+```bash
+# Stage all changes including CHANGELOG.md
+git add -A
+
+# Squash to single commit
+git reset --soft origin/main
+git commit -m "<descriptive message>" \
+    --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
+    --trailer "Co-authored-by: <Human-Name> <human-email>"
+```
+
+### Step 5: Push to Remote
+
+```bash
+git push --force-with-lease origin <branch>
+```
+
+### Step 6: Create PR via GitHub MCP
 
 ```python
 github_create_pull_request(
     owner=<GIT_OWNER>,
     repo=<GIT_REPO>,
     title="[SPEC] <description>",
-    body="""<description>
+    body="""## Summary
+
+<Executive summary from changelog skill>
+
+## Changes
+
+<Changelog content from skill invocation>
 
 Fixes #<parent>
 Fixes #<child1>
@@ -78,11 +154,12 @@ Fixes #<child2>
 
 **PR Body Requirements:**
 
-- Must include `Fixes #<issue-number>` for autoclose
+- Executive summary section (from changelog skill)
+- Changes section with user-facing descriptions
+- `Fixes #<issue-number>` for autoclose
 - Include ALL sub-issues for multi-task specs
-- Brief description of changes
 
-### Step 5: Report PR URL and HALT
+### Step 7: Report PR URL and HALT
 
 **⚠️ CRITICAL: PR URL Reporting is MANDATORY**
 
@@ -120,6 +197,7 @@ Fixes #<child2>
 
 | Failure Reason | Response |
 |----------------|----------|
+| Merged PR exists on branch | Report: "Branch has merged PR. Creating new branch and PR." → Create new branch |
 | No commits between branches | Report: "Branch has no commits to main. Changes may already be merged. Verify and HALT." |
 | Branch conflicts | Report: "Branch conflicts with main. Rebase and push, then create PR." |
 | GitHub API error | Report error details and HALT |

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -70,6 +70,74 @@ Before creating ANY PR:
   - AI: `Co-authored-by: <AI-Name> (<model-id>) <ai-email>`
   - Human: `Co-authored-by: <Human-Name> <human-email>`
 
+☑ **Merged PR Check**
+- Run: `gh pr list --head <branch> --state merged --json number`
+- Verify: No merged PR exists on this branch
+- If merged PR exists: Create new branch before PR creation
+
+☑ **Changelog Skill Availability**
+- Verify: changelog-generator skill is available for invocation
+
+## Sub-Issue Autoclose with Changelog
+
+### Single-Task Spec PR Body
+
+```markdown
+## Summary
+
+<Executive summary from changelog skill>
+
+## Changes
+
+<Changelog content from skill invocation>
+
+Fixes #<parent>
+```
+
+### Multi-Task Spec PR Body
+
+```markdown
+## Summary
+
+<Executive summary from changelog skill>
+
+## Changes
+
+<Changelog content from skill invocation>
+
+Fixes #<parent>
+Fixes #<child1>
+Fixes #<child2>
+```
+
+## Edge Case Handling
+
+### Merged PR on Branch
+
+**Detection:**
+```bash
+gh pr list --head <branch> --state merged --json number,url,mergedAt
+```
+
+**If merged PR exists:**
+1. Report: "Branch has merged PR. Creating new PR against current main."
+2. Fetch and checkout main: `git fetch origin && git checkout main && git pull origin main`
+3. Create new branch: `git checkout -b <new-branch-name>`
+4. Cherry-pick or reapply changes
+5. Continue with PR creation workflow
+
+### No Changelog Entries
+
+**If changelog skill returns empty:**
+
+Use squash commit message as PR body:
+```markdown
+## Changes
+
+
+Fixes #
+```
+
 ## Quick Start
 
 Use `/skill pr-creation-workflow --task overview` for complete workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- **Changelog Integration in PR Workflow**: Automatically generates user-facing changelogs during PR creation. Changelogs are created from git commits and included in the squash commit.
+- **Merged PR Detection**: New workflow step detects previously merged PRs before creating new ones, preventing duplicate work.
+- **CHANGELOG.md with Keep a Changelog Format**: Initial changelog file added following the industry-standard Keep a Changelog format.
+- **Write Task for Changelog Generator**: New task in the changelog-generator skill for writing changelog output directly to CHANGELOG.md.
+
+### Changed
+- **Restructured PR Creation Workflow**: Steps reorganized to include Step 0 (merged PR detection) and integrated changelog writing (Step 3). Squash commits now include CHANGELOG.md changes (Step 4).


### PR DESCRIPTION
## Summary

Enhanced PR creation workflow to automatically update CHANGELOG.md before squash, detect merged PRs, and generate user-facing changelogs via skill invocation.

## Changes

### Added

- **Changelog Integration**: Automatic CHANGELOG.md generation before squash commit using changelog-generator skill
- **Merged PR Detection**: Step 0 checks for existing merged PRs and creates new branch if needed
- **CHANGELOG.md**: Initial changelog file following Keep a Changelog format
- **Write Task**: New task in changelog-generator skill for writing entries to file

### Changed

- **Restructured Workflow**: Steps reordered to generate changelog BEFORE squash
- **Squash Includes Documentation**: CHANGELOG.md changes included in single commit

### Files Changed

| File | Change |
|------|--------|
| `CHANGELOG.md` | Initial file with [Unreleased] section |
| `.opencode/skills/git-workflow/tasks/pr-creation.md` | Restructured steps for CHANGELOG.md |
| `.opencode/skills/changelog-generator/SKILL.md` | Added write task reference |
| `.opencode/skills/changelog-generator/tasks/write.md` | Created write task |
| `.opencode/skills/pr-creation-workflow/SKILL.md` | Added checklist items, edge cases |

## Workflow Changes

**Before:**
1. Check PR State
2. Squash Commits
3. Push
4. Create PR

**After:**
1. Check PR State
2. Collect Sub-Issues
3. Generate Changelog
4. Write CHANGELOG.md
5. Squash (includes CHANGELOG.md)
6. Push
7. Create PR

Fixes #156