### PR TITLE
[SPEC] Guidelines: Executive Summary URL Formatting

### DIFF
--- a/.opencode/guidelines/125-github-issue-comments.md
+++ b/.opencode/guidelines/125-github-issue-comments.md
@@ -9,10 +9,11 @@ GitHub issue comments are **general comments**, NOT interactive dialogs.
 Agents are adding "awaiting authorization" prompts like:
 
 > The 5 fields can be added when you're ready to proceed.
-> 
+>
 > Awaiting authorization to implement.
 
 This is incorrect because:
+
 - Developers cannot read agent internal reasoning
 - Issue comments are public records, not chat interfaces
 - Dialog prompts create noise and confusion
@@ -49,6 +50,7 @@ This is incorrect because:
 | This guideline | Don't prompt for authorization via comments |
 
 The HALT protocol (see `010-approval-gate.md`) is the correct mechanism for authorization flow:
+
 - Complete task → report completion → **STOP and wait**
 - Do NOT post "awaiting authorization" comments
 
@@ -109,12 +111,14 @@ AI: <AgentName> (<ModelID>) 🔍 Analysis complete: Found 3 issues in validation
 ## Summary
 
 **Issue comments are for:**
+
 - Documenting progress
 - Answering questions
 - Explaining decisions
 - Providing evidence
 
 **Issue comments are NOT for:**
+
 - Prompting for authorization
 - Starting dialogs
 - Asking "ready to proceed?"
@@ -127,12 +131,14 @@ AI: <AgentName> (<ModelID>) 🔍 Analysis complete: Found 3 issues in validation
 ### What is "Substantive" vs "Non-Substantive"
 
 **Substantive** (Comment Required):
+
 - Changes to requirements, objectives, success criteria
 - Adding/removing phases or tasks
 - Altering spec scope or approach
 - Significant content changes that affect understanding
 
 **Non-Substantive** (No Comment):
+
 - Adding links/references at the top of issue body (origin links, cross-references)
 - STATUS field updates
 - Label changes
@@ -140,9 +146,76 @@ AI: <AgentName> (<ModelID>) 🔍 Analysis complete: Found 3 issues in validation
 - Typo/formatting fixes
 - Housekeeping edits that don't change meaning
 
+## URL Placement in Executive Summaries (MANDATORY)
+
+**URLs MUST appear LAST in all executive summaries and progress comments.**
+
+### Rule
+
+When a comment includes a URL (issue link, PR link, code compare link, etc.), the URL MUST be the final line of the comment.
+
+### Format
+
+```markdown
+**Summary:**
+
+<Summary content>
+
+**Outcome:** <What changed>
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+
+https://github.com/<owner>/<repo>/compare/main...<branch>
+```
+
+### Why URL Last
+
+- URLs are typically long and may wrap across lines
+- Placing URLs last allows developers to quickly scan summary content first
+- Easy visual anchor: "look for the URL at the end"
+- Consistent pattern across all AI-generated summaries
+
+### Multiple URLs
+
+If multiple URLs are relevant (e.g., both issue and PR):
+
+- Place the primary URL (most actionable) last
+- Secondary URLs can appear in body with context
+
+**Example:**
+
+```markdown
+**Summary:**
+
+Skills imported from external repository. Parent issue #149 tracks overall progress.
+
+**Outcome:** 5 new skills added to repository.
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+
+https://github.com/<owner>/<repo>/compare/main...<branch>
+```
+
+### No URLs
+
+If no URLs are relevant (pure summary, no links):
+
+- Executive summary ends with the agent byline
+- No URL placeholder needed
+
+**Applicable to:**
+
+- Executive summaries in progress comments
+- Completion comments on issues
+- Review-prep completion comments
+- PR creation confirmation comments
+
 ### Examples
 
 **Non-Substantive (No Comment Needed):**
