### PR TITLE
[SPEC] Fix approval gate compound command recognition

### DIFF
--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -95,6 +95,19 @@ When a developer says `approved` or `go` **without a phase qualifier**, the agen
 2. HALT after completing that phase/step
 3. Wait for next authorization before continuing
 
+## Compound Command Recognition
+
+**Approval tokens must be STANDALONE (separated by whitespace) to constitute valid authorization.**
+
+| Message | Standalone? | Authorization? |
+|---------|-------------|----------------|
+| `"approved check pr"` | YES (space separation) | YES |
+| `"#196 approved"` | YES (space separation) | YES |
+| `"#196 approvedcheck pr"` | NO (compound text) | NO |
+| `"check pr"` | N/A (verification) | NO |
+
+See `approval-gate` skill → `verify-authorization` task for complete pattern matching algorithm.
+
 ### Revision Revokes Approval (MANDATORY)
 
 **Any modification to a spec or task document MUST immediately revoke approval.**

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -159,6 +159,40 @@ When a developer says `approved` or `go` **without a phase qualifier**, the agen
 2. HALT after completing that phase/step
 3. Wait for next authorization before continuing
 
+## Compound Command Handling
+
+**Compound command:** A user message containing multiple instructions without proper separation, where approval parsing may be ambiguous.
+
+### Recognition Pattern
+
+| Message | Parsed As | Authorization? |
+|---------|-----------|----------------|
+| `"check pr"` | Verify PR status only | NO - verification command |
+| `"#196 approvedcheck pr"` | Issue reference + compound text | NO - approval not standalone |
+| `"#196 approved"` | Issue #196 approved | YES - explicit, standalone |
+| `"approved check pr"` | Approval + verification | YES - properly separated |
+| `"approved - check pr"` | Approval + verification | YES - properly separated |
+
+**Key Principle:** Authorization tokens must be **standalone** (separated by whitespace or end-of-message) to constitute valid approval.
+
+### Standalone Definition
+
+An approval word is standalone when:
+- It is separated by whitespace: `"approved check pr"` (space after "approved")
+- It is the only content: `"approved"`
+- It is separated by punctuation: `"approved - check"` (hyphen separator)
+
+An approval word is **NOT** standalone when:
+- Part of a compound word: `"approvedcheck pr"` (no space, single compound)
+- Embedded in text without separation: `"#196 approvedcheck pr"`
+
+### Pattern Matching Rules
+
+See `verify-authorization` task for complete pattern matching algorithm including:
+- Approval patterns (`approved`, `go`, `approved: N.M`)
+- Non-approval patterns (verification commands, questions)
+- Separation requirements for compound commands
+
 ## Post-Implementation Workflow
 
 ### After Implementation Completes

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -46,16 +46,89 @@ Authorization applies to:
 - Current phase/task only
 - This session only (no carryover)
 
