### PR TITLE
[SPEC] Fix mandatory audit chain and PR verification gates

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on
 
 ## [0.2.0] - Unreleased
 
+### skill/audit-chain-clean-room
+
+- **Fixed: Clean-Room Draft Generation as First Auditor**: Corrected the
+  mandatory audit chain to include clean-room draft generation as the
+  FIRST step. The spec-auditor now has a `generate-independent-spec` task
+  that creates a complete, implementable spec draft WITHOUT viewing the
+  live spec. This prevents pollution where the agent's view of existing
+  content influences its draft. The audit chain now runs in this order:
+  1) clean-room draft generation, 2) concern-separation audit (phase
+  structure), 3) spec-audit (content quality), 4) dev-architect review
+  (architectural correctness).
+
 ### spec/anchor-based-references
 
 - **Added: Anchor Infrastructure for Stable References**: Created verification

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -35,6 +35,41 @@ Create pull request after explicit user instruction. Squash commits to single co
 
 ## Procedure
 
+### ⚠️ MANDATORY EXECUTION ORDER - NO GATE SKIPPING {#mandatory-order}
+
+**CRITICAL: Every step has a verification gate. Gates MUST pass before proceeding.**
+
+```
+Step 1: [Check PR State](#check-pr-state)
+  └─ ✅ Gate: PR state determined (open/merged/closed/none)
+
+Step 2: [Collect Sub-Issues](#collect-sub-issues)
+  └─ ✅ Gate: Sub-issues collected or single-task confirmed
+
+Step 3: [Version Bump](#version-bump)
+  └─ ✅ Gate: `git diff` run AND (version-bump invoked OR skip recorded)
+
+Step 4: [Generate Changelog](#generate-changelog)
+  └─ ✅ Gate: Subtask returned `success: true` AND CHANGELOG.md created
+
+Step 5: [Stage Changelog](#stage-changelog)
+  └─ ✅ Gate: `git status` shows CHANGELOG.md staged
+
+Step 6: [Squash Commit](#squash-commit)
+  └─ ✅ Gate: `git log` shows EXACTLY ONE commit
+
+Step 7: [Push Remote](#push-remote)
+  └─ ✅ Gate: Force push succeeded
+
+Step 8: [Create PR](#create-pr)
+  └─ ✅ Gate: PR URL returned
+
+Step 9: [Report URL](#report-url)
+  └─ ✅ Gate: URL posted to chat (URL-LAST format)
+```
+
+**If ANY gate fails: STOP and fix before proceeding.**
+
 ### Check PR State {#check-pr-state}
 
 **Before creating PR, check if branch already has a PR (open OR merged):**
@@ -46,6 +81,16 @@ CURRENT_BRANCH=$(git branch --show-current)
 # Check for ALL existing PRs on this branch (open, merged, closed)
 gh pr list --head "$CURRENT_BRANCH" --state all --json number,url,state,mergedAt
 ```
+
+#### Post-PR State Verification (MANDATORY)
+
+**Gate Checklist:**
+- [ ] Current branch name retrieved
+- [ ] GitHub MCP queried for existing PRs
+- [ ] PR state determined (open/merged/closed/none)
+- [ ] Decision recorded: UPDATE | CREATE_NEW_BRANCH | CREATE_NEW_PR
+
+**✅ GATE: PR state determined. Proceed to Collect Sub-Issues.**
 
 **If open PR exists via GitHub MCP:**
 
@@ -127,26 +172,47 @@ autoclose_issues = [<parent>] + [sub["number"] for sub in sub_issues]
 
 No sub-issues needed. Include only parent issue.
 
+#### Post-Sub-Issues Verification (MANDATORY)
+
+**Gate Checklist:**
+- [ ] Queried sub-issues via `github_issue_read(method="get_sub_issues")`
+- [ ] Result is either: empty array (single-task) OR list of sub-issues (multi-task)
+- [ ] If multi-task: autoclose list includes parent + ALL sub-issues
+- [ ] If single-task: autoclose list includes only parent
+
+**✅ GATE: Sub-issues collected or single-task confirmed. Proceed to Version Bump.**
+
 ### Version Bump {#version-bump}
 
 **⚠️ CRITICAL: Only for PRs with code changes. Skip for docs/chore/refactor PRs.**
 
-**Detect code changes:**
+#### Pre-Version-Bump Checklist (MANDATORY)
+
+Run these checks BEFORE deciding on version bump:
 
 ```bash
