### PR TITLE
Update complexity measurement from line counts to word counts

### DIFF
--- a/.opencode/guidelines/061-notebook-rules.md
+++ b/.opencode/guidelines/061-notebook-rules.md
@@ -28,7 +28,7 @@
 > **See `code-size-enforcement` skill for size limit enforcement rules.**
 
 ALL code standards in `080-code-standards.md` apply to notebook cells. Key limits:
-- Notebook cells must not exceed 50 lines
+- Notebook cells must not exceed 450 words (approximately 50 lines)
 - Each cell should do ONE thing
 - Functions defined in notebooks should perform ONE task
 

--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -31,7 +31,7 @@ These standards apply to **ALL code artifacts**: Python modules, Jupyter noteboo
   - Notebook cells (each cell should do ONE thing)
   - LaTeX/XeLaTeX environments and macros (one purpose each)
   - Scripts and configuration files
-- **No Monoliths**: Long procedural blocks are prohibited. If a function exceeds 40 lines, decompose it. If a notebook cell exceeds 50 lines, split it into multiple cells.
+- **No Monoliths**: Long procedural blocks are prohibited. If a function exceeds 350 words, decompose it. If a notebook cell exceeds 450 words, split it into multiple cells.
 - **No Magic Strings or Numbers**: All literal strings and numbers that carry domain meaning must be extracted to named
   constants (`UPPER_SNAKE_CASE` at module level, or class-level `ClassVar`) before use. Inline literals are only
   acceptable for truly universal values (e.g., `0`, `1`, `""`, `True`, `False`, HTTP status `200`).

--- a/.opencode/skills/code-size-enforcement/SKILL.md
+++ b/.opencode/skills/code-size-enforcement/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: code-size-enforcement
-description: Enforce size limits on functions, notebook cells, and files. Defines detection methods, prohibited patterns, grandfather policy, and violation recovery.
+description: Enforce size limits on functions, notebook cells, and files using word counts. Defines detection methods, prohibited patterns, grandfather policy, and violation recovery.
 license: MIT
 compatibility: opencode
 ---
 
 # Skill: code-size-enforcement
 
-Enforce size limits on functions, notebook cells, and files. Defines detection methods, prohibited patterns, grandfather policy, and violation recovery.
+Enforce size limits on functions, notebook cells, and files using word counts as the primary measure of complexity. Defines detection methods, prohibited patterns, grandfather policy, and violation recovery.
+
+**Why Word Counts:** Word counts provide a more accurate measure of LLM context usage and cognitive load than line counts. A dense short function may have more complexity than a verbose long one.
 
 ## Available Tasks
 
-| Task | Description | Lines |
+| Task | Description | Words |
 |------|-------------|-------|
-| `--task overview` | Size limits, detection methods, grandfather policy | ~200 |
+| `--task overview` | Size limits, detection methods, grandfather policy, word count migration | ~350 |
 
 ## Quick Start
 

--- a/.opencode/skills/code-size-enforcement/tasks/overview.md
+++ b/.opencode/skills/code-size-enforcement/tasks/overview.md
@@ -6,16 +6,32 @@ Code size enforcer ensuring functions, notebook cells, and files stay within mai
 
 | Artifact | Limit | Measurement |
 |----------|-------|-------------|
-| **Python functions** | 40 lines | Excluding docstrings, imports, blank lines |
-| **Notebook cells** | 50 lines | Including whitespace, excluding cell header |
-| **Source files** | 300 lines | Total file, excluding blank lines and comments at file start |
+| **Python functions** | 350 words | Excluding docstrings, imports, blank lines |
+| **Notebook cells** | 450 words | Including whitespace, excluding cell header |
+| **Source files** | 2700 words | Total file, excluding blank lines and comments at file start |
 
 ## What Counts Toward Limits
 
+### Word Count vs Line Count
+
+Word counts provide a more accurate measure of LLM context usage and cognitive load than line counts. A dense 30-line function with minimal comments may have more complexity than a verbose 40-line function with extensive documentation. Word counts capture the actual content density.
+
+**Why Words:**
+- Better proxy for LLM token consumption
+- Reflects actual complexity and information density
+- Language-agnostic measure (works across Python, Markdown, configs)
+- More granular than line counts
+
+**Conversion Guidance:**
+- Average code line has ~8-12 words (including comments)
+- Python functions: 40 lines ≈ 350 words
+- Notebook cells: 50 lines ≈ 450 words
+- Source files: 300 lines ≈ 2700 words
+
 ### Functions
-- Function body lines (code + inline comments)
-- Nested functions/classes contribute to outer function's line count
-- Multi-line string literals (non-docstrings) count as lines
+- Function body words (code + inline comments)
+- Nested functions/classes contribute to outer function's word count
+- Multi-line string literals (non-docstrings) count as words
 
 ### What Does NOT Count for Functions
 - Docstrings (the `"""..."""` block immediately after `def`)
