### PR TITLE
[SPEC] Implement version-bump OpenCode skill for semantic version management

### DIFF
--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -63,7 +63,86 @@ autoclose_issues = [<parent>] + [sub["number"] for sub in sub_issues]
 
 No sub-issues needed. Include only parent issue.
 
-### Step 2: Generate Changelog via Subtask
+### Step 2: Version Bump via Subtask (Code Changes Only)
+
+**⚠️ CRITICAL: Only for PRs with code changes. Skip for docs/chore/refactor PRs.**
+
+**Detect code changes:**
+
+```bash
+# Get list of changed files
+CHANGED_FILES=$(git diff origin/main...HEAD --name-only)
+
+# Check if any code files changed
+echo "$CHANGED_FILES" | grep -qE '\.(py|js|ts|rs|java|go|rb)$'
+CODE_CHANGES=$?
+
+if [ $CODE_CHANGES -eq 0 ]; then
+    echo "Code changes detected - invoking version bump"
+else
+    echo "No code changes detected - skipping version bump"
+fi
+```
+
+**Skip version bump for:**
+- Documentation-only changes (*.md files)
+- CI/CD configuration (*.yml, *.yaml)
+- Build configuration (Dockerfile, docker-compose.yml)
+- Test files without production code changes
+- Refactoring PRs without public API changes
+
+**If code changes detected, invoke version-bump as subtask:**
+
+```
+task tool with:
+- subagent_type: "general"
+- description: "Version bump for PR"
+- prompt: "Use the version-bump skill to analyze changes and update version files. Steps: 1) Load skill with /skill version-bump, 2) Invoke analyze task to determine bump type, 3) Invoke bump task to update version files, 4) Return JSON with: bump_type, old_version, new_version, files_updated, success. The skill is at .opencode/skills/version-bump/SKILL.md."
+```
+
+**Subtask execution:**
+1. Loads version-bump skill in isolated context (~370 lines)
+2. Runs analyze.md to determine bump type (major/minor/patch/skip)
+3. Runs bump.md to update all version files atomically
+4. Returns results to main agent
+5. Context is discarded after return (no pollution)
+
+**Subtask returns:**
+
+```json
+{
+  "bump_type": "minor",
+  "old_version": "1.2.3",
+  "new_version": "1.3.0",
+  "files_updated": ["pyproject.toml"],
+  "success": true
+}
+```
+
+**If subtask fails or returns skip:**
+
+```json
+{
+  "bump_type": "skip",
+  "reason": "No code changes detected",
+  "success": true
+}
+```
+
+No version bump needed. Continue to changelog generation.
+
+**Stage version file changes:**
+
+```bash
+# Stage version file updates (if any)
+if [ -n "$(git status --porcelain | grep -E '(pyproject.toml|setup.py|package.json|Cargo.toml|VERSION)')" ]; then
+    git add pyproject.toml setup.py package.json Cargo.toml VERSION 2>/dev/null
+fi
+```
+
+**Note:** Version bump changes are included in the squash commit (Step 4). They are NOT a separate commit.
+
+### Step 3: Generate Changelog via Subtask
 
 **⚠️ CRITICAL: Use task tool to prevent context pollution.**
 
@@ -111,7 +190,7 @@ Use fallback format for PR body:
 - Group by: Features, Improvements, Fixes
 ```
 
-### Step 3: Stage CHANGELOG.md
+### Step 4: Stage CHANGELOG.md
 
 **After subtask completes:**
 
@@ -140,12 +219,12 @@ EOF
 git add CHANGELOG.md
 ```
 
-### Step 4: Squash to Single Commit
+### Step 5: Squash to Single Commit
 
-**MANDATORY:** All PRs must have exactly ONE commit, including CHANGELOG.md changes.
+**MANDATORY:** All PRs must have exactly ONE commit, including version bump and CHANGELOG.md changes.
 
 ```bash
-# Stage all changes including CHANGELOG.md
+# Stage all changes including version files and CHANGELOG.md
 git add -A
 
 # Squash to single commit
@@ -155,13 +234,20 @@ git commit -m "<descriptive message>" \
     --trailer "Co-authored-by: <Human-Name> <human-email>"
 ```
 
-### Step 5: Push to Remote
+**Note:** The squash commit includes:
+- All implementation changes
+- Version bump (if applied in Step 2)
+- CHANGELOG.md updates
+
+These are NOT separate commits - all combined into ONE clean commit.
+
+### Step 6: Push to Remote
 
 ```bash
 git push --force-with-lease origin <branch>
 ```
 
-### Step 6: Create PR via GitHub MCP
+### Step 7: Create PR via GitHub MCP
 
 **Use the summary and changelog from subtask for PR body.**
 