-# Get list of changed files
-CHANGED_FILES=$(git diff origin/dev...HEAD --name-only)
+# Step 1: Get list of changed files
+git diff origin/dev...HEAD --name-only
 
-# Check if any code files changed
+# Step 2: Check if any code files changed
+CHANGED_FILES=$(git diff origin/dev...HEAD --name-only)
 echo "$CHANGED_FILES" | grep -qE '\.(py|js|ts|rs|java|go|rb)$'
 CODE_CHANGES=$?
 
 if [ $CODE_CHANGES -eq 0 ]; then
-    echo "Code changes detected - invoking version bump"
+    echo "✅ Gate: Code changes detected - version bump required"
+    # Continue to invoke version-bump subtask
 else
-    echo "No code changes detected - skipping version bump"
+    echo "✅ Gate: No code changes - version bump skipped (docs/chore/refactor)"
+    # Skip version bump, proceed to changelog
 fi
 ```
+
+**Gate Checklist:**
+- [ ] Ran `git diff origin/dev...HEAD --name-only`
+- [ ] Checked file extensions for code files
+- [ ] If code changes: Invoked version-bump subtask
+- [ ] If docs only: Recorded "skip" and proceeded
 
 **Skip version bump for:**
 - Documentation-only changes (*.md files)
@@ -206,6 +272,30 @@ fi
 
 **Note:** Version bump changes are included in the [Squash](#squash-commit) step. They are NOT a separate commit.
 
+#### Post-Version-Bump Verification (MANDATORY)
+
+**After version-bump subtask completes, verify BEFORE proceeding to Generate Changelog:**
+
+```bash
+# Gate: Verify version bump was processed
+# Subtask must return: { "bump_type": "...", "success": true }
+
+# Gate: If code changes detected, version file must exist
+if [ -n "$(git diff origin/dev...HEAD --name-only | grep -E '\.(py|js|ts|rs|java|go|rb)$')" ]; then
+    # Code changes - version bump required
+    # Verify version file was updated (or subtask recorded skip)
+    git status --porcelain | grep -qE '(pyproject.toml|package.json|Cargo.toml|VERSION)' && echo "✅ Gate: Version file updated"
+fi
+```
+
+**Gate Checklist:**
+- [ ] Pre-Version-Bump checklist completed
+- [ ] version-bump subtask invoked (if code changes) OR skip recorded (if docs only)
+- [ ] Subtask returned `success: true`
+- [ ] Version file staged (if version bump applied)
+
+**✅ GATE: Version bump processed. Proceed to Generate Changelog.**
+
 ### Generate Changelog {#generate-changelog}
 
 **⚠️ CRITICAL: Use task tool to prevent context pollution.**
@@ -254,6 +344,28 @@ Use fallback format for PR body:
 - Group by: Features, Improvements, Fixes
 ```
 
+#### Post-Changelog Verification (MANDATORY)
+
+**After subtask returns, verify BEFORE proceeding to Stage Changelog:**
+
+```bash
+# Gate 1: Check subtask result
+# Subtask must return: { "summary": "...", "changelog": "...", "success": true }
+
+# Gate 2: Verify CHANGELOG.md exists
+ls -la .opencode/CHANGELOG.md && echo "✅ Gate: CHANGELOG.md created"
+
+# Gate 3: Verify file has content
+test -s .opencode/CHANGELOG.md && echo "✅ Gate: CHANGELOG.md not empty"
+```
+
+**Gate Checklist:**
+- [ ] Subtask returned `success: true`
+- [ ] CHANGELOG.md file exists
+- [ ] CHANGELOG.md has content (> 0 bytes)
+
+**If ANY gate fails: STOP and fix before proceeding to Stage Changelog.**
+
 ### Stage Changelog {#stage-changelog}
 
 **After subtask completes:**
@@ -284,6 +396,24 @@ git add CHANGELOG.md
 ```
 
 **✅ STAGE CHANGELOG COMPLETE:** CHANGELOG.md staged
+
+#### Post-Stage Verification (MANDATORY)
+
+**After staging CHANGELOG.md, verify BEFORE proceeding to Squash:**
+
+```bash
+# Gate: Verify CHANGELOG.md is staged
+git status --porcelain | grep -q "M.*CHANGELOG.md" && echo "✅ Gate: CHANGELOG.md staged"
+```
+
+**Gate Checklist:**
+- [ ] `git status` shows `modified: CHANGELOG.md` (staged)
+
+**If gate fails:**
+```bash
+git add CHANGELOG.md
+git status  # Re-verify
+```
 
 ### Squash Commit {#squash-commit}
 
@@ -385,7 +515,108 @@ git log --oneline origin/dev..HEAD  # Verify single commit
 git push --force-with-lease origin <branch>
 ```
 
