### PR TITLE
[SPEC] Revise spec-auditor skill for independent draft and codebase verification

### DIFF
--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -37,6 +37,9 @@ Post "ready for review" comment
 | Task | Purpose | Words |
 |------|---------|-------|
 | `overview` | Full skill content for spec content quality auditing | ~1800 |
+| `create-draft` | Generate independent temporary draft BEFORE viewing live spec | ~400 |
+| `audit` | Run full audit: fresh-start context, codebase verification, content quality | ~600 |
+| `verify-codebase` | Verify spec references match live codebase (files, modules, functions) | ~400 |
 
 ## Operating Protocol
 
@@ -167,6 +170,129 @@ Per `085-engineering-approach.md`:
 - All tests must pass before declaring complete
 - Documentation must be updated
 
+## Subtask Separation Requirement (CRITICAL)
+
+**⚠️ MANDATORY: Independent draft generation BEFORE viewing live spec.**
+
+### Why This Matters
+
+When auditors view the live spec first, their analysis is influenced by what they see. Spec drifts, missing elements, and conflicts may be missed because they become "normal" through exposure. Independent draft generation ensures fresh eyes.
+
+### Workflow Sequence
+
+| Step | Task | Purpose |
+|------|------|---------|
+| 1 | `create-draft` | Generate independent temporary draft WITHOUT viewing live spec |
+| 2 | `audit` | Load live spec, compare to draft, identify gaps and conflicts |
+| 3 | `verify-codebase` | Check spec references against live codebase |
+| 4 | Post audit log | Attach results to GitHub Issue |
+
+**CRITICAL: Step 1 MUST complete BEFORE Step 2 starts.**
+
+### Pollution Prevention
+
+The `create-draft` task runs in a subtask to prevent ANY access to the live spec:
+
+- Subtask has NO access to the live spec GitHub Issue body
+- Subtask works ONLY from the issue number and general knowledge
+- Draft is written to `./tmp/tmp-spec-{issue}-draft.md`
+- Live spec is loaded ONLY after draft is complete
+
+**This separation is MANDATORY and CANNOT be bypassed.**
+
+## Independent Draft Generation (CRITICAL)
+
+**The draft is NOT a format checklist. It's a prose-driven analysis.**
+
+### What the Draft Contains
+
+- **Expected Structure**: Prose description of what a good spec should include
+- **Fresh-Start Requirements**: Prose explanation of inline context requirements
+- **Six Core Areas**: Prose coverage of commands, testing, structure, style, git, boundaries
+- **Common Pitfalls**: Prose description of typical issues for this spec type
+- **Draft Checklist**: Checklist of essential elements (NOT static format checks)
+
+### What the Draft Does NOT Contain
+
+- Static format checks (e.g., "STATUS header must exist")
+- Boilerplate requirements (e.g., "Phases must be numbered")
+- Copy-paste checks from templates
+
+**The draft is a narrative that EXPLAINS what should be in the spec, not a checklist that ENFORCES formats.**
+
+## Codebase Verification (CRITICAL)
+
+**Specs MUST reference live codebase accurately. Obsolete references cause implementation failures.**
+
+### Why Codebase Verification Matters
+
+- Spec references a file that was deleted or moved → implementation fails
+- Spec references a function that was renamed → implementation fails
+- Spec references a module pattern that no longer exists → implementation fails
+- Spec references a dependency that was removed → implementation fails
+
+### Codebase Verification Process
+
+| Step | Action | Tool |
+|------|------|------|
+| 1 | Extract all file/function/module references from spec | Parse spec body |
+| 2 | Verify each file exists | `pycharm_find_files_by_glob` or `srclight_symbols_in_file` |
+| 3 | Verify each function exists | `srclight_get_symbol` |
+| 4 | Verify each module exists | `srclight_search_symbols` |
+| 5 | Identify obsolete references | Compare spec references to live codebase |
+| 6 | Identify missing context | Find codebase elements that SHOULD be referenced |
+
+### Tool Preference for Codebase Verification
+
+Per `016-srclight-preference.md`:
+
+| Task | Tool |
+|------|------|
+| Verify Python symbol exists | `srclight_get_symbol` |
+| Find Python symbols by name | `srclight_search_symbols` |
+| Find Python symbols by meaning | `srclight_semantic_search` |
+| Verify Python file exists | `srclight_symbols_in_file` |
+| Verify non-Python file exists | `pycharm_find_files_by_glob` |
+| Search text in files | `pycharm_search_in_files_by_text` |
+
+**Use srclight tools PREFERENTIALLY for Python code verification.**
+
+### New Problem Classes for Codebase Verification
+
+- **STALE-SPEC**: Spec references code that has changed, moved, or been removed.
+- **CONFLICTING-SPEC**: Spec contradicts current codebase architecture.
+- **SUPERSEDED-SPEC**: Another spec has already implemented this work.
+- **DUPLICATE-SPEC**: Multiple specs describe the same work.
+
+## Prose-Driven Analysis Requirement (CRITICAL)
+
+**Audits are prose-driven analysis, NOT static format enforcement.**
+
+### What This Means
+
+- **Analyze content quality through prose explanations**, NOT tick boxes
+- **Explain WHY something is problematic**, NOT just flag it
+- **Describe what SHOULD be there**, NOT just check if template matches
+- **Focus on LLM implementability**, NOT template compliance
+
+### Anti-Patterns (DO NOT)
+
+```markdown
+❌ WRONG: "STATUS: 1.2 header is missing. All specs must have STATUS header."
+
+✅ CORRECT: "A new LLM agent starting fresh has no way to know where this spec is in its workflow. 
+The STATUS field provides crucial context: the agent knows whether to start from Phase 1 or 
+continue from Phase 3. Without this, the agent might re-implement completed work or skip 
+required steps. The STATUS should be: `STATUS: 1.2` to indicate Phase 1, Step 2 is in progress."
+```
+
+### Why Prose-Driven Matters
+
+- **Focus on implementability**, NOT template compliance
+- **Explain reasoning**, NOT enforce rules
+- **Describe context gaps**, NOT check boxes
+- **Identify conflicts through understanding**, NOT pattern matching
+
 ## Content Quality Checks (CRITICAL)
 
 ### What This Auditor Checks