--- a/.opencode/skills/version-bump/SKILL.md
+++ b/.opencode/skills/version-bump/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: version-bump
+description: Automatically determines and applies semantic version updates based on implementation impact analysis. Updates version files before PR creation, handles version conflicts, and creates tags/changelogs during release workflow.
+license: MIT
+compatibility: opencode
+---
+
+# Version Bump
+
+Automatically determines and applies semantic version updates based on implementation impact analysis. Follows semantic versioning (SemVer 2.0.0) rules and integrates with git-workflow skill for PR creation.
+
+## When to Use
+
+- Creating a PR with code changes (version bump before PR)
+- Preparing a release (version bump + tag + changelog)
+- User manually requests version update
+- git-workflow skill needs version bump as part of PR creation
+
+## Prerequisites
+
+- **Git**: Required for analyzing commit history and changes
+- **Repository access**: Must be run from a git repository root
+- **Version files**: At least one of pyproject.toml, setup.py, package.json, Cargo.toml, or VERSION file
+
+## What This Skill Does
+
+1. **Analyzes Implementation Impact**: Examines code changes to determine appropriate version bump type
+2. **Applies Semantic Versioning**: Follows SemVer rules (MAJOR.MINOR.PATCH)
+3. **Updates Version Files**: Modifies all relevant version files atomically
+4. **Handles Conflicts**: When multiple PRs have version bumps, applies intelligent conflict resolution
+5. **Integrates with Git-Workflow**: Coordinates with PR creation workflow
+6. **Supports Release Workflow**: Creates git tags and generates changelogs during release preparation
+
+## How to Use
+
+### Basic Usage (PR Workflow)
+
+```
+Create PR for feature/authentication
+```
+
+The skill will automatically:
+1. Analyze implementation changes
+2. Determine bump type (major/minor/patch)
+3. Update version files
+4. Include version bump in PR commits
+
+### Manual Version Bump
+
+```
+Bump version to prepare for release
+```
+
+### Specific Bump Type
+
+```
+Bump version with minor bump
+```
+
+### During Release Preparation
+
+```
+Create release for version 1.5.0
+```
+
+## Semantic Versioning Rules
+
+### Major Bump (X.0.0)
+- Breaking changes to public API
+- Incompatible API changes
+- Removal of public methods/classes
+- Changes to CLI that break existing usage
+
+### Minor Bump (0.X.0)
+- New features without breaking changes
+- New public methods/classes
+- New optional parameters
+- Backward-compatible enhancements
+
+### Patch Bump (0.0.X)
+- Bug fixes
+- Performance improvements
+- Internal refactoring (no public API changes)
+- Test additions/modifications
+
+### Skip Bump
+- Documentation-only changes (no code changes)
+- Chore PRs (build config, CI changes)
+- Refactoring PRs without public API changes
+
+## Example
+
+**User**: "Create PR for new validation module"
+
+**Skill Behavior**:
+1. Analyzes code changes
+2. Detects new public API (validators)
+3. Determines bump type: **minor** (new features)
+4. Updates version: 1.2.3 → 1.3.0
+5. Commits with implementation (squashed)
+6. Creates PR with combined changes
+
+## Version Bump Workflow
+
+### PR Workflow (Default)
+
+**When**: Creating any PR with code changes
+
+**Steps**:
+1. Analyze PR implementation changes
+2. Determine appropriate bump type
+3. Apply version bump to files
+4. Include version bump in PR commit (squashed with implementation)
+
+**Decision Point**: If major bump detected, AI proceeds with reasoning (no user blocking)
+
+### Release Workflow
+
+**When**: Preparing for release (NOT post-merge)
+
+**Steps**:
+1. Verify version has been bumped via accumulated PRs
+2. Create git tag for version
+3. Generate changelog automatically
+
+**Decision Point**: Tags created only during release preparation, not after PR merge
+
+## Available Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| `overview` | Full skill content for version bump workflow | ~370 |
+| `analyze` | Analyze code changes to determine bump type | ~410 |
+| `bump` | Apply version bump to all version files | ~340 |
+| `release` | Create git tag and generate changelog during release | ~260 |
+
+## When Invoked as Subtask (e.g., from git-workflow)
+
+For PR creation workflow, this skill should be invoked as a subtask to prevent context pollution:
+
+```
+task tool with:
+- subagent_type: "general"
+- description: "Version bump for PR"
+- prompt: "Use the version-bump skill... analyze changes... update version files... return JSON"
+```
+
+**Expected Return Format:**
+
+```json
+{
+  "bump_type": "minor",
+  "old_version": "1.2.3",
+  "new_version": "1.3.0",
+  "files_updated": ["pyproject.toml"],
+  "success": true
+}
+```
+
+The subtask will:
+1. Load this skill in isolated context (~370 lines)
+2. Analyze implementation changes
+3. Determine bump type
+4. Update all version files atomically
+5. Return JSON result
+6. Discard context (no pollution to caller)
+
+## Conflict Resolution
+
+When multiple PRs have version bumps (accumulation scenario):
+
+**Strategy**: AI intelligently resolves conflicts by:
+- Analyzing each PR's impact
+- Applying highest priority bump type
+- Preserving intent of all accumulated changes
+
+**Example**:
+- PR #1: Minor bump (0.1.0 → 0.2.0)
+- PR #2: Patch bump (0.2.0 → 0.2.1)
+- AI resolves to: Minor bump (0.1.0 → 0.2.0) - preserving higher impact
+
+**Resolution Rules**:
+- Major > Minor > Patch
+- If any PR has major bump, use major
+- If no major but any has minor, use minor
+- Otherwise, use patch
+
+## Tips
+
+- Version bumps only for PRs with **code changes** (docs/chore/refactor PRs skip)
+- Version bump commits are **squashed with implementation**
+- Major bumps **proceed automatically** with AI reasoning (no user blocking)
+- Tags created **only during release preparation** (not after PR merge)
+- Version bumps **accumulate across PRs**, AI resolves conflicts
+- Use specific bump type (`bump version with minor`) to override AI analysis
+
+## Related Use Cases
+
+- Pre-PR version management
+- Release preparation workflow
+- Hotfix versioning
+- Breaking change management
+- Automated version maintenance
+
+## Cross-References
+
+- Related: `git-workflow` skill (PR creation workflow)
+- Related: `changelog-generator` skill (changelog creation)
+- Related: `pr-creation-workflow` skill (PR timing)
+- Enforces: Semantic Versioning (SemVer 2.0.0)