+#### Post-Push Verification (MANDATORY)
+
+**Verify push succeeded before creating PR:**
+
+```bash
+# Gate: Verify push succeeded
+git log --oneline origin/dev..HEAD | head -1
+# MUST show exactly one commit
+
+# Gate: Verify remote branch exists
+git branch -r | grep "origin/$(git branch --show-current)"
+# MUST show remote tracking branch
+```
+
+**Gate Checklist:**
+- [ ] Push succeeded (no error)
+- [ ] Remote branch created
+- [ ] Single commit on remote
+
+**✅ GATE: Push succeeded. Proceed to Create PR.**
+
+### Pre-Create PR Verification (MANDATORY)
+
+**Before creating PR, VERIFY base branch is correct:**
+
+```bash
+# Gate: Determine base branch
+CURRENT_BRANCH=$(git branch --show-current)
+
+case "$CURRENT_BRANCH" in
+    feature/*)
+        BASE_BRANCH="dev"
+        ;;
+    release/*)
+        BASE_BRANCH="main"
+        ;;
+    hotfix/*)
+        BASE_BRANCH="main"
+        ;;
+    *)
+        # Default to dev for unknown branch types
+        BASE_BRANCH="dev"
+        ;;
+esac
+
+echo "✅ Gate: Branch '$CURRENT_BRANCH' targets '$BASE_BRANCH'"
+```
+
+**Gate Checklist:**
+- [ ] Current branch is feature/release/hotfix
+- [ ] Base branch determined correctly
+- [ ] Base is `dev` for features (CRITICAL)
+- [ ] Base is `main` ONLY for releases/hotfixes
+
+**⚠️ CRITICAL: Feature branches MUST target `dev`.**
+
+If base is `main` for a feature branch:
+```
+❌ WRONG: base="main" for feature/* branch
+✅ CORRECT: base="dev" for feature/* branch
+```
+
+**✅ GATE: Base branch verified. Proceed to Create PR.**
+
 ### Create PR {#create-pr}
+
+**⚠️ CRITICAL: Base Branch Determination (MANDATORY)**
+
+**Feature branches MUST target `dev`, NOT `main`.**
+
+| Branch Type | Base Branch | Workflow |
+|-------------|-------------|---------|
+| `feature/*` | `dev` | Feature PRs merge to dev for integration testing |
+| `release/*` | `main` | Release PRs merge from dev to main for production |
+| `hotfix/*` | `main` | Hotfixes merge to main, then sync back to dev |
+
+**Verification Gate:**
+
+```bash
+# Gate: Get base branch
+BASE_BRANCH="dev"  # Feature branches ALWAYS target dev
+
+# Gate: Confirm we're on a feature branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == feature/* ]]; then
+    BASE_BRANCH="dev"
+elif [[ "$CURRENT_BRANCH" == release/* ]]; then
+    BASE_BRANCH="main"
+elif [[ "$CURRENT_BRANCH" == hotfix/* ]]; then
+    BASE_BRANCH="main"
+else
+    # Default to dev for unknown branch types
+    BASE_BRANCH="dev"
+fi
+
+echo "✅ Gate: Base branch determined: $BASE_BRANCH"
+```
+
+**Gate Checklist:**
+- [ ] Base branch is `dev` for feature branches
+- [ ] Base branch is `main` ONLY for release/hotfix branches
+- [ ] NEVER use `main` for feature PRs
 
 **Use the summary and changelog from subtask for PR body.**
 
