### PR TITLE
feat(guidelines): eliminate unauthorized question asking during implementation

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -202,6 +202,53 @@ This repository was created with assistance from AI:
 
 **See `.opencode/guidelines/080-code-standards.md` for complete attribution requirements.**
 
+## Critical Violation: Unauthorized Question Asking
+
+**⚠️ Asking questions during implementation is a CRITICAL GUIDELINE VIOLATION.**
+
+### 🚫 FORBIDDEN Question Patterns
+
+The agent must NEVER ask questions like:
+- "What would you prefer I focus on first?"
+- "Should I continue?"
+- "Ready for PR?"
+- "What should I do next?"
+- "How would you like me to proceed?"
+- "Ready when you are"
+
+**These questions violate the silent HALT protocol:**
+- `000-critical-rules.md`: HALT protocol requires SILENT halt, not questions
+- `010-approval-gate.md`: No authorization prompts after task completion
+- `050-scope-autonomy.md`: Questions are NOT authorization
+- `125-github-issue-comments.md`: No "awaiting authorization" or dialog prompts
+
+### ✅ REQUIRED Behavior
+
+| Situation | Action |
+|-----------|--------|
+| Task complete but more work remains | Continue implementation autonomously |
+| Task complete and no more work | HALT silently, post progress comment |
+| Blocked by genuine ambiguity | Post comment to issue asking for clarification, then HALT |
+| Error encountered | Post error details to issue, then HALT |
+| Waiting for authorization | HALT silently, wait for explicit "approved" or "go" |
+
+### Edge Cases
+
+| Edge Case | Action |
+|-----------|--------|
+| Genuine ambiguity about requirements | Post comment to issue explaining ambiguity, ask for clarification, then HALT |
+| Blocked by external factor | Post comment explaining blocker, then HALT |
+| Error encountered | Post error details to issue, then HALT |
+| Multiple tasks remaining | Continue with next task (if authorized for all phases) |
+
+**Why This Matters:**
+- Questions break the non-interactive, autonomous execution model
+- Questions create friction and require user intervention
+- Questions signal confusion about task completion
+- Questions during implementation are NEVER appropriate
+
+---
+
 ## Critical Violation: Missing Progress Comments
 
 **⚠️ Failing to post progress comments to the associated issue is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/050-scope-autonomy.md
+++ b/.opencode/guidelines/050-scope-autonomy.md
@@ -35,6 +35,49 @@ Agent is strictly an execution tool. All architectural/design decisions are the 
 - **Questions are NOT authorization to make changes.** A question like "should I do X?" or "would you like me to X?" is seeking permission, not receiving it. Answer questions directly without making code changes. Wait for explicit approval before acting.
 - Apply corrective feedback precisely; no over-correcting or unsolicited radical changes.
 
+### 🚫 CRITICAL: Unauthorized Question Asking (ZERO TOLERANCE)
+
+**CRITICAL VIOLATION: Asking questions during implementation is PROHIBITED.**
+
+The agent must NEVER ask questions like:
+- "What would you prefer I focus on first?"
+- "Should I continue?"
+- "Ready for PR?"
+- "What should I do next?"
+- "How would you like me to proceed?"
+- "Ready when you are"
+
+**These questions violate the silent HALT protocol:**
+- `000-critical-rules.md`: HALT protocol requires SILENT halt, not questions
+- `010-approval-gate.md`: No authorization prompts after task completion
+- `050-scope-autonomy.md`: Questions are NOT authorization
+- `125-github-issue-comments.md`: No "awaiting authorization" or dialog prompts
+
+### ✅ REQUIRED Behavior
+
+| Situation | Action |
+|-----------|--------|
+| Task complete but more work remains | Continue implementation autonomously |
+| Task complete and no more work | HALT silently, post progress comment |
+| Blocked by genuine ambiguity | Post comment to issue asking for clarification, then HALT |
+| Error encountered | Post error details to issue, then HALT |
+| Waiting for authorization | HALT silently, wait for explicit "approved" or "go" |
+
+### Edge Cases
+
+| Edge Case | Action |
+|-----------|--------|
+| Genuine ambiguity about requirements | Post comment to issue explaining ambiguity, ask for clarification, then HALT |
+| Blocked by external factor | Post comment explaining blocker, then HALT |
+| Error encountered | Post error details to issue, then HALT |
+| Multiple tasks remaining | Continue with next task (if authorized for all phases) |
+
+**Why This Matters:**
+- Questions break the non-interactive, autonomous execution model
+- Questions create friction and require user intervention
+- Questions signal confusion about task completion
+- Questions during implementation are NEVER appropriate
+
 ## 5. Command Rejection Protocol
 
 - A "rejected by the user" terminal result signals a directive violation. Immediately halt, re-read guidelines, and assess whether guidelines need reinforcement.