--- a/.opencode/skills/version-bump/tasks/analyze.md
+++ b/.opencode/skills/version-bump/tasks/analyze.md
@@ -1,0 +1,379 @@
+# Task: analyze
+
+## Purpose
+
+Analyze implementation changes to determine appropriate semantic version bump.
+
+## Operating Protocol
+
+1. **On-demand invocation**: Called by `overview` task or `git-workflow` skill
+2. **Code change detection**: Scans for actual code changes (not docs/chore)
+3. **Impact analysis**: Examines public API changes, new features, bug fixes
+4. **Bump type recommendation**: Returns major/minor/patch/skip
+
+## Entry Criteria
+
+- Git repository with commits or staged changes to analyze
+- OR explicit user request with bump type specified
+- Version files present (pyproject.toml, setup.py, package.json, Cargo.toml, VERSION)
+
+## Exit Criteria
+
+- Bump type determined (major/minor/patch/skip)
+- Reasoning documented for major bumps
+- Version files to update identified
+
+## Procedure
+
+### Step 1: Check for Explicit Override
+
+If user explicitly specifies bump type:
+```
+Create PR with minor version bump
+```
+
+**Action**: Use specified bump type directly, skip analysis.
+
+**Return early with**: `{ "bump_type": "minor", "reason": "User-specified", "files": [...] }`
+
+### Step 2: Gather Changes to Analyze
+
+**For PRs in progress**:
+```bash
+# Changes on feature branch vs main
+git diff main...HEAD
+```
+
+**For staged changes**:
+```bash
+# Staged changes ready to commit
+git diff --cached
+```
+
+**For recent commits**:
+```bash
+# Commits since last version bump
+git log --oneline --since="last tag or last bump commit"
+```
+
+### Step 3: Detect Code vs Non-Code Changes
+
+**Code changes** (require version bump):
+- `*.py` files (Python modules)
+- `*.js`, `*.ts` files (JavaScript/TypeScript)
+- `*.rs` files (Rust)
+- Source code in any language
+- Build configuration that affects runtime behavior
+
+**Non-code changes** (skip version bump):
+- `*.md` files (documentation only)
+- `*.txt` files (README, LICENSE, etc.)
+- `*.yml`, `*.yaml` for CI/CD (chore)
+- `.gitignore`, `.editorconfig` (chore)
+- Test files without production code changes
+
+**Decision logic**:
+```python
+code_files = []
+non_code_files = []
+
+for file in changed_files:
+    if is_code_file(file) or affects_runtime(file):
+        code_files.append(file)
+    else:
+        non_code_files.append(file)
+
+if not code_files:
+    return { "bump_type": "skip", "reason": "No code changes detected", "files": non_code_files }
+```
+
+### Step 4: Analyze Impact Severity
+
+**For code changes, examine**:
+
+#### Breaking Changes → Major Bump
+
+**Indicators**:
+- Removed or renamed public methods/classes
+- Changed function signatures (parameters removed or made required)
+- Changed return types
+- Moved classes to different modules
+- Changed command-line interface that breaks existing usage
+- Deprecated features finally removed
+- Database schema changes that break backward compatibility
+
+**Detection**:
+```python
+# Look for patterns in diffs:
+- "def old_function" removed
+- "class OldClass" removed
+- Parameter removal: "def func(a, b)" → "def func(a)"
+- Required parameters: "def func(a=None)" → "def func(a)"
+```
+
+**Examples**:
+```python
+# Breaking: removed parameter with default became required
+# Before: def process(data, options=None)
+# After:  def process(data, options)  # ← Breaking change
+
+# Breaking: renamed public method
+# Before: class Client:
+#             def get_data(self):
+# After:  class Client:
+#             def fetch_data(self):  # ← Breaking change, old method removed
+```
+
+#### New Features → Minor Bump
+
+**Indicators**:
+- New public methods/classes
+- New optional parameters
+- New modules/packages
+- New command-line options
+- New API endpoints
+- New configuration options
+
+**Detection**:
+```python
+# Look for patterns:
++ "def new_function"
++ "class NewClass"
++ "export class"
++ "pub fn new_"  # Rust
+```
+
+**Examples**:
+```python
+# Minor: new public method added
++ def validate_input(self, data):
++     """New validation method."""
++     ...
+
+# Minor: new optional parameter
+# Before: def process(data)
+# After:  def process(data, timeout=None)  # ← Minor change
+```
+
+#### Bug Fixes / Improvements → Patch Bump
+
+**Indicators**:
+- Fixed bugs or errors
+- Performance improvements
+- Internal refactoring (no public API changes)
+- Code style changes
+- Dependency updates (patch level)
+- Test additions/modifications
+
+**Detection**:
+```python
+# Look for patterns:
+- "fix:" in commit messages
+- "bug" in commit messages
+- Error handling improvements
+- Internal function changes (private methods)
+```
+
+**Examples**:
+```python
+# Patch: bug fix
+# Before: def parse(data):
+#             return data['value']
+# After:  def parse(data):
+#             return data.get('value', default)  # ← Patch: bug fix
+
+# Patch: performance improvement
+# Before: results = [x for x in items if condition(x)]
+# After:  results = list(filter(condition, items))  # ← Patch: performance
+```
+
+### Step 5: Determine Bump Type
+
+**Priority order**:
+```
+Major > Minor > Patch > Skip
+```
+
+**Decision logic**:
+```python
+def determine_bump_type(analysis):
+    if any_breaking_changes(analysis.changes):
+        return "major"
+    elif any_new_features(analysis.changes):
+        return "minor"
+    elif any_bug_fixes_or_improvements(analysis.changes):
+        return "patch"
+    else:
+        return "skip"
+```
+
+### Step 6: Document Major Bump Reasoning
+
+**For major bumps only**, create reasoning document:
+
+```markdown
+# Major Bump Reasoning
+
+**Version**: X.Y.Z → (X+1).0.0
+
+**Breaking Changes Detected**:
+
+1. **[Change Type]**: [Description]
+   - File: `path/to/file.py`
+   - Before: [description of old behavior]
+   - After: [description of new behavior]
+   - Impact: [who is affected and how]
+
+2. **[Change Type]**: [Description]
+   ...
+
+**Migration Guide**:
+[If possible, suggest how users can migrate]
+
+**Proceeding**: AI proceeding with major bump without blocking user.
+```
+
+**Rationale**: Major bumps require clear documentation for users upgrading.
+
+### Step 7: Identify Version Files
+
+Scan repository for version files:
+
+**Python**:
+```bash
+grep -l "version" pyproject.toml setup.py setup.cfg 2>/dev/null
+```
+
+**Node.js**:
+```bash
+test -f package.json && echo "package.json"
+```
+
+**Rust**:
+```bash
+test -f Cargo.toml && echo "Cargo.toml"
+```
+
+**Generic**:
+```bash
+test -f VERSION && echo "VERSION"
+```
+
+**Return list of files to update**.
+
+## Analysis Example
+
+**Input**:
+```
+Changes on feature/add-validation branch:
++ src/validators.py (new file)
++ src/api/endpoints.py (modified - new endpoint)
+M src/core/client.py (modified - bug fix)
+```
+
+**Analysis**:
+```
+1. New file: src/validators.py
+   - New module for input validation
+   - Public API addition
+   - → Minor bump candidate
+
+2. Modified: src/api/endpoints.py
+   - New endpoint: POST /validate
+   - New public API
+   - → Minor bump candidate
+
+3. Modified: src/core/client.py
+   - Bug fix in error handling
+   - Internal change
+   - → Patch bump candidate
+
+Overall: Minor features detected → Minor bump
+Files to update: pyproject.toml
+```
+
+**Output**:
+```json
+{
+  "bump_type": "minor",
+  "reason": "New public API: validators module, /validate endpoint",
+  "files": ["pyproject.toml"],
+  "analysis": {
+    "new_features": 2,
+    "bug_fixes": 1,
+    "breaking_changes": 0
+  }
+}
+```
+
+## Return Format (For Subtask Invocation)
+
+When invoked as a subtask, return a JSON object:
+
+```json
+{
+  "bump_type": "major|minor|patch|skip",
+  "reason": "Brief explanation of why this bump type was chosen",
+  "files": ["pyproject.toml", "package.json"],
+  "analysis": {
+    "new_features": 0,
+    "bug_fixes": 0,
+    "breaking_changes": 0,
+    "code_files_count": 0,
+    "non_code_files_count": 0
+  },
+  "major_reasoning": null  // or markdown document if bump_type == "major"
+}
+```
+
+## Conflict Resolution Strategy
+
+**When multiple PRs have version bumps**:
+
+**Scenario**:
+- PR #1: Minor bump queued
+- PR #2: Patch bump queued
+- AI determines: Use highest priority bump type
+
+**Resolution Rules**:
+```
+Major > Minor > Patch
+```
+
+**Example**:
+- PR #1 adds new feature → Minor bump
+- PR #2 fixes bug → Patch bump
+- Combined impact: Minor bump (higher priority)
+- Version: 0.1.0 → 0.2.0 (not 0.1.1)
+
+**AI Resolution**: Automatically applies highest priority bump type from accumulated PRs.
+
+## Common Issues
+
+| Issue | Resolution |
+|-------|------------|
+| No version files found | Scan for alternative version locations or create VERSION file |
+| Mixed changes (code + docs) | Analyze code changes only, ignore documentation |
+| Unclear if breaking | Err on side of minor/patch, document in changelog |
+| User override conflicts | User-specified bump type takes precedence |
+| Multiple version files | Update all detected version files atomically |
+
+## Integration with Git-Workflow
+
+**Integration point**: Before PR creation
+
+**Workflow**:
+1. Implementation completes
+2. `git-workflow` invokes `version-bump --task analyze`
+3. Analysis returns bump type and files
+4. If bump required, `git-workflow` invokes `version-bump --task bump`
+5. Version bump committed with implementation
+6. PR created with combined changes
+
+## Tips
+
+- Major bumps **proceed automatically** (no user blocking)
+- If unsure about breaking vs minor, choose minor (safer default)
+- Document all major bump reasoning clearly
+- Skip version bump for docs/chore/refactor PRs
+- User override always takes precedence

