### PR TITLE
Enforce mandatory push before HALT in review workflow

### DIFF
--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -195,6 +195,44 @@ See `verify-authorization` task for complete pattern matching algorithm includin
 
 ## Post-Implementation Workflow
 
+### ⚠️ MANDATORY PUSH BEFORE HALT CHECKLIST
+
+**CRITICAL VIOLATION WARNING: Implementation task MUST push branch BEFORE any HALT.**
+
+**Pre-HALT Verification Checklist (MANDATORY):**
+
+Before ANY HALT (task complete, phase complete, awaiting approval, awaiting clarification, error, session ending):
+
+```bash
+# Step 1: CHECK FOR COMMITS
+git log origin/<branch>..HEAD --oneline
+
+# If output shows commits → PUSH IS REQUIRED
+# If output is empty → No push needed (skip to HALT)
+
+# Step 2: PUSH IF COMMITS EXIST
+git push -u origin <branch>
+
+# Step 3: VERIFY PUSH
+git branch -vv
+# Must show: [origin/<branch>] tracking ref
+
+# Step 4: REPORT PUSH STATUS
+"Branch pushed with X commits. Ready for review-prep."
+```
+
+**Violation Detection:**
+
+If review-prep is invoked AND branch is NOT pushed:
+
+1. **STOP** - Workflow violation detected
+2. **FIX IMMEDIATELY:** `git push -u origin <branch-name>`
+3. **REPORT:** "Implementation task failed to push - workflow violation fixed"
+4. **CONTINUE:** Generate compare URL
+5. **DOCUMENT:** Note gap in completion comment
+
+**This is NOT optional. This is ZERO TOLERANCE. Violation = CRITICAL GUIDELINE BREACH.**
+
 ### After Implementation Completes
 
 1. Push feature branch to remote

--- a/.opencode/skills/git-workflow/tasks/implementation.md
+++ b/.opencode/skills/git-workflow/tasks/implementation.md
@@ -148,10 +148,47 @@ git log -1 --oneline
 
 ## After Implementation Completes
 
-1. **Commit all changes** (`git add -A && git commit`)
-1. **Push to remote** (`git push -u origin <branch-name>`)
-1. **Report completion** (executive summary to issue AND chat)
-1. **HALT** — do NOT create PR
-1. **WAIT** for explicit "create a PR" instruction
+### ⚠️ MANDATORY PUSH BEFORE HALT
+
+**Implementation task MUST commit AND push before ANY HALT.**
+
+**Pre-HALT Checklist:**
+
+```bash
+# Step 1: CHECK FOR UNCOMMITTED CHANGES
+git status
+
+# Step 2: COMMIT IF CHANGES EXIST
+if git status shows changes:
+    git add -A
+    git commit -m "[Phase N] Implementation complete" \
+        --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
+        --trailer "Co-authored-by: <Human-Name> <human-email>"
+
+# Step 3: CHECK FOR LOCAL COMMITS
+git log origin/<branch>..HEAD --oneline
+
+# Step 4: PUSH IF COMMITS EXIST
+if output shows commits:
+    git push -u origin <branch-name>
+
+# Step 5: VERIFY PUSH
+git branch -vv
+# Must show: [origin/<branch>] tracking ref
+
+# Step 6: REPORT COMPLETION
+"Implementation complete. Branch pushed with X commits."
+```
+
+### Implementation Workflow Sequence
+
+1. **Make file changes** (edit tool, etc.)
+2. **Commit changes** (`git add -A && git commit`)
+3. **Push to remote** (`git push -u origin <branch-name>`)
+4. **Report completion** (executive summary to issue AND chat)
+5. **HALT** — do NOT create PR
+6. **WAIT** for explicit "create a PR" instruction
+
+**CRITICAL: Skipping push is a ZERO TOLERANCE violation.**
 
 **See:** `pr-creation-workflow` skill for complete PR workflow.

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -118,7 +118,7 @@ ls ./tmp/
 
 ### Step 1: Verify Branch Is Pushed
 