--- a/.opencode/guidelines/120-github-issue-first.md
+++ b/.opencode/guidelines/120-github-issue-first.md
@@ -207,7 +207,8 @@ Users communicating via GitHub Issues are:
 3. **Conversational, not bureaucratic**:
    - Answer questions directly
    - State findings clearly
-   - Ask for authorization simply: "Ready when you are" or just ask the question
+   - HALT silently and wait for explicit authorization
+   - **NEVER** ask "Ready when you are?" or similar questions during implementation
    - **NEVER** use phrases like "Awaiting authorization to implement"
 
 ### Example
@@ -217,8 +218,10 @@ User asks in issue #203: "how do these keys seem?"
 
 BAD: "Awaiting authorization to implement."
 
-GOOD: "The keys look correct. Ready when you are."
+GOOD: "The keys look correct."
 ```
+
+**Note:** During implementation tasks, do NOT ask questions like "Ready when you are?" or "Should I continue?" - HALT silently and wait for explicit authorization.
 
 **⚠️ NEVER analyze issue comments silently without posting a response.**
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -293,6 +293,41 @@ When implementation halts (awaiting approval, awaiting clarification, error, ses
 | Analyzing code (read-only) | NO - investigation exempt |
 | Modifying `.opencode/guidelines/` | **YES - requires spec + approval** |
 
+## Critical Violation: Unauthorized Question Asking
+
+**⚠️ CRITICAL VIOLATION (Zero Tolerance): Asking questions during implementation is PROHIBITED.**
+
+The agent must NEVER ask questions like:
+- "What would you prefer I focus on first?"
+- "Should I continue?"
+- "Ready for PR?"
+- "What should I do next?"
+- "How would you like me to proceed?"
+- "Ready when you are"
+
+**These questions violate the silent HALT protocol:**
+- `000-critical-rules.md`: HALT protocol requires SILENT halt, not questions
+- `010-approval-gate.md`: No authorization prompts after task completion
+- `125-github-issue-comments.md`: No "awaiting authorization" or dialog prompts
+
+### Detection Checklist (verify-authorization task)
+
+**When verifying authorization, also check for question-asking behavior:**
+
+| Checklist Item | Detection Method |
+|----------------|------------------|
+| Task complete, more work? | Should continue implementation autonomously, NOT ask questions |
+| Task complete, no work? | Should HALT silently and post progress comment |
+| Blocked by ambiguity? | Should post issue comment asking for clarification, then HALT |
+| Waiting for auth? | Should HALT silently for explicit "approved" or "go" |
+| Multiple tasks remaining? | Should continue with next task if authorized for all phases |
+
+**If question-asking detected:**
+1. STOP immediately
+2. Report the violation
+3. HALT silently (do NOT ask questions)
+4. Wait for explicit authorization
+
 ## Git Workflow Sequence
 
 **After authorization, the git workflow is automatically triggered:**

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -234,3 +234,50 @@ When user provides explicit authorization, it **OVERRIDES** the needs-approval l
 
 - Guidelines: `010-approval-gate.md`
 - Related tasks: `verify-sub-issues`, `verify-codebase`
+
+## Critical: Question-Asking Detection (ZERO TOLERANCE)
+
+**CRITICAL VIOLATION: Asking questions during implementation is PROHIBITED.**
+
+### Detection Checklist
+
+**When verifying authorization, also check for question-asking behavior:**
+
+| Situation | Correct Behavior | Violation |
+|-----------|-----------------|-----------|
+| Task complete, more work? | Continue implementation autonomously | Asking "What should I do next?" |
+| Task complete, no work? | HALT silently, post progress comment | Asking "Should I continue?" |
+| Blocked by ambiguity? | Post issue comment asking for clarification, then HALT | Asking in chat instead of issue |
+| Waiting for auth? | HALT silently for explicit "approved" or "go" | Asking "Ready when you are" |
+| Multiple tasks remaining? | Continue with next task if authorized for all phases | Asking "What would you prefer?" |
+
+### Prohibited Question Patterns
+
+The agent must NEVER ask:
+- "What would you prefer I focus on first?"
+- "Should I continue?"
+- "Ready for PR?"
+- "What should I do next?"
+- "How would you like me to proceed?"
+- "Ready when you are"
+
+**These violate the silent HALT protocol defined in:**
+- `000-critical-rules.md`: HALT protocol requires SILENT halt, not questions
+- `010-approval-gate.md`: No authorization prompts after task completion
+- `125-github-issue-comments.md`: No "awaiting authorization" or dialog prompts
+
+### Detection Procedure
+
+```python
+# During authorization verification, check for question-asking behavior
+if question_asking_detected:
+    # STOP immediately
+    # Report the violation
+    # HALT silently (do NOT ask questions)
+    # Wait for explicit authorization from user
+```
+
+**If detected during verification:**
+1. STOP immediately
+2. Report violation on issue (not in chat)
+3. HALT silently for explicit authorization

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -217,6 +217,7 @@ Per `085-engineering-approach.md`:
 - **VERIFICATION-GAP**: Success criteria untestable, vague, or missing acceptance criteria.
 - **DEPENDENCY-INCOMPLETE**: Dependencies lack specific integration points or migration guides.
 - **COMMENT-FORMAT-VIOLATION**: Wrong comment format (wrong emoji, missing Summary/Outcome sections).
+- **QUESTION-ASKING-VIOLATION**: Spec contains agent question patterns that violate silent HALT protocol (asking for preferences, continuation, PR readiness, etc.).
 
 ### Scope/Semantic Classes
 


### PR DESCRIPTION
## Summary

Enforces the silent HALT protocol and eliminates agent asking unauthorized questions ("what would you prefer?", "should I continue?", "ready for PR?", etc.) during implementation tasks. These questions violate the non-interactive, autonomous execution model and break the approval gate workflow.

## Changes

1. **`000-critical-rules.md`**: Added new "Critical Violation: Unauthorized Question Asking" section with zero-tolerance rules and detection heuristics
2. **`050-scope-autonomy.md`**: Added explicit prohibition section with required behavior table
3. **`approval-gate/SKILL.md`**: Added violation detection checklist with detection procedure
4. **`approval-gate/tasks/verify-authorization.md`**: Added question-asking detection section with prohibited patterns and correct behavior
5. **`spec-auditor/SKILL.md`**: Added `QUESTION-ASKING-VIOLATION` content quality class
6. **`120-github-issue-first.md`**: Fixed violation where "Ready when you are" was incorrectly shown as acceptable

## Why

During git workflow implementation (Phase 6), the agent asked "What would you prefer I focus on first?" instead of continuing autonomously or halting silently. This violated the HALT protocol defined in multiple guidelines.

## Edge Cases

- Genuine ambiguity: Post clarification question to issue, then HALT
- Blocked by external factor: Post blocker comment, then HALT
- Error encountered: Post error details, then HALT

Fixes #261
Fixes #263
Fixes #264