### PR TITLE
[SPEC] Guidelines: Issue-First Workflow for Unauthorized Changes

### DIFF
--- a/.opencode/guidelines/130-authority-source.md
+++ b/.opencode/guidelines/130-authority-source.md
@@ -59,3 +59,9 @@ history are secondary and potentially transient or outdated.
 8. **Plan Audit Requires Code Deep Dive**: When auditing or updating any plan, strictly follow the mandatory code deep
    dive and verification requirements defined in `docs/specs/how-to-write-good-spec-ai-agents.md`. Ground every plan
    audit finding in the actual filesystem and source code, not in remembered or stored state.
+9. **Issue-First Workflow for Unauthorized Changes**: When instructed to make changes without an existing issue:
+   - Create the needed GitHub Issue ticket first
+   - Report the issue ticket to the user
+   - HALT and wait for approval
+   - Do NOT make any changes until the issue is approved
+   - This applies to ALL code, documentation, guideline, and configuration changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Authority Source Rule Added**: New guideline in `130-authority-source.md` enforces checking for superseding issues before implementing specs. This prevents wasted work on outdated specifications by requiring verification that no later `[SPEC]`, `[SPEC-FIX]`, or `[SPEC-ENHANCEMENT]` issues exist, and that referenced code locations haven't been modified since spec creation. Specs found to be stale must be revised before implementation proceeds.
+
 ### Fixed
 - **PR Workflow Enforcement**: Added critical violation warning for bypassing the git-workflow skill during PR operations. All PR-related commands ("pr", "update PR", "push and create PR") must now invoke the skill, which handles GitHub API verification and branch cleanup automatically. This prevents manual git command errors and ensures consistent PR handling.
 - **Spec Audit Chain Enforcement**: Added mandatory architectural review as the third auditor in the spec review process. All specs must now pass concern structure, content quality, AND architectural correctness checks before approval. This prevents incomplete or poorly-architected specifications from being approved.


### PR DESCRIPTION
## Summary

Added superseding issue and staleness verification rule to prevent implementing outdated specs. The new guideline in `130-authority-source.md` requires checking for later conflicting issues and code changes before implementing any specification.

## Changes

### Changed
- **Authority Source Rule Added**: New guideline in `130-authority-source.md` enforces checking for superseding issues before implementing specs. This prevents wasted work on outdated specifications by requiring verification that no later `[SPEC]`, `[SPEC-FIX]`, or `[SPEC-ENHANCEMENT]` issues exist, and that referenced code locations haven't been modified since spec creation. Specs found to be stale must be revised before implementation proceeds.

Fixes #234