@@ -226,6 +352,13 @@ Per `085-engineering-approach.md`:
 - **SCOPE-CREEP-RISK**: Spec includes features or changes beyond the stated objective without explicit approval.
 - **SUPERSEDED-CLOSURE-VIOLATION**: Issue closing comment claims future action without execution, or references non-existent replacement.
 
+### Codebase Verification Classes
+
+- **STALE-SPEC**: Spec references code that has changed, moved, or been removed since spec creation.
+- **CONFLICTING-SPEC**: Spec contradicts current codebase architecture or patterns.
+- **SUPERSEDED-SPEC**: Another spec has already implemented this work (duplicate or conflicting).
+- **DUPLICATE-SPEC**: Multiple specs describe the same work (consolidate needed).
+
 ## Audit Checklist
 
 For each GitHub Issue `[SPEC]`, verify:
@@ -269,9 +402,18 @@ For each GitHub Issue `[SPEC]`, verify:
 
 ### Superseded Issue Closure (When Closing Issues)
 
-- \[ \] Closing comment does NOT claim future action without execution
-- \[ \] Replacement issue exists BEFORE old issue is closed
-- \[ \] No forward-looking language ("will be created", "to be done separately")
+- [ ] Closing comment does NOT claim future action without execution
+- [ ] Replacement issue exists BEFORE old issue is closed
+- [ ] No forward-looking language ("will be created", "to be done separately")
+
+### Codebase Verification (CRITICAL)
+
+- [ ] All referenced files exist at specified paths
+- [ ] All referenced functions/methods exist with matching signatures
+- [ ] All referenced modules/classes exist and are importable
+- [ ] Codebase patterns mentioned still exist (no obsolete references)
+- [ ] Dependencies mentioned still exist in project
+- [ ] No STALE-SPEC, CONFLICTING-SPEC, SUPERSEDED-SPEC, or DUPLICATE-SPEC issues
 
 ## Post-Fix Verification (Required)
 
@@ -279,6 +421,7 @@ After each fix is applied, the auditor MUST:
 
 1. **Re-read the modified spec** (via GitHub MCP tools) to verify the change was applied correctly.
 1. **Re-check compliance** for the specific requirement that was fixed — does the fix resolve the identified problem class?
+1. **Re-verify codebase references** (if applicable) using srclight/pycharm tools per `016-srclight-preference.md`.
 1. **Report verification** in the next response before moving to the next issue:
    - **Verification signal**: `changed` — the fix was applied and the issue is resolved.
    - **Verification signal**: `blocked` — the fix could not be applied (explain why).
@@ -371,6 +514,14 @@ GitHub Comment: <URL to comment>
 - Code Style: <PASS|FAIL|N/A>
 - Git Workflow: <PASS|FAIL|N/A>
 - Boundaries: <PASS|FAIL|N/A>
