### PR TITLE
[SPEC] Fix review-prep Skill Invocation and Chat Output

### DIFF
--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -74,7 +74,7 @@ Authorization Gatekeeper ensuring all code changes follow the spec + authorizati
 
 ### ⚠️ MANDATORY: Post-Implementation Review-Prep Invocation
 
-**After implementation completes, the agent MUST invoke review-prep from the git-workflow skill — this is AUTOMATIC.**
+**After implementation completes, the agent MUST invoke review-prep from the git-workflow skill — this is VERIFIED, not just stated as automatic.**
 
 The sequence is FIXED:
 
@@ -85,10 +85,38 @@ The sequence is FIXED:
 5. **git-workflow review-prep task is invoked AUTOMATICALLY**
 6. review-prep generates compare URL → HALTs
 
+**VERIFICATION ENFORCEMENT (CRITICAL):**
+
+Before reporting completion, the agent MUST verify:
+
+| Verification Step | Required Action |
+|-------------------|-----------------|
+| Branch pushed? | `git log origin/<branch>..HEAD --oneline` must show commits OR be empty (already pushed) |
+| Compare URL generated? | `https://github.com/<owner>/<repo>/compare/main...<branch>` |
+| GitHub comment posted? | Executive summary + compare URL to GitHub issue |
+| Chat output posted? | Executive summary + compare URL to chat (BOTH locations required) |
+
 **DO NOT:**
 - Return to chat after implementation without invoking review-prep
 - Report completion and HALT without pushing branch first
 - Skip compare URL generation because "no changes needed"
+- Post to GitHub without also posting to chat (BOTH are required)
+- Post to chat without executive summary and compare URL
+
+**Chat Output Format (MANDATORY):**
+
+```markdown
+**Summary:**
+
+<1-2 sentences describing the impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+
+https://github.com/<owner>/<repo>/compare/main...<branch>
+```
 
 **The review-prep task provides MANDATORY developer visibility before PR creation.**
 


### PR DESCRIPTION
## Summary

Added Post-Implementation Verification Checklist to approval-gate SKILL.md to enforce review-prep invocation and ensure executive summaries with compare URLs are posted to both GitHub AND chat after implementation completes.

## Changes

- Added explicit verification steps in approval-gate SKILL.md
- Documented that review-prep invocation is VERIFIED, not just stated as "automatic"
- Added enforcement table for: branch push, compare URL generation, dual posting (GitHub + chat)
- Added chat output format requirement (executive summary + byline + URL-LAST format)
- Verified review-prep.md already documents correct workflow (no changes needed)

Fixes #218
Fixes #220
Fixes #221