### PR TITLE
[SPEC] Skills Wording Quality Remediation

### DIFF
--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package.json
+bun.lock
+package-lock.json

--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -8,6 +8,29 @@ The format is based on
 
 ## [0.2.0] - Unreleased
 
+### skill/wording-remediation
+
+- **Changed: Standardized Skill Trigger Format**: All 29 skills now use explicit
+  `/skill X --task Y` commands in master trigger table. Replaced ambiguous
+  trigger descriptions with precise invocation commands for better agent
+  clarity. All skills follow consistent workflow trigger format.
+- **Fixed: Removed Junie Language**: Replaced all "invoked automatically" and
+  similar passive construction with explicit "is invoked at these triggers"
+  format. Removed "Automatic Invocation" headings replaced with "Workflow
+  Triggers" or "Enforcement Points".
+- **Changed: Terminology Standardization**: Replaced "Entry/Exit Criteria" with
+  "Preconditions/Postconditions" across all task files and templates. Replaced
+  "Operating Protocol" with "Workflow" section to match skill convention.
+- **Fixed: Hardcoded Identity References**: Removed hardcoded "OpenCode (ollama-cloud/glm-5)"
+  example values from skill files. Guidelines now explicitly state these are
+  illustrative examples and agents must detect their own identity at runtime.
+- **Added: Verification Tool**: Moved verify-skill-wording.sh to .opencode/scripts/
+  for ongoing enforcement of linguistic standards. The tool detects Junie
+  patterns and terminology violations.
+- **Changed: Master Trigger Table**: AGENTS.md now has single source-of-truth
+  trigger table with explicit /skill invocations. All skills reference this
+  table instead of duplicating trigger information.
+
 ### skill/audit-chain-clean-room
 
 - **Fixed: Clean-Room Draft Generation as First Auditor**: Corrected the

--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -5,7 +5,7 @@
 AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach:
 
 1. **Specify Phase**: Define **What & Why**. Kick off with a high-level vision (product brief), then expand it into a detailed specification focusing on user journeys, experiences, and success criteria.
-2. **Plan Phase**: Define **How**. Draft the technical plan (architecture, technical stack, and constraints). **Auto-invoke `/skill dev-architect --task design-plan` at Plan phase.**
+2. **Plan Phase**: Define **How**. Draft the technical plan (architecture, technical stack, and constraints). **Invoke `/skill dev-architect --task design-plan` at Plan phase.**
 3. **Tasks Phase**: Break the plan into **small, reviewable chunks** (tasks) that can be implemented and tested in isolation.
 4. **Implement Phase**: **Execute** tasks and **verify** results.
 

--- a/.opencode/scripts/verify-skill-wording.sh
+++ b/.opencode/scripts/verify-skill-wording.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Verification tool for Unit 12 - Checks for remaining Junie language patterns
+
+echo "=== Skill Wording Quality Verification ==="
+echo ""
+
+FOUND_ISSUES=0
+
+echo "1. Checking for 'invoked automatically'..."
+grep -r --include="*.md" "invoked automatically" .opencode/skills/ .opencode/guidelines/ AGENTS.md 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "2. Checking for 'Operating Protocol'..."
+grep -r --include="*.md" "Operating Protocol" .opencode/skills/ 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "3. Checking for 'Entry Criteria'..."
+grep -r --include="*.md" "Entry Criteria" .opencode/skills/ 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "4. Checking for 'Exit Criteria'..."
+grep -r --include="*.md" "Exit Criteria" .opencode/skills/ 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "5. Checking for 'Auto-invoke'..."
+grep -r --include="*.md" "Auto-invoke" .opencode/ 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "6. Checking for 'auto-invoke'..."
+grep -r --include="*.md" "auto-invoke" .opencode/ 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "7. Checking for 'Automatic Invocation'..."
+grep -r --include="*.md" "Automatic Invocation" .opencode/ AGENTS.md 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "8. Checking for hardcoded identity examples..."
+grep -r --include="*.md" "OpenCode (ollama-cloud/glm-5)" .opencode/skills/ 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "9. Checking for 'Sneh Kothari'..."
+grep -r --include="*.md" "Sneh Kothari" .opencode/skills/ 2>/dev/null
+if [ $? -eq 0 ]; then
+    FOUND_ISSUES=$((FOUND_ISSUES + 1))
+fi
+
+echo ""
+echo "=== Verification Complete ==="
+if [ $FOUND_ISSUES -gt 0 ]; then
+    echo ""
+    echo "❌ FOUND $FOUND_ISSUES issue(s) above"
+    echo "   Fix the highlighted occurrences before proceeding to Unit 13"
+    exit 1
+else
+    echo ""
+    echo "✅ No Junie language patterns found"
+    echo "   All skill wording is compliant"
+    exit 0
+fi

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -7,13 +7,20 @@ compatibility: opencode
 
 # Skill: approval-gate
 
-Authorization Gatekeeper ensuring all code changes follow the spec + authorization workflow. Invoked automatically before implementation begins.
+Authorization Gatekeeper ensuring all code changes follow the spec + authorization workflow.
 
-## When to Use
+## When to Invoke
 
-- Before ANY file edit (MANDATORY - auto-loaded)
-- Before implementation (verify auth + sub-issues)
-- Before issue body edits (verify authorization)
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Before ANY file edit | `/skill approval-gate --task verify-authorization` | Confirm spec + approval exist |
+| Before implementation | `/skill approval-gate --task verify-sub-issues` | Check sub-issue structure for multi-task specs |
+| User says "approved" or "go" | `/skill approval-gate --task verify-authorization` | Verify auth + needs-approval label status |
+| Before implementing any task | `/skill approval-gate --task verify-sub-issues` | Verify sub-issue structure |
 
 ## Tasks
 
@@ -36,41 +43,34 @@ Authorization Gatekeeper ensuring all code changes follow the spec + authorizati
 - `/skill approval-gate --task post-implementation` - After implementation done
 - `/skill approval-gate` - Overview only
 
-## Operating Protocol
+## This Skill's Tasks
 
-1. **Automatic invocation (mandatory):** This skill is referenced when:
+**`verify-authorization`**: Use before ANY file edit. Confirms spec exists as GitHub Issue, verifies explicit authorization received, checks needs-approval label status.
 
-   - User says `approved`, `go`, or similar authorization
-   - User asks about approval workflow
-   - Implementation is about to begin
-   - DO NOT prompt for invocation - the skill is triggered automatically
+**`verify-sub-issues`**: Use before implementing multi-task specs. Confirms parent issue has sub-issues, verifies sub-issue structure matches spec phases, ensures each phase has tracking.
 
-1. **Pre-Implementation Verification:**
+**`verify-codebase`**: Use when re-evaluating implementation against current codebase. Detects spec staleness, checks if referenced code still exists.
 
-   - Verify spec exists as GitHub Issue
-   - Verify spec has received explicit authorization
-   - Verify sub-issues structure (multi-task only)
-   - Check for blocking issues/updates
+**`verify-blockers`**: Use to check for blocking issues. Verifies dependencies are resolved, checks for superseding issues.
 
-1. **Implementation Scope:**
+**`verify-open-questions`**: Use to check for unresolved questions in spec. Ensures all open questions are answered before implementation.
 
-   - Authorization grants ONLY the specified phase/task
-   - HALT after completing authorized work
-   - Wait for explicit authorization for next phase/task
+**`post-implementation`**: Use after implementation completes. Pushes branch, generates compare URL, HALTs for developer review.
 
-## Automatic Invocation Triggers
+## Workflow Context
 
-**This skill MUST be invoked automatically (no user prompt) at these enforcement points:**
+**Pre-Implementation Verification:**
 
-| Trigger Point | Action | Verification |
-|---------------|--------|--------------|
-| **Before ANY file edit** | Load skill → `verify-authorization` task | Confirm spec + approval exist |
-| **Before implementation** | Load skill → `verify-authorization` + `verify-sub-issues` | Confirm multi-task specs have sub-issues |
-| **After user says "approved" or "go"** | Load `git-workflow` → `pre-work` task | Stash changes (with --include-untracked), create branch |
-| **After implementation completes** | Load `git-workflow` → `review-prep` task | Push branch, generate compare URL, HALT |
-| **Before posting GitHub comments** | Load `github-comments` skill | Verify byline format, agent identity |
+- Verify spec exists as GitHub Issue
+- Verify spec has received explicit authorization
+- Verify sub-issues structure (multi-task only)
+- Check for blocking issues/updates
 
-**Enforcement:** Do NOT proceed with edits, implementation, or comments without first loading this skill and verifying authorization.
+**Implementation Scope:**
+
+- Authorization grants ONLY the specified phase/task
+- HALT after completing authorized work
+- Wait for explicit authorization for next phase/task
 
 ### ⚠️ MANDATORY: Post-Implementation Review-Prep Invocation
 

--- a/.opencode/skills/approval-gate/tasks/post-implementation.md
+++ b/.opencode/skills/approval-gate/tasks/post-implementation.md
@@ -4,25 +4,26 @@
 
 Push feature branch, generate compare URL, and report completion for developer review.
 
-## ⚠️ MANDATORY INVOCATION
+## Workflow Triggers
 