+
+## Codebase Verification Results
+- Files verified: <N/M> (<pass/fail count> / <total references>)
+- Functions verified: <N/M>
+- Modules verified: <N/M>
+- Stale references found: <list or "none">
+- Missing context: <list or "none">
+- Problem classes: <STALE-SPEC|CONFLICTING-SPEC|SUPERSEDED-SPEC|DUPLICATE-SPEC|none>
 ```
 
 **Requirements:**

--- a/.opencode/skills/spec-auditor/tasks/create-draft.md
+++ b/.opencode/skills/spec-auditor/tasks/create-draft.md
@@ -1,0 +1,87 @@
+# Task: create-draft
+
+Generate an independent temporary draft spec BEFORE viewing the live spec.
+
+## Purpose
+
+Prevent the existing live spec from influencing/biasing the auditor's independent analysis. This subtask separation ensures the auditor writes their draft fresh, without seeing the spec they're auditing.
+
+## Workflow
+
+**Step 1: Generate Independent Draft**
+
+Write a prose-driven analysis to `./tmp/tmp-spec-{issue}-draft.md` based ONLY on:
+- The issue number (for context)
+- Common spec template knowledge
+- General best practices
+
+**Step 2: DO NOT Load Live Spec**
+
+At this stage, you MUST NOT:
+- Read the GitHub Issue body
+- Read any spec content
+- View any related documentation
+- Check previous audit results
+
+**Step 3: Prose-Driven Analysis**
+
+The draft must use prose, not static format checks:
+- Explain what SHOULD be in a good spec for this issue type
+- Describe the expected structure for fresh-start context
+- List typical requirements for the six core areas
+- Identify common pitfalls for this spec type
+
+## Output
+
+Create `./tmp/tmp-spec-{issue}-draft.md` with:
+
+```markdown
+# Independent Draft: Spec Content Analysis
+
+Issue: #{issue_number}
+Generated: {timestamp}
+
+## Expected Structure (Prose Analysis)
+
+### What a Good Spec Should Include
+
+<prose description of expected content>
+
+### Fresh-Start Context Requirements
+
+<prose description of inline context requirements>
+
+### Six Core Areas Coverage
+
+<prose description of commands, testing, structure, style, git, boundaries>
+
+### Common Pitfalls for This Spec Type
+
+<prose description of typical issues>
+
+## Draft Checklist
+
+- [ ] Problem statement with context
+- [ ] Affected files with anchors
+- [ ] Related issues with summaries
+- [ ] Constraints documented
+- [ ] Assumptions stated
+- [ ] Success criteria testable
+- [ ] Edge cases identified
+- [ ] Dependencies specified
+- [ ] Risk assessment included
+- [ ] Decision rationale present
+```
+
+## Constraints
+
+- Use `./tmp/` directory for temporary draft (per `070-environment.md`)
+- Prose-driven analysis, NOT static format enforcement
+- DO NOT view the live spec at this stage
+- Cleanup required after audit completes
+
+## Return Value
+
+- Path to the generated draft file
+- Confirmation that draft was created without viewing live spec
+- Readiness to proceed to `audit` task

--- a/.opencode/skills/spec-auditor/tasks/overview.md
+++ b/.opencode/skills/spec-auditor/tasks/overview.md
@@ -156,6 +156,129 @@ Per `085-engineering-approach.md`:
 - All tests must pass before declaring complete
 - Documentation must be updated
 
+## Subtask Separation Requirement (CRITICAL)
+
+**⚠️ MANDATORY: Independent draft generation BEFORE viewing live spec.**
+
+### Why This Matters
+
+When auditors view the live spec first, their analysis is influenced by what they see. Spec drifts, missing elements, and conflicts may be missed because they become "normal" through exposure. Independent draft generation ensures fresh eyes.
+
+### Workflow Sequence
+
+| Step | Task | Purpose |
+|------|------|---------|
+| 1 | `create-draft` | Generate independent temporary draft WITHOUT viewing live spec |
+| 2 | `audit` | Load live spec, compare to draft, identify gaps and conflicts |
+| 3 | `verify-codebase` | Check spec references against live codebase |
+| 4 | Post audit log | Attach results to GitHub Issue |
+
+**CRITICAL: Step 1 MUST complete BEFORE Step 2 starts.**
+
+### Pollution Prevention
+
+The `create-draft` task runs in a subtask to prevent ANY access to the live spec:
+
+- Subtask has NO access to the live spec GitHub Issue body
+- Subtask works ONLY from the issue number and general knowledge
+- Draft is written to `./tmp/tmp-spec-{issue}-draft.md`
+- Live spec is loaded ONLY after draft is complete
+
+**This separation is MANDATORY and CANNOT be bypassed.**
+
+## Independent Draft Generation (CRITICAL)
+
+**The draft is NOT a format checklist. It's a prose-driven analysis.**
+
+### What the Draft Contains
+
+- **Expected Structure**: Prose description of what a good spec should include
+- **Fresh-Start Requirements**: Prose explanation of inline context requirements
+- **Six Core Areas**: Prose coverage of commands, testing, structure, style, git, boundaries
+- **Common Pitfalls**: Prose description of typical issues for this spec type
+- **Draft Checklist**: Checklist of essential elements (NOT static format checks)
+
+### What the Draft Does NOT Contain
+
+- Static format checks (e.g., "STATUS header must exist")
+- Boilerplate requirements (e.g., "Phases must be numbered")
+- Copy-paste checks from templates
+
+**The draft is a narrative that EXPLAINS what should be in the spec, not a checklist that ENFORCES formats.**
+
+## Codebase Verification (CRITICAL)
+
+**Specs MUST reference live codebase accurately. Obsolete references cause implementation failures.**
+
+### Why Codebase Verification Matters
+
+- Spec references a file that was deleted or moved → implementation fails
+- Spec references a function that was renamed → implementation fails
+- Spec references a module pattern that no longer exists → implementation fails
+- Spec references a dependency that was removed → implementation fails
+
+### Codebase Verification Process
+
+| Step | Action | Tool |
+|------|------|------|
+| 1 | Extract all file/function/module references from spec | Parse spec body |
+| 2 | Verify each file exists | `pycharm_find_files_by_glob` or `srclight_symbols_in_file` |
+| 3 | Verify each function exists | `srclight_get_symbol` |
+| 4 | Verify each module exists | `srclight_search_symbols` |
+| 5 | Identify obsolete references | Compare spec references to live codebase |
+| 6 | Identify missing context | Find codebase elements that SHOULD be referenced |
+
+### Tool Preference for Codebase Verification
+
+Per `016-srclight-preference.md`:
+
+| Task | Tool |
+|------|------|
+| Verify Python symbol exists | `srclight_get_symbol` |
+| Find Python symbols by name | `srclight_search_symbols` |
+| Find Python symbols by meaning | `srclight_semantic_search` |
+| Verify Python file exists | `srclight_symbols_in_file` |
+| Verify non-Python file exists | `pycharm_find_files_by_glob` |
+| Search text in files | `pycharm_search_in_files_by_text` |
+
+**Use srclight tools PREFERENTIALLY for Python code verification.**
+
+### New Problem Classes for Codebase Verification
+
+- **STALE-SPEC**: Spec references code that has changed, moved, or been removed.
+- **CONFLICTING-SPEC**: Spec contradicts current codebase architecture.
+- **SUPERSEDED-SPEC**: Another spec has already implemented this work.
+- **DUPLICATE-SPEC**: Multiple specs describe the same work.
+
+## Prose-Driven Analysis Requirement (CRITICAL)
+
+**Audits are prose-driven analysis, NOT static format enforcement.**
+
+### What This Means
+
+- **Analyze content quality through prose explanations**, NOT tick boxes
+- **Explain WHY something is problematic**, NOT just flag it
+- **Describe what SHOULD be there**, NOT just check if template matches
+- **Focus on LLM implementability**, NOT template compliance
+
+### Anti-Patterns (DO NOT)
+
+```markdown
+❌ WRONG: "STATUS: 1.2 header is missing. All specs must have STATUS header."
+
+✅ CORRECT: "A new LLM agent starting fresh has no way to know where this spec is in its workflow. 
+The STATUS field provides crucial context: the agent knows whether to start from Phase 1 or 
+continue from Phase 3. Without this, the agent might re-implement completed work or skip 
+required steps. The STATUS should be: `STATUS: 1.2` to indicate Phase 1, Step 2 is in progress."
+```
+
+### Why Prose-Driven Matters
+
+- **Focus on implementability**, NOT template compliance
+- **Explain reasoning**, NOT enforce rules
+- **Describe context gaps**, NOT check boxes
+- **Identify conflicts through understanding**, NOT pattern matching
+
 ## Content Quality Checks (CRITICAL)
 
 ### What This Auditor Checks
@@ -214,6 +337,13 @@ Per `085-engineering-approach.md`:
 - **SCOPE-CREEP-RISK**: Spec includes features or changes beyond the stated objective without explicit approval.
 - **SUPERSEDED-CLOSURE-VIOLATION**: Issue closing comment claims future action without execution, or references non-existent replacement.
 
+### Codebase Verification Classes
+
+- **STALE-SPEC**: Spec references code that has changed, moved, or been removed since spec creation.
+- **CONFLICTING-SPEC**: Spec contradicts current codebase architecture or patterns.
+- **SUPERSEDED-SPEC**: Another spec has already implemented this work (duplicate or conflicting).
+- **DUPLICATE-SPEC**: Multiple specs describe the same work (consolidate needed).
+
 ## Audit Checklist
 
 For each GitHub Issue `[SPEC]`, verify:
@@ -261,12 +391,22 @@ For each GitHub Issue `[SPEC]`, verify:
 - [ ] Replacement issue exists BEFORE old issue is closed
 - [ ] No forward-looking language ("will be created", "to be done separately")
 
+### Codebase Verification (CRITICAL)
+
+- [ ] All referenced files exist at specified paths
+- [ ] All referenced functions/methods exist with matching signatures
+- [ ] All referenced modules/classes exist and are importable
+- [ ] Codebase patterns mentioned still exist (no obsolete references)
+- [ ] Dependencies mentioned still exist in project
+- [ ] No STALE-SPEC, CONFLICTING-SPEC, SUPERSEDED-SPEC, or DUPLICATE-SPEC issues
+
 ## Post-Fix Verification (Required)
 
 After each fix is applied, the auditor MUST:
 
 1. **Re-read the modified spec** (via GitHub MCP tools) to verify the change was applied correctly.
 1. **Re-check compliance** for the specific requirement that was fixed — does the fix resolve the identified problem class?
+1. **Re-verify codebase references** (if applicable) using srclight/pycharm tools per `016-srclight-preference.md`.
 1. **Report verification** in the next response before moving to the next issue:
    - **Verification signal**: `changed` — the fix was applied and the issue is resolved.
    - **Verification signal**: `blocked` — the fix could not be applied (explain why).
@@ -359,6 +499,14 @@ GitHub Comment: <URL to comment>
 - Code Style: <PASS|FAIL|N/A>
 - Git Workflow: <PASS|FAIL|N/A>
 - Boundaries: <PASS|FAIL|N/A>
+
+## Codebase Verification Results
+- Files verified: <N/M> (<pass/fail count> / <total references>)
+- Functions verified: <N/M>
+- Modules verified: <N/M>
+- Stale references found: <list or "none">
+- Missing context: <list or "none">
+- Problem classes: <STALE-SPEC|CONFLICTING-SPEC|SUPERSEDED-SPEC|DUPLICATE-SPEC|none>
 ```
 
 **Requirements:**

