### PR TITLE
[SPEC-FIX] Sub-issue status not checked before parent closure

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -816,14 +816,46 @@ When working with parent/child issue hierarchies (specs with sub-issues):
 - Closing a parent after PR merge if other child tasks are incomplete
 - Assuming "the PR covers everything" when sub-issues exist
 - **Assuming parent status reflects sub-issue status — ALWAYS query sub-issues**
+- **Closing ANY issue without first calling `github_issue_read(method="get_sub_issues")`**
 
-**✅ REQUIRED:**
-- Only close the child issue that corresponds to the merged PR
-- Parent issue remains open until ALL child issues are closed
-- After closing a child: **ALWAYS call `github_issue_read method=get_sub_issues` on parent**
-- If the result is NOT empty (children remain open) → STOP, do NOT close parent
-- If the result IS empty (all children closed) → Close parent with summary
-- If all children are closed, then (and only then) close the parent
+**⚠️ CRITICAL: Step 1 is MANDATORY before closing ANY issue - parent or child. No exceptions.**
+
+### MANDATORY Pre-Close Checklist (NO EXCEPTIONS)
+
+Before closing ANY issue (parent OR child), the agent MUST complete this checklist in order:
+
+| Step | Action | MUST Result |
+|------|--------|-------------|
+| **1** | Query sub-issues: `github_issue_read(method="get_sub_issues", issue_number=N)` | `[]` empty or verified all closed |
+| **2** | Verify PR merge state: `github_pull_request_read(method="get", pullNumber=PR)` | `merged_at` field exists |
+| **3** | Close child issues | Only children addressed by merged PR |
+| **4** | Re-query parent sub-issues | Verify all children now closed |
+| **5** | Close parent | Only if ALL children closed |
+
+**If ANY step fails → DO NOT CLOSE the issue.**
+
+### Example: Parent Closure Workflow
+
+```python
+# Step 1: ALWAYS query sub-issues FIRST (MANDATORY)
+children = github_issue_read(method="get_sub_issues", issue_number=parent_issue)
+
+if children:
+    # Parent with sub-issues - must verify all children closed
+    open_children = [c for c in children if c.state == "open"]
+    if open_children:
+        # BLOCK: Cannot close parent with open children
+        post_warning_comment(parent_issue, open_children)
+        return  # DO NOT CLOSE
+    
+# Step 2: Verify PR merge
+pr = github_pull_request_read(method="get", pullNumber=pr_number)
+if not pr.get("merged_at"):
+    return  # DO NOT CLOSE - PR not merged
+
+# Steps 3-5: Proceed with closure only after all checks pass
+close_issue_with_summary(parent_issue)
+```
 
 ### Correct Workflow
 
@@ -866,6 +898,7 @@ Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
 - Premature parent closure loses visibility into remaining work
 - Stakeholders need to see open issues for incomplete work
 - GitHub sub-issue view shows which children remain
+- **The MANDATORY sub-issue query prevents violations**
 
 ### Sub-Issue Double-Check (MANDATORY)
 

--- a/.opencode/guidelines/124-github-archive-workflow.md
+++ b/.opencode/guidelines/124-github-archive-workflow.md
@@ -48,6 +48,44 @@ Archive a spec **immediately** after the final phase is approved and the PR is m
 
 **Before closing ANY issue, the agent MUST call `github_pull_request_read method=get` to verify the PR is merged.**
 
