### PR TITLE
fix(guidelines): enforce mandatory skill invocation for all PR operations

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -568,6 +568,37 @@ PRs require the developer to say one of these EXACT phrases:
 
 ---
 
+## Critical Violation: Manual PR Merge Confirmation (BYPASS PR WORKFLOW SKILL)
+
+**⚠️ Manually handling PR merge confirmation without invoking the mandatory skill is a CRITICAL GUIDELINE VIOLATION.**
+
+**🚫 FORBIDDEN:**
+- Manually verifying PR merge via `git pull` or `git status`
+- Manually closing issues after seeing "merged" in chat
+- Manually deleting branches without GitHub API verification
+- Manually cleaning up stashes or branches after PR merge
+- Running ANY git commands after user says "pr merged" or "merged"
+
+**✅ REQUIRED:**
+- When user says "pr merged", "merged", or similar: **INVOKE `/skill git-workflow --task cleanup`**
+- Let the skill handle ALL post-merge operations:
+  - GitHub API verification (`github_pull_request_read method=get`)
+  - Issue closure (parent and child issues)
+  - Branch cleanup (local and remote)
+  - Stash cleanup (if applicable)
+
+**Trigger Phrases for Mandatory Skill Invocation:**
+| User Says | Skill Task |
+|-----------|-----------|
+| "pr merged" | `/skill git-workflow --task cleanup` |
+| "merged" | `/skill git-workflow --task cleanup` |
+| "PR is merged" | `/skill git-workflow --task cleanup` |
+| "merge confirmed" | `/skill git-workflow --task cleanup` |
+
+**See `git-workflow` skill → `cleanup` task for complete post-merge workflow.**
+
+---
+
 ## Critical Violation: Closing Issues Before PR Merge
 
 **⚠️ Closing issues BEFORE the PR is merged is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/114-git-branch-cleanup.md
+++ b/.opencode/guidelines/114-git-branch-cleanup.md
@@ -6,14 +6,23 @@
 
 **After EVERY merged PR, cleanup is MANDATORY — no exceptions, no "I'll do it later".**
 
-### ✅ ALWAYS DO — IMMEDIATELY After Merge Confirmation
+### ⚠️ MANDATORY SKILL INVOCATION
 
-1. **Delete local feature branch** — `git branch -d <branch-name>`
-2. **Delete remote branch** — `git push origin --delete <branch-name>` (if not auto-deleted by GitHub)
-3. **Verify cleanup** — `git branch -vv` to confirm deletion
-4. **Prune remote references** — `git fetch --prune`
+**When user says "pr merged", "merged", or similar:**
+- **MUST invoke `/skill git-workflow --task cleanup`**
+- **NEVER run git commands manually**
+- The skill handles ALL post-merge operations including GitHub API verification
 
-**This is NOT optional.** Cleanup happens in the same session as merge confirmation.
+### ✅ REQUIRED: Skill Handles Everything
+
+The `git-workflow --task cleanup` skill automatically:
+1. **Verifies PR merge via GitHub API** — `github_pull_request_read method=get`
+2. **Closes issues** (parent and child issues)
+3. **Deletes local feature branch** — `git branch -d <branch-name>`
+4. **Deletes remote branch** — `git push origin --delete <branch-name>`
+5. **Prunes remote references** — `git fetch --prune`
+
+**This is NOT optional.** The skill MUST be invoked after merge confirmation.
 
 ### ✅ ALWAYS DO — When User Asks "cleanup branches"
 

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -14,7 +14,7 @@ Git Workflow Enforcer ensuring all git operations follow the repository's strict
 - User says "approved" or "go" (pre-work phase - AUTO)
 - Implementation completes (review-prep phase - AUTO)
 - User says "create a PR" or "pr" (pr-creation phase)
-- PR merge confirmed (cleanup phase - AUTO)
+- User says "pr merged" or "merged" or similar (cleanup phase - AUTO)
 
 ## Tasks
 
@@ -34,7 +34,7 @@ Git Workflow Enforcer ensuring all git operations follow the repository's strict
 - `/skill git-workflow --task review-prep` - **AFTER implementation done** (automatic, no decision point)
 - `/skill git-workflow --task commit-prep` - When user says "commit"
 - `/skill git-workflow --task pr-creation` - When user says "create a PR" or "pr"
-- `/skill git-workflow --task cleanup` - After PR merge confirmed
+- `/skill git-workflow --task cleanup` - **When user says "pr merged" or "merged"** (automatic)
 - `/skill git-workflow` - Overview only
 
 ## Operating Protocol
