### PR TITLE
Skills: Check Sub-issues When Verifying Task Completion

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -683,7 +683,7 @@ PRs require the developer to say one of these EXACT phrases:
 
 ## Critical Violation: Parent/Child Issue Closure
 
-**⚠️ Closing a parent issue while child issues remain open is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Closing a parent issue while child issues remain open, or assuming parent status reflects sub-issue completion, is a CRITICAL GUIDELINE VIOLATION.**
 
 When working with parent/child issue hierarchies (specs with sub-issues):
 
@@ -691,11 +691,14 @@ When working with parent/child issue hierarchies (specs with sub-issues):
 - Closing a parent `[SPEC]` issue when ANY child `[Task]` issues are still open
 - Closing a parent after PR merge if other child tasks are incomplete
 - Assuming "the PR covers everything" when sub-issues exist
+- **Assuming parent status reflects sub-issue status — ALWAYS query sub-issues**
 
 **✅ REQUIRED:**
 - Only close the child issue that corresponds to the merged PR
 - Parent issue remains open until ALL child issues are closed
-- After closing a child: check if other children remain open
+- After closing a child: **ALWAYS call `github_issue_read method=get_sub_issues` on parent**
+- If the result is NOT empty (children remain open) → STOP, do NOT close parent
+- If the result IS empty (all children closed) → Close parent with summary
 - If all children are closed, then (and only then) close the parent
 
 ### Correct Workflow

--- a/.opencode/guidelines/124-github-archive-workflow.md
+++ b/.opencode/guidelines/124-github-archive-workflow.md
@@ -94,11 +94,14 @@ github_issue_write(method="update", issue_number=456, state="closed", state_reas
 
 **Parent issues MUST NOT be closed while ANY child issues remain open.**
 
+**CRITICAL: When checking if a task is complete, ALWAYS verify sub-issues — NEVER assume parent status reflects sub-issue completion.**
+
 ### 🚫 PROHIBITED
 
 1. **NEVER close a parent `[SPEC]` issue when ANY child `[Task]` issues are still open**
 2. **NEVER close a parent after PR merge if other child tasks are incomplete**
 3. **NEVER assume "the PR covers everything" when sub-issues exist**
+4. **NEVER assume parent status reflects sub-issue status — ALWAYS query sub-issues**
 
 ### ✅ REQUIRED WORKFLOW
 

--- a/.opencode/guidelines/125-github-issue-comments.md
+++ b/.opencode/guidelines/125-github-issue-comments.md
@@ -211,6 +211,7 @@ If no URLs are relevant (pure summary, no links):
 - Completion comments on issues
 - Review-prep completion comments
 - PR creation confirmation comments
+- **New issue creation comments** (URL after summary, not before)
 
 ### Examples
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -330,6 +330,40 @@ When implementation halts (awaiting approval, awaiting clarification, error, ses
 - Related skills: `git-workflow` (branch operations, cleanup with parent closure check), `pr-creation-workflow` (PR timing)
 - Related guidelines: `010-approval-gate.md`, `120-github-issue-first.md`, `000-critical-rules.md`, `124-github-archive-workflow.md` (parent closure pre-check)
 
+## Sub-Issue Verification (CRITICAL)
+
+**Before marking ANY task as complete, ALWAYS verify sub-issues explicitly.**
+
+### Task Completion Verification
+
+When completing a task that has sub-issues:
+
+```python
+# CRITICAL: Never assume parent closed = sub-issues complete
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=parent_issue)
+
+for sub in sub_issues:
+    if sub.state == "open":
+        # DO NOT PROCEED - sub-issue still open
+        # DO NOT ASSUME parent completion covers this
+        report("Sub-issue #{} is still open. Cannot proceed.", sub.number)
+        HALT
+```
+
+### Why This Matters
+
+- Parent issues can be closed while sub-issues remain open
+- `issue.state == "closed"` does NOT mean all sub-issues are complete
+- ALWAYS query sub-issues explicitly before declaring completion
+
+### Enforcement Points
+
+| Checkpoint | Verification |
+|------------|--------------|
+| Before implementation | `verify-sub-issues` task |
+| After PR merge | `git-workflow` cleanup task |
+| Before closing parent | Sub-issue double-check |
+
 ## Parent Closure Pre-Check Reference
 
 Parent/child issue closure verification is handled in:

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -38,6 +38,30 @@ if has_label and explicit_authorization:
     # Optionally note: "needs-approval label can be removed"
 ```
 
+### Step 2.5: Verify Sub-Issues for Multi-Task Specs (CRITICAL)
+
+**This check is MANDATORY before proceeding with implementation.**
+
+```python
+# CRITICAL: Check sub-issues to verify task completion
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=parent_issue)
+
+# NEVER assume parent status reflects sub-issue status
+for sub in sub_issues:
+    if sub.state == "open":
+        # Sub-issue is open - DO NOT ASSUME IT IS COMPLETE
+        # Check if this is the sub-issue we're implementing
+        if sub.number == current_sub_issue:
+            # This is the one we're implementing - proceed
+            continue
+        else:
+            # Other sub-issue is open and not being implemented
+            # HALT - parent cannot be considered complete
+            report("Sub-issue #{} is still open. Cannot proceed.", sub.number)
+```
+
+**Key Point:** A parent issue marked "closed" does NOT mean all sub-issues are complete. ALWAYS verify sub-issues explicitly.
+
 ### Step 3: Record Authorization Scope
 
 Authorization applies to:

--- a/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
@@ -109,6 +109,25 @@ github_sub_issue_write(
 - Assuming markdown checkboxes = task tracking
 - Implementing when STATUS doesn't match authorized subtask
 - Parallel execution of subtasks (enforce single-subtask flow)
+- **Assuming parent status reflects sub-issue status — ALWAYS query sub-issues explicitly**
+
+## Sub-Issue Completion Verification (CRITICAL)
+
+**Before marking ANY task or parent issue as complete, ALWAYS verify sub-issues:**
+
+```python
+# CRITICAL: Never assume parent closed = all sub-issues complete
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=parent_issue)
+
+# Check each sub-issue state
+for sub in sub_issues:
+    if sub.state == "open":
+        # DO NOT PROCEED - sub-issue still open
+        # DO NOT ASSUME parent completion covers this
+        report("Sub-issue #{} is still open. Parent cannot be marked complete.", sub.number)
+```
+
+**Key Rule:** A parent issue marked "closed" does NOT mean all sub-issues are complete. Always query sub-issues explicitly.
 
 ## Common Issues
 


### PR DESCRIPTION
## Summary

Added mandatory sub-issue verification to all task completion checks. When checking if a task is complete, agents must now ALWAYS query sub-issues explicitly rather than assuming parent status reflects completion.

Also clarified URL placement requirements for new issue creation (URLs after summary content).

## Changelog

- **Sub-issue verification gate**: All task completion checks now require explicit sub-issue verification
- **Guideline updates**: 
  - `124-github-archive-workflow.md`: NEVER assume parent status reflects sub-issue status
  - `000-critical-rules.md`: Critical violation for closing parent with open children
  - `125-github-issue-comments.md`: URL placement applies to new issue creation
- **Skill updates**:
  - `approval-gate/SKILL.md`: Added sub-issue verification checkpoint
  - `approval-gate/tasks/verify-authorization.md`: Added sub-issue check logic
  - `approval-gate/tasks/verify-sub-issues.md`: Added completion verification requirement

Fixes #244