+**MANDATORY Pre-Close Checklist (NO EXCEPTIONS):**
+
+Before closing ANY issue (parent OR child), the agent MUST complete this checklist in order:
+
+| Step | Action | MUST Result |
+|------|--------|-------------|
+| **1** | Query sub-issues: `github_issue_read(method="get_sub_issues", issue_number=N)` | `[]` empty or verified all closed |
+| **2** | Verify PR merge state: `github_pull_request_read(method="get", pullNumber=PR)` | `merged_at` field exists |
+| **3** | Close child issues | Only children addressed by merged PR |
+| **4** | Re-query parent sub-issues | Verify all children now closed |
+| **5** | Close parent | Only if ALL children closed |
+
+**⚠️ CRITICAL: Step 1 is MANDATORY before closing ANY issue - parent or child.**
+
+```python
+# MANDATORY: Before closing ANY issue
+def before_close_issue(issue_number: int, pr_number: int):
+    # Step 1: Query sub-issues (MANDATORY for ALL issues)
+    children = github_issue_read(method="get_sub_issues", issue_number=issue_number)
+    
+    if children:
+        # Parent with sub-issues - must verify all children closed
+        open_children = [c for c in children if c.state == "open"]
+        if open_children:
+            # BLOCK: Cannot close parent with open children
+            post_warning_comment(issue_number, open_children)
+            return  # DO NOT CLOSE
+    
+    # Step 2: Verify PR merge
+    pr = github_pull_request_read(method="get", pullNumber=pr_number)
+    if not pr.get("merged_at"):
+        report = f"PR #{pr_number} is not yet merged. Cannot close issue."
+        return  # DO NOT CLOSE
+    
+    # Step 3-5: Proceed with closure
+    close_issue_with_summary(issue_number)
+```
+
 **Why `git pull` is insufficient:**
 - Local fast-forward shows `git pull` succeeded
 - Does NOT verify the PR merge state in GitHub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Sub-issue Verification Before Parent Closure**: Added mandatory pre-close checklist requiring all agents to call `get_sub_issues` before closing any issue (parent or child). This prevents violations where parent issues were closed while children remained open. The checklist includes: (1) Query sub-issues first, (2) Verify PR merge state via GitHub API, (3) Close children only after PR merge confirmed, (4) Re-query before closing parent. Step 1 is now a MUST requirement with explicit code flow and MUST Result columns in checklists.
+
 ### Changed
 - **Auto-Issue Creation for Workflow Violations**: When AI agents bypass critical workflow steps like review-prep or PR creation, the system now automatically creates GitHub issues to track the violations. This creates accountability for workflow compliance and enables systematic improvement of guidelines.
 - **Post-Implementation Pattern Enforcement**: A new post-implementation task in the implementation-quality skill now ensures review-prep is invoked after every implementation. This mandatory gate prevents workflow bypass and ensures all code changes are properly reviewed before PR creation.


### PR DESCRIPTION
## Summary

Added mandatory sub-issue verification step before closing ANY issue (parent or child). This prevents the violation where parent #233 was closed while children #236 and #237 remained open by requiring a 5-step MUST checklist with explicit API calls.

## Changes

### Fixed
- **Sub-issue Verification Before Parent Closure**: Added mandatory pre-close checklist requiring all agents to call `get_sub_issues` before closing any issue (parent or child). This prevents violations where parent issues were closed while children remained open. The checklist includes: (1) Query sub-issues first, (2) Verify PR merge state via GitHub API, (3) Close children only after PR merge confirmed, (4) Re-query before closing parent. Step 1 is now a MUST requirement with explicit code flow and MUST Result columns in checklists.

### Files Modified
- `.opencode/guidelines/124-github-archive-workflow.md` - Added mandatory pre-close checklist in "Issue Closure Timing" section
- `.opencode/guidelines/000-critical-rules.md` - Added explicit Step 1 requirement in "Parent/Child Issue Closure" section
- Both files now include verification flowcharts and MUST Result columns in checklists

## Technical Details

Added two enforcement points:
1. **124-github-archive-workflow.md**: MANDATORY Pre-Close Checklist with 5 steps, where Step 1 is MUST call `github_issue_read(method="get_sub_issues")`
2. **000-critical-rules.md**: Same checklist with code example showing the mandatory query before any closure

Both files now explicitly state:
- Step 1 is MANDATORY before closing ANY issue (parent OR child)
- Query MUST return empty array or all children closed before proceeding
- Code examples show the exact API call requirement
- MUST Result columns make verification explicit

Fixes #250