@@ -64,7 +64,7 @@ Git Workflow Enforcer ensuring all git operations follow the repository's strict
 | **After implementation completes** | Load skill → `review-prep` task | Push branch, generate compare URL, HALT |
 | **Before ANY git branch operation** | Load skill → `pre-work` task | Verify branch state, stash changes |
 | **When user says "create a PR"** | Load skill → `pr-creation` task | Squash to single commit, push, create PR, HALT |
-| **After PR merge confirmed** | Load skill → `cleanup` task | Verify merge via GitHub API, close issues, delete branches |
+| **When user says "pr merged" or "merged"** | Load skill → `cleanup` task | Verify merge via GitHub API, close issues, delete branches |
 
 **Enforcement:** Do NOT proceed with git operations at these trigger points without first loading this skill and verifying workflow compliance.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,8 @@ See `.opencode/guidelines/085-engineering-approach.md` for complete requirements
 - **Create PRs without EXPLICIT developer instruction** — "approved" and "go" authorize implementation ONLY. PRs require explicit "create a PR" instruction. Completing implementation does NOT authorize PR creation.
 - **Submit unsquashed PRs** — ALL PRs must have exactly ONE commit (squashed). Multiple commits in a PR will be rejected. Always `git reset --soft origin/main && git commit` before pushing.
 - **Create PRs after implementation** — The developer must run human tests and may require adjustments BEFORE any PR. Wait for explicit "create a PR" after developer has tested.
-- **BYPASS PR WORKFLOW SKILL** — When user says "pr", "create a PR", "update PR", or any PR-related command, MUST invoke `/skill git-workflow --task pr-creation`. NEVER manually update/create PRs. The skill handles existing PR detection (Step 0 checks for open/merged PRs).
+- **BYPASS PR WORKFLOW SKILL** — When user says "pr", "create a PR", "update PR", or ANY PR-related command, MUST invoke `/skill git-workflow --task <appropriate-task>`. NEVER manually create/update/close PRs. The skill handles existing PR detection (Step 0 checks for open/merged PRs).
+- **PR MERGE CONFIRMATION REQUIRES SKILL** — When user says "pr merged", "merged", or similar, MUST invoke `/skill git-workflow --task cleanup`. NEVER manually handle PR merge confirmation, issue closure, or branch cleanup. The skill handles ALL post-merge operations including GitHub API verification and branch deletion.
 - Use `/tmp/` — only use `./tmp/`
 - **DELETE MERGED BRANCHES IMMEDIATELY** — After PR merge confirmation, delete the branch immediately. No asking, no waiting. Unmerged branches with work ARE preserved until explicit delete request.
 - **ANALYZE ISSUE COMMENTS SILENTLY** — Always respond to user comments via GitHub issue comment. Users cannot see your internal reasoning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **PR Workflow Enforcement**: Added critical violation warning for bypassing the git-workflow skill during PR operations. All PR-related commands ("pr", "update PR", "push and create PR") must now invoke the skill, which handles GitHub API verification and branch cleanup automatically. This prevents manual git command errors and ensures consistent PR handling.
 - **Spec Audit Chain Enforcement**: Added mandatory architectural review as the third auditor in the spec review process. All specs must now pass concern structure, content quality, AND architectural correctness checks before approval. This prevents incomplete or poorly-architected specifications from being approved.
 
 ### Changed


### PR DESCRIPTION
## Summary

Fixed PR workflow enforcement by making git-workflow skill invocation mandatory for all PR operations, preventing manual git command errors and ensuring consistent GitHub API verification.

## Changes

### Fixed
- **PR Workflow Enforcement**: Added critical violation warning for bypassing the git-workflow skill during PR operations. All PR-related commands ("pr", "update PR", "push and create PR") must now invoke the skill, which handles GitHub API verification and branch cleanup automatically. This prevents manual git command errors and ensures consistent PR handling.

## Files Changed

- `AGENTS.md` - Added mandatory skill invocation for PR merge confirmation
- `.opencode/guidelines/000-critical-rules.md` - Added "Manual PR Merge Confirmation" violation section
- `.opencode/guidelines/114-git-branch-cleanup.md` - Replaced manual cleanup steps with mandatory skill invocation
- `.opencode/skills/git-workflow/SKILL.md` - Clarified cleanup task is AUTO on 'pr merged'/'merged' trigger