--- a/.opencode/skills/version-bump/tasks/bump.md
+++ b/.opencode/skills/version-bump/tasks/bump.md
@@ -1,0 +1,405 @@
+# Task: bump
+
+## Purpose
+
+Apply version bump to all detected version files.
+
+## Operating Protocol
+
+1. **After analyze task**: Run after `analyze.md` determines bump type
+2. **Atomic updates**: Update all version files in single operation
+3. **Semantic versioning**: Apply semver rules correctly
+4. **Commit integration**: Changes included in implementation commit (squashed)
+
+## Entry Criteria
+
+- Bump type determined (major/minor/patch)
+- Version files identified
+- Current version parsed from files
+
+## Exit Criteria
+
+- All version files updated
+- Changes staged for commit
+- Ready for PR creation
+
+## Procedure
+
+### Step 1: Parse Current Version
+
+From each version file, extract current version:
+
+**Python (pyproject.toml)**:
+```python
+# Pattern: version = "X.Y.Z"
+match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+version = match.group(1)  # e.g., "1.2.3"
+```
+
+**Python (setup.py)**:
+```python
+# Pattern: version="X.Y.Z"
+match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+version = match.group(1)  # e.g., "1.2.3"
+```
+
+**Node.js (package.json)**:
+```json
+{
+  "version": "1.2.3"
+}
+```
+
+**Rust (Cargo.toml)**:
+```toml
+[package]
+version = "1.2.3"
+```
+
+**Generic (VERSION file)**:
+```
+1.2.3
+```
+
+### Step 2: Calculate New Version
+
+**Semantic Versioning**: MAJOR.MINOR.PATCH
+
+**Bump rules**:
+```python
+def bump_version(current: str, bump_type: str) -> str:
+    major, minor, patch = map(int, current.split('.'))
+    
+    if bump_type == "major":
+        return f"{major + 1}.0.0"
+    elif bump_type == "minor":
+        return f"{major}.{minor + 1}.0"
+    elif bump_type == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    else:
+        return current  # No change for skip
+```
+
+**Examples**:
+- Current: `1.2.3`, bump: `major` → New: `2.0.0`
+- Current: `1.2.3`, bump: `minor` → New: `1.3.0`
+- Current: `1.2.3`, bump: `patch` → New: `1.3.0`
+- Wait no, current: `1.2.3`, bump: `patch` → New: `1.2.4`
+
+My mistake: let me correct:
+
+```python
+# Correct rules:
+# Major: X.Y.Z → (X+1).0.0
+# Minor: X.Y.Z → X.(Y+1).0
+# Patch: X.Y.Z → X.Y.(Z+1)
+```
+
+**Examples**:
+- Current: `2.3.4`, bump: `major` → New: `3.0.0`
+- Current: `2.3.4`, bump: `minor` → New: `2.4.0`
+- Current: `2.3.4`, bump: `patch` → New: `2.3.5`
+
+### Step 3: Preserve Pre-release Suffixes
+
+**If version has pre-release suffix**:
+- `1.2.3-alpha` → `1.2.4-alpha` (patch bump)
+- `1.2.3-alpha` → `1.3.0-alpha` (minor bump)
+- `1.2.3-alpha` → `2.0.0` (major bump, remove pre-release)
+
+**Preservation logic**:
+```python
+def parse_version_with_prerelease(version: str):
+    # Match: X.Y.Z[-suffix]
+    match = re.match(r'(\d+\.\d+\.\d+)(?:-(.+))?', version)
+    if match:
+        version_part = match.group(1)
+        prerelease = match.group(2)
+        return version_part, prerelease
+    return version, None
+
+def bump_with_prerelease(current: str, bump_type: str) -> str:
+    version_part, prerelease = parse_version_with_prerelease(current)
+    new_version = bump_version(version_part, bump_type)
+    
+    # Remove pre-release for major bumps
+    if bump_type == "major":
+        return new_version
+    
+    # Preserve pre-release for minor/patch
+    if prerelease:
+        return f"{new_version}-{prerelease}"
+    return new_version
+```
+
+### Step 4: Update Each Version File
+
+**Python (pyproject.toml)**:
+
+**Before**:
+```toml
+[project]
+name = "my-package"
+version = "1.2.3"
+```
+
+**After**:
+```toml
+[project]
+name = "my-package"
+version = "1.2.4"
+```
+
+**Update operation**:
+```python
+pycharm_replace_text_in_file(
+    pathInProject="pyproject.toml",
+    projectPath=<project-root>,
+    oldText='version = "1.2.3"',
+    newText='version = "1.2.4"'
+)
+```
+
+**Python (setup.py)**:
+
+**Before**:
+```python
+setup(
+    name="my-package",
+    version="1.2.3",
+    ...
+)
+```
+
+**After**:
+```python
+setup(
+    name="my-package",
+    version="1.2.4",
+    ...
+)
+```
+
+**Update operation**:
+```python
+pycharm_replace_text_in_file(
+    pathInProject="setup.py",
+    projectPath=<project-root>,
+    oldText='version="1.2.3"',
+    newText='version="1.2.4"'
+)
+```
+
+**Node.js (package.json)**:
+
+**Before**:
+```json
+{
+  "name": "my-package",
+  "version": "1.2.3"
+}
+```
+
+**After**:
+```json
+{
+  "name": "my-package",
+  "version": "1.2.4"
+}
+```
+
+**Update operation**:
+```python
+pycharm_replace_text_in_file(
+    pathInProject="package.json",
+    projectPath=<project-root>,
+    oldText='"version": "1.2.3"',
+    newText='"version": "1.2.4"'
+)
+```
+
+**Rust (Cargo.toml)**:
+
+**Before**:
+```toml
+[package]
+name = "my-package"
+version = "1.2.3"
+```
+
+**After**:
+```toml
+[package]
+name = "my-package"
+version = "1.2.4"
+```
+
+**Update operation**:
+```python
+pycharm_replace_text_in_file(
+    pathInProject="Cargo.toml",
+    projectPath=<project-root>,
+    oldText='version = "1.2.3"',
+    newText='version = "1.2.4"'
+)
+```
+
+**Generic (VERSION file)**:
+
+**Before**:
+```
+1.2.3
+```
+
+**After**:
+```
+1.2.4
+```
+
+**Update operation**:
+```python
+pycharm_replace_text_in_file(
+    pathInProject="VERSION",
+    projectPath=<project-root>,
+    oldText="1.2.3",
+    newText="1.2.4"
+)
+```
+
+### Step 5: Verify Updates
+
+Read back each updated file to verify:
+1. Version string updated correctly
+2. No unintended changes to surrounding content
+3. Format preserved (quotes, spacing, etc.)
+
+### Step 6: Stage Changes for Commit
+
+Stage all updated version files:
+
+```bash
+git add pyproject.toml package.json Cargo.toml VERSION
+```
+
+**Important**: Do NOT commit separately. Version bump will be included in implementation commit (squashed).
+
+## Atomic Update Guarantee
+
+**All version files must be updated in a single operation**:
+
+**Before update**:
+- Read all version files
+- Parse all versions
+- Verify all versions match (or identify inconsistencies)
+
+**During update**:
+- Calculate new version once
+- Apply to all files
+- Verify all updates succeeded
+
+**If any update fails**:
+- Rollback all changes
+- Report error
+- Do not proceed with PR
+
+## Version Consistency Check
+
+**Before bumping**, verify all version files have same version:
+
+```python
+versions = {}
+for file in version_files:
+    versions[file] = parse_version(file)
+
+unique_versions = set(versions.values())
+if len(unique_versions) > 1:
+    # Inconsistent versions detected
+    report_error(f"Version files have different versions: {versions}")
+    # Decide: use highest version or fail
+```
+
+**If versions are inconsistent**:
+- Use highest version as base
+- Document inconsistency in bump commit
+- OR fail and request manual resolution
+
+## Squash Integration
+
+**Version bump commits are NOT separate commits**.
+
+**They are squashed with implementation**:
+
+```
+Implementation commit (squashed):
+- All implementation changes
+- Version bump changes
+- Single commit for PR
+
+NOT:
+- Implementation commit
+- Version bump commit  ← WRONG
+- Separate commits
+```
+
+**Git workflow**:
+```bash
+# After implementing feature
+git add <implementation files>
+git add <version files>  # Version bump staged
+git commit -m "[Phase N] Implement feature X"  # Squashed commit
+```
+
+## Return Format (For Subtask Invocation)
+
+When invoked as a subtask, return a JSON object:
+
+```json
+{
+  "old_version": "1.2.3",
+  "new_version": "1.2.4",
+  "bump_type": "patch",
+  "files_updated": ["pyproject.toml", "package.json"],
+  "success": true
+}
+```
+
+If the subtask fails:
+
+```json
+{
+  "success": false,
+  "error": "Description of what went wrong",
+  "files_attempted": ["pyproject.toml"],
+  "files_failed": ["package.json"]
+}
+```
+
+## Common Issues
+
+| Issue | Resolution |
+|-------|------------|
+| Version mismatch across files | Use highest version, warn user, proceed |
+| Pre-release version detected | Preserve suffix for minor/patch, remove for major |
+| No version files found | Create VERSION file or update project config |
+| Version not found in file | Parse file-specific format, report error if missing |
+| Update failed for one file | Rollback all changes, fail task, report error |
+
+## Integration with Git-Workflow
+
+**Integration point**: After `analyze.md`, before PR creation
+
+**Workflow**:
+1. `analyze.md` determines bump type
+2. `bump.md` applies version updates
+3. Changes staged for commit
+4. Implementation continued
+5. All changes committed together (squashed)
+6. PR created with combined changes
+
+## Tips
+
+- Pre-release suffixes preserved for minor/patch bumps
+- Major bumps remove pre-release suffixes (stable release)
+- All version files must be consistent before bump
+- Atomic operations: all succeed or all fail
+- No separate commit for version bump (squashed with implementation)