-**This task is ALWAYS invoked automatically after implementation completes. There is NO decision point.**
+**Invoke this task at these workflow points:**
+- After implementation completes (mandatory - no decision point)
 
 The sequence is:
 
-1. Implementation complete → **post-implementation invoked automatically**
+1. Implementation complete → **invoke post-implementation**
 1. Branch pushed, compare URL generated → HALT
 1. Wait for developer to say "create a PR"
 
 **DO NOT skip this task after implementation. DO NOT ask the developer if they want review. Just push the branch.**
 
-## Entry Criteria
+## Preconditions
 
 - Implementation work complete
 - All changes committed on feature branch
 - Authorization scope verified
 
-## Exit Criteria
+## Postconditions
 
 - Feature branch pushed to remote
 - GitHub compare URL generated

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -4,12 +4,12 @@
 
 Check for explicit authorization and needs-approval label status before implementation.
 
-## Entry Criteria
+## Preconditions
 
 - User says "approved", "go", or similar authorization
 - Spec exists as GitHub Issue
 
-## Exit Criteria
+## Postconditions
 
 - Authorization verified as explicit and for correct issue
 - needs-approval label status checked

--- a/.opencode/skills/approval-gate/tasks/verify-blockers.md
+++ b/.opencode/skills/approval-gate/tasks/verify-blockers.md
@@ -4,13 +4,13 @@
 
 Check for blocking issues or dependencies that prevent implementation.
 
-## Entry Criteria
+## Preconditions
 
 - Authorization verified
 - Sub-issues verified
 - Codebase verified
 
-## Exit Criteria
+## Postconditions
 
 - No `needs-approval` label present (or explicit authorization received)
 - No blocking issues superseding spec

--- a/.opencode/skills/approval-gate/tasks/verify-codebase.md
+++ b/.opencode/skills/approval-gate/tasks/verify-codebase.md
@@ -4,12 +4,12 @@
 
 Re-evaluate codebase state before implementation to detect staleness or superseding issues.
 
-## Entry Criteria
+## Preconditions
 
 - Authorization verified
 - Sub-issues verified
 
-## Exit Criteria
+## Postconditions
 
 - Files mentioned in spec still exist
 - Referenced code is still valid

--- a/.opencode/skills/approval-gate/tasks/verify-open-questions.md
+++ b/.opencode/skills/approval-gate/tasks/verify-open-questions.md
@@ -4,12 +4,12 @@
 
 Check for unresolved open questions in the spec before implementation.
 
-## Entry Criteria
+## Preconditions
 
 - Authorization verified
 - Blockers checked
 
-## Exit Criteria
+## Postconditions
 
 - All open questions resolved
 - Ready to proceed with implementation

--- a/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
@@ -4,13 +4,13 @@
 
 Verify sub-issue structure and STATUS gate for multi-task specs before implementation.
 
-## Entry Criteria
+## Preconditions
 
 - Spec exists as GitHub Issue
 - Authorization received for specific subtask (e.g., "approved: 1.2")
 - Subtask number provided or extracted from authorization
 
-## Exit Criteria
+## Postconditions
 
 - Sub-issues verified present (multi-task) OR exemption confirmed (single-task)
 - STATUS in parent matches requested subtask number

--- a/.opencode/skills/changelog-generator/SKILL.md
+++ b/.opencode/skills/changelog-generator/SKILL.md
@@ -5,31 +5,28 @@ license: MIT
 compatibility: opencode
 ---
 
-# Changelog Generator
+# Skill: changelog-generator
 
-Transforms technical git commits into polished, user-friendly changelogs that customers will understand and appreciate.
-
-## When to Use
-
-- Preparing release notes for a new version
-- Creating weekly/monthly product updates
-- Writing changelog entries for app store submissions
-
-## Prerequisites
-
-- **Git**: Required for reading commit history
-- **Repository access**: Must be run from a git repository root
-- **Optional**: Custom changelog style guide (CHANGELOG_STYLE.md)
+Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes.
 
 ## When to Use This Skill
 
-- Preparing release notes for a new version
-- Creating weekly or monthly product update summaries
-- Documenting changes for customers
-- Writing changelog entries for app store submissions
-- Generating update notifications
-- Creating internal release documentation
-- Maintaining a public changelog/product updates page
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Generating changelog | `/skill changelog-generator` | Create changelog from commits |
+| Updating CHANGELOG.md | `/skill changelog-generator --task write` | Write entries to changelog file |
+| PR creation workflow | Invoked as subtask by `git-workflow` | Generate commit messages for PR |
+
+## This Skill's Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| `overview` | Full skill content for changelog generation | ~400 |
+| `write` | Write generated entries to CHANGELOG.md | ~300 |
 
 ## Dual Changelog Workflow
 

--- a/.opencode/skills/changelog-generator/tasks/write.md
+++ b/.opencode/skills/changelog-generator/tasks/write.md
@@ -4,7 +4,7 @@
 
 Write generated changelog entries to CHANGELOG.md file.
 
-## Operating Protocol
+## Workflow
 
 1. **After generate task:** Run after `overview` task generates entries
 2. **Prepend entries:** Add new entries to `[Unreleased]` section
@@ -34,14 +34,14 @@ This repository maintains TWO changelogs:
 
 **Default:** If uncertain, default to `.opencode/CHANGELOG.md` for AI-focused changes.
 
-## Entry Criteria
+## Preconditions
 
 - Changelog entries generated from `overview` task
 - Repository has git history to analyze
 - Working directory is clean or changes are acceptable to include
 - Target changelog path determined (project or AI agent)
 
-## Exit Criteria
+## Postconditions
 
 - CHANGELOG.md updated with new entries
 - File formatted per Keep a Changelog standard

--- a/.opencode/skills/code-review/SKILL.md
+++ b/.opencode/skills/code-review/SKILL.md
@@ -7,7 +7,23 @@ compatibility: opencode
 
 # Code Review Agent
 
-You are a senior code reviewer. Your role is to analyze code and provide constructive, actionable feedback.
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| PR code review request | `/skill code-review` | Analyze pull request changes |
+| File/directory review request | `/skill code-review <path>` | Review specific files |
+| Post-implementation review | `/skill code-review` | Review recent changes |
+
+## This Skill's Tasks
+
+| Task | Description | Words |
+|------|-------------|-------|
+| `overview` | Code review for bugs, security, performance | ~400 |
 
 ## Context Detection
 

--- a/.opencode/skills/code-review/tasks/review-code.md
+++ b/.opencode/skills/code-review/tasks/review-code.md
@@ -6,11 +6,11 @@ Review code for bugs, security, performance, and best practices.
 
 Provide constructive feedback on code changes.
 
-## Entry Criteria
+## Preconditions
 
 - Code changes available (staged, unstaged, PR, or file)
 
-## Exit Criteria
+## Postconditions
 
 - Structured review provided
 

--- a/.opencode/skills/code-size-enforcement/SKILL.md
+++ b/.opencode/skills/code-size-enforcement/SKILL.md
@@ -11,7 +11,19 @@ Enforce size limits on functions, notebook cells, and files using word counts as
 
 **Why Word Counts:** Word counts provide a more accurate measure of LLM context usage and cognitive load than line counts. A dense short function may have more complexity than a verbose long one.
 
-## Available Tasks
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Writing or modifying code | `/skill code-size-enforcement --task overview` | Check size limits |
+| Before merge/PR | `/skill code-size-enforcement --task overview` | Verify compliance |
+| Size limit violations | `/skill code-size-enforcement --task overview` | Get remediation guidance |
+
+## This Skill's Tasks
 
 | Task | Description | Words |
 |------|-------------|-------|
@@ -29,13 +41,14 @@ Invoke the overview task for complete enforcement rules:
 
 Code Size Enforcer ensuring code artifacts stay within size limits for maintainability and readability.
 
-## Operating Protocol
+## Workflow
 
-1. **Automatically Applied** - This skill is referenced whenever code is written or modified
-2. **Check Size Limits Before Merge** - Verify limits when code changes are prepared for commit/PR
-3. **Use Permitted Detection Tools** - Use documented measurement methods
-4. **Grandfather Existing Files** - Files before this skill are NOT flagged
-5. **Enforce on New/Modified Files** - Created/modified after skill introduction must comply
+**Automatic by default — no manual invocation needed.**
+
+1. Automatically enforced when code is written or modified
+2. Check limits before merge/PR
+3. Use permitted detection tools
+4. Grandfather existing files, enforce on new/modified
 
 ---
 

--- a/.opencode/skills/coherence-auditor/SKILL.md
+++ b/.opencode/skills/coherence-auditor/SKILL.md
@@ -9,13 +9,19 @@ compatibility: opencode
 
 Audits coherence between `.opencode/guidelines/`, `.opencode/skills/`, and AI agent behavior. Identifies procedural workflows for extraction and detects drift over time.
 
-## When to Use
+## When to Invoke
 
-- Creating new skills from guideline content (extraction)
-- Ongoing drift detection and verification (maintenance)
-- Before approving guideline/skill changes
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
 
-## Tasks
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Creating new skills | `/skill coherence-auditor --mode extraction` | Identify skill candidates |
+| Periodic maintenance | `/skill coherence-auditor --mode maintenance` | Detect drift from baseline |
+| Before approving changes | `/skill coherence-auditor --mode maintenance` | Verify coherence |
+
+## This Skill's Tasks
 
 | Task | Purpose | Words |
 |------|---------|-------|