+
 ```markdown
 > **Origin:** Investigated in https://github.com/<owner>/<repo>/issues/100
 > **Investigation Result:** api-agent cannot be used
@@ -151,6 +224,7 @@ AI: <AgentName> (<ModelID>) 🔍 Analysis complete: Found 3 issues in validation
 This is just a reference link at the top of the issue body. No comment explaining "added cross-reference" is needed.
 
 **Substantive (Comment Required):**
+
 - Adding a new phase to the spec
 - Changing the requirements section
 - Modifying success criteria

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -11,8 +11,8 @@ Generate GitHub compare URL for developer review AFTER the implementation task h
 The sequence is:
 
 1. Implementation complete → commit → push → **review-prep invoked automatically**
-1. Compare URL generated → HALT
-1. Wait for developer to say "create a PR"
+2. Compare URL generated → HALT
+3. Wait for developer to say "create a PR"
 
 **DO NOT skip this task after implementation. DO NOT ask the developer if they want review. Just generate the compare URL.**
 
@@ -61,9 +61,9 @@ Review-prep task:
 When implementation determines "no file changes needed":
 
 1. **STILL push branch** - git will report "up-to-date", which is acceptable
-1. **STILL generate compare URL** - developer can see branch state
-1. **STILL post completion comment** - clear signal that work is done
-1. **NEVER skip review prep** - visibility is mandatory
+2. **STILL generate compare URL** - developer can see branch state
+3. **STILL post completion comment** - clear signal that work is done
+4. **NEVER skip review prep** - visibility is mandatory
 
 **Why this matters:** Developer needs visibility into what was checked, even if no changes were made.
 
@@ -78,8 +78,8 @@ When implementation determines "no file changes needed":
 ## Operating Protocol
 
 1. **After implementation:** This task runs AFTER all implementation is complete - NO EXCEPTIONS
-1. **MANDATORY step:** Branch MUST be pushed to remote for developer review - NO ASKING
-1. **HALT after push:** Wait for developer to review and authorize PR creation
+2. **MANDATORY step:** Branch MUST be pushed to remote for developer review - NO ASKING
+3. **HALT after push:** Wait for developer to review and authorize PR creation
 
 ## Entry Criteria
 
@@ -125,6 +125,7 @@ git branch -vv
 ```
 
 **Expected output:**
+
 ```
 * spec/my-branch  abc123 [origin/spec/my-branch] Commit message
 ```
@@ -146,7 +147,7 @@ If review-prep is invoked but branch is NOT pushed:
    git commit -m "Implementation complete" \
        --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
        --trailer "Co-authored-by: <Human-Name> <human-email>"
-   
+
    # Push branch
    git push -u origin <branch-name>
    ```
@@ -180,18 +181,20 @@ Post to GitHub issue:
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-**Ready for Review:**
-
 https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 ```
+
+**⚠️ URL-LAST FORMAT (MANDATORY): Compare URL MUST be the FINAL line of the comment.**
 
 Post to chat (same format):
 
 **✅ MANDATORY - DO NOT SKIP:**
+
 - **GitHub Issue Comment:** Full executive summary with byline and compare URL
 - **Chat Output:** SAME executive summary with byline and compare URL
 
 **Why both locations:**
+
 - GitHub preserves long-term history for future reference
 - Chat maintains session context for current discussion
 - Both must have identical content for completeness
@@ -226,9 +229,9 @@ Post to chat (same format):
 **If review-prep is invoked but branch is NOT pushed:**
 
 1. **Detect missed push:** `git branch -vv` shows no upstream
-1. **Inform user:** "Implementation task must commit and push. Fixing now."
-1. **Fix and continue:** `git push -u origin <branch-name>`
-1. **Continue:** Generate compare URL, post completion comment
+2. **Inform user:** "Implementation task must commit and push. Fixing now."
+3. **Fix and continue:** `git push -u origin <branch-name>`
+4. **Continue:** Generate compare URL, post completion comment
 
 **Why:** Commit without push = empty compare URL. Push is mandatory after commit.
 
@@ -341,8 +344,6 @@ Updated git-workflow skill to push feature branches after implementation and pro
 
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
-
-**Ready for Review:**
 
 https://github.com/<owner>/<repo>/compare/main...<branch-name>
 ```

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -1,9 +1,6 @@
----
-name: github-comments
-description: GitHub comment format and protocol for AI agents. Defines AI identity attribution, lifecycle status indicators, comment types, progress comments, closure summaries, and when to comment vs edit issue bodies.
-license: MIT
-compatibility: opencode
----
+______________________________________________________________________
+
+## name: github-comments description: GitHub comment format and protocol for AI agents. Defines AI identity attribution, lifecycle status indicators, comment types, progress comments, closure summaries, and when to comment vs edit issue bodies. license: MIT compatibility: opencode
 
 # GitHub Comment Protocol
 
@@ -44,11 +41,13 @@ Ensures all comments on issues and PRs follow correct format, are posted at the 
 | `<ai-email>` | Agent's noreply email | Using project domain email |
 
 **Example Values in Guidelines are ILLUSTRATIVE:**
+
 - `OpenCode (ollama-cloud/glm-5)` → Example only
 - `AI Assistant (model-id)` → Placeholder only
 - **DETECT YOUR OWN IDENTITY** at runtime
 
 **When Identity Unknown:**
+
 - STOP and ask user for clarification
 - DO NOT use example values as defaults
 - DO NOT guess or invent identity values
@@ -75,7 +74,31 @@ Ensures all comments on issues and PRs follow correct format, are posted at the 
 
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
+
+https://github.com/<owner>/<repo>/compare/main...<branch>
 ```
