### PR TITLE
docs(skills): document 'pr' as valid shortcut for 'create a PR'

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -545,6 +545,7 @@ When posting completion after review-prep, the agent MUST include an executive s
 
 PRs require the developer to say one of these EXACT phrases:
 - "create a PR"
+- "pr"
 - "make a PR"
 - "push and create PR"
 - "let's get a PR up"

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -13,7 +13,7 @@ Git Workflow Enforcer ensuring all git operations follow the repository's strict
 
 - User says "approved" or "go" (pre-work phase - AUTO)
 - Implementation completes (review-prep phase - AUTO)
-- User says "create a PR" (pr-creation phase)
+- User says "create a PR" or "pr" (pr-creation phase)
 - PR merge confirmed (cleanup phase - AUTO)
 
 ## Tasks
@@ -33,7 +33,7 @@ Git Workflow Enforcer ensuring all git operations follow the repository's strict
 - `/skill git-workflow --task implementation` - During implementation work
 - `/skill git-workflow --task review-prep` - **AFTER implementation done** (automatic, no decision point)
 - `/skill git-workflow --task commit-prep` - When user says "commit"
-- `/skill git-workflow --task pr-creation` - When user says "create a PR"
+- `/skill git-workflow --task pr-creation` - When user says "create a PR" or "pr"
 - `/skill git-workflow --task cleanup` - After PR merge confirmed
 - `/skill git-workflow` - Overview only
 
@@ -42,7 +42,7 @@ Git Workflow Enforcer ensuring all git operations follow the repository's strict
 1. **Automatic invocation (mandatory):** This skill is referenced when:
 
    - User says `approved`, `go`, or similar authorization
-   - User says `create a PR`, `make a PR`, or similar PR request
+   - User says `create a PR`, `pr`, or similar PR request
    - Implementation completes (review-prep task invoked automatically)
    - DO NOT prompt for invocation - the skill is triggered automatically
 

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -36,6 +36,7 @@ Defines when PRs can be created, what authorizes PR creation, and the mandatory 
 | Authorization | Valid? |
 |--------------|--------|
 | "create a PR" | ✅ YES |
+| "pr" | ✅ YES |
 | "make a PR" | ✅ YES |
 | "push and create PR" | ✅ YES |
 | "let's get a PR up" | ✅ YES |

--- a/.opencode/skills/pr-creation-workflow/tasks/overview.md
+++ b/.opencode/skills/pr-creation-workflow/tasks/overview.md
@@ -25,6 +25,7 @@ PR creation workflow enforcer ensuring PRs are created ONLY with explicit develo
 | Authorization           | Valid? |
 |-------------------------|--------|
 | "create a PR"           | ✅ YES  |
+| "pr"                    | ✅ YES  |
 | "make a PR"             | ✅ YES  |
 | "push and create PR"    | ✅ YES  |
 | "let's get a PR up"     | ✅ YES  |


### PR DESCRIPTION
Add 'pr' as valid authorization phrase for PR creation.

## Changes
- Updated pr-creation-workflow/SKILL.md authorization table
- Updated pr-creation-workflow/tasks/overview.md authorization table
- Updated 000-critical-rules.md with 'pr' shortcut
- Updated git-workflow/SKILL.md skill invocation guidance

## Rationale
"pr" is a natural shortcut for "create a PR", matching the existing convention where short-form commands (like 'approved'/'go') are documented alongside longer forms.

Fixes documentation to reflect actual usage.