@@ -36,7 +42,7 @@ Audits coherence between `.opencode/guidelines/`, `.opencode/skills/`, and AI ag
 - `/skill coherence-auditor --task create-report` — Load specific task
 - `/skill coherence-auditor` — Overview only
 
-## Operating Protocol
+## Workflow
 
 1. **Automatic invocation (mandatory):** This skill is invoked when auditing guideline/skill coherence or when user requests extraction/maintenance audit.
 

--- a/.opencode/skills/coherence-auditor/tasks/create-report.md
+++ b/.opencode/skills/coherence-auditor/tasks/create-report.md
@@ -4,12 +4,12 @@
 
 Generate and attach audit report to GitHub Issue for fresh-start context preservation.
 
-## Entry Criteria
+## Preconditions
 
 - Audit completed (extraction or maintenance mode)
 - Findings documented in memory
 
-## Exit Criteria
+## Postconditions
 
 - Audit report created in `./tmp/coherence-audit-YYYYMMDD-<mode>.md`
 - Report attached as GitHub Issue comment

--- a/.opencode/skills/coherence-auditor/tasks/extract-analyze.md
+++ b/.opencode/skills/coherence-auditor/tasks/extract-analyze.md
@@ -4,12 +4,12 @@
 
 Calculate metrics and rank extraction candidates identified during scan phase.
 
-## Entry Criteria
+## Preconditions
 
 - Extraction candidates identified by `extract-scan`
 - Guideline files available for analysis
 
-## Exit Criteria
+## Postconditions
 
 - Each candidate has metrics (lines, tokens, duplication, complexity)
 - Candidates ranked by priority

--- a/.opencode/skills/coherence-auditor/tasks/extract-scan.md
+++ b/.opencode/skills/coherence-auditor/tasks/extract-scan.md
@@ -4,12 +4,12 @@
 
 Scan all `.opencode/guidelines/*.md` files to identify skill extraction candidates during extraction mode.
 
-## Entry Criteria
+## Preconditions
 
 - Skill invoked with `--mode extraction`
 - Guidelines directory exists and is readable
 
-## Exit Criteria
+## Postconditions
 
 - All guideline files scanned
 - Extraction candidates identified and ranked

--- a/.opencode/skills/coherence-auditor/tasks/maintenance-detect.md
+++ b/.opencode/skills/coherence-auditor/tasks/maintenance-detect.md
@@ -4,13 +4,13 @@
 
 Detect drift between guidelines and skills during maintenance mode by comparing current state to baseline.
 
-## Entry Criteria
+## Preconditions
 
 - Skill invoked with `--mode maintenance`
 - Previous baseline exists (from prior audit log)
 - Current guidelines and skills available
 
-## Exit Criteria
+## Postconditions
 
 - Token drift calculated (±% from baseline)
 - Duplicate content flagged

--- a/.opencode/skills/coherence-auditor/tasks/maintenance-verify.md
+++ b/.opencode/skills/coherence-auditor/tasks/maintenance-verify.md
@@ -4,12 +4,12 @@
 
 Verify guideline-skill references remain valid and detect missing references during maintenance mode.
 
-## Entry Criteria
+## Preconditions
 
 - Drift patterns identified by `maintenance-detect`
 - Skills and guidelines available for cross-reference check
 
-## Exit Criteria
+## Postconditions
 
 - All skill references verified
 - Missing references identified

--- a/.opencode/skills/commit-writer/SKILL.md
+++ b/.opencode/skills/commit-writer/SKILL.md
@@ -7,9 +7,22 @@ compatibility: opencode
 
 # Commit Message Writer
 
-You are a commit message specialist. Your role is to analyze staged changes and generate clear, concise commit messages following Conventional Commits.
+## When to Invoke
 
-Load the `git-conventions` skill for format reference if needed.
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Preparing commit message | `/skill commit-writer` | Generate Conventional Commits message |
+| After git add, before commit | `/skill commit-writer` | Analyze staged changes |
+
+## This Skill's Tasks
+
+| Task | Description | Words |
+|------|-------------|-------|
+| `overview` | Generate commit message from staged changes | ~150 |
 
 ## Process
 

--- a/.opencode/skills/commit-writer/tasks/generate-message.md
+++ b/.opencode/skills/commit-writer/tasks/generate-message.md
@@ -6,11 +6,11 @@ Generate Conventional Commits compliant commit message.
 
 Analyze staged changes and generate appropriate commit message.
 
-## Entry Criteria
+## Preconditions
 
 - Changes are staged (`git add`)
 
-## Exit Criteria
+## Postconditions
 
 - Commit message generated following Conventional Commits format
 

--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -9,13 +9,19 @@ compatibility: opencode
 
 Analyzes spec phase structures to identify concern quality issues and apply smart fixes. Posts findings to GitHub comments.
 
-## When to Use
+## When to Invoke
 
-- Creating new spec issues (MANDATORY - runs first)
-- Reviewing existing specs for phase quality
-- Auditing multi-phase implementations
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
 
-## Available Tasks
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Creating new spec issues | `/skill concern-separation-auditor --issue N` | First auditor in mandatory chain |
+| Reviewing spec quality | `/skill concern-separation-auditor --issue N` | Phase structure analysis |
+| Auditing multi-phase implementations | `/skill concern-separation-auditor --issue N` | Concern separation check |
+
+## This Skill's Tasks
 
 | Task | Description |
 |------|-------------|

--- a/.opencode/skills/context7-lookup/SKILL.md
+++ b/.opencode/skills/context7-lookup/SKILL.md
@@ -9,6 +9,24 @@ compatibility: opencode
 
 Context7 is an MCP server that injects up-to-date, version-specific documentation directly into your context. Use it to avoid hallucinated APIs and outdated code examples.
 
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Before implementing with external libraries | `/skill context7-lookup` | Fetch current API documentation |
+| When unsure about current API signatures | `/skill context7-lookup` | Get version-specific docs |
+| User asks about specific library version | `/skill context7-lookup` | Look up library docs |
+
+## This Skill's Tasks
+
+| Task | Description | Words |
+|------|-------------|-------|
+| `overview` | How to use Context7 MCP tools effectively | ~400 |
+
 ## What This Skill Is
 
 This skill teaches you **how to use** Context7 MCP tools effectively. It does not replace Context7 — you must have Context7 MCP configured in OpenCode.

--- a/.opencode/skills/context7-lookup/tasks/lookup-docs.md
+++ b/.opencode/skills/context7-lookup/tasks/lookup-docs.md
@@ -6,11 +6,11 @@ Fetch up-to-date library documentation.
 
 Get current API signatures and examples for external libraries.
 
-## Entry Criteria
+## Preconditions
 
 - Need documentation for an external library
 
-## Exit Criteria
+## Postconditions
 
 - Current documentation retrieved
 

--- a/.opencode/skills/debugger/SKILL.md
+++ b/.opencode/skills/debugger/SKILL.md
@@ -9,6 +9,24 @@ compatibility: opencode
 
 You are a debugging specialist. Your role is to analyze errors, understand root causes, and propose hypotheses — **without modifying any code**. You investigate, the user decides what to fix.
 
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Error analysis request | `/skill debugger` | Analyze errors and stack traces |
+| Bug investigation | `/skill debugger` | Diagnose without modifying code |
+| Test failure investigation | `/skill debugger` | Analyze test failures |
+
+## This Skill's Tasks
+
+| Task | Description | Words |
+|------|-------------|-------|
+| `overview` | Error analysis and root cause investigation | ~350 |
+
 ## Philosophy
 
 > "Understand before you fix."

--- a/.opencode/skills/debugger/tasks/analyze-error.md
+++ b/.opencode/skills/debugger/tasks/analyze-error.md
@@ -6,11 +6,11 @@ Analyze errors, stack traces, and bugs without modifying code.
 
 Investigate root causes and propose hypotheses for user to decide on fixes.
 
-## Entry Criteria
+## Preconditions
 
 - User reports an error or bug
 
-## Exit Criteria
+## Postconditions
 
 - Root cause identified or hypotheses documented
 - Suggested investigation steps provided

--- a/.opencode/skills/dev-architect/SKILL.md
+++ b/.opencode/skills/dev-architect/SKILL.md
@@ -7,7 +7,24 @@ compatibility: opencode
 
 # Dev Architect Agent
 
-You are a senior technical architect. Your role is to analyze requirements and design a clear implementation plan before any code is written.
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Plan phase of spec creation | `/skill dev-architect --task design-plan` | Create implementation plan |
+| Reviewing specs for correctness | `/skill dev-architect --task review-spec` | Check correctness, compliance |
+| Design question during implementation | `/skill dev-architect --task design-plan` | Architectural guidance |
+
+## This Skill's Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| `design-plan` | Create detailed implementation plan before coding | ~500 |
+| `review-spec` | Review and revise specs for correctness and compliance | ~400 |
 
 ## Philosophy
 
@@ -125,13 +142,13 @@ Create an ordered execution plan:
 | Plan phase of spec creation | `/skill dev-architect --task design-plan` |
 | Reviewing specs for correctness | `/skill dev-architect --task review-spec` |
 