+
+### ⚠️ URL Placement Rule (MANDATORY)
+
+**URLs MUST appear LAST in executive summaries.**
+
+| Element | Position |
+|---------|----------|
+| Summary text | First |
+| Outcome | Middle |
+| Agent byline | Last line before URL |
+| URL | FINAL LINE (always last) |
+
+**Why URL last:**
+
+- URLs are typically long and may wrap across lines
+- Placing URLs last allows developers to quickly scan summary content first
+- Easy visual anchor: "look for the URL at the end"
+- Consistent pattern across all AI-generated summaries
+
+**Multiple URLs:** Place the primary URL (most actionable) last. Secondary URLs can appear in body with context.
+
+**No URLs:** If no URLs are relevant, executive summary ends with the summary text. No URL placeholder needed.
 
 **FORBIDDEN in Progress Comments:**
 
@@ -83,6 +106,7 @@ Ensures all comments on issues and PRs follow correct format, are posted at the 
 - "Next" field (dialog prompt)
 - "Awaiting authorization" (use HALT)
 - Technical changelogs (focus on impact)
+- URLs anywhere except at the end
 
 ## When to Comment vs Edit Body
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ OpenCode loads guidelines from:
 | Coverage | `uv run coverage run -m pytest test/ && uv run coverage report` | - |
 | Dead code scan | `uvx vulture src/` | Python ONLY |
 | Markdown lint | `uvx pymarkdownlnt scan -r .opencode/guidelines/ docs/` | Markdown ONLY |
-| Markdown format | `uvx mdformat .opencode/guidelines/ docs/` | Markdown ONLY |
+| Markdown format | `uvx mdformat --number --wrap keep --end-of-line lf .opencode/guidelines/ docs/` | Markdown ONLY |
 
 **Never** use bare `python`, `python3`, or `pip`. Always prefix with `uv run` for project commands.
 **Standalone tools** (ruff, pyright, vulture) use `uvx` or `uv tool install` — NOT `uv run`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **URL-Last Format for Executive Summaries**: Executive summaries in GitHub comments now place URLs at the end, making it easier to scan the summary content before accessing the link. This improves readability and establishes a consistent visual pattern across all AI-generated progress comments.
 - **Mandatory Push Before HALT**: AI agents now automatically push feature branches to remote before halting after implementation, eliminating a common workflow violation where developers couldn't review changes. This ensures the compare URL is always available for code review.
 - **Compound Command Recognition**: Added explicit pattern matching rules to verify that approval tokens (`approved`, `go`) must be standalone words separated by whitespace to constitute valid authorization. Compound phrases like `#196approvedcheck pr` are no longer incorrectly parsed as approvals. This prevents authorization errors when approval tokens appear adjacent to other text.
 - **AI Attribution Identity Detection**: AI agents must now detect their actual runtime identity (name, model ID, email) dynamically instead of using hardcoded placeholder values. Example values in guidelines are explicitly illustrative only. When identity is unknown, agents must stop and ask for clarification rather than guessing. This ensures AI co-authored attribution reflects the actual AI assistant that created the content, preventing misattribution from copied example values.


### PR DESCRIPTION
## Summary

Added URL-last formatting rule for executive summaries, ensuring URLs appear at the end of progress comments for improved readability and consistent visual pattern across AI-generated summaries.

## Changes

### Changed
- **URL-Last Format for Executive Summaries**: Executive summaries in GitHub comments now place URLs at the end, making it easier to scan the summary content before accessing the link. This improves readability and establishes a consistent visual pattern across all AI-generated progress comments.

Fixes #155