@@ -408,7 +639,7 @@ Fixes #<child2>
 ...
 """,
     head=<branch-name>,
-    base="main"
+    base=BASE_BRANCH  # MUST be "dev" for feature branches
 )
 ```
 

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -11,23 +11,27 @@ compatibility: opencode
 
 **This auditor checks whether an LLM agent with NO memory context can implement the spec correctly.**
 
-**Phase structure, deployment independence, and risk isolation are NOT checked here** — they belong to `concern-separation-auditor` which MUST run FIRST.
+**Phase structure, deployment independence, and risk isolation are NOT checked here** — they belong to `concern-separation-auditor` which runs SECOND (after clean-room draft generation).
 
 ### Division of Responsibility
 
 | Auditor | Scope | Role |
 |---------|-------|------|
-| **concern-separation-auditor** | Phase structure, deployment independence, risk isolation, blast radius, phase names | Runs FIRST - structural safety |
-| **spec-auditor** | Fresh-start context, completeness, content quality, LLM implementability | Runs SECOND - content quality |
+| `spec-auditor --task generate-independent-spec` | Clean-room draft generation | FIRST - generate spec WITHOUT viewing live (pollution prevention) |
+| `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names | SECOND - structural safety |
+| `spec-auditor --task audit` | Fresh-start context, completeness, content quality, LLM implementability | THIRD - content quality |
+| `dev-architect --task review-spec` | Architectural correctness, compliance, interdependencies, ordering | FOURTH - architectural correctness |
 
-**CRITICAL: Both auditors are MANDATORY. No skipping.**
+**CRITICAL: All FOUR auditors are MANDATORY. No skipping.**
 
 **Workflow:**
 
 ```
 Create spec issue #N →
-Invoke concern-separation-auditor --issue N (FIRST - phase structure, auto-fix) →
-Invoke spec-auditor --issue N (SECOND - content quality) →
+Invoke spec-auditor --task generate-independent-spec --issue N (FIRST - clean-room draft) →
+Invoke concern-separation-auditor --issue N (SECOND - phase structure, auto-fix) →
+Invoke spec-auditor --task audit --issue N (THIRD - content quality) →
+Invoke dev-architect --task review-spec (FOURTH - architectural correctness) →
 Add needs-approval label →
 Post "ready for review" comment
 ```
@@ -90,21 +94,22 @@ Post "ready for review" comment
 
 | Order | Skill | Purpose |
 |-------|-------|---------|
-| **1st** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names |
-| **2nd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
-| **3rd** | `dev-architect --task review-spec` | Architectural correctness, compliance, interdependencies, ordering |
+| **1st** | `spec-auditor --task generate-independent-spec` | Generate complete, implementable spec draft WITHOUT viewing live spec (pollution prevention) |
+| **2nd** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names |
+| **3rd** | `spec-auditor --task audit` | Fresh-start context, completeness, content quality, LLM implementability |
+| **4th** | `dev-architect --task review-spec` | Architectural correctness, compliance, interdependencies, ordering |
 
 **Trigger words that require ALL skills:**
 
 - "audit this spec"
 - "review this issue"
 - "revisit this task"
-- "check this \[SPEC\]"
+- "check this [SPEC]"
 - "validate the spec"
 - "audit the issue"
 - Any request involving spec quality or structure
 
-**CRITICAL: If you run ONE auditor, you MUST run ALL THREE in order.**
+**CRITICAL: If you run ONE auditor, you MUST run ALL FOUR in order.**
 
 ______________________________________________________________________
 
@@ -631,9 +636,10 @@ GitHub Comment: <URL to comment>
 When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 
 1. Create the spec issue with all required content
-1. Invoke `/skill concern-separation-auditor --issue N` (FIRST - phase structure, auto-fix by default)
-1. Invoke `/skill spec-auditor --issue N` (SECOND - content quality)
-1. Invoke `/skill dev-architect --task review-spec` (THIRD - architectural correctness)
+1. Invoke `/skill spec-auditor --task generate-independent-spec --issue N` (FIRST - clean-room draft generation)
+1. Invoke `/skill concern-separation-auditor --issue N` (SECOND - phase structure, auto-fix by default)
+1. Invoke `/skill spec-auditor --task audit --issue N` (THIRD - content quality)
+1. Invoke `/skill dev-architect --task review-spec` (FOURTH - architectural correctness)
 1. Apply any fixes identified by auditors
 1. Add `needs-approval` label
 1. Post "ready for review" comment
@@ -652,15 +658,16 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 
 ### Integration with concern-separation-auditor and dev-architect
 
-**ALL THREE auditors are required. They check different things.**
+**ALL FOUR auditors are required. They check different things.**
 
 | Auditor | Runs When | Checks |
 |---------|----------|--------|
-| `concern-separation-auditor` | FIRST | Phase structure, deployment independence, risk isolation, blast radius, phase names, BOILERPLATE-TITLE |
-| `spec-auditor` | SECOND | Fresh-start context, completeness, content quality, LLM implementability |
-| `dev-architect --task review-spec` | THIRD | Architectural correctness, compliance, interdependencies, ordering |
+| `spec-auditor --task generate-independent-spec` | FIRST | Clean-room draft generation WITHOUT viewing live spec (pollution prevention) |
+| `concern-separation-auditor` | SECOND | Phase structure, deployment independence, risk isolation, blast radius, phase names, BOILERPLATE-TITLE |
+| `spec-auditor --task audit` | THIRD | Fresh-start context, completeness, content quality, LLM implementability |
+| `dev-architect --task review-spec` | FOURTH | Architectural correctness, compliance, interdependencies, ordering |
 
-**Order matters:** concern-separation-auditor fixes structural issues first, then spec-auditor checks content quality, then dev-architect reviews architectural correctness.
+**Order matters:** spec-auditor draft generation runs first to prevent pollution, then concern-separation-auditor fixes structural issues, then spec-auditor audit checks content quality, then dev-architect reviews architectural correctness.
 
 ### Integration with Approval Gate
 
@@ -670,11 +677,12 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 
 ### Enforcement Flow
 
-1. User creates a \[SPEC\] issue.
+1. User creates a [SPEC] issue.
+1. spec-auditor generates independent draft WITHOUT viewing live spec (pollution prevention).
 1. concern-separation-auditor runs (phase structure fixes).
-1. spec-auditor runs (content quality fixes).
+1. spec-auditor audit runs (content quality fixes).
 1. dev-architect runs (architectural correctness review).
-1. After all three auditors pass → Add `needs-approval` label.
+1. After all FOUR auditors pass → Add `needs-approval` label.
 1. After approval → Implementation begins.
 
 ## Example Session


### PR DESCRIPTION
## Summary

Fixed three critical skill defects:
1. **Mandatory Audit Chain**: Added clean-room draft generation as the FIRST auditor to prevent pollution from existing spec content
2. **PR Verification Gates**: Added mandatory verification gates to prevent steps from being skipped during PR creation
3. **Base Branch Enforcement**: Enforced dev branch for feature PRs (prevented main targeting)

## Changes

### spec-auditor/SKILL.md (Issue #333)

- **Fixed: Clean-Room Draft Generation as First Auditor**: Corrected the mandatory audit chain to include clean-room draft generation as the FIRST step. The spec-auditor now has a `generate-independent-spec` task that creates a complete, implementable spec draft WITHOUT viewing the live spec. This prevents pollution where the agent's view of existing content influences its draft.
- **Fixed: Database ID Lookup for Parent/Sub-Issue Linking**: Added explicit database ID requirement for `github_sub_issue_write method=add` to prevent "invalid sub_issue_id" errors.

### git-workflow/tasks/pr-creation.md (Issue #337)

- **Added: Mandatory Execution Order Section**: Gate symbols (✅) at every step with clear verification requirements
- **Added: Post-PR State Verification**: Gate checklist after PR state check
- **Added: Post-Sub-Issues Verification**: Gate checklist after sub-issue collection
- **Added: Pre-Version-Bump Checklist**: Gate checklist before version bump subtask
- **Added: Post-Version-Bump Verification**: Gate checklist after version bump
- **Added: Post-Changelog Verification**: Gate checklist after changelog generation
- **Added: Post-Stage Verification**: Gate checklist after staging changelog
- **Added: Pre-Squash Verification**: Gate checklist before squash commit
- **Added: Post-Squash Verification**: Gate checklist after squash commit
- **Added: Base Branch Determination (CRITICAL)**: Enforced `dev` base for feature branches, `main` base ONLY for release/hotfix branches
- **Added: Pre-Create PR Verification**: Mandatory base branch check before PR creation
- **Added: Post-Push Verification**: Verify push succeeded before creating PR

## Root Cause

**Issue #333**: The spec-auditor was instructed to audit but lacked guidance on HOW to audit - specifically, that it MUST generate a clean-room draft BEFORE viewing the live spec. Without this, the agent's view of existing content polluted its draft.

**Issue #337**: The git-workflow/pr-creation task documented 9 steps with expected outcomes but provided NO enforcement mechanism. The skill documented "what should happen" without verification that "it DID happen," allowing steps to be skipped.

**Issue #336**: The PR incorrectly targeted `main` instead of `dev` because the skill had `base="main"` hardcoded in the code example and lacked verification that feature branches must merge to `dev` first.

Fixes #333
Fixes #337