### PR TITLE
[SPEC] Enforce Review-Prep and Executive Summary After Implementation

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -455,6 +455,70 @@ Invoked with: `/skill concern-separation-auditor --issue N`
 
 ---
 
+## Critical Violation: Skipping Review-Prep After Implementation
+
+**⚠️ Failing to invoke review-prep after implementation completes is a CRITICAL GUIDELINE VIOLATION.**
+
+After implementation completes, the agent MUST automatically:
+1. **Push the feature branch** to remote
+2. **Generate GitHub compare URL** for developer review
+3. **Post compare URL** to the issue AND chat
+4. **HALT** and wait for "create a PR" instruction
+
+**🚫 FORBIDDEN:**
+- Skipping review-prep because "changes are trivial"
+- Skipping review-prep because "developer can use git log"
+- Skipping review-prep and asking "do you want to review?"
+- Proceeding directly to PR creation without compare URL
+- Completing implementation and HALTing without pushing branch
+- Reporting completion without providing compare URL
+
+**✅ REQUIRED SEQUENCE:**
+1. Implementation completes all file changes
+2. Agent commits all changes
+3. Agent pushes branch to remote (`git push -u origin <branch>`)
+4. Agent generates compare URL (`https://github.com/<owner>/<repo>/compare/main...<branch>`)
+5. Agent posts compare URL to issue AND chat
+6. **Agent HALTs** — waits for "create a PR" instruction
+
+**Why This Matters:**
+- Developers need visibility into ALL changes before PR creation
+- GitHub diff viewer provides superior review experience
+- Prevents accidental PRs without developer review
+- Establishes clear boundary between "implementation done" and "PR requested"
+- Compare URL is the canonical way for developers to review branch changes
+
+**Executive Summary REQUIREMENT:**
+
+When posting completion after review-prep, the agent MUST include an executive summary:
+
+| Location | Content |
+|----------|---------|
+| **GitHub Issue Comment** | Full executive summary (summary, outcome) |
+| **Chat Output** | Same executive summary (summary, outcome) |
+
+**Executive Summary Format:**
+```
+**Summary:**
+
+<1-2 sentences describing the impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+**🚫 FORBIDDEN in Completion Comments:**
+- File lists (redundant with git diff)
+- "Next" field (dialog prompt)
+- Punch-list format
+- Technical changelog (focus on impact)
+
+**See `113-git-pr-workflow.md` → "Review Phase" and `git-workflow` skill → `review-prep` task.**
+
+---
+
 ## Critical Violation: Creating PRs Without Explicit Instruction
 
 **⚠️ Creating a PR without EXPLICIT developer instruction is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -19,6 +19,7 @@
 | **Authorization required** | NO implementation WITHOUT explicit `"approved"` or `"go"` |
 | **Explicit auth overrides label** | When user says `approved`/`go`, proceed REGARDLESS of `needs-approval` label |
 | **Branch first** | Create feature branch BEFORE any file modification |
+| **Review-prep after implementation** | Push branch, generate compare URL, post summary, HALT — MANDATORY after implementation |
 | **Human-only merge** | Agents MUST NEVER merge PRs |
 | **MCP tools** | Use PyCharm/GitHub MCP for file operations when available |
 | **Silent halt** | HALT after completion, after PR creation — no prompts |

--- a/.opencode/guidelines/113-git-pr-workflow.md
+++ b/.opencode/guidelines/113-git-pr-workflow.md
@@ -13,26 +13,64 @@
 
 After implementation completes and BEFORE PR creation authorization:
 
-1. **Agent pushes feature branch** to remote:
+### Mandatory Post-Implementation Sequence
+
+**The following sequence is MANDATORY after every implementation:**
+
+1. **Commit all changes**:
+   ```bash
+   git add -A
+   git commit -m "Descriptive message"
+   ```
+
+2. **Push feature branch to remote**:
    ```bash
    git push -u origin <branch-name>
    ```
 
-2. **Agent provides GitHub compare URL**:
+3. **Generate GitHub compare URL**:
    ```
    https://github.com/<owner>/<repo>/compare/main...<branch-name>
    ```
 
-3. **Developer reviews changes** via GitHub diff viewer
-4. **Developer decides** whether to create PR or request changes
-5. **If satisfied, developer says** "create a PR"
-6. **Agent creates PR** (squash, push, create PR, HALT)
+4. **Post compare URL to issue AND chat**:
+   - GitHub Issue Comment: Full executive summary with compare URL
+   - Chat Output: Same executive summary
 
-**Why This Matters:**
-- Developer can review changes before PR exists
+5. **HALT and wait** for "create a PR" instruction
+
+### Executive Summary Format (Mandatory)
+
+**When reporting completion after review-prep, include:**
+
+```
+**Summary:**
+
+<1-2 sentences describing the impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+
+GitHub compare URL: https://github.com/<owner>/<repo>/compare/main...<branch-name>
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### Why This Matters
+
+- Developers need visibility into ALL changes before PR creation
+- GitHub diff viewer provides superior review experience
 - Clear separation between "implementation done" and "PR requested"
-- No accidental PR creation without developer visibility
-- GitHub diff viewer is superior to local review
+- Compare URL is canonical way for developers to review branch changes
+- Prevents accidental PRs without developer review
+
+### Developer Review Flow
+
+1. Agent posts compare URL
+2. Developer reviews changes via GitHub diff viewer
+3. Developer decides whether to create PR or request changes
+4. If satisfied, developer says "create a PR"
+5. Agent creates PR (squash, push, create PR, HALT)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Review Phase Enforcement**: Mandatory review phase after all implementations. Branches must be pushed and a compare URL generated before any PR can be created, ensuring all changes are visible for developer review. This prevents accidental PRs and enforces a clear boundary between "implementation complete" and "PR requested."
+
+### Added
 - **Version Bump Skill**: New AI skill for automatic semantic version management. Analyzes implementation changes to determine version bump type (major/minor/patch), updates all version files atomically (pyproject.toml, setup.py, package.json, Cargo.toml, VERSION), and integrates with the PR creation workflow.
 
 ### Changed


### PR DESCRIPTION
## Summary

Added mandatory review phase enforcement after all implementations, requiring branches to be pushed with a compare URL generated before any PR creation, preventing accidental PRs and enforcing a clear boundary between implementation completion and PR request.

## Changes

### Added
- **Review Phase Enforcement**: Mandatory review phase after all implementations. Branches must be pushed and a compare URL generated before any PR can be created, ensuring all changes are visible for developer review. This prevents accidental PRs and enforces a clear boundary between "implementation complete" and "PR requested."

### Updated
- **000-critical-rules.md**: New critical violation section for skipping review-prep after implementation
- **113-git-pr-workflow.md**: Expanded review phase with mandatory post-implementation sequence
- **010-approval-gate.md**: Added review-prep to mandatory requirements table

Fixes #143