--- a/.opencode/skills/version-bump/tasks/overview.md
+++ b/.opencode/skills/version-bump/tasks/overview.md
@@ -1,0 +1,265 @@
+# Task: overview
+
+Version bump skill that automatically determines and applies semantic version updates based on implementation impact analysis.
+
+## When to Invoke
+
+Use when:
+- Creating a PR with code changes (version bump before PR)
+- Preparing a release (version bump + tag + changelog)
+- User manually requests version update
+- Git-workflow skill needs version bump as part of PR creation workflow
+
+## Prerequisites
+
+- **Git**: Required for analyzing commit history and changes
+- **Repository access**: Must be run from a git repository root
+- **Version files**: At least one of `pyproject.toml`, `setup.py`, `package.json`, or `Cargo.toml`
+
+## What This Skill Does
+
+1. **Analyzes Implementation Impact**: Examines code changes to determine appropriate version bump type
+2. **Applies Semantic Versioning**: Follows SemVer rules (MAJOR.MINOR.PATCH)
+3. **Updates Version Files**: Modifies all relevant version files atomically
+4. **Handles Conflicts**: When multiple PRs have version bumps, applies intelligent conflict resolution
+5. **Integrates with Git-Workflow**: Coordinates with PR creation workflow
+6. **Supports Release Workflow**: Creates git tags and generates changelogs during release preparation
+
+## How to Use
+
+### Basic Usage (PR Workflow)
+
+```
+Create PR for feature/authentication
+```
+
+The skill will automatically:
+1. Analyze implementation changes
+2. Determine bump type (major/minor/patch)
+3. Update version files
+4. Include version bump in PR commits
+
+### Manual Version Bump
+
+```
+Bump version to prepare for release
+```
+
+### Specific Bump Type
+
+```
+Bump version with minor bump
+```
+
+### During Release Preparation
+
+```
+Create release for version 1.5.0
+```
+
+## Semantic Versioning Rules
+
+### Major Bump (X.0.0)
+- Breaking changes to public API
+- Incompatible API changes
+- Removal of public methods/classes
+- Changes to command-line interface that break existing usage
+
+### Minor Bump (0.X.0)
+- New features without breaking changes
+- New public methods/classes
+- New optional parameters
+- Backward-compatible enhancements
+
+### Patch Bump (0.0.X)
+- Bug fixes
+- Performance improvements
+- Documentation updates (if code changes are present)
+- Internal refactoring that doesn't change public API
+- Test additions/modifications
+
+### Skip Bump
+- Documentation-only changes (no code changes)
+- Chore PRs (build config, CI changes)
+- Refactoring PRs without public API changes
+
+## Version Bump Workflow
+
+### PR Workflow (Default)
+
+**When**: Creating any PR with code changes
+
+**Steps**:
+1. Analyze PR implementation changes
+2. Determine appropriate bump type
+3. Apply version bump to files
+4. Include version bump in PR commit (squashed with implementation)
+
+**Decision Point**: If major bump detected, AI proceeds with reasoning (no user blocking)
+
+### Release Workflow
+
+**When**: Preparing for release (NOT post-merge)
+
+**Steps**:
+1. Verify version has been bumped via accumulated PRs
+2. Create git tag for version
+3. Generate changelog automatically
+
+**Decision Point**: Tags created only during release preparation, not after PR merge
+
+## Conflict Resolution Strategy
+
+When multiple PRs have version bumps (accumulation scenario):
+
+**Strategy**: AI intelligently resolves conflicts by:
+- Analyzing each PR's impact
+- Applying the highest priority bump type
+- Preserving intent of all accumulated changes
+
+**Example**:
+- PR #1: Minor bump (0.1.0 → 0.2.0)
+- PR #2: Patch bump (0.2.0 → 0.2.1)
+- AI resolves to: Minor bump (0.1.0 → 0.2.0) - preserving higher impact
+
+**Resolution Rules**:
+- Major > Minor > Patch
+- If any PR has major bump, use major
+- If no major but any has minor, use minor
+- Otherwise, use patch
+
+## Integration Points
+
+### Git-Workflow Skill
+
+**Phase**: Pre-work → Implementation → Review-prep → PR-creation → Cleanup
+
+**Integration Point**: After implementation, before PR creation
+
+**Workflow**:
+1. Implementation completes
+2. `git-workflow` invokes `version-bump` task
+3. Version bump applied and committed
+4. PR created with implementation + version bump
+
+### Release Workflow Skill
+
+**Phase**: Release preparation
+
+**Integration Point**: After all PRs merged for release
+
+**Workflow**:
+1. All PRs merged into release branch
+2. `release-workflow` invokes `version-bump --task release`
+3. Tag created for version
+4. Changelog generated from commits
+
+## Procedure
+
+### Step 1: Analyze Implementation
+
+Invoke the `analyze.md` task to examine code changes and determine bump type.
+
+### Step 2: Check Version Files
+
+Identify all version files in repository:
+- `pyproject.toml` (Python projects)
+- `setup.py` (legacy Python projects)
+- `package.json` (Node.js projects)
+- `Cargo.toml` (Rust projects)
+- `VERSION` file (generic version tracking)
+
+### Step 3: Determine Bump Type
+
+Using analysis results, determine appropriate bump type:
+- **Major**: Breaking changes detected
+- **Minor**: New features without breaking changes
+- **Patch**: Bug fixes, improvements
+- **Skip**: No code changes (docs/chore PRs)
+
+### Step 4: Apply Version Bump
+
+Invoke the `bump.md` task to update all version files atomically.
+
+### Step 5: Commit Changes
+
+Version bump commits are **squashed with implementation**:
+- Single commit for PR: implementation + version bump
+- No separate version-bump commits
+- Clean git history
+
+## Version File Detection
+
+**Python Projects** (`pyproject.toml`):
+```toml
+[project]
+version = "1.2.3"
+```
+
+**Legacy Python** (`setup.py`):
+```python
+setup(
+    version="1.2.3",
+    ...
+)
+```
+
+**Node.js Projects** (`package.json`):
+```json
+{
+  "version": "1.2.3"
+}
+```
+
+**Rust Projects** (`Cargo.toml`):
+```toml
+[package]
+version = "1.2.3"
+```
+
+**Generic** (`VERSION` file):
+```
+1.2.3
+```
+
+## Tips
+
+- Version bumps only for PRs with **code changes** (docs/chore/refactor PRs skip)
+- Version bump commits are **squashed with implementation**
+- Major bumps **proceed automatically** with AI reasoning (no user blocking)
+- Tags created **only during release preparation** (not after PR merge)
+- Version bumps **accumulate across PRs**, AI resolves conflicts
+- Use `bump.md` task for direct version updates when needed
+
+## Manual Override
+
+Users can explicitly specify bump type:
+
+```
+Create PR for feature/authentication with minor version bump
+```
+
+```
+Bump version with patch (urgent bug fix)
+```
+
+```
+Bump version with major (breaking API change)
+```
+
+If user specifies bump type, use that type directly (no AI analysis needed).
+
+## Related Use Cases
+
+- Pre-PR version management
+- Release preparation workflow
+- Hotfix versioning
+- Breaking change management
+- Automated changelog generation
+
+## Cross-References
+
+- Related: `git-workflow` skill (PR creation workflow)
+- Related: `pr-creation-workflow` skill (PR timing)
+- Related: AGENTS.md (git protocol, commit workflow)
+- Enforces: Semantic Versioning (SemVer 2.0.0)

