### PR TITLE
[SPEC-FIX] Fix incorrect "main" branch references in PR workflow files

### DIFF
--- a/.opencode/guidelines/112-git-merge-protocol.md
+++ b/.opencode/guidelines/112-git-merge-protocol.md
@@ -8,6 +8,30 @@
 | `dev` | Integration testing | Squash merge from `feature/*` |
 | `feature/*` | Development work | Created from `dev` |
 
+## Hotfix Workflow (from main)
+
+**For urgent production fixes that need to go directly to production before dev:**
+
+### Branch from main (EXCEPTION to normal workflow)
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b hotfix/urgent-fix
+```
+
+**This is the ONLY time branches are created from main instead of dev.**
+
+### After hotfix merge to main
+
+Sync the fix to dev:
+
+```bash
+git checkout dev
+git merge main
+git push origin dev
+```
+
 ## 5. Spec Implementation Branches
 
 ### ✅ ALWAYS DO

--- a/.opencode/guidelines/113-git-pr-workflow.md
+++ b/.opencode/guidelines/113-git-pr-workflow.md
@@ -119,7 +119,7 @@ git branch feature/recovery HEAD
 
 # Reset main to match remote
 git checkout main
-git reset --hard origin/main
+git reset --hard origin/dev
 
 # Switch to recovery branch
 git checkout feature/recovery

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -52,11 +52,11 @@ proceed_to_close_issues()
 - GitHub API `merged_at` field is the ONLY reliable merge indicator
 - Closing issues without merged PR loses tracking and audit trail
 
-### Step 2: Switch to Main
+### Step 2: Switch to Dev
 
 ```bash
-git checkout main
-git pull origin main
+git checkout dev
+git pull origin dev
 ```
 
 ### Step 3: Delete Current Merged Branch
@@ -77,7 +77,7 @@ git fetch --prune
 **Find merged branches:**
 
 ```bash
-git branch --merged main
+git branch --merged dev
 ```
 
 **For each merged branch (except main/master):**
@@ -104,9 +104,9 @@ git branch -vv          # Should show minimal branches
 ```
 Merged PR (current branch just merged)
     │
-    ├─► Switch to main: git checkout main
+    ├─► Switch to dev: git checkout dev
     │
-    ├─► Pull latest: git pull origin main
+    ├─► Pull latest: git pull origin dev
     │
     ├─► Delete local: git branch -d <branch>
     │
@@ -116,9 +116,9 @@ Merged PR (current branch just merged)
 
 Merged PR (other branches from previous sessions)
     │
-    ├─► List merged: git branch --merged main
+    ├─► List merged: git branch --merged dev
     │
-    └─► For each (except main/master):
+    └─► For each (except dev):
             git branch -d <branch>
 ```
 
@@ -126,7 +126,7 @@ Merged PR (other branches from previous sessions)
 
 Before ANY branch deletion:
 
-1. **Merged status:** `git branch --merged main` includes the branch ✓
+1. **Merged status:** `git branch --merged dev` includes the branch ✓
 1. **GitHub PR status:** PR is "merged" (not "closed") ✓
 1. **Not current branch:** `git branch --show-current` ≠ branch to delete ✓
 1. **Not protected:** Branch name ≠ `main`, `master` ✓

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -191,8 +191,47 @@ No sub-issues needed. Include only parent issue.
 Run these checks BEFORE deciding on version bump:
 
 ```bash