+## Critical: Approval Pattern Matching Rules
+
+### Approval Patterns (EXPLICIT Authorization)
+
+**These patterns constitute valid authorization:**
+
+| Pattern | Example | Authorization Scope |
+|---------|---------|---------------------|
+| `approved` (standalone) | `"approved"` | All phases |
+| `go` (standalone) | `"go"` | All phases |
+| `approved: N` | `"approved: 2"` | Phase N only |
+| `approved: N.M` | `"approved: 2.3"` | Phase N, step M only |
+| `#N approved` | `"#198 approved"` | Issue #N, all phases |
+| `approved #N` | `"approved #198"` | Issue #N, all phases |
+
+**Standalone definition:** The approval word is separated by whitespace or is the only content. It is NOT part of a larger compound word or command.
+
+### Non-Approval Patterns (Informational/Verification)
+
+**These patterns are NOT authorization:**
+
+| Pattern | Example | Why Not Authorization |
+|---------|---------|----------------------|
+| Compound commands | `"check pr"` | Verification command, not approval |
+| Embedded in text | `"approvedcheck pr"` | Part of compound text, not standalone |
+| Issue reference + verification | `"#196 approvedcheck pr"` | Verification instruction, not approval |
+| Questions | `"should I do X?"` | Seeking permission, not granting |
+
+### Compound Command Handling
+
+**Compound command:** A message containing multiple instructions without proper separation.
+
+| Message | Parsed As | Authorization? |
+|---------|-----------|----------------|
+| `"check pr"` | Verify PR status | NO - verification |
+| `"#196 approvedcheck pr"` | Issue reference + compound text | NO - not explicit approval |
+| `"#196 approved"` | Issue #196 approved | YES - standalone |
+| `"approved check pr"` | Approval + verification | YES - proper separation |
+
+**Separation Requirements:**
+- Space between commands: `"approved check pr"` → approval is standalone
+- No space (compound): `"approvedcheck pr"` → NOT standalone approval
+- Hyphen/dash separator: `"approved - check pr"` → approval is standalone
+
+### Pattern Matching Algorithm
+
+```
+1. Tokenize message by whitespace
+2. Check for approval tokens:
+   - Exact match: "approved" or "go"
+   - Qualified match: "approved:N", "approved:N.M"
+   - Issue reference: "#N approved" or "approved #N"
+3. Verify token is standalone (separated by whitespace or end-of-message)
+4. If standalone approval found → Authorization granted
+5. If no standalone approval → Check for compound commands → HALT
+```
+
+### Examples
+
+**✅ VALID Authorization:**
+- `"approved"` → Standalone, all phases
+- `"go"` → Standalone, all phases
+- `"approved: 1"` → Phase 1 only
+- `"#198 approved"` → Issue 198, all phases
+- `"approved #198"` → Issue 198, all phases
+- `"approved - check pr"` → Approval + verification (separate)
+
+**❌ NOT Authorization:**
+- `"check pr"` → Verification only
+- `"#196 approvedcheck pr"` → Compound text, approval not standalone
+- `"approvedcheck pr"` → Compound word, not separate commands
+- `"should I check pr?"` → Question, seeking permission
+
 ## Critical: Explicit Authorization Priority
 
 When user provides explicit authorization, it **OVERRIDES** the needs-approval label.
 
 | Scenario | Action |
 |----------|--------|
-| "approved" AND label present | PROCEED - explicit auth wins |
-| "approved" AND no label | PROCEED |
-| NO auth AND label present | HALT - wait for authorization |
-| NO auth AND no label | Check other blockers |
+| `"approved"` (standalone) AND label present | PROCEED - explicit auth wins |
+| `"approved"` (standalone) AND no label | PROCEED |
+| Compound text (no standalone approval) AND label present | HALT - wait for authorization |
+| NO approval AND no label | Check other blockers |
 
 ## Context Required
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Compound Command Recognition**: Added explicit pattern matching rules to verify that approval tokens (`approved`, `go`) must be standalone words separated by whitespace to constitute valid authorization. Compound phrases like `#196approvedcheck pr` are no longer incorrectly parsed as approvals. This prevents authorization errors when approval tokens appear adjacent to other text.
 - **AI Attribution Identity Detection**: AI agents must now detect their actual runtime identity (name, model ID, email) dynamically instead of using hardcoded placeholder values. Example values in guidelines are explicitly illustrative only. When identity is unknown, agents must stop and ask for clarification rather than guessing. This ensures AI co-authored attribution reflects the actual AI assistant that created the content, preventing misattribution from copied example values.
 
 ### Added


### PR DESCRIPTION
## Summary

Added explicit compound command recognition rules to prevent incorrect authorization parsing when approval tokens appear alongside other directives.

## Changes

### Changed
- **Compound Command Recognition**: Added explicit pattern matching rules to verify that approval tokens (`approved`, `go`) must be standalone words separated by whitespace to constitute valid authorization. Compound phrases like `#196approvedcheck pr` are no longer incorrectly parsed as approvals. This prevents authorization errors when approval tokens appear adjacent to other text.

Fixes #198