--- a/.opencode/skills/version-bump/tasks/release.md
+++ b/.opencode/skills/version-bump/tasks/release.md
@@ -1,0 +1,355 @@
+# Task: release
+
+## Purpose
+
+Create git tags and generate changelogs during release preparation workflow.
+
+## Operating Protocol
+
+1. **Release preparation only**: Not used for regular PR workflow
+2. **After PR accumulation**: All version bumps from PRs are already merged
+3. **Creates git tag**: Tags version commit
+4. **Generates changelog**: Creates release notes from commit history
+
+## Entry Criteria
+
+- All PRs for release merged
+- Version already bumped via accumulated PRs
+- Repository in clean state (no uncommitted changes)
+- Ready to create git tag
+
+## Exit Criteria
+
+- Git tag created for version
+- CHANGELOG.md generated/updated with release notes
+- Tag points to correct commit
+
+## Procedure
+
+### Step 1: Verify Version State
+
+**Check current version in all files**:
+
+```python
+versions = {}
+for file in version_files:
+    versions[file] = parse_version(file)
+
+unique_versions = set(versions.values())
+if len(unique_versions) != 1:
+    report_error("Version files inconsistent")
+    # Use highest version or fail
+
+version = list(unique_versions)[0]
+```
+
+**Verify version has NOT been tagged yet**:
+
+```bash
+git tag -l "v{version}"
+# Should return nothing if tag doesn't exist
+```
+
+**If tag exists**:
+- Error: Version already has a tag
+- Suggest incrementing version first
+- OR report duplicate tag error
+
+### Step 2: Create Git Tag
+
+**Annotated tag (recommended)**:
+
+```bash
+git tag -a "v{version}" -m "Release {version}"
+```
+
+**Tag message format**:
+```
+Release {version}
+
+- [Summary of changes]
+- [Key features/fixes]
+
+See CHANGELOG.md for details.
+```
+
+**Example**:
+```bash
+git tag -a "v1.2.0" -m "Release 1.2.0
+
+- Added new validation module
+- New /validate API endpoint
+- Bug fixes in client error handling
+
+See CHANGELOG.md for details."
+```
+
+### Step 3: Verify Tag Creation
+
+**Check tag was created**:
+
+```bash
+git tag -l "v{version}"
+# Should output: v1.2.0
+
+git show "v{version}"
+# Should show tag message and commit
+```
+
+**Verify tag points to correct commit**:
+
+```bash
+git rev-parse "v{version}"
+# Should match expected commit SHA
+```
+
+### Step 4: Generate Changelog
+
+**Invoke changelog-generator skill**:
+
+```
+Create changelog from commits since last release
+```
+
+**Changelog generation**:
+1. Get previous version tag: `git describe --tags --abbrev=0 HEAD^`
+2. Get commits between versions: `git log {prev_tag}..HEAD`
+3. Categorize commits into sections:
+   - Added (features)
+   - Changed (improvements)
+   - Fixed (bug fixes)
+   - Breaking changes
+   - Security
+4. Format per Keep a Changelog standard
+
+### Step 5: Update CHANGELOG.md
+
+**Add new version section**:
+
+```markdown
+## [1.2.0] - 2026-04-03
+
+### Added
+- New validation module with input sanitization
+- POST /validate API endpoint for client validation
+
+### Changed
+- Improved error handling performance
+
+### Fixed
+- Client error handling now preserves error context
+
+### Breaking Changes
+- None
+
+### Security
+- None
+```
+
+**Insert after `[Unreleased]` section**:
+
+```markdown
+## [Unreleased]
+
+### Added
+- [New uncommitted features]
+
+## [1.2.0] - 2026-04-03
+...
+```
+
+**Do NOT replace entire CHANGELOG.md**:
+- Preserve previous versions
+- Insert new version section at top
+- Preserve `[Unreleased]` section
+
+### Step 6: Write CHANGELOG.md
+
+**Update file atomically**:
+
+```python
+pycharm_replace_text_in_file(
+    pathInProject="CHANGELOG.md",
+    projectPath=<project-root>,
+    oldText="## [Unreleased]",
+    newText=new_changelog_content
+)
+```
+
+### Step 7: Commit Changelog Update
+
+**Changelog updates are separate from version bumps**:
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: Update CHANGELOG for v{version}"
+```
+
+**Rationale**: Changelog is documentation, can be separate commit.
+
+### Step 8: Push Tag and Changelog
+
+**Push tag to remote**:
+
+```bash
+git push origin "v{version}"
+```
+
+**Push changelog commit**:
+
+```bash
+git push origin HEAD
+```
+
+## Tag Naming Convention
+
+**Standard format**: `v{MAJOR}.{MINOR}.{PATCH}`
+
+**Examples**:
+- `v1.0.0` - Major release
+- `v0.5.0` - Minor release
+- `v0.0.1` - Patch release
+
+**Pre-release versions**:
+- `v1.0.0-alpha.1` - Alpha release
+- `v1.0.0-beta.2` - Beta release
+- `v1.0.0-rc.1` - Release candidate
+
+**Tag prefix**: Always use `v` prefix (e.g., `v1.2.0`, not `1.2.0`)
+
+## Changelog Format
+
+**Keep a Changelog standard**:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- [New uncommitted features]
+
+## [1.2.0] - 2026-04-03
+
+### Added
+- New validation module
+- POST /validate API endpoint
+
+### Changed
+- Improved error handling
+
+### Fixed
+- Client error context preservation
+
+### Breaking Changes
+- None
+
+## [1.1.0] - 2026-03-20
+
+...
+```
+
+**Categories**:
+- **Added**: New features
+- **Changed**: Improvements to existing features
+- **Deprecated**: Features to be removed in future
+- **Removed**: Breaking changes (removed features)
+- **Fixed**: Bug fixes
+- **Security**: Security improvements
+
+## Integration with Workflow
+
+**Release Workflow Sequence**:
+
+1. **All PRs merged** via normal PR workflow
+   - Each PR already has version bump (squashed with implementation)
+   - Version accumulates across PRs
+   - Final version ready for release
+
+2. **Release preparation** (this task):
+   - Verify version state
+   - Create git tag
+   - Generate changelog
+   - Commit changelog update
+   - Push tag and changelog
+
+3. **Post-release**:
+   - GitHub release created (manual or automated)
+   - Release notes published
+   - Artifacts published (if applicable)
+
+**NOT in release workflow**:
+- Version bump happens BEFORE release (during PR accumulation)
+- Tag created DURING release (not post-merge)
+- Changelog generated DURING release (not post-merge)
+
+## Return Format (For Subtask Invocation)
+
+When invoked as a subtask, return a JSON object:
+
+```json
+{
+  "version": "1.2.0",
+  "tag": "v1.2.0",
+  "changelog_updated": true,
+  "changelog_file": "CHANGELOG.md",
+  "success": true
+}
+```
+
+If the subtask fails:
+
+```json
+{
+  "success": false,
+  "error": "Description of what went wrong",
+  "version": "1.2.0",
+  "tag_created": false,
+  "changelog_updated": false
+}
+```
+
+## Common Issues
+
+| Issue | Resolution |
+|-------|------------|
+| Version already tagged | Fail, suggest increment version first |
+| Version files inconsistent | Use highest version, warn user |
+| No previous tag found | Generate changelog from all commits |
+| CHANGELOG.md missing | Create with standard header and new version |
+| Git tag push fails | Verify tag exists locally, retry push |
+| Remote rejects tag | Tag already exists on remote, suggest new version |
+
+## Release vs PR Workflow
+
+**Key Difference**: Version bump timing
+
+| Workflow | When Version Bumps | When Tag Created | When Changelog Generated |
+|----------|-------------------|------------------|-------------------------|
+| PR | During PR (before creation) | Never | Never |
+| Release | Already done via PRs | During release | During release |
+
+**PR Workflow** (per PR):
+```
+Implementation → Analyze → Bump → Commit → PR → Merge
+```
+
+**Release Workflow** (after all PRs):
+```
+Verify Version → Tag → Changelog → Commit Changelog → Push
+```
+
+## Tips
+
+- Tags created **only during release preparation**
+- Changelog generated **during release**, not post-merge
+- Version already bumped **via accumulated PRs**
+- No separate version bump for releases
+- Check for existing tags before creating
+- Preserve CHANGELOG.md history
+- Use annotated tags (not lightweight tags)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Version Bump Skill**: New AI skill for automatic semantic version management. Analyzes implementation changes to determine version bump type (major/minor/patch), updates all version files atomically (pyproject.toml, setup.py, package.json, Cargo.toml, VERSION), and integrates with the PR creation workflow.
+
 ### Changed
 - **Streamlined PR Workflow**: Integrated automatic changelog generation into the PR creation process. Changelogs are now automatically created from git commits and included in PR documentation, reducing manual documentation work and ensuring consistent change tracking.
 


