### PR TITLE
fix(audit): add dev-architect to mandatory audit chain

### DIFF
--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -44,8 +44,9 @@ Analyzes spec phase structures to identify concern quality issues and apply smar
 |-------|-------|---------|
 | **1st** | `concern-separation-auditor` | Phase structure, BOILERPLATE-TITLE, concern analysis |
 | **2nd** | `spec-auditor` | Fresh-start context, completeness, content quality |
+| **3rd** | `dev-architect --task review-spec` | Architectural correctness, compliance, interdependencies |
 
-**CRITICAL: If you run ONE auditor, you MUST run BOTH in order.**
+**CRITICAL: If you run ONE auditor, you MUST run ALL THREE in order.**
 
 ## Mandatory Invocation for AI Agents
 
@@ -54,7 +55,8 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 1. Create the spec issue with phases and steps
 1. **Invoke `/skill concern-separation-auditor --issue N`** (auto-fix phase structure)
 1. **Invoke `/skill spec-auditor --issue N`** (check content quality)
-1. Fixes applied automatically by both auditors
+1. **Invoke `/skill dev-architect --task review-spec`** (review architectural correctness)
+1. Fixes applied automatically by all three auditors
 1. Add `needs-approval` label
 1. Post "ready for review" comment
 

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -50,6 +50,7 @@ Post "ready for review" comment
 |-------|-------|---------|
 | **1st** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names |
 | **2nd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
+| **3rd** | `dev-architect --task review-spec` | Architectural correctness, compliance, interdependencies, ordering |
 
 **Trigger words that require ALL skills:**
 
@@ -61,7 +62,7 @@ Post "ready for review" comment
 - "audit the issue"
 - Any request involving spec quality or structure
 
-**CRITICAL: If you run ONE auditor, you MUST run BOTH auditors in order.**
+**CRITICAL: If you run ONE auditor, you MUST run ALL THREE in order.**
 
 ______________________________________________________________________
 
@@ -426,6 +427,7 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 1. Create the spec issue with all required content
 1. Invoke `/skill concern-separation-auditor --issue N` (FIRST - phase structure, auto-fix by default)
 1. Invoke `/skill spec-auditor --issue N` (SECOND - content quality)
+1. Invoke `/skill dev-architect --task review-spec` (THIRD - architectural correctness)
 1. Apply any fixes identified by auditors
 1. Add `needs-approval` label
 1. Post "ready for review" comment
@@ -442,16 +444,17 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 
 ## Coordination Points
 
-### Integration with concern-separation-auditor
+### Integration with concern-separation-auditor and dev-architect
 
-**BOTH auditors are required. They check different things.**
+**ALL THREE auditors are required. They check different things.**
 
 | Auditor | Runs When | Checks |
 |---------|----------|--------|
 | `concern-separation-auditor` | FIRST | Phase structure, deployment independence, risk isolation, blast radius, phase names, BOILERPLATE-TITLE |
 | `spec-auditor` | SECOND | Fresh-start context, completeness, content quality, LLM implementability |
+| `dev-architect --task review-spec` | THIRD | Architectural correctness, compliance, interdependencies, ordering |
 
-**Order matters:** concern-separation-auditor fixes structural issues first, then spec-auditor checks content quality.
+**Order matters:** concern-separation-auditor fixes structural issues first, then spec-auditor checks content quality, then dev-architect reviews architectural correctness.
 
 ### Integration with Approval Gate
 
@@ -464,7 +467,8 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 1. User creates a \[SPEC\] issue.
 1. concern-separation-auditor runs (phase structure fixes).
 1. spec-auditor runs (content quality fixes).
-1. After both auditors pass → Add `needs-approval` label.
+1. dev-architect runs (architectural correctness review).
+1. After all three auditors pass → Add `needs-approval` label.
 1. After approval → Implementation begins.
 
 ## Example Session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Spec Audit Chain Enforcement**: Added mandatory architectural review as the third auditor in the spec review process. All specs must now pass concern structure, content quality, AND architectural correctness checks before approval. This prevents incomplete or poorly-architected specifications from being approved.
+
 ### Changed
 - **Dev-Architect Review-Spec Task Rewritten**: Review-spec task now uses comprehensive violation mapping with 100% auto-revise for format violations (boilerplate phases, missing elements), incomplete context (file references, success criteria), and content quality (vague/untestable criteria). Prompt-only mode is reserved for catastrophic failures like circular dependencies and architecture conflicts. This makes spec review more predictable and thorough.
 - **Mandatory PR Skill Invocation**: Added explicit CRITICAL VIOLATION warning for bypassing the git-workflow skill when handling PR commands. Commands like "pr", "update PR", and "push and create PR" MUST invoke the pr-creation task. Manual PR updates are FORBIDDEN. The skill now handles existing PR detection automatically, checking for both open and merged PRs before proceeding.


### PR DESCRIPTION
## Summary

Enforced mandatory architectural review as the third auditor in the spec approval chain, ensuring all specs pass concern structure, content quality, AND architectural correctness checks before approval.

## Changes

### Fixed
- **Spec Audit Chain Enforcement**: Added mandatory architectural review as the third auditor in the spec review process. All specs must now pass concern structure, content quality, AND architectural correctness checks before approval. This prevents incomplete or poorly-architected specifications from being approved.

## Files Changed

**Updated Skills:**
- `.opencode/skills/concern-separation-auditor/SKILL.md` - Added dev-architect as third auditor, updated mandatory audit chain section
- `.opencode/skills/spec-auditor/SKILL.md` - Added dev-architect as third auditor in 4 places: complete audit chain, integration section, enforcement flow, and mandatory invocation section

**Enforcement:**
The audit chain now requires all three auditors to run in order:
1. `concern-separation-auditor` (phase structure, BOILERPLATE-TITLE, concern analysis)
2. `spec-auditor` (fresh-start context, completeness, content quality)
3. `dev-architect --task review-spec` (architectural correctness, compliance, interdependencies, ordering)

This matches the existing auto-invocation workflow documented in `dev-architect` skill for Plan phase.