### PR TITLE
fix(spec-auditor): add tool fallback protocol and clarify line number guidance

### DIFF
--- a/.opencode/skills/spec-auditor/tasks/create-draft.md
+++ b/.opencode/skills/spec-auditor/tasks/create-draft.md
@@ -71,6 +71,22 @@ Generated: {timestamp}
 - [ ] Dependencies specified
 - [ ] Risk assessment included
 - [ ] Decision rationale present
+
+## Architectural Reasoning Checklist
+
+- [ ] WHY explained: Does the spec explain why this approach was chosen?
+- [ ] Alternatives considered: Does the spec describe alternatives and why they were rejected?
+- [ ] Constraints documented: Are technical/resource/time constraints specified?
+- [ ] Risky dependencies identified: Are external/system dependencies called out with their risks?
+- [ ] Implementation details: Are affected functions, modules, and patterns specified?
+
+## Fresh-Start Context Checklist
+
+- [ ] No memory references: No "see above", "as discussed", "previous comment"
+- [ ] Stable anchors: File paths use function names or section headers (NOT line numbers)
+- [ ] Inline context: All necessary context restated in spec body
+- [ ] Cross-references complete: Issue links include summaries and relevance
+- [ ] Line numbers flagged: Any line number references flagged as FRESH-START-VIOLATION
 ```
 
 ## Constraints

--- a/.opencode/skills/spec-auditor/tasks/overview.md
+++ b/.opencode/skills/spec-auditor/tasks/overview.md
@@ -314,7 +314,7 @@ required steps. The STATUS should be: `STATUS: 1.2` to indicate Phase 1, Step 2 
 
 ### Fresh-Start Context Classes
 
-- **FRESH-START-VIOLATION**: Spec relies on memory context, chat history, or external references not included inline.
+- **FRESH-START-VIOLATION**: Spec relies on memory context, chat history, external references not included inline, or uses unstable anchors like line numbers `file.py:42` which break on every edit.
 - **CONTEXT-OVERFLOW**: Spec section is overly long or complex, risking truncation or dilution in LLM context.
 
 ### Structure Classes

--- a/.opencode/skills/spec-auditor/tasks/verify-codebase.md
+++ b/.opencode/skills/spec-auditor/tasks/verify-codebase.md
@@ -136,6 +136,26 @@ Generated: {timestamp}
 - Superseded Specs: {count}
 ```
 
+## Tool Fallback Protocol
+
+**Per `015-mcp-preference.md`:**
+1. Use **srclight tools** for Python symbol search (semantic analysis)
+2. If srclight unavailable, **fallback to pycharm tools** for symbol search
+3. Use **pycharm tools** for file operations and content reading (not srclight)
+4. Use **GitHub MCP** for PR status checks
+
+**Fallback Chain:**
+```
+srclight_get_symbol/srclight_search_symbols
+    ↓ (unavailable)
+pycharm_get_symbol_info/pycharm_search_in_files_by_text
+```
+
+**File operations ALWAYS use pycharm:**
+- File existence: `pycharm_find_files_by_glob`
+- File reading: `pycharm_get_file_text_by_path`
+- Content search: `pycharm_search_in_files_by_text`
+
 ## Constraints
 
 - Use srclight for Python symbol search (per `016-srclight-preference.md`)


### PR DESCRIPTION
## Summary

Cherry-picks additional changes from commit 2683386 that were not included in PR #298.

**Changes:**
- Added tool fallback protocol to `verify-codebase.md` task
  - Primary: srclight for Python symbol search
  - Fallback: pycharm tools when srclight unavailable
  - Always use pycharm for file operations
- Clarified line number guidance in `overview.md`
  - Line numbers `file.py:42` are unstable anchors (break on every edit)
  - Prefer stable anchors: function names, section headers

**Why this wasn't in PR #298:**
The original PR was merged before these additional edits were made. This PR captures the missing changes that complete the spec-auditor revision.

## Checklist
- [x] Changes align with Issue #300
- [x] Co-author trailers included
- [x] Branch targets `dev`

Fixes #300