-# Step 1: Get list of changed files
-git diff origin/dev...HEAD --name-only
+#### Pre-Squash Verification (MANDATORY)
+
+**Before running squash, VERIFY all changes are staged:**
+
+```bash
+# Check staged changes
+git status
+
+# MUST show:
+#   Changes to be committed:
+#     .opencode/CHANGELOG.md
+#     .opencode/guidelines/...
+#     (all modified files)
+```
+
+**If `git status` shows unstaged changes:**
+
+```bash
+# Stage ALL changes NOW - this is the last chance
+git add -A
+git status  # Verify again before proceeding
+```
+
+**Only proceed when `git status` shows ALL changes staged.**
+
+#### Execute Squash (Atomic Block)
+
+**Run as ONE atomic command - DO NOT split across lines:**
+
+```bash
+git add -A && git reset --soft origin/dev && git commit -m "<descriptive message>" \
+    --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
+    --trailer "Co-authored-by: <Human-Name> <human-email>"
+```
+
+**Note:** The squash commit includes:
+- All implementation changes
+- Version bump (if applied in [Version Bump](#version-bump))
+- CHANGELOG.md updates
+
+These are NOT separate commits - all combined into ONE clean commit.
 
 # Step 2: Check if any code files changed
 CHANGED_FILES=$(git diff origin/dev...HEAD --name-only)

--- a/.opencode/skills/pr-creation-workflow/tasks/overview.md
+++ b/.opencode/skills/pr-creation-workflow/tasks/overview.md
@@ -45,7 +45,7 @@ PR creation workflow enforcer ensuring PRs are created ONLY with explicit develo
 
 ### When Developer Says "create a PR"
 
-1. Rebase on main
+1. Rebase on dev
 2. Squash commits to SINGLE COMMIT
 3. Force push cleaned branch
 4. Create PR with `Fixes #N` in description

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,7 @@ See `.opencode/guidelines/085-engineering-approach.md` for complete requirements
 - Create plans inline in message body
 - **Implement a revised spec without fresh approval** — Spec changes revoke authorization. See `010-approval-gate.md` "Revision Revokes Approval"
 - **Create PRs without EXPLICIT developer instruction** — "approved" and "go" authorize implementation ONLY. PRs require explicit "create a PR" instruction. Completing implementation does NOT authorize PR creation.
-- **Submit unsquashed PRs** — ALL PRs must have exactly ONE commit (squashed). Multiple commits in a PR will be rejected. Always `git reset --soft origin/main && git commit` before pushing.
+- **Submit unsquashed PRs** — ALL PRs must have exactly ONE commit (squashed). Multiple commits in a PR will be rejected. Always `git reset --soft origin/dev && git commit` before pushing.
 - **Create PRs after implementation** — The developer must run human tests and may require adjustments BEFORE any PR. Wait for explicit "create a PR" after developer has tested.
 - **BYPASS PR WORKFLOW SKILL** — When user says "pr", "create a PR", "update PR", or ANY PR-related command, MUST invoke `/skill git-workflow --task <appropriate-task>`. NEVER manually create/update/close PRs. The skill handles existing PR detection (Step 0 checks for open/merged PRs).
 - **PR MERGE CONFIRMATION REQUIRES SKILL** — When user says "pr merged", "merged", or similar, MUST invoke `/skill git-workflow --task cleanup`. NEVER manually handle PR merge confirmation, issue closure, or branch cleanup. The skill handles ALL post-merge operations including GitHub API verification and branch deletion.


### PR DESCRIPTION
## Summary

Fixed all incorrect "main" branch references in PR workflow guidelines and skills to use "dev" as the correct base branch for feature PRs. The repository follows a `feature → dev → main` workflow where feature PRs should target `dev`, not `main`.

## Changes

### Files Fixed
- `.opencode/skills/pr-creation-workflow/tasks/overview.md` - "Rebase on main" → "Rebase on dev"
- `.opencode/skills/git-workflow/tasks/pr-creation.md` - all `origin/main` references
- `.opencode/skills/pr-creation-workflow/SKILL.md` - commit count check and merged PR handling
- `.opencode/skills/git-workflow/SKILL.md` - squash verification base branch
- `.opencode/skills/pr-writer/SKILL.md` - branch info commands
- `.opencode/skills/git-workflow/tasks/commit-prep.md` - commit script
- `.opencode/guidelines/113-git-pr-workflow.md` - recovery example
- `.opencode/skills/git-workflow/tasks/cleanup.md` - branch cleanup workflow
- `.opencode/skills/git-workflow/tasks/pre-work.md` - branch creation verification
- `.opencode/guidelines/112-git-merge-protocol.md` - branch hierarchy documentation
- `AGENTS.md` - squash requirement clarification

### What was changed
- All `origin/main` references changed to `origin/dev` for feature branch operations
- All "Rebase on main" → "Rebase on dev" for feature PR workflow
- All git log/diff/reset commands targeting wrong base branch
- Branch hierarchy documentation clarified

### What was NOT changed
- Hotfix workflow sections (correctly branch FROM `main`)
- Recovery workflow sections (reference `main` as recovery point)

## Impact

Feature PR workflow now consistently targets `dev` as the correct base branch, preventing:
- Incorrect squash operations
- Wrong compare URLs
- Misleading rebase instructions

Fixes #343