--- a/.opencode/skills/spec-auditor/tasks/verify-codebase.md
+++ b/.opencode/skills/spec-auditor/tasks/verify-codebase.md
@@ -1,0 +1,150 @@
+# Task: verify-codebase
+
+Verify spec references match the live codebase.
+
+## Purpose
+
+Per `130-authority-source.md`, the current state of the filesystem (the code) is the only absolute source of truth. Specs must match reality. This task verifies that spec references to files, modules, functions, and classes actually exist in the codebase.
+
+## Workflow
+
+**Step 1: Extract References from Spec**
+
+Parse the spec for:
+- File paths: `src/module/file.py`
+- Function anchors: `process_data()`
+- Class anchors: `ClassName`
+- Section anchors: `"Section Name"` (less common, verify context)
+
+**Step 2: Verify File Existence**
+
+For each file path:
+```
+pycharm_find_files_by_glob(globPattern="**/file.py")
+pycharm_find_files_by_name_keyword(nameKeyword="file")
+```
+
+Report:
+- ✅ VERIFIED: File exists
+- ⚠️ PATH CHANGED: File exists at different location
+- ❌ MISSING: File not found
+
+**Step 3: Verify Symbol Existence**
+
+For each function/class anchor:
+```
+srclight_get_symbol(name="ClassName")
+srclight_search_symbols(query="function_name")
+```
+
+Report:
+- ✅ VERIFIED: Symbol exists
+- ❌ MISSING: Symbol not found
+- ⚠️ DEFINITION CHANGED: Symbol exists but signature changed
+
+**Step 4: Detect Staleness**
+
+Compare spec descriptions against current implementation:
+- Read referenced files via `pycharm_get_file_text_by_path`
+- Compare spec description to actual code behavior
+- Identify discrepancies between spec and implementation
+
+Report:
+- ✅ MATCHES: Description matches implementation
+- ⚠️ STALE: Description doesn't match current code
+- ❌ CONFLICT: Spec contradicts implementation
+
+**Step 5: Detect Obsolescence**
+
+Check for merged PRs that supersede open specs:
+```
+github_pull_request_read(method="get", pullNumber=N)
+github_list_pull_requests(state="merged")
+```
+
+Report:
+- ✅ ACTIVE: No merged PR addresses this topic
+- ⚠️ POTENTIALLY SUPERSEDED: Related merged PR found
+- ❌ SUPERSEDED: Merged PR directly addresses spec topic
+
+**Step 6: Detect Duplicates**
+
+Query open specs for overlapping objectives:
+```
+github_list_issues(state="open")
+github_search_issues(query="is:issue is:open [SPEC]")
+```
+
+Report:
+- ✅ UNIQUE: No overlap with other open specs
+- ⚠️ POTENTIAL OVERLAP: Similar topics found (review needed)
+- ❌ DUPLICATE: Multiple specs cover same ground
+
+## Verification Report Format
+
+```markdown
+# Codebase Verification Report
+
+Issue: #{issue_number}
+Generated: {timestamp}
+
+## File References
+
+| File | Status | Notes |
+|------|--------|-------|
+| path/to/file.py | ✅ VERIFIED | File exists at expected location |
+
+## Symbol References
+
+| Symbol | Type | Status | Notes |
+|--------|------|--------|-------|
+| ClassName | class | ✅ VERIFIED | Symbol exists |
+| process_data() | function | ❌ MISSING | Function removed |
+
+## Staleness Detection
+
+| Description | Status | Notes |
+|-------------|--------|-------|
+| "function returns X" | ⚠️ STALE | Now returns Y |
+
+## Conflicts
+
+| Requirement | Implementation | Status |
+|-------------|---------------|--------|
+| "Must validate input" | No validation code | ❌ CONFLICT |
+
+## Obsolescence
+
+| Related PR | Status | Notes |
+|------------|--------|-------|
+| #123 | ⚠️ POTENTIALLY SUPERSEDED | PR merged, may address topic |
+
+## Duplicates
+
+| Related Issue | Topic | Status |
+|---------------|-------|--------|
+| #456 | Same feature | ❌ DUPLICATE |
+
+## Summary
+
+- Files Verified: {count}
+- Files Missing: {count}
+- Symbols Verified: {count}
+- Symbols Missing: {count}
+- Stale References: {count}
+- Conflicts Found: {count}
+- Superseded Specs: {count}
+```
+
+## Constraints
+
+- Use srclight for Python symbol search (per `016-srclight-preference.md`)
+- Use pycharm for file operations and content reading
+- Use GitHub MCP for PR status checks
+- Report errors gracefully, continue with remaining verifications
+
+## Return Value
+
+- Verification report with all checked references
+- Count of verified/missing/stale/conflicting items
+- Recommendations for spec updates


