### PR TITLE
[SPEC] Guidelines: Auditor Comment Practices - Revision Focus Only

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -767,6 +767,80 @@ Invoked with: `/skill concern-separation-auditor --issue N`
 
 ---
 
+## Critical Violation: Auditor Comment Practices — Two-Channel Rule
+
+**⚠️ Posting complete audit reports to GitHub Issues when no revision was made is a CRITICAL GUIDELINE VIOLATION.**
+
+### The Problem
+
+Auditors have been posting complete audit findings as GitHub Issue comments even when no revision was made. This creates noise that:
+- Buries revision history
+- Makes it hard for future developers to find what actually changed
+- Violates the distinction between chat (developer coordination) and GitHub Issues (revision history)
+
+### 🚫 FORBIDDEN
+
+| Channel | When NOT to Post | Why |
+|---------|------------------|-----|
+| GitHub Issues | Complete audit report when no revision made | Creates noise, buries history |
+| Chat | Silence when audit finds no issues | Developer doesn't know audit ran |
+| GitHub Issues | Checklist-style pass/fail without revision | No context for future developers |
+
+### ✅ REQUIRED (Two-Channel Rule)
+
+| Channel | When to Post | Content |
+|---------|--------------|---------|
+| **Chat** | ALWAYS (success OR fixes) | Executive summary: pass/fail status, fixes applied |
+| **GitHub Issues** | ONLY on revision | WHY revision needed, WHAT changed - for future developer context |
+
+### Chat Executive Summary Format
+
+```
+**Audit Complete:** [audit type] [passed/failed]
+
+**Issues Found:** N
+**Issues Fixed:** M (if any)
+**Status:** [No concerns detected | N issues fixed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### GitHub Issue Revision Comment Format
+
+```
+Fixed [issue description]
+
+**Why:** [reason for revision]
+**What:** [what changed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### Examples
+
+**Audit passed (no issues):**
+- Chat: Post executive summary with "passed" status
+- GitHub Issues: NO COMMENT (no revision made)
+
+**Audit found issues and fixed them:**
+- Chat: Post executive summary with issues found and fixes applied
+- GitHub Issues: Post revision comment explaining WHY and WHAT changed
+
+**Audit found catastrophic issue (HALT):**
+- Chat: Post summary explaining blocker
+- GitHub Issues: NO COMMENT (issue is blocking, not fixed)
+
+### Why This Matters
+
+- Developers need confirmation audits ran (even when pass)
+- Future developers read GitHub Issues to understand WHAT changed and WHY
+- Audit reports are noise without revision context
+- Two channels serve different purposes: chat for coordination, issues for history
+
+---
+
 ## Critical Violation: Bypassing Skills At Workflow Points
 
 **⚠️ Bypassing MANDATORY skill invocations is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -127,6 +127,77 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 
 **Skipping this auditor is a CRITICAL GUIDELINE VIOLATION.**
 
+## Two-Channel Comment Rules
+
+**CRITICAL: Distinguish between chat (developer coordination) and GitHub Issues (revision history).**
+
+### Chat (Developer Coordination)
+
+| When to Post | Content |
+|--------------|---------|
+| ALWAYS (success OR fixes) | Executive summary: pass/fail status, fixes applied |
+
+**Chat Executive Summary Format:**
+
+```
+**Audit Complete:** [audit type] [passed/failed]
+
+**Issues Found:** N
+**Issues Fixed:** M (if any)
+**Status:** [No concerns detected | N issues fixed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### GitHub Issues (Revision History)
+
+| When to Post | Content |
+|--------------|---------|
+| ONLY on revision | WHY revision needed, WHAT changed - for future developer context |
+
+**GitHub Issue Revision Comment Format:**
+
+```
+Fixed [issue description]
+
+**Why:** [reason for revision]
+**What:** [what changed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### Examples
+
+**Audit passed (no issues):**
+
+- Chat: Post executive summary with "passed" status
+- GitHub Issues: NO COMMENT (no revision made)
+
+**Audit found issues and fixed them:**
+
+- Chat: Post executive summary with issues found and fixes applied
+- GitHub Issues: Post revision comment explaining WHY and WHAT changed
+
+**Audit found catastrophic issue (HALT):**
+
+- Chat: Post summary explaining blocker
+- GitHub Issues: NO COMMENT (issue is blocking, not fixed)
+
+### ⚠️ CRITICAL: Never Post Full Audit Reports to GitHub Issues
+
+**FORBIDDEN:**
+
+- Posting checklist-style pass/fail results as GitHub comments
+- Posting complete audit findings when no revision was made
+- Posting audit logs/scores without revision context
+
+**CORRECT:**
+
+- Chat: Always post executive summary (pass or fix)
+- GitHub Issues: Only post when revision made (WHY/WHAT context)
+
 ## Quick Start
 
 Use `/skill concern-separation-auditor --task overview` for complete workflow.

--- a/.opencode/skills/dev-architect/tasks/review-spec.md
+++ b/.opencode/skills/dev-architect/tasks/review-spec.md
@@ -148,6 +148,77 @@ After review:
 2. **If user-prompt issues found**: Post comment explaining conflict, HALT
 3. **If all checks pass**: Report spec ready for implementation
 
+## Two-Channel Comment Rules
+
+**CRITICAL: Distinguish between chat (developer coordination) and GitHub Issues (revision history).**
+
+### Chat (Developer Coordination)
+
+| When to Post | Content |
+|--------------|---------|
+| ALWAYS (success OR fixes) | Executive summary: pass/fail status, fixes applied |
+
+**Chat Executive Summary Format:**
+
+```
+**Audit Complete:** [audit type] [passed/failed]
+
+**Issues Found:** N
+**Issues Fixed:** M (if any)
+**Status:** [No concerns detected | N issues fixed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### GitHub Issues (Revision History)
+
+| When to Post | Content |
+|--------------|---------|
+| ONLY on revision | WHY revision needed, WHAT changed - for future developer context |
+
+**GitHub Issue Revision Comment Format:**
+
+```
+Fixed [issue description]
+
+**Why:** [reason for revision]
+**What:** [what changed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### Examples
+
+**Audit passed (no issues):**
+
+- Chat: Post executive summary with "passed" status
+- GitHub Issues: NO COMMENT (no revision made)
+
+**Audit found issues and fixed them:**
+
+- Chat: Post executive summary with issues found and fixes applied
+- GitHub Issues: Post revision comment explaining WHY and WHAT changed
+
+**Audit found catastrophic issue (HALT):**
+
+- Chat: Post summary explaining blocker
+- GitHub Issues: NO COMMENT (issue is blocking, not fixed)
+
+### ⚠️ CRITICAL: Never Post Full Audit Reports to GitHub Issues
+
+**FORBIDDEN:**
+
+- Posting checklist-style pass/fail results as GitHub comments
+- Posting complete audit findings when no revision was made
+- Posting audit logs/scores without revision context
+
+**CORRECT:**
+
+- Chat: Always post executive summary (pass or fix)
+- GitHub Issues: Only post when revision made (WHY/WHAT context)
+
 ## Cross-References
 
 - `144-planning-spec-templates.md` - Spec template requirements

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -199,6 +199,77 @@ https://github.com/<owner>/<repo>/compare/dev...<branch>
 
 **URLs:** REQUIRED (when relevant)
 
+## Two-Channel Rule for Auditor Comments
+
+**CRITICAL: Auditors must distinguish between chat (developer coordination) and GitHub Issues (revision history).**
+
+### Chat (Developer Coordensation)
+
+| When to Post | Content |
+|--------------|---------|
+| ALWAYS (success OR fixes) | Executive summary: pass/fail status, fixes applied |
+
+**Chat Executive Summary Format:**
+
+```
+**Audit Complete:** [audit type] [passed/failed]
+
+**Issues Found:** N
+**Issues Fixed:** M (if any)
+**Status:** [No concerns detected | N issues fixed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### GitHub Issues (Revision History)
+
+| When to Post | Content |
+|--------------|---------|
+| ONLY on revision | WHY revision needed, WHAT changed - for future developer context |
+
+**GitHub Issue Revision Comment Format:**
+
+```
+Fixed [issue description]
+
+**Why:** [reason for revision]
+**What:** [what changed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### Examples
+
+**Audit passed (no issues):**
+
+- Chat: Post executive summary with "passed" status
+- GitHub Issues: NO COMMENT (no revision made)
+
+**Audit found issues and fixed them:**
+
+- Chat: Post executive summary with issues found and fixes applied
+- GitHub Issues: Post revision comment explaining WHY and WHAT changed
+
+**Audit found catastrophic issue (HALT):**
+
+- Chat: Post summary explaining blocker
+- GitHub Issues: NO COMMENT (issue is blocking, not fixed)
+
+### ⚠️ CRITICAL: Never Post Full Audit Reports to GitHub Issues
+
+**FORBIDDEN:**
+
+- Posting checklist-style pass/fail results as GitHub comments
+- Posting complete audit findings when no revision was made
+- Posting audit logs/scores without revision context
+
+**CORRECT:**
+
+- Chat: Always post executive summary (pass or fix)
+- GitHub Issues: Only post when revision made (WHY/WHAT context)
+
 ## AI Identity Attribution Format
 
 **ALL comments MUST end with ONE byline:**

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -151,6 +151,77 @@ ______________________________________________________________________
    - **Required remediation indicators**: Explicitly list the exact edits needed (section + concrete change).
    - **Verification signal**: State how completion is verified (`changed`, `blocked`, or `no change required`) with evidence reference.
 1. **AUTO-FIX BY DEFAULT**: Apply fixes automatically unless user says "don't fix" or "just report". Post GitHub Issue comment documenting the fix with brief one-liner.
+
+## Two-Channel Comment Rules
+
+**CRITICAL: Distinguish between chat (developer coordination) and GitHub Issues (revision history).**
+
+### Chat (Developer Coordination)
+
+| When to Post | Content |
+|--------------|---------|
+| ALWAYS (success OR fixes) | Executive summary: pass/fail status, fixes applied |
+
+**Chat Executive Summary Format:**
+
+```
+**Audit Complete:** [audit type] [passed/failed]
+
+**Issues Found:** N
+**Issues Fixed:** M (if any)
+**Status:** [No concerns detected | N issues fixed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### GitHub Issues (Revision History)
+
+| When to Post | Content |
+|--------------|---------|
+| ONLY on revision | WHY revision needed, WHAT changed - for future developer context |
+
+**GitHub Issue Revision Comment Format:**
+
+```
+Fixed [issue description]
+
+**Why:** [reason for revision]
+**What:** [what changed]
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>)
+```
+
+### Examples
+
+**Audit passed (no issues):**
+
+- Chat: Post executive summary with "passed" status
+- GitHub Issues: NO COMMENT (no revision made)
+
+**Audit found issues and fixed them:**
+
+- Chat: Post executive summary with issues found and fixes applied
+- GitHub Issues: Post revision comment explaining WHY and WHAT changed
+
+**Audit found catastrophic issue (HALT):**
+
+- Chat: Post summary explaining blocker
+- GitHub Issues: NO COMMENT (issue is blocking, not fixed)
+
+### ⚠️ CRITICAL: Never Post Full Audit Reports to GitHub Issues
+
+**FORBIDDEN:**
+
+- Posting checklist-style pass/fail results as GitHub comments
+- Posting complete audit findings when no revision was made
+- Posting audit logs/scores without revision context
+
+**CORRECT:**
+
+- Chat: Always post executive summary (pass or fix)
+- GitHub Issues: Only post when revision made (WHY/WHAT context)
 1. **User responses drive action:**
    - No response → AUTO-FIX immediately, post comment, proceed to next issue.
    - "don't fix" → Skip this issue, move to next.


### PR DESCRIPTION
## Summary

Implemented two-channel comment rules for auditor skills. Auditors now post executive summaries to Chat (ALWAYS) and revision comments to GitHub Issues (ONLY when changes are made).

## Changes

### Documentation Updates

- **`.opencode/skills/concern-separation-auditor/SKILL.md`**
  - Added "Two-Channel Comment Rules" section
  - Defined Chat vs GitHub Issues distinction
  - Added format examples for executive summaries and revision comments

- **`.opencode/skills/spec-auditor/SKILL.md`**
  - Added "Two-Channel Comment Rules" section
  - Clarified when to post to Chat vs GitHub Issues
  - Added examples for each channel

- **`.opencode/skills/dev-architect/tasks/review-spec.md`**
  - Added "Two-Channel Comment Rules" section
  - Clarified chat-only vs GitHub Issue comments
  - Added format requirements

- **`.opencode/guidelines/000-critical-rules.md`**
  - Added "Critical Violation: Auditor Comment Practices — Two-Channel Rule" section
  - Documented Chat vs GitHub Issue requirements
  - Added examples for both channels

- **`.opencode/skills/github-comments/SKILL.md`**
  - Added "Two-Channel Rule for Auditor Comments" section
  - Defined Chat Executive Summary format
  - Defined GitHub Issue Revision Comment format
  - Added examples for audit pass, issues found, and catastrophic scenarios

## Key Behaviors

| Channel | When to Post | Content |
|---------|--------------|---------|
| **Chat** | ALWAYS (success OR fixes) | Executive summary: pass/fail status, fixes applied |
| **GitHub Issues** | ONLY on revision | WHY revision needed, WHAT changed |

## Success Criteria

1. ✅ Chat ALWAYS receives executive summary (pass or fix)
2. ✅ GitHub Issues ONLY receive comments on revision
3. ✅ Revision comments explain WHY and WHAT
4. ✅ Developers know audits ran when chat shows summary
5. ✅ Future developers can find revision history without noise

Fixes #331
Fixes #378
Fixes #379
Fixes #380