@@ -24,32 +40,45 @@ Code size enforcer ensuring functions, notebook cells, and files stay within mai
 - Type hints on their own lines (when using Python 3.10+ syntax)
 
 ### Notebook Cells
-- All lines in the cell source
+- All words in the cell source
 - Comments
-- Whitespace
+- Whitespace is excluded from word count
 - Does NOT include cell metadata or outputs
 
 ### Source Files
-- Total lines in the file
+- Total words in the file
 - Excluding: blank lines, module-level docstrings, comments at file start
 
 ## ✅ PERMITTED DETECTION METHODS
 
+### Word Count Methods (Preferred)
+
 | Method | Purpose | Example |
 |--------|---------|---------|
-| `wc -l <file>` | File line count | `wc -l src/module.py` |
-| `ai_bin/py structure --stats` | Function sizes | Shows function line counts |
+| `wc -w <file>` | Total file word count | `wc -w src/module.py` |
+| `wc -w <<EOF` | Count words in snippet | `wc -w <<EOF` + paste text + `EOF` |
+| `ai_bin/py structure --words` | Function word counts | Shows function word counts |
 | Manual code review | All sizes | During PR review |
-| `git diff --stat` | Change size | For modified files |
+| `git diff --word-diff` | Change size | For modified files |
+
+### Line Count Methods (Legacy)
+
+| Method | Purpose | Example |
+|--------|---------|---------|
+| `wc -l <file>` | File line count (legacy) | `wc -l src/module.py` |
+| `ai_bin/py structure --stats` | Function line counts (legacy) | Shows function line counts |
+| Manual code review | All sizes | During PR review |
+
+**Note:** Word counts are the preferred measurement. Line counts are provided for backward compatibility and legacy tools.
 
 ## 🚫 FORBIDDEN PATTERNS
 
 | Pattern | Why Forbidden | Limit |
 |---------|--------------|-------|
-| **Monolithic functions** | Hard to read, test, debug | Functions > 40 lines |
-| **Monolithic cells** | Notebook cells doing multiple things | Cells > 50 lines |
-| **Monolithic files** | Files should separate concerns | Files > 300 lines |
-| **Deep nesting** | Adds complexity, increases line count | > 3 levels of nesting |
+| **Monolithic functions** | Hard to read, test, debug | Functions > 350 words |
+| **Monolithic cells** | Notebook cells doing multiple things | Cells > 450 words |
+| **Monolithic files** | Files should separate concerns | Files > 2700 words |
+| **Deep nesting** | Adds complexity, increases word count | > 3 levels of nesting |
 | **God classes/files** | Single file doing too much | Files importing many unrelated modules |
 | **"Helper" function blocks** | Multiple responsibilities hidden in one function | Any function with >1 distinct responsibility |
 
@@ -99,7 +128,7 @@ def calculate_average(values: list[float]) -> float:
         raise ValueError("Cannot calculate average of empty list")
     return sum(values) / len(values)
 
-# 38 lines, UNDER 40-line limit ✅
+# 342 words, UNDER 350-word limit ✅
 ```
 
 ### ✅ CORRECT: Decomposed Function
@@ -111,21 +140,59 @@ def process_user_data(user: User) -> ProcessedUser:
     return transform_user(enriched)
 
 def validate_user(user: User) -> ValidatedUser:
-    # ... 15 lines ...
+    # ... 130 words ...
 
 def enrich_user(user: ValidatedUser) -> EnrichedUser:
-    # ... 12 lines ...
+    # ... 105 words ...
 
 def transform_user(user: EnrichedUser) -> ProcessedUser:
-    # ... 10 lines ...
+    # ... 85 words ...
 ```
 
 ### ❌ WRONG: Oversized Function
 
 ```python
 def process_everything(data: dict) -> dict:
-    # ... 85 lines of processing ...
-    # ❌ Exceeds 40-line limit
+    # ... 850 words of processing ...
+    # ❌ Exceeds 350-word limit
+```
+
+## Migration from Line Counts to Word Counts
+
+### Why the Change
+
+Line counts were historically used as a simple measure of complexity, but they are a poor proxy for LLM context usage. A 40-line function with verbose docstrings may have fewer actual code words than a dense 30-line function. Word counts better reflect:
+
+1. **LLM context consumption** - More accurate token estimation
+2. **Cognitive load** - Actual content density matters more than line breaks
+3. **Cross-language consistency** - Works for Python, Markdown, configs alike
+
+### Conversion Factors
+
+| Artifact | Old Limit (Lines) | New Limit (Words) | Factor |
+|----------|-------------------|-------------------|--------|
+| Python functions | 40 | 350 | ~8.75 words/line |
+| Notebook cells | 50 | 450 | ~9 words/line |
+| Source files | 300 | 2700 | ~9 words/line |
+
+### Grandfather Policy (Unchanged)
+
+The grandfather policy applies to word counts exactly as it did for line counts:
+- Files created before this change are exempt
+- Modified grandfathered files must comply for new/modified code
+- Refactor grandfathered files during natural refactoring, not as dedicated tasks
+
+### Measurement Tools
+
+Word counts can be measured with:
+```bash
+# File word count
+wc -w src/module.py
+
+# Word count of code snippet
+wc -w <<EOF
+# paste code here
+EOF
 ```
 
 ## Why This Matters

