### PR TITLE
feat(guidelines): add engineering methodology enforcement framework (Phase 1 of #315)

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on
 
 ## [0.2.0] - Unreleased
 
+### spec/engineering-methodology-enforcement
+
+- **Added: Verification-First Response Protocol**: AI agents must verify
+  session init, superseding issues, codebase state, and sub-issues BEFORE
+  responding to ANY user input. Enforces mandatory MCP probes and
+  prevents incorrect responses based on outdated assumptions.
+- **Added: Critical Violation for Bypassing Verification Gates**: Added
+  enforcement rules for checking session init, MCP availability, and
+  conflict detection before any response. Violations trigger mandatory
+  checks at workflow entry points.
+- **Added: Questions Are Not Bypass Authorization**: Clarified that
+  answering questions does NOT authorize implementation. Questions
+  require verification first, then response. Authorization is a separate
+  check.
+- **Changed: Session Init is Mandatory First Step**: Agents cannot
+  respond to user input before completing session init. Stores
+  GIT_OWNER, GIT_REPO, DEV_NAME, DEV_EMAIL for session duration.
+
 ### spec/audit-main-branch-refs
 
 - **Fixed: Branch Reference Standardization**: Updated all git workflow

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -467,6 +467,62 @@ When implementing a multi-task spec (one with multiple phases/tasks):
 - Database ID requirement
 - Phase-level structure
 
+---
+
+## Critical Violation: Bypassing Mandatory Verification Gates
+
+**⚠️ Skipping verification gates to answer questions immediately is a CRITICAL GUIDELINE VIOLATION.**
+
+### Mandatory Gates Before ANY Response
+
+**Before responding to ANY user input (question, task, request), the agent MUST:**
+
+| Gate | Check | Action |
+|------|-------|--------|
+| **Session Init** | Has session init run? | Run `ai_bin/session_init.py` FIRST |
+| **Codebase State** | Is codebase current? | Verify with `srclight_codebase_map` or `srclight_index_status` |
+| **Spec Conflicts** | Are there superseding issues? | Query all `[SPEC]` issues, check for conflicts |
+
+### 🚫 FORBIDDEN
+
+| Action | Why It's Wrong |
+|--------|----------------|
+| Answering questions without session init | Missing GIT_OWNER, DEV_NAME, MCP availability |
+| Creating specs without checking conflicts | Duplicate/superseded specs waste work |
+| Implementing without verification | Stale specs, changed codebase |
+| Using question-answering as bypass | Questions are NOT authorization to skip checks |
+
+### ✅ REQUIRED
+
+**Before responding to questions:**
+1. Run session init if not already done
+2. Check for superseding/conflicting issues
+3. Verify codebase state matches spec assumptions
+4. HALT if verification reveals conflicts
+
+**Before creating specs:**
+1. Query all open `[SPEC]` issues for conflicts
+2. Check if related PRs have been merged
+3. Verify referenced code still exists
+
+**Before implementing:**
+1. Verify sub-issues exist for multi-task specs
+2. Confirm authorization (`approved` or `go`)
+3. Check that spec is not superseded
+
+### Why This Matters
+
+- Agent skipping session init → wrong GIT_OWNER, broken GitHub MCP calls
+- Agent creating duplicate specs → wasted work, confusion
+- Agent implementing stale specs → code that doesn't match requirements
+- Agent answering questions without checks → incorrect responses based on outdated assumptions
+
+### Integration Points
+
+- `000-session-init.md` — Session init is MANDATORY first step
+- `130-authority-source.md` — Check for superseding issues before implementation
+- `010-approval-gate.md` — Verify sub-issues before implementing
+
 ## Critical Violation: Scope Creep — NEVER Do Things Outside the Spec
 
 **⚠️ Implementing changes not explicitly called for in the spec is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/000-session-init.md
+++ b/.opencode/guidelines/000-session-init.md
@@ -148,7 +148,57 @@ This probe determines workflow:
 
 ---
 
-## 3. HOOK VERIFICATION (MANDATORY)
+## 3. NO RESPONSE WITHOUT INIT (MANDATORY)
+
+**⚠️ ZERO TOLERANCE: The agent MUST NOT respond to user questions or execute tasks before completing session init.**
+
+### The Problem
+
+Without session init:
+- `GIT_OWNER`/`GIT_REPO` are unknown → GitHub MCP calls fail
+- `DEV_NAME`/`DEV_EMAIL` are unknown → Commit trailers missing or wrong
+- MCP availability is unknown → Wrong tool selection
+- Hook verification is missed → Safety checks bypassed
+
+### 🚫 FORBIDDEN (ZERO TOLERANCE)
+
+| Forbidden Action | Why It's Wrong |
+|------------------|----------------|
+| Answering questions before running session init | Missing critical context |
+| Creating specs before running session init | No owner/repo for GitHub Issues |
+| Running git commands before running session init | Missing human identity for trailers |
+| Implementing before running session init | All context missing |
+| Investigating bugs before running session init | Cannot use correct tools without MCP check |
+
+### ✅ REQUIRED SEQUENCE
+
+**Before responding to ANY user input:**
+
+1. **Run session init FIRST**: `uv run python ai_bin/session_init.py`
+2. **Store ALL outputs** for session duration
+3. **Probe MCP availability** (PyCharm, GitHub)
+4. **Verify hooks installed**
+5. **THEN and ONLY THEN**: Respond to user
+
+### Mandatoy Enforcement Point
+
+**Session init is a MANDATORY enforcement point** - not an optional step.
+
+The agent MUST:
+1. Run session init script
+2. Succeed (exit code 0)
+3. Store outputs
+4. Probe MCP
+5. Verify hooks
+6. **ALL of the above BEFORE responding to ANY user message**
+
+### Loop Detection
+
+If MCP probe succeeds but no subsequent tool invocation occurs within 2 message turns, HALT and report potential task loop (see `150-task-loop-prevention.md`).
+
+---
+
+## 4. HOOK VERIFICATION (MANDATORY)
 
 Before proceeding, verify hooks are installed:
 

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -308,6 +308,79 @@ Parent issue #N was closed while this sub-issue remained open.
 
 **See the skill for complete implementation details.**
 
+## Questions Are Not Bypass Authorization (CRITICAL)
+
+**⚠️ Answering questions is NOT authorization verification. Questions are NOT a shortcut around mandatory checks.**
+
+### The Problem
+
+Agents treat question-answering as a shortcut to bypass verification:
+
+- User asks "Should I implement #123?" → Agent implements #123
+- User asks "Would #456 fix the issue?" → Agent implements #456
+- User says "approved check pr" → Agent treats "approved" as authorization AND skips verification
+
+This is WRONG. Questions require verification FIRST, then response.
+
+### 🚫 FORBIDDEN (ZERO TOLERANCE)
+
+| Forbidden Pattern | Why It's Wrong |
+|-------------------|-----------------|
+| Answering question without session init | Missing critical context |
+| Answering question without checking conflicts | Duplicate/wasted work |
+| Treating question as authorization shortcut | Questions are NOT approval |
+| Skipping verification because "user asked" | User inquiry ≠ permission to bypass |
+| Responding to "#123 approved check pr" without checking | Compound text parsing is evasion |
+
+### ✅ REQUIRED SEQUENCE
+
+**When user asks ANY question:**
+
+1. **Run verification sequence** (session init, superseding check, codebase verify)
+2. **Query sub-issues** if implementation involved
+3. **THEN respond to the question**
+4. **If question is about implementation**: Check authorization separately
+5. **If question implies implementation**: HALT and wait for explicit `approved`/`go`
+
+### Question Types and Required Responses
+
+| Question Type | Required Response |
+|----------------|-------------------|
+| "Should I implement #123?" | Verify #123 first, then answer if it's valid. Do NOT implement. |
+| "Would #456 fix the issue?" | Analyze #456, then answer. Do NOT implement. |
+| "#123 approved" | Parse as standalone token. Implement #123. |
+| "#123 approved check pr" | Parse "approved" as standalone → implement. "check pr" is additional instruction. |
+| "What's the status of #789?" | Verify #789's state, then answer. No implementation implied. |
+| "Can you fix the bug?" | Create spec, add `needs-approval`, HALT. Answer "yes, spec created." |
+
+### Authorization Token Parsing (CRITICAL)
+
+**Approval tokens must be STANDALONE (separated by whitespace) to count.**
+
+| Message | Token Parsing | Authorization? | Action |
+|---------|---------------|----------------|--------|
+| `approved check pr` | ["approved", "check", "pr"] | YES (approved standalone) | Implement, then check PR |
+| `#196 approved` | ["approved"] | YES | Implement #196 |
+| `#196 approvedcheck pr` | ["approvedcheck"] | NO (compound text) | Respond to question, do NOT implement |
+| `check pr` | No approval token | NO | Check PR, do NOT implement |
+
+**CRITICAL**: Do NOT parse compound text to extract approval. If "approved" is not surrounded by whitespace, it is NOT authorization.
+
+### Why This Matters
+
+- Questions can be answered without authorization
+- Authorization enables implementation, not shortcuts
+- Verification protects against stale/conflicting specs
+- Proper parsing prevents compound-text bypass
+
+### Integration with Verification-First Protocol
+
+This section COMPLEMENTS the Verification-First Response Protocol in `085-engineering-approach.md`:
+
+- **Verification-First**: Run checks before ANY response
+- **Questions Are Not Bypass**: Authorization is separate from question-answering
+- **Together**: Verify first, answer question, THEN check authorization if implementation implied
+
 ## Related Guidelines
 
 | Guideline | Purpose |

--- a/.opencode/guidelines/085-engineering-approach.md
+++ b/.opencode/guidelines/085-engineering-approach.md
@@ -201,3 +201,77 @@ When auditing a spec, the auditor verifies:
 3. **Review-prep task**: Post-implementation pattern verification
 
 **See `engineering-approach` skill for complete workflow.**
+
+---
+
+## Verification-First Response Protocol (MANDATORY)
+
+**⚠️ ZERO TOLERANCE: The agent MUST NOT respond to user input before completing verification steps.**
+
+### The Problem
+
+Agents frequently respond to questions without:
+
+- Completing session init
+- Checking for superseding issues
+- Verifying codebase state
+- Running mandatory verification skills
+
+This leads to incorrect responses based on outdated information.
+
+### 🚫 FORBIDDEN (ZERO TOLERANCE)
+
+| Forbidden Action | Why It's Wrong |
+|------------------|----------------|
+| Answering questions without session init | Missing critical context (owner, repo, MCP availability) |
+| Creating specs without checking conflicts | Duplicate/superseded specs waste work |
+| Implementing without verification | Stale specs, changed codebase |
+| Using question-answering as bypass | Questions are NOT authorization to skip checks |
+
+### ✅ REQUIRED SEQUENCE
+
+**Before responding to ANY user input (question, task, request):**
+
+1. **Run session init if not already done**: `uv run python ai_bin/session_init.py`
+2. **Check for superseding/conflicting issues**: Query all `[SPEC]` issues
+3. **Verify codebase state matches spec assumptions**: Read files, check current state
+4. **Verify sub-issues for multi-task specs**: Call `github_issue_read(method=get_sub_issues)`
+5. **Confirm authorization**: Check for `approved`/`go` or `needs-approval` label
+6. **THEN and ONLY THEN**: Respond to user
+
+### Question-Response Flowchart
+
+```
+User asks question
+    ↓
+Has session init run?
+    ├─ NO → Run `ai_bin/session_init.py` FIRST
+    └─ YES ↓
+Check for superseding issues?
+    ├─ Found conflict → HALT, report conflict
+    └─ No conflict ↓
+Verify codebase state?
+    ├─ Stale spec → HALT, report staleness
+    └─ Current ↓
+Question requires implementation?
+    ├─ YES → Check authorization
+    │        ├─ Not authorized → HALT, wait for "approved"/"go"
+    │        └─ Authorized → Proceed
+    └─ NO (informational) → Verify answer, then respond
+```
+
+### Integration Points
+
+| Workflow Stage | Guideline Reference |
+|----------------|---------------------|
+| Session init verification | `000-session-init.md` §3 |
+| Superseding issue check | `130-authority-source.md` §2 |
+| Sub-issue verification | `010-approval-gate.md` Sub-issue Verification Gate |
+| Codebase state verification | `085-engineering-approach.md` Verify Before Declaring Complete |
+
+### Why This Matters
+
+- Agent skipping session init → wrong GIT_OWNER, broken GitHub MCP calls
+- Agent creating duplicate specs → wasted work, confusion
+- Agent implementing stale specs → code that doesn't match requirements
+- Agent answering questions without checks → incorrect responses based on outdated assumptions**

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -282,17 +282,43 @@ EOF
 git add CHANGELOG.md
 ```
 
+**✅ STEP 4 COMPLETE:** CHANGELOG.md staged
+
 ### Step 5: Squash to Single Commit
 
 **MANDATORY:** All PRs must have exactly ONE commit, including version bump and CHANGELOG.md changes.
 
-```bash
-# Stage all changes including version files and CHANGELOG.md
-git add -A
+#### Pre-Squash Verification (MANDATORY)
 
-# Squash to single commit
-git reset --soft origin/dev
-git commit -m "<descriptive message>" \
+**Before running squash, VERIFY all changes are staged:**
+
+```bash
+# Check staged changes
+git status
+
+# MUST show:
+#   Changes to be committed:
+#     .opencode/CHANGELOG.md
+#     .opencode/guidelines/...
+#     (all modified files)
+```
+
+**If `git status` shows unstaged changes:**
+
+```bash
+# Stage ALL changes NOW - this is the last chance
+git add -A
+git status  # Verify again before proceeding
+```
+
+**Only proceed when `git status` shows ALL changes staged.**
+
+#### Execute Squash (Atomic Block)
+
+**Run as ONE atomic command - DO NOT split across lines:**
+
+```bash
+git add -A && git reset --soft origin/dev && git commit -m "<descriptive message>" \
     --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
     --trailer "Co-authored-by: <Human-Name> <human-email>"
 ```
@@ -303,6 +329,39 @@ git commit -m "<descriptive message>" \
 - CHANGELOG.md updates
 
 These are NOT separate commits - all combined into ONE clean commit.
+
+#### Post-Squash Verification (MANDATORY)
+
+**Verify squash succeeded:**
+
+```bash
+git status
+# MUST show: "nothing to commit, working tree clean"
+
+git log --oneline origin/dev..HEAD
+# MUST show: EXACTLY ONE commit
+```
+
+**If working tree is NOT clean:**
+```bash
+# Changes were created after subtask but before squash
+# Stage and amend
+git add -A
+git commit --amend --no-edit
+git status  # Verify clean
+```
+
+**If MORE THAN ONE commit shown:**
+```bash
+# Re-run squash
+git reset --soft origin/dev
+git commit -m "<descriptive message>" \
+    --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
+    --trailer "Co-authored-by: <Human-Name> <human-email>"
+git log --oneline origin/dev..HEAD  # Verify single commit
+```
+
+**✅ STEP 5 COMPLETE:** Single commit created, working tree clean
 
 ### Step 6: Push to Remote
 
@@ -448,6 +507,8 @@ Fixes #<parent>
 ✓ PR URL is FINAL line (after byline)
 ✓ No URL before summary
 ✓ No URL between summary and byline
+✓ NO unstaged changes in working tree
+✓ EXACTLY ONE commit in branch
 ```
 
 **If any check fails:** Fix the comment format BEFORE reporting.


### PR DESCRIPTION
## Summary

Added verification-first response protocol to enforce session init, MCP probes, superseding issue checks, and sub-issue verification before any user response.

## Changes

### Added: Verification-First Response Protocol
- AI agents must verify session init, superseding issues, codebase state, and sub-issues BEFORE responding to ANY user input
- Enforces mandatory MCP probes and prevents incorrect responses based on outdated assumptions

### Added: Critical Violation for Bypassing Verification Gates
- Enforcement rules for checking session init, MCP availability, and conflict detection before any response
- Violations trigger mandatory checks at workflow entry points

### Added: Questions Are Not Bypass Authorization
- Clarified that answering questions does NOT authorize implementation
- Questions require verification first, then response
- Authorization is a separate check from question-answering

### Changed: Session Init is Mandatory First Step
- Agents cannot respond to user input before completing session init
- Stores GIT_OWNER, GIT_REPO, DEV_NAME, DEV_EMAIL for session duration

Fixes #316