-**Before generating compare URL, verify branch is on remote.**
+**MANDATORY ENFORCEMENT CHECK: Branch MUST be on remote before generating compare URL.**
 
 ```bash
 git branch -vv
@@ -131,16 +131,30 @@ git branch -vv
 
 **If branch shows `[origin/<branch>]` with upstream tracking → ✅ Branch is pushed**
 
-**If branch shows NO upstream or "gone" → 🚫 Branch NOT pushed**
+**If branch shows NO upstream or "gone" → 🚫 BRANCH NOT PUSHED - VIOLATION DETECTED**
 
-**If branch is NOT pushed to remote:**
+**VIOLATION REMEDIATION (MANDATORY):**
 
-```bash
-# Push branch immediately
-git push -u origin <branch-name>
-```
+If review-prep is invoked but branch is NOT pushed:
 
-**This ensures compare URL will work correctly.**
+1. **STOP** - Detection: Workflow violation
+2. **FIX IMMEDIATELY:**
+   ```bash
+   # Check for uncommitted changes
+   git status
+   git add -A
+   git commit -m "Implementation complete" \
+       --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
+       --trailer "Co-authored-by: <Human-Name> <human-email>"
+   
+   # Push branch
+   git push -u origin <branch-name>
+   ```
+3. **REPORT VIOLATION:** "Workflow violation detected: implementation task failed to push. Remediated now."
+4. **CONTINUE:** Generate compare URL
+5. **DOCUMENT IN COMPLETION COMMENT:** Note the workflow gap was fixed
+
+**This violation indicates implementation task did NOT follow Pre-HALT Verification Checklist.**
 
 ### Step 2: Generate Compare URL
 

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -53,6 +53,12 @@ Defines when PRs can be created, what authorizes PR creation, and the mandatory 
 
 Before creating ANY PR:
 
+☑ **Review Workflow Verification (MANDATORY)**
+- Verify: Branch is pushed to remote (prerequisite for compare URL)
+- Verify: Compare URL was posted to chat (NOT issue)
+- Verify: Executive summary was posted to issue AND chat
+- **If NOT completed:** HALT - review workflow was skipped (CRITICAL VIOLATION)
+
 ☑ **Squash Verification**
 - Run: `git log origin/main..HEAD --oneline`
 - Verify: EXACTLY ONE commit on branch
@@ -77,6 +83,8 @@ Before creating ANY PR:
 
 ☑ **Changelog Skill Availability**
 - Verify: changelog-generator skill is available for invocation
+
+**⚠️ CRITICAL: Skipping review workflow verification is a ZERO TOLERANCE violation.**
 
 ## Sub-Issue Autoclose with Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Mandatory Push Before HALT**: AI agents now automatically push feature branches to remote before halting after implementation, eliminating a common workflow violation where developers couldn't review changes. This ensures the compare URL is always available for code review.
 - **Compound Command Recognition**: Added explicit pattern matching rules to verify that approval tokens (`approved`, `go`) must be standalone words separated by whitespace to constitute valid authorization. Compound phrases like `#196approvedcheck pr` are no longer incorrectly parsed as approvals. This prevents authorization errors when approval tokens appear adjacent to other text.
 - **AI Attribution Identity Detection**: AI agents must now detect their actual runtime identity (name, model ID, email) dynamically instead of using hardcoded placeholder values. Example values in guidelines are explicitly illustrative only. When identity is unknown, agents must stop and ask for clarification rather than guessing. This ensures AI co-authored attribution reflects the actual AI assistant that created the content, preventing misattribution from copied example values.
 


### PR DESCRIPTION
## Summary

Added mandatory push-before-HALT enforcement to the review workflow, ensuring feature branches are automatically pushed to remote after implementation so developers can always review changes via compare URL.

## Changes

### Changed
- **Mandatory Push Before HALT**: AI agents now automatically push feature branches to remote before halting after implementation, eliminating a common workflow violation where developers couldn't review changes. This ensures the compare URL is always available for code review.

Fixes #199
Fixes #202
Fixes #203
Fixes #204