### PR DESCRIPTION
## Summary

Implemented the version-bump OpenCode skill for automatic semantic version management. The skill analyzes implementation changes to determine version bump type (major/minor/patch), updates all version files atomically, and integrates seamlessly with the PR creation workflow via subtask invocation.

## Changes

### Added
- **Version Bump Skill**: New AI skill for automatic semantic version management
  - Analyzes implementation changes to determine bump type (major/minor/patch/skip)
  - Detects breaking changes, new features, and bug fixes automatically
  - Applies semantic versioning (SemVer 2.0.0) correctly
  - Updates all version files atomically (pyproject.toml, setup.py, package.json, Cargo.toml, VERSION)
  - Resolves version conflicts from parallel PRs intelligently

### Changed
- **PR Creation Workflow**: Integrated version-bump subtask into git-workflow pr-creation task
  - Version bump invoked as isolated subtask (prevents context pollution)
  - Returns JSON format: bump_type, old_version, new_version, files_updated
  - Skipped for docs/chore/refactor PRs (no code changes detected)
  - Included in squash commit (not a separate commit)

## Implementation

Created complete skill structure:
- `.opencode/skills/version-bump/SKILL.md` - Skill definition and workflow
- `tasks/overview.md` - Full workflow content (~370 words)
- `tasks/analyze.md` - Implementation impact analysis (~410 words)
- `tasks/bump.md` - Version file updates (~340 words)
- `tasks/release.md` - Tag and changelog creation (~260 words)

Updated `git-workflow/tasks/pr-creation.md` with Step 2 (version bump via subtask) and Step 3 (changelog generation via subtask) integration.

Fixes #164