### PR DESCRIPTION
## Summary

Revised the spec-auditor skill to generate independent temporary drafts BEFORE viewing live specs, directly inspect the live codebase to validate spec accuracy, and maintain prose-driven analysis instead of static format enforcement.

## Changes

**Added Critical Sections:**
- Subtask Separation Requirement (CRITICAL) - Independent draft generation BEFORE viewing live spec
- Independent Draft Generation (CRITICAL) - Prose-driven analysis, not static format enforcement
- Codebase Verification (CRITICAL) - Verify spec references against live codebase
- Prose-Driven Analysis Requirement (CRITICAL) - Focus on implementability, not template compliance

**New Tasks:**
- `create-draft` task - Generate independent temporary draft without viewing live spec
- `verify-codebase` task - Verify spec references match live codebase

**New Problem Classes:**
- STALE-SPEC - Spec references code that has changed, moved, or been removed
- CONFLICTING-SPEC - Spec contradicts current codebase architecture
- SUPERSEDED-SPEC - Another spec has already implemented this work
- DUPLICATE-SPEC - Multiple specs describe the same work

**Updated Components:**
- Available Tasks table with 4 tasks
- Problem Class Definitions section
- Audit Checklist with Codebase Verification section
- Audit Log format with Codebase Verification Results
- Post-Fix Verification to include codebase re-verification

Fixes #293
Fixes #294
Fixes #295
Fixes #296