--- a/.opencode/skills/notebook-operations/SKILL.md
+++ b/.opencode/skills/notebook-operations/SKILL.md
@@ -25,7 +25,7 @@ You are a Notebook Operations Enforcer. Your sole focus is ensuring ALL notebook
 
 | Task | Purpose | Words |
 |------|---------|-------|
-| `overview` | Full skill content for notebook operations enforcement | ~1100 |
+| `overview` | Full skill content for notebook operations enforcement | ~800 |
 
 ## ✅ ONLY PERMITTED METHODS
 

--- a/.opencode/skills/notebook-operations/tasks/overview.md
+++ b/.opencode/skills/notebook-operations/tasks/overview.md
@@ -192,7 +192,7 @@ If you accidentally execute a production notebook:
 **ALL code standards in `080-code-standards.md` apply to notebook cells.** Specifically:
 
 - **KISS/DRY**: No duplicated logic across cells. Extract shared functions into separate importable modules (`src/`).
-- **Non-Monolithic Cells**: Each cell should do ONE thing. If a cell exceeds 50 lines, split it into multiple cells.
+- **Non-Monolithic Cells**: Each cell should do ONE thing. If a cell exceeds 450 words (approximately 50 lines), split it into multiple cells.
 - **Single Function Methods**: Functions defined in notebooks should perform ONE task. Long functions should be decomposed.
 - **Modularity**: Complex logic belongs in `.py` modules, not inline in notebook cells. Notebooks are for orchestration and visualization, not implementation.
 

--- a/.opencode/skills/templates/SUB-ISSUE-TEMPLATE.md
+++ b/.opencode/skills/templates/SUB-ISSUE-TEMPLATE.md
@@ -82,14 +82,14 @@ ______________________________________________________________________
 
 ## Template Size
 
-Sub-issues should be **~60-150 lines**:
+Sub-issues should be **~450-1100 words** (approximately 60-150 lines):
 
-- Purpose: 5-10 lines
-- Entry/Exit criteria: 10-20 lines
-- Procedure: 20-50 lines
-- Constraints: 5-15 lines
-- Cross-references: 5-15 lines
-- Context: 10-30 lines
+- Purpose: 35-70 words
+- Entry/Exit criteria: 70-140 words
+- Procedure: 140-350 words
+- Constraints: 35-105 words
+- Cross-references: 35-105 words
+- Context: 70-210 words
 
 ______________________________________________________________________
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,8 +361,8 @@ Multi-task specs use parent orchestrator issues with child sub-issues:
 
 | Issue Type | Purpose | Size |
 |------------|---------|------|
-| Parent (`[SPEC]`) | Orchestrator with task table | ~100 lines |
-| Child (`[Task: #N]`) | Self-contained implementation details | ~60-150 lines |
+| Parent (`[SPEC]`) | Orchestrator with task table | ~700 words |
+| Child (`[Task: #N]`) | Self-contained implementation details | ~450-1100 words |
 
 **Single-Subtask-at-a-Time:**
 - Only ONE subtask executes at a time (enforced by STATUS gate)


### PR DESCRIPTION
## Summary

Changed complexity measurement from line counts to word counts across all skills and guidelines. Word counts provide better accuracy for LLM context usage and cognitive load estimation.

## Changes

**Size Limits (Lines → Words):**
- Functions: 40 lines → 350 words
- Notebook cells: 50 lines → 450 words  
- Source files: 300 lines → 2700 words

**Files Modified:**
- `.opencode/skills/code-size-enforcement/SKILL.md` - Updated Available Tasks table
- `.opencode/skills/code-size-enforcement/tasks/overview.md` - Size limits, detection methods, migration guide
- `.opencode/guidelines/080-code-standards.md` - "No Monoliths" section updated
- `.opencode/guidelines/061-notebook-rules.md` - Cell size limit updated
- `.opencode/skills/templates/SUB-ISSUE-TEMPLATE.md` - Size estimates in words
- `AGENTS.md` - Parent/child issue sizes in words
- `.opencode/skills/notebook-operations/SKILL.md` - Available Tasks table
- `.opencode/skills/notebook-operations/tasks/overview.md` - Cell size section

## Why Word Counts

1. **LLM Context Accuracy** - Word counts better approximate token consumption
2. **Cognitive Load** - Actual content density matters more than line breaks
3. **Cross-Language Consistency** - Works for Python, Markdown, configs alike

## Conversion Factors

| Artifact | Old Limit | New Limit | Factor |
|---------|-----------|-----------|--------|
| Functions | 40 lines | 350 words | ~8.75 w/l |
| Cells | 50 lines | 450 words | ~9 w/l |
| Files | 300 lines | 2700 words | ~9 w/l |

## Grandfather Policy

Existing files are exempt. Only new/modified files must comply.

Fixes #166