-## Auto-Invocation
+## Workflow
 
-**These invocations are AUTOMATIC:**
+**Invoke at these triggers:**
 
-1. **Plan Phase**: When creating a new spec, auto-invoke `/skill dev-architect --task design-plan` to analyze requirements and create execution plan.
+1. **Plan Phase**: When creating a new spec, invoke `/skill dev-architect --task design-plan` to analyze requirements and create execution plan.
 
-2. **Spec Review**: When reviewing or revising specs, auto-invoke `/skill dev-architect --task review-spec` to check for correctness, compliance, interdependencies, and ordering.
+2. **Spec Review**: When reviewing or revising specs, invoke `/skill dev-architect --task review-spec` to check for correctness, compliance, interdependencies, and ordering.
 
 ## Tasks
 

--- a/.opencode/skills/dev-architect/tasks/design-plan.md
+++ b/.opencode/skills/dev-architect/tasks/design-plan.md
@@ -6,12 +6,12 @@ Design a detailed implementation plan before coding.
 
 Analyze requirements and create a clear execution plan with files to touch, dependencies, and risks.
 
-## Entry Criteria
+## Preconditions
 
 - User requests a feature or change
 - Requirements are understood or clarified
 
-## Exit Criteria
+## Postconditions
 
 - Execution plan documented
 - Files to touch listed

--- a/.opencode/skills/git-conventions/tasks/reference.md
+++ b/.opencode/skills/git-conventions/tasks/reference.md
@@ -6,11 +6,11 @@ Reference for Git conventions and best practices.
 
 Provide authoritative reference for Conventional Commits, branch naming, and PR standards.
 
-## Entry Criteria
+## Preconditions
 
 - Need to understand Git conventions
 
-## Exit Criteria
+## Postconditions
 
 - Convention information provided
 

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -7,7 +7,7 @@ compatibility: opencode
 
 # Skill: git-workflow
 
-Git Workflow Enforcer ensuring all git operations follow the repository's strict branch-first, stash-first, squash-merge workflow. Invoked automatically before implementation and when PR creation is requested.
+Git Workflow Enforcer ensuring all git operations follow the repository's strict branch-first, stash-first, squash-merge workflow.
 
 ## ⚠️ CRITICAL: THIS SKILL IS MANDATORY - NO BYPASS {#critical-skill}
 
@@ -25,12 +25,18 @@ At workflow trigger points, the agent MUST invoke this skill - NOT run git comma
 
 ---
 
-## When to Use
+## When to Invoke
 
-- User says "approved" or "go" (pre-work phase - AUTO)
-- Implementation completes (review-prep phase - AUTO)
-- User says "create a PR" or "pr" (pr-creation phase)
-- User says "pr merged" or "merged" or similar (cleanup phase - AUTO)
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| After approval ("approved" or "go") | `/skill git-workflow --task pre-work` | Stash changes, create feature branch |
+| After implementation completes | `/skill git-workflow --task review-prep` | Push branch, generate compare URL, HALT |
+| User says "create a PR" | `/skill git-workflow --task pr-creation` | Squash to single commit, push, create PR, HALT |
+| User says "PR merged" | `/skill git-workflow --task cleanup` | Close issues, delete branches |
 
 ## Tasks
 
@@ -53,14 +59,44 @@ At workflow trigger points, the agent MUST invoke this skill - NOT run git comma
 - `/skill git-workflow --task cleanup` - **When user says "pr merged" or "merged"** (automatic)
 - `/skill git-workflow` - Overview only
 
-## Operating Protocol
+## This Skill's Tasks
 
-1. **Automatic invocation (mandatory):** This skill is referenced when:
+**`pre-work`**: Use after authorization. Verifies branch state, stashes external changes (with --include-untracted), creates feature branch from dev.
+
+**`implementation`**: Use during work. Handles grouped commits, WIP commits before HALT, executive summaries after completion.
+
+**`review-prep`**: Use after implementation completes (automatic). Pushes branch, generates GitHub compare URL, posts to issue AND chat, HALTs for developer review.
+
+**`commit-prep`**: Use when user says "commit". Prepares squash commit message by reading commit history (read-only, no commits).
+
+**`pr-creation`**: Use when user says "create a PR" or "pr". Squashes to single commit, pushes, creates PR with changelog, HALTs.
+
+**`cleanup`**: Use when user says "pr merged" or "merged" (automatic). Verifies merge via GitHub API, closes issues, deletes local and remote branches.
+
+## Workflow Context
+
+**Phase Sequence:**
+
+1. `pre-work` → Create branch, verify clean state
+2. `implementation` → Agent performs work, grouped commits
+3. `review-prep` (automatic) → Push, generate compare URL, HALT
+4. `commit-prep` (optional) → Prepare commit message
+5. `pr-creation` (user-initiated) → Squash, push, create PR, HALT
+6. `cleanup` (after merge) → Close issues, delete branches
+- `/skill git-workflow --task review-prep` - **AFTER implementation done** (automatic, no decision point)
+- `/skill git-workflow --task commit-prep` - When user says "commit"
+- `/skill git-workflow --task pr-creation` - When user says "create a PR" or "pr"
+- `/skill git-workflow --task cleanup` - **When user says "pr merged" or "merged"** (automatic)
+- `/skill git-workflow` - Overview only
+
+## Workflow Triggers
+
+**Invoke this skill at these triggers:**
 
    - User says `approved`, `go`, or similar authorization
    - User says `create a PR`, `pr`, or similar PR request
-   - Implementation completes (review-prep task invoked automatically)
-   - DO NOT prompt for invocation - the skill is triggered automatically
+   - Implementation completes (invoke review-prep task)
+   - DO NOT prompt for invocation - invoke at these triggers
 
 1. **Phase sequence:**
 
@@ -71,9 +107,9 @@ At workflow trigger points, the agent MUST invoke this skill - NOT run git comma
    - Phase 5: PR Creation (user-initiated) → `pr-creation` task
    - Phase 6: Branch Cleanup (after merge) → `cleanup` task
 
-## Automatic Invocation Triggers
+## Enforcement Points
 
-**This skill MUST be invoked automatically (no user prompt) at these enforcement points:**
+**Invoke this skill at these triggers (no user prompt needed):**
 
 | Trigger Point | Action | Verification |
 |---------------|--------|--------------|
@@ -104,16 +140,16 @@ This is NOT optional. This is NOT a decision point. This is MANDATORY.
 - Not "I already reviewed"
 - **ALWAYS INVOKE THE SKILL**
 
-### ⚠️ MANDATORY: review-prep Is Automatic (No Decision Point)
+### ⚠️ MANDATORY: review-prep Invoked After Implementation (No Decision Point)
 
-**After implementation completes, the agent MUST automatically invoke review-prep — there is NO choice.**
+**After implementation completes, the agent MUST invoke review-prep — there is NO choice.**
 
 The sequence is FIXED:
 
 1. Implementation task finishes all file changes
 2. Implementation task commits AND pushes the branch
 3. Implementation task reports completion
-4. **review-prep is invoked AUTOMATICALLY** → generates compare URL → HALTs
+4. **review-prep is invoked** → generates compare URL → HALTs
 
 **DO NOT:**
 - Skip review-prep because "changes are trivial"
@@ -132,7 +168,7 @@ The sequence is FIXED:
 ```
 Implementation complete
     ↓
-review-prep invoked AUTOMATICALLY (Phase 3)
+review-prep invoked (Phase 3)
     ↓
 Push branch → Generate compare URL → HALT
     ↓

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -4,18 +4,18 @@
 
 Delete merged branches after PR merge, clean stale references, and verify repository state is ready for next work session.
 
-## Operating Protocol
+## Workflow
 
 1. **After PR merge:** Run when human confirms "PR merged" or similar
 1. **Automatic detection:** Can also run when invoked to check for merged branches
 1. **Mandatory cleanup:** ALL merged branches must be deleted (local and remote)
 
-## Entry Criteria
+## Preconditions
 
 - Human confirms "PR merged" or similar
 - OR skill invoked with cleanup detection enabled
 
-## Exit Criteria
+## Postconditions
 
 - Local merged branch deleted
 - Remote merged branch deleted (if applicable)

--- a/.opencode/skills/git-workflow/tasks/commit-prep.md
+++ b/.opencode/skills/git-workflow/tasks/commit-prep.md
@@ -4,19 +4,19 @@
 
 Prepare commit message for squash commit during PR creation. This is a read-only analysis phase - no commits are executed.
 
-## Operating Protocol
+## Workflow
 
 1. **User-initiated only:** This task runs when user says "commit" or "prepare a commit"
 1. **Read-only analysis:** Discover changes but DO NOT execute commits
 1. **HALT after analysis:** Wait for user to review and approve
 
-## Entry Criteria
+## Preconditions
 
 - User says "commit" or "prepare a commit"
 - Implementation is complete
 - Feature branch pushed to remote
 
-## Exit Criteria
+## Postconditions
 
 - Commit script created in `./tmp/`
 - Proposed commit message documented

--- a/.opencode/skills/git-workflow/tasks/implementation.md
+++ b/.opencode/skills/git-workflow/tasks/implementation.md
@@ -4,19 +4,19 @@
 
 Handle work-in-progress commits during implementation. Multiple commits during implementation are acceptable for checkpointing.
 
-## Operating Protocol
+## Workflow
 
 1. **User-driven work:** The agent performs approved implementation tasks
 1. **Checkpoint commits allowed:** Commits during implementation serve to stage changes and prevent accidental loss
 1. **Squashing is deferred:** Squashing to single commit happens during PR creation, not during implementation
 
-## Entry Criteria
+## Preconditions
 
 - Feature branch exists and is checked out
 - Implementation authorized for this phase/task
 - Working tree clean (or stashed)
 
-## Exit Criteria
+## Postconditions
 
 - All implementation work complete for authorized phase/task
 - Changes committed (implementation commits acceptable)

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -4,7 +4,7 @@
 
 Create pull request after explicit user instruction. Squash commits to single commit, push branch, create PR via GitHub MCP.
 
-## Operating Protocol
+## Workflow
 
 1. **User-initiated only:** This task runs when user says "create a PR" or similar
 1. **Squash to single commit:** ALL implementation commits combined into ONE clean commit
@@ -21,13 +21,13 @@ Create pull request after explicit user instruction. Squash commits to single co
 
 **Bypassing this skill is a CRITICAL GUIDELINE VIOLATION.**
 
-## Entry Criteria
+## Preconditions
 
 - User says "create a PR", "make a PR", "push and create PR", or similar
 - Implementation is complete
 - Developer has reviewed changes via compare URL
 
-## Exit Criteria
+## Postconditions
 
 - PR created via GitHub MCP
 - PR URL reported to user

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -4,19 +4,19 @@
 
 Verify branch state, preserve changes, create feature branch BEFORE any implementation work begins.
 
-## Operating Protocol
+## Workflow Triggers
 
-1. **Automatic invocation (mandatory):** This task is invoked automatically when:
-   - User says `approved`, `go`, or similar authorization to begin implementation
-   - DO NOT prompt for invocation - the skill is triggered automatically
+**Invoke this task at these workflow points:**
+- User says `approved`, `go`, or similar authorization to begin implementation
+- DO NOT prompt for invocation - invoke automatically at these triggers
 
-## Entry Criteria
+## Preconditions
 
 - User has authorized implementation (explicit `approved` or `go`)
 - Authorization is for the correct issue
 - Sub-issue structure verified (for multi-task specs)
 
-## Exit Criteria
+## Postconditions
 
 - Feature branch created from dev
 - Working tree clean (stashed if needed)

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -4,13 +4,14 @@
 
 Generate GitHub compare URL for developer review AFTER the implementation task has already pushed the branch. This provides the developer with visibility into changes BEFORE deciding to create a PR.
 
-## ⚠️ MANDATORY INVOCATION
+## Workflow Triggers
 
-**This task is ALWAYS invoked automatically after implementation completes. There is NO decision point.**
+**Invoke this task at these workflow points:**
+- After implementation completes (mandatory - no decision point)
 
 The sequence is:
 
-1. Implementation complete → commit → push → **review-prep invoked automatically**
+1. Implementation complete → commit → push → **invoke review-prep**
 2. Compare URL generated → HALT
 3. Wait for developer to say "create a PR"
 
@@ -75,20 +76,20 @@ When implementation determines "no file changes needed":
 - **MUST detect actual runtime identity** from environment/MCP tools
 - **If model ID unknown:** STOP and ask user - DO NOT use example from documentation
 
-## Operating Protocol
+## Workflow
 
 1. **After implementation:** This task runs AFTER all implementation is complete - NO EXCEPTIONS
 2. **MANDATORY step:** Branch MUST be pushed to remote for developer review - NO ASKING
 3. **HALT after push:** Wait for developer to review and authorize PR creation
 
-## Entry Criteria
+## Preconditions
 
 - All implementation work complete AND pushed to remote
 - Feature branch pushed (done by implementation task)
 - No explicit "create a PR" instruction yet
 - Temp files cleaned up (see Step 0)
 
-## Exit Criteria
+## Postconditions
 
 - Compare URL generated and posted
 - Developer can review changes via GitHub diff viewer

--- a/.opencode/skills/github-comments/tasks/overview.md
+++ b/.opencode/skills/github-comments/tasks/overview.md
@@ -10,7 +10,7 @@ Github Comments management for effective GitHub workflow.
 
 This skill is automatically referenced when working with GitHub Issues and PRs.
 
-## Operating Protocol
+## Workflow
 
 Review the full skill content via `/skill github-comments --task overview` or load the skill for detailed workflow guidance.
 

--- a/.opencode/skills/github-sub-issues/tasks/overview.md
+++ b/.opencode/skills/github-sub-issues/tasks/overview.md
@@ -10,7 +10,7 @@ Github Sub Issues management for effective GitHub workflow.
 
 This skill is automatically referenced when working with GitHub Issues and PRs.
 
-## Operating Protocol
+## Workflow
 
 Review the full skill content via `/skill github-sub-issues --task overview` or load the skill for detailed workflow guidance.
 

--- a/.opencode/skills/guideline-auditor/SKILL.md
+++ b/.opencode/skills/guideline-auditor/SKILL.md
@@ -5,14 +5,30 @@ license: MIT
 compatibility: opencode
 ---
 
-# Persona: Guideline Auditor
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Before approving guideline changes | `/skill guideline-auditor` | Verify guideline quality |
+| Periodic guideline maintenance | `/skill guideline-auditor` | Drift detection |
+| Post-implementation verification | `/skill guideline-auditor` | Check for new issues |
+
+## This Skill's Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| `overview` | Full skill content for guideline auditing | ~1500 |
 
 ## Role
 
 You are an LLM Guideline Auditor. Your sole focus is analyzing the `.opencode/guidelines/` files to identify instructions
 that are ambiguous, conflicting, or unlikely to be followed by an LLM agent.
 
-## Operating Protocol
+## Workflow
 
 1. **No-directive load fallback (mandatory):** If this persona is loaded without a specific user directive, immediately perform a general guideline audit of your scoped files (`.opencode/guidelines/`) using this protocol.
 1. **One issue at a time.** Present exactly one identified issue per interaction. Do not batch or preview other issues.

--- a/.opencode/skills/guideline-auditor/tasks/overview.md
+++ b/.opencode/skills/guideline-auditor/tasks/overview.md
@@ -9,7 +9,7 @@ description: Analyzes guideline files for ambiguity, conflicts, and LLM complian
 
 You are an LLM Guideline Auditor. Your sole focus is analyzing the `.opencode/guidelines/` files to identify instructions that are ambiguous, conflicting, or unlikely to be followed by an LLM agent.
 
-## Operating Protocol
+## Workflow
 
 1. **No-directive load fallback (mandatory):** If this persona is loaded without a specific user directive, immediately perform a general guideline audit of your scoped files (`.opencode/guidelines/`) using this protocol.
 1. **One issue at a time.** Present exactly one identified issue per interaction. Do not batch or preview other issues.

--- a/.opencode/skills/implementation-quality/SKILL.md
+++ b/.opencode/skills/implementation-quality/SKILL.md
@@ -9,17 +9,21 @@ compatibility: opencode
 
 Pattern verification for file locations, code structure, environment, and data integrity. Invoke at workflow gates to catch violations before they reach production.
 
-## When to Use
+## When to Invoke
 
-| Gate | Invocation |
-|------|------------|
-| Before creating ANY file | `/skill implementation-quality --task file-locations` |
-| At implementation start | `/skill implementation-quality --task code-structure` (load once, reference continuously) |
-| Before running commands | `/skill implementation-quality --task environment` |
-| Before handling data | `/skill implementation-quality --task data-integrity` |
-| **After implementation completes** | **MANDATORY: Automatically invoke review-prep workflow** (see `post-implementation` task) |
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
 
-## Blast Radius
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Before creating ANY file | `/skill implementation-quality --task file-locations` | Verify file location patterns |
+| At implementation start | `/skill implementation-quality --task code-structure` | Verify code structure patterns |
+| Before running commands | `/skill implementation-quality --task environment` | Verify environment patterns |
+| Before handling data | `/skill implementation-quality --task data-integrity` | Verify data integrity patterns |
+| After implementation completes | Automatic: review-prep workflow | Post-implementation verification |
+
+## This Skill's Tasks
 
 | Task | Blast Radius | When to Invoke |
 |------|--------------|----------------|
@@ -55,7 +59,7 @@ Pattern verification for file locations, code structure, environment, and data i
 
 **Note:** The `post-implementation` task is automatically invoked after every implementation. Do NOT skip it.
 
-## Operating Protocol
+## Workflow
 
 1. **Automatic invocation:** Load at workflow gates (see `010-approval-gate.md`)
 2. **Selective loading:** Load only the task needed for current concern

--- a/.opencode/skills/implementation-quality/tasks/post-implementation.md
+++ b/.opencode/skills/implementation-quality/tasks/post-implementation.md
@@ -4,12 +4,12 @@
 
 Enforce mandatory review-prep workflow after every implementation. This is a CRITICAL verification gate with ZERO TOLERANCE for violations.
 
-## Entry Criteria
+## Preconditions
 
 - Implementation task has completed all file changes
 - Agent is about to HALT or report completion
 
-## Exit Criteria
+## Postconditions
 
 - Branch is pushed to remote (verified)
 - Compare URL is generated

--- a/.opencode/skills/mcp-tool-usage/SKILL.md
+++ b/.opencode/skills/mcp-tool-usage/SKILL.md
@@ -80,15 +80,14 @@ owner = "<cached-value>"  # from previous session
 github_issue_read(owner=owner, ...)  # WRONG - stale cached value
 ```
 
-## Operating Protocol
+## Workflow
 
-1. **Automatically Applied:** This skill is referenced whenever any file operation is needed. It is NOT invoked by name - the agent follows these rules at all times.
+**This skill is invoked when any file operation is needed. It is NOT invoked by name - the agent follows these rules at all times.**
 
-1. **MCP Probe First:** Before any file operation, the agent MUST have probed MCP availability (see `000-session-init.md`).
-
-1. **Tool Selection Hierarchy:** Use the table below to select the CORRECT tool for each operation type.
-
-1. **Zero Tolerance:** Violations of MANDATORY tool usage are hard-stop violations.
+**Key requirements:**
+- MCP Probe First: Before any file operation, the agent MUST have probed MCP availability (see `000-session-init.md`).
+- Tool Selection Hierarchy: Use the table below to select the CORRECT tool for each operation type.
+- Zero Tolerance: Violations of MANDATORY tool usage are hard-stop violations.
 
 ## Three-Tier Boundary System
 

--- a/.opencode/skills/mcp-tool-usage/tasks/overview.md
+++ b/.opencode/skills/mcp-tool-usage/tasks/overview.md
@@ -72,7 +72,7 @@ owner = "<cached-value>"  # from previous session
 github_issue_read(owner=owner, ...)  # WRONG - stale cached value
 ```
 
-## Operating Protocol
+## Workflow
 
 1. **Automatically Applied:** This skill is referenced whenever any file operation is needed. It is NOT invoked by name - the agent follows these rules at all times.
 

--- a/.opencode/skills/notebook-operations/SKILL.md
+++ b/.opencode/skills/notebook-operations/SKILL.md
@@ -11,15 +11,14 @@ compatibility: opencode
 
 You are a Notebook Operations Enforcer. Your sole focus is ensuring ALL notebook operations use `the-notebook-mcp` tools exclusively. This is a ZERO TOLERANCE rule — violations cause notebook corruption, data integrity issues, and broken functionality.
 
-## Operating Protocol
+## Workflow
 
-1. **Automatically Applied:** This skill is referenced whenever any notebook operation is needed. It is NOT invoked by name - the agent follows these rules at all times.
+**This skill is invoked when any notebook operation is needed. It is NOT invoked by name - the agent follows these rules at all times.**
 
-1. **MCP Required:** Notebook operations are ONLY permitted when `the-notebook-mcp` is available from MCP probe.
-
-1. **No Fallback:** If `the-notebook-mcp` is unavailable, ALL notebook operations are FORBIDDEN.
-
-1. **Zero Tolerance:** Violations of MCP-only notebook operations are hard-stop violations.
+**Key requirements:**
+- MCP Required: Notebook operations are ONLY permitted when `the-notebook-mcp` is available from MCP probe.
+- No Fallback: If `the-notebook-mcp` is unavailable, ALL notebook operations are FORBIDDEN.
+- Zero Tolerance: Violations of MCP-only notebook operations are hard-stop violations.
 
 ## Available Tasks
 

--- a/.opencode/skills/notebook-operations/tasks/overview.md
+++ b/.opencode/skills/notebook-operations/tasks/overview.md
@@ -9,7 +9,7 @@ description: Jupyter notebook operations with zero-tolerance corruption rules. D
 
 You are a Notebook Operations Enforcer. Your sole focus is ensuring ALL notebook operations use `the-notebook-mcp` tools exclusively. This is a ZERO TOLERANCE rule — violations cause notebook corruption, data integrity issues, and broken functionality.
 
-## Operating Protocol
+## Workflow
 
 1. **Automatically Applied:** This skill is referenced whenever any notebook operation is needed. It is NOT invoked by name - the agent follows these rules at all times.
 

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -13,6 +13,18 @@ Defines when PRs can be created, what authorizes PR creation, and the mandatory 
 
 **PR creation is a DISTINCT phase requiring EXPLICIT instruction — it is NOT automatic after implementation.**
 
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at this workflow trigger:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| User says "create a PR" | `/skill git-workflow --task pr-creation` | Squash to single commit, push, create PR, HALT |
+
+**Note:** PR creation timing is part of `git-workflow` skill. This skill (`pr-creation-workflow`) defines the RULES, not the invocation.
+
 ## Available Tasks
 
 | Task | Description |

--- a/.opencode/skills/pr-writer/SKILL.md
+++ b/.opencode/skills/pr-writer/SKILL.md
@@ -5,11 +5,28 @@ license: MIT
 compatibility: opencode
 ---
 
-# PR Writer Agent
+# Skill: pr-writer
 
-You are a pull request assistant. Your role is to gather context, analyze changes, and **create the PR directly** on GitHub or GitLab.
+Create a pull request on GitHub/GitLab with a well-structured description. Asks for context, then publishes.
 
-## Process
+## When to Use This Skill
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| User requests PR description | `/skill pr-writer` | Create well-structured PR description |
+| Preparing PR for review | `/skill pr-writer` | Get context, generate PR title/body |
+
+## This Skill's Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| (no subtasks) | Skill invoked directly for PR creation | ~180 |
+
+## Workflow
 
 ### 1. Detect the Git Provider
 

--- a/.opencode/skills/pr-writer/tasks/create-pr.md
+++ b/.opencode/skills/pr-writer/tasks/create-pr.md
@@ -6,12 +6,12 @@ Create a pull request on GitHub/GitLab.
 
 Gather context and create PR with structured description.
 
-## Entry Criteria
+## Preconditions
 
 - Branch has commits ready to push
 - User wants to create PR
 
-## Exit Criteria
+## Postconditions
 
 - PR created and URL provided
 

--- a/.opencode/skills/release-notes/SKILL.md
+++ b/.opencode/skills/release-notes/SKILL.md
@@ -5,11 +5,28 @@ license: MIT
 compatibility: opencode
 ---
 
-# Release Notes Agent
+# Skill: release-notes
 
-You are a release manager. Your role is to analyze changes since the last release, understand their business impact, and **publish a release** that matches the project's existing style.
+Generate and publish release notes based on project style. Analyzes previous releases, asks for context, then publishes.
 
-## Process
+## When to Use This Skill
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Preparing release notes | `/skill release-notes` | Generate release notes from commits |
+| Publishing release | `/skill release-notes` | Create release with changelog |
+
+## This Skill's Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| (no subtasks) | Skill invoked directly for release generation | ~180 |
+
+## Workflow
 
 ### 1. Detect Git Provider
 

--- a/.opencode/skills/release-notes/tasks/publish-release.md
+++ b/.opencode/skills/release-notes/tasks/publish-release.md
@@ -6,12 +6,12 @@ Generate and publish release notes.
 
 Analyze changes and publish release matching project style.
 
-## Entry Criteria
+## Preconditions
 
 - Changes since last release
 - User wants to publish a release
 
-## Exit Criteria
+## Postconditions
 
 - Release published with appropriate notes
 

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -5,7 +5,26 @@ license: MIT
 compatibility: opencode
 ---
 
-# Persona: Spec Auditor
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Creating new specs | `/skill spec-auditor --task generate-independent-spec --issue N` | First: clean-room draft |
+| After concern-separation-auditor | `/skill spec-auditor --task audit --issue N` | Third: content quality |
+| After spec changes | `/skill spec-auditor --task audit --issue N` | Post-change verification |
+
+## This Skill's Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| `overview` | Full skill content for spec content quality auditing | ~1800 |
+| `generate-independent-spec` | Generate complete, implementable spec draft from scratch | ~600 |
+| `audit` | Run full audit: fresh-start context, codebase verification, content quality | ~600 |
+| `verify-codebase` | Verify spec references match live codebase | ~400 |
 
 ## Scope: Content Quality for LLM Implementation
 
@@ -84,7 +103,7 @@ Post "ready for review" comment
 
 **You're generating a REAL spec. CORRECT.**
 
-## Operating Protocol
+## Workflow
 
 **⚠️ MANDATORY AUDIT CHAIN (ALL SKILLS RUN)**
 

--- a/.opencode/skills/spec-auditor/tasks/audit-sub-issue.md
+++ b/.opencode/skills/spec-auditor/tasks/audit-sub-issue.md
@@ -91,7 +91,7 @@ GitHub Comment: <URL>
 ## Report Format
 
 ```markdown
-AI: OpenCode (ollama-cloud/glm-5) 📝 Sub-Issue Audit: #{sub_issue}
+AI: <AgentName> (<ModelID>) 📝 Sub-Issue Audit: #{sub_issue}
 
 ## Summary
 - Draft generated: YES
@@ -108,7 +108,7 @@ AI: OpenCode (ollama-cloud/glm-5) 📝 Sub-Issue Audit: #{sub_issue}
 <brief summary>
 
 ---
-🤖 ✅ Completed by OpenCode (ollama-cloud/glm-5)
+🤖 ✅ Completed by <AgentName> (<ModelID>)
 ```
 
 ## Return Value

--- a/.opencode/skills/spec-auditor/tasks/overview.md
+++ b/.opencode/skills/spec-auditor/tasks/overview.md
@@ -30,7 +30,7 @@ Add needs-approval label →
 Post "ready for review" comment
 ```
 
-## Operating Protocol
+## Workflow
 
 **⚠️ MANDATORY AUDIT CHAIN (ALL SKILLS RUN)**
 

--- a/.opencode/skills/sync-guidelines/tasks/overview.md
+++ b/.opencode/skills/sync-guidelines/tasks/overview.md
@@ -11,7 +11,7 @@ Guidelines Sync Manager that intelligently synchronizes between repositories thr
 - User runs `/skill sync-guidelines`
 - Automated workflow detects changes in `.opencode/guidelines/`, `.opencode/skills/`, or `ai_bin/`
 
-## Operating Protocol
+## Workflow
 
 ### Phase 0: Pre-Work Verification
 
@@ -41,7 +41,7 @@ A file is **core** if it:
 - Can be dropped into ANY project and work without modification
 
 Examples of core content:
-- `## Operating Protocol` - workflow definition
+- `## Workflow` - workflow definition
 - `git checkout`, `github_issue_write` - generic operations
 - `## Critical Requirements` - universal standards
 - Generic error handling, data integrity rules
@@ -94,7 +94,7 @@ Post comment to spec issue documenting:
 
 ```python
 # Core file: Defines generic workflow
-"## Operating Protocol" → core (workflow definition)
+"## Workflow" → core (workflow definition)
 "git checkout" → core (generic operation)
 "github_issue_write" → core (generic MCP usage)
 

--- a/.opencode/skills/task-writer/SKILL.md
+++ b/.opencode/skills/task-writer/SKILL.md
@@ -7,7 +7,23 @@ compatibility: opencode
 
 # Task Writer Agent
 
-You are a technical writer specialized in drafting clear, actionable tasks. Your role is to transform a rough idea, bug report, or need into a well-structured ticket ready for a backlog.
+## When to Invoke
+
+**See `AGENTS.md` → "Skill Invocation Guidance" for the complete trigger table.**
+
+This skill is invoked at these workflow triggers:
+
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Creating task/ticket from idea | `/skill task-writer` | Draft structured task |
+| Creating bug report | `/skill task-writer` | Format bug description |
+| Creating feature request | `/skill task-writer` | Write feature ticket |
+
+## This Skill's Tasks
+
+| Task | Description | Words |
+|------|-------------|-------|
+| `overview` | Draft task/ticket from idea or bug | ~300 |
 
 ## Philosophy
 

--- a/.opencode/skills/task-writer/tasks/draft-task.md
+++ b/.opencode/skills/task-writer/tasks/draft-task.md
@@ -6,11 +6,11 @@ Draft a task/ticket from an idea or bug report.
 
 Transform rough ideas into well-structured tickets.
 
-## Entry Criteria
+## Preconditions
 
 - User describes an idea, bug, or need
 
-## Exit Criteria
+## Postconditions
 
 - Task drafted in markdown format
 

--- a/.opencode/skills/templates/PARENT-ISSUE-TEMPLATE.md
+++ b/.opencode/skills/templates/PARENT-ISSUE-TEMPLATE.md
@@ -40,7 +40,7 @@ CREATED: YYYY-MM-DD
 
 ---
 
-## Entry Criteria
+## Preconditions
 
 - [ ] Authorization received for this specific subtask
 - [ ] STATUS in parent matches this subtask number
@@ -48,7 +48,7 @@ CREATED: YYYY-MM-DD
 
 ---
 
-## Exit Criteria
+## Postconditions
 
 - [ ] All verification steps pass
 - [ ] Subtask issue closed with summary
@@ -197,7 +197,7 @@ Skills are monolithic documents that load entirely into context. For skills with
 
 ---
 
-## Entry Criteria
+## Preconditions
 
 - [ ] Authorization received for specific subtask
 - [ ] STATUS matches subtask number
@@ -205,7 +205,7 @@ Skills are monolithic documents that load entirely into context. For skills with
 
 ---
 
-## Exit Criteria
+## Postconditions
 
 - [ ] All subtasks marked ☑
 - [ ] Context savings measured (50%+ target)

--- a/.opencode/skills/templates/SUB-ISSUE-TEMPLATE.md
+++ b/.opencode/skills/templates/SUB-ISSUE-TEMPLATE.md
@@ -26,7 +26,7 @@ Subtask: X.Y  # Must match STATUS in parent
 
 ---
 
-## Entry Criteria
+## Preconditions
 
 - [ ] Authorization received for this specific subtask
 - [ ] STATUS in parent matches this subtask number
@@ -34,7 +34,7 @@ Subtask: X.Y  # Must match STATUS in parent
 
 ---
 
-## Exit Criteria
+## Postconditions
 
 - [ ] [What defines completion - testable criteria]
 - [ ] [Each criterion should be independently verifiable]
@@ -154,7 +154,7 @@ Task: Database schema                       # Missing parent reference
 
 ______________________________________________________________________
 
-## Entry Criteria
+## Preconditions
 
 **Before starting ANY work:**
 
@@ -168,7 +168,7 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## Exit Criteria
+## Postconditions
 
 **Each criterion MUST be:**
 
@@ -176,7 +176,7 @@ ______________________________________________________________________
 1. **Specific** - Clear pass/fail determination
 1. **Complete** - No ambiguity about what "done" means
 
-### ✅ Good Exit Criteria
+### ✅ Good Postconditions
 
 ```
 - [ ] All Tier 1 skills refactored with tasks/ subdirectory
@@ -185,7 +185,7 @@ ______________________________________________________________________
 - [ ] Backwards compatibility maintained
 ```
 
-### ❌ Bad Exit Criteria
+### ❌ Bad Postconditions
 
 ```
 - [ ] Complete implementation
@@ -267,7 +267,7 @@ Design and implement the architecture for GitHub sub-issue sub-task tracking, en
 
 ---
 
-## Entry Criteria
+## Preconditions
 
 - [ ] Tier 1 skills refactored (Phase 1 complete)
 - [ ] Sub-task pattern validated (PR #471 merged)
@@ -275,7 +275,7 @@ Design and implement the architecture for GitHub sub-issue sub-task tracking, en
 
 ---
 
-## Exit Criteria
+## Postconditions
 
 - [ ] Parent issue orchestrator template defined
 - [ ] Sub-issue task template defined

--- a/.opencode/skills/version-bump/tasks/analyze.md
+++ b/.opencode/skills/version-bump/tasks/analyze.md
@@ -4,20 +4,20 @@
 
 Analyze implementation changes to determine appropriate semantic version bump.
 
-## Operating Protocol
+## Workflow
 
 1. **On-demand invocation**: Called by `overview` task or `git-workflow` skill
 2. **Code change detection**: Scans for actual code changes (not docs/chore)
 3. **Impact analysis**: Examines public API changes, new features, bug fixes
 4. **Bump type recommendation**: Returns major/minor/patch/skip
 
-## Entry Criteria
+## Preconditions
 
 - Git repository with commits or staged changes to analyze
 - OR explicit user request with bump type specified
 - Version files present (pyproject.toml, setup.py, package.json, Cargo.toml, VERSION)
 
-## Exit Criteria
+## Postconditions
 
 - Bump type determined (major/minor/patch/skip)
 - Reasoning documented for major bumps

--- a/.opencode/skills/version-bump/tasks/bump.md
+++ b/.opencode/skills/version-bump/tasks/bump.md
@@ -4,20 +4,20 @@
 
 Apply version bump to all detected version files.
 
-## Operating Protocol
+## Workflow
 
 1. **After analyze task**: Run after `analyze.md` determines bump type
 2. **Atomic updates**: Update all version files in single operation
 3. **Semantic versioning**: Apply semver rules correctly
 4. **Commit integration**: Changes included in implementation commit (squashed)
 
-## Entry Criteria
+## Preconditions
 
 - Bump type determined (major/minor/patch)
 - Version files identified
 - Current version parsed from files
 
-## Exit Criteria
+## Postconditions
 
 - All version files updated
 - Changes staged for commit

--- a/.opencode/skills/version-bump/tasks/release.md
+++ b/.opencode/skills/version-bump/tasks/release.md
@@ -4,21 +4,21 @@
 
 Create git tags and generate changelogs during release preparation workflow.
 
-## Operating Protocol
+## Workflow
 
 1. **Release preparation only**: Not used for regular PR workflow
 2. **After PR accumulation**: All version bumps from PRs are already merged
 3. **Creates git tag**: Tags version commit
 4. **Generates changelog**: Creates release notes from commit history
 
-## Entry Criteria
+## Preconditions
 
 - All PRs for release merged
 - Version already bumped via accumulated PRs
 - Repository in clean state (no uncommitted changes)
 - Ready to create git tag
 
-## Exit Criteria
+## Postconditions
 
 - Git tag created for version
 - CHANGELOG.md generated/updated with release notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,54 +321,58 @@ To use a skill, the agent loads it when relevant to the current task.
 
 ### Skill Invocation Guidance
 
-| When to Invoke | Skill | Purpose |
-|----------------|-------|---------|
-| When writing or modifying code | `code-size-enforcement` | Enforce size limits on functions, cells, and files |
-| Before creating ANY file | `implementation-quality --task file-locations` | Verify file location patterns |
-| At implementation start | `implementation-quality --task code-structure` | Verify code structure patterns (load once, reference continuously) |
-| Before running commands | `implementation-quality --task environment` | Verify environment patterns |
-| Before handling data | `implementation-quality --task data-integrity` | Verify data integrity patterns |
-| Before approving guideline changes | `guideline-auditor` | Verify guideline quality, find ambiguities/conflicts |
-| Before approving spec implementation | `concern-separation-auditor --issue N` | FIRST: phase structure, BOILERPLATE-TITLE, concern analysis |
-| After concern-separation-auditor | `spec-auditor --issue N` | SECOND: content quality, fresh-start context, sub-issue discovery |
-| After spec-auditor | `dev-architect --task review-spec` | THIRD: architectural correctness, sub-issue checks |
-| User says "approved" or "go" | `approval-gate` | Verify spec+authorization requirements, sub-issues |
-| Before implementing any task | `approval-gate` | Verify authorization, check sub-issues, re-evaluate |
-| Periodic guideline maintenance | `guideline-auditor` | Check for guideline drift over time |
-| Post-implementation verification | `spec-auditor --issue N` | Verify spec was implemented correctly |
-| User says "approved" or "go" | `git-workflow --task pre-work` | Pre-work: verify branch state, stash external changes, create branch |
-| After implementation completes | `git-workflow --task review-prep` | **Automatic: push branch, generate compare URL for review** |
-| User says "create a PR", "pr", "update PR", "make a PR", "push and create PR" | `git-workflow --task pr-creation` | Post-work: squash commits, push, create/update PR |
-| PR timing questions | `pr-creation-workflow` | PR authorization boundary, when PRs can be created |
-| Before skill extraction | `coherence-auditor --mode extraction` | Identify skill candidates from guideline content |
-| Periodic coherence maintenance | `coherence-auditor --mode maintenance` | Detect guideline-skill drift |
-| After guideline/skill update | `coherence-auditor --mode maintenance` | Verify coherence after changes |
-| Before major release | `coherence-auditor --mode maintenance` | Verify guideline-skill coherence |
-| Designing architecture | `dev-architect --task design-plan` | Create architecture design plans |
-| Reviewing specs for correctness | `dev-architect --task review-spec` | Review and revise specs for correctness and compliance |
-| Plan phase of spec creation | `dev-architect --task design-plan` | Auto-invoke at Plan phase |
-| Encountering errors/bugs | `debugger` | Analyze errors and debug issues |
-| Preparing commit messages | `commit-writer` | Generate commit messages |
-| After implementation | `code-review` | Review code quality |
-| Creating task descriptions | `task-writer` | Draft task descriptions |
-| Preparing PR descriptions | `pr-writer` | Create pull request descriptions |
-| Publishing releases | `release-notes` | Publish release notes |
-| Checking Git conventions | `git-conventions` | Reference Git convention knowledge |
-| Looking up documentation | `context7-lookup` | Look up Context7 documentation |
+**Master Trigger Table — AGENTS.md is the single source of truth.**
+Allskill trigger definitions are in this table. SKILL.md files reference this table.
 
-**Automatic Invocation:**
-- `git-workflow` skill is invoked automatically when:
+| Workflow Trigger | Invocation | Purpose |
+|------------------|------------|---------|
+| Before ANY file edit | `/skill approval-gate --task verify-authorization` | Confirm spec + approval exist |
+| Before implementation | `/skill approval-gate --task verify-sub-issues` | Check sub-issue structure for multi-task specs |
+| After approval ("approved" or "go") | `/skill git-workflow --task pre-work` | Stash changes, create feature branch |
+| After implementation completes | `/skill git-workflow --task review-prep` | Push branch, generate compare URL, HALT |
+| User says "create a PR" | `/skill git-workflow --task pr-creation` | Squash to single commit, push, create PR, HALT |
+| User says "PR merged" | `/skill git-workflow --task cleanup` | Close issues, delete branches |
+| Before creating ANY file | `/skill implementation-quality --task file-locations` | Verify file location patterns |
+| At implementation start | `/skill implementation-quality --task code-structure` | Verify code structure patterns |
+| Before running commands | `/skill implementation-quality --task environment` | Verify environment patterns |
+| Before handling data | `/skill implementation-quality --task data-integrity` | Verify data integrity patterns |
+| Writing or modifying code | `/skill code-size-enforcement` | Enforce size limits on functions, cells, files |
+| Before approving guideline changes | `/skill guideline-auditor` | Verify guideline quality, find ambiguities/conflicts |
+| Before approving spec implementation | `/skill concern-separation-auditor --issue N` | FIRST: phase structure, concern analysis |
+| After concern-separation-auditor | `/skill spec-auditor --issue N` | SECOND: content quality, fresh-start context |
+| After spec-auditor | `/skill dev-architect --task review-spec` | THIRD: architectural correctness |
+| User says "approved" or "go" | `/skill approval-gate --task verify-authorization` | Verify auth + needs-approval label status |
+| Before implementing any task | `/skill approval-gate --task verify-sub-issues` | Verify sub-issue structure |
+| Periodic guideline maintenance | `/skill guideline-auditor` | Check for guideline drift |
+| Post-implementation verification | `/skill spec-auditor --issue N` | Verify spec was implemented correctly |
+| Before skill extraction | `/skill coherence-auditor --mode extraction` | Identify skill candidates from guidelines |
+| Periodic coherence maintenance | `/skill coherence-auditor --mode maintenance` | Detect guideline-skill drift |
+| Designing architecture | `/skill dev-architect --task design-plan` | Create architecture design plans |
+| Plan phase of spec creation | `/skill dev-architect --task design-plan` | Invoke at Plan phase |
+| Encountering errors/bugs | `/skill debugger` | Analyze errors and debug issues |
+| Preparing commit messages | `/skill commit-writer` | Generate commit messages |
+| Creating task descriptions | `/skill task-writer` | Draft task descriptions |
+| Preparing PR descriptions | `/skill pr-writer` | Create pull request descriptions |
+| Publishing releases | `/skill release-notes` | Publish release notes |
+| Checking Git conventions | `/skill git-conventions` | Reference Git convention knowledge |
+| Looking up documentation | `/skill context7-lookup` | Look up Context7 documentation |
+
+**When task names are specified:** Use `/skill <name> --task <task>` for specific workflow phases.
+**When task names are NOT specified:** Use `/skill <name>` for skill overview only.
+
+**Skill Invocation:**
+- `git-workflow` skill is invoked at these triggers:
   1. User authorizes implementation ("approved", "go", "proceed") → `pre-work` task
-  2. Implementation completes → **`review-prep` task (automatic, no decision point)**
+  2. Implementation completes → **`review-prep` task (no decision point)**
   3. User requests PR creation ("create a PR", "make a PR", "push and create PR") → `pr-creation` task
 - The skill handles all git operations (branch, stash, commit, squash, push, PR creation) according to guidelines.
 - `pr-creation-workflow` skill defines when PRs can be created and what authorizes PR creation. It is NOT automatically invoked - it documents the rules.
-- `implementation-quality` skill is invoked automatically at implementation gates:
+- `implementation-quality` skill is invoked at implementation gates:
   1. Before creating ANY file → `file-locations` task
   2. At implementation start → `code-structure` task (load once, reference continuously)
   3. Before running commands → `environment` task
   4. Before handling data → `data-integrity` task
-- `dev-architect` skill is invoked automatically at Plan phase:
+- `dev-architect` skill is invoked at Plan phase:
   1. When creating a new spec → `design-plan` task
   2. When reviewing specs → `review-spec` task
 


### PR DESCRIPTION
## Summary

Standardized skill trigger format across all 29 skills, removed Junie language, and unified terminology throughout the AI agent framework.

## Changes

- **Changed: Standardized Skill Trigger Format**: All 29 skills now use explicit `/skill X --task Y` commands in master trigger table. Replaced ambiguous trigger descriptions with precise invocation commands for better agent clarity. All skills follow consistent workflow trigger format.
- **Fixed: Removed Junie Language**: Replaced all "invoked automatically" and similar passive construction with explicit "is invoked at these triggers" format. Removed "Automatic Invocation" headings replaced with "Workflow Triggers" or "Enforcement Points".
- **Changed: Terminology Standardization**: Replaced "Entry/Exit Criteria" with "Preconditions/Postconditions" across all task files and templates. Replaced "Operating Protocol" with "Workflow" section to match skill convention.
- **Fixed: Hardcoded Identity References**: Removed hardcoded "OpenCode (ollama-cloud/glm-5)" example values from skill files. Guidelines now explicitly state these are illustrative examples and agents must detect their own identity at runtime.
- **Added: Verification Tool**: Moved verify-skill-wording.sh to .opencode/scripts/ for ongoing enforcement of linguistic standards. The tool detects Junie patterns and terminology violations.
- **Changed: Master Trigger Table**: AGENTS.md now has single source-of-truth trigger table with explicit /skill invocations. All skills reference this table instead of duplicating trigger information.

Fixes #355