### PR TITLE
[SPEC] Fix missing YAML frontmatter in git-workflow and github-comments skills

### DIFF
--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -1,4 +1,9 @@
 ---
+name: git-workflow
+description: Git Workflow Enforcer ensuring all git operations follow the repository's strict branch-first, stash-first, squash-merge workflow. Invoked automatically before implementation and when PR creation is requested.
+license: MIT
+compatibility: opencode
+---
 
 # Skill: git-workflow
 

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -1,8 +1,11 @@
-______________________________________________________________________
+---
+name: github-comments
+description: GitHub comment format and protocol for AI agents. Defines AI identity attribution, lifecycle status indicators, comment types, progress comments, closure summaries, and when to comment vs edit issue bodies.
+license: MIT
+compatibility: opencode
+---
 
-## name: github-comments description: GitHub comment format and protocol for AI agents. Defines AI identity attribution, lifecycle status indicators, comment types, progress comments, closure summaries, and when to comment vs edit issue bodies. license: MIT compatibility: opencode
-
-# GitHub Comment Protocol
+# Skill: github-comments
 
 Ensures all comments on issues and PRs follow correct format, are posted at the right time, and preserve history.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Skill Discovery YAML Frontmatter**: Fixed missing and malformed YAML frontmatter in `git-workflow` and `github-comments` skills. Both skills now have proper YAML blocks with `name`, `description`, `license`, and `compatibility` fields, enabling correct skill discovery by the skill tool.
 - **Sub-issue Verification Before Parent Closure**: Added mandatory pre-close checklist requiring all agents to call `get_sub_issues` before closing any issue (parent or child). This prevents violations where parent issues were closed while children remained open. The checklist includes: (1) Query sub-issues first, (2) Verify PR merge state via GitHub API, (3) Close children only after PR merge confirmed, (4) Re-query before closing parent. Step 1 is now a MUST requirement with explicit code flow and MUST Result columns in checklists.
 
 ### Changed


### PR DESCRIPTION
## Summary

Fixed YAML frontmatter in git-workflow and github-comments skills to enable proper skill discovery.

## Changes

### Fixed
- **Skill Discovery YAML Frontmatter**: Fixed missing and malformed YAML frontmatter in `git-workflow` and `github-comments` skills. Both skills now have proper YAML blocks with `name`, `description`, `license`, and `compatibility` fields, enabling correct skill discovery by the skill tool.

Fixes #267