### PR TITLE
docs: remove GitHub progress comments, enforce review-prep invocation, add TODO clearing

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -227,7 +227,7 @@ The agent must NEVER ask questions like:
 | Situation | Action |
 |-----------|--------|
 | Task complete but more work remains | Continue implementation autonomously |
-| Task complete and no more work | HALT silently, post progress comment |
+| Task complete and no more work | HALT silently, provide executive summary in chat |
 | Blocked by genuine ambiguity | Post comment to issue asking for clarification, then HALT |
 | Error encountered | Post error details to issue, then HALT |
 | Waiting for authorization | HALT silently, wait for explicit "approved" or "go" |
@@ -249,18 +249,34 @@ The agent must NEVER ask questions like:
 
 ---
 
-## Critical Violation: Missing Progress Comments
+## Critical Violation: GitHub Progress Comments Are NOISE — CHAT ONLY
 
-**⚠️ Failing to post progress comments to the associated issue is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Posting progress comments to GitHub Issues is a CRITICAL GUIDELINE VIOLATION.**
 
-Every implementation task MUST be documented with progress comments on the GitHub issue:
-- Post comment IMMEDIATELY after completing each task
-- Post comment when creating PR
-- Never proceed to next task without commenting first
+GitHub Issue comments are for **historical record (closure summaries)**, NOT for implementation progress.
 
-### Required Format: Executive Summary
+**The PR itself is the notification. The compare URL in chat is the progress update.**
 
-**Intermediate task (multi-task spec):**
+### ✅ REQUIRED Behavior
+
+| Event | GitHub Comment? | Chat Update? |
+|-------|-----------------|--------------|
+| Implementation done | ❌ NO | ✅ YES - executive summary |
+| Review-prep done | ❌ NO | ✅ YES - compare URL |
+| PR created | ❌ NO | ✅ YES - PR URL |
+| Issue closed AFTER MERGE | ✅ YES - closure summary | ✅ YES - completion notice |
+
+### 🚫 FORBIDDEN
+
+| Forbidden Action | Why |
+|-----------------|-----|
+| Posting progress after implementation | NOISE - compare URL in chat is sufficient |
+| Posting progress after review-prep | NOISE - developer can view GitHub diff |
+| Posting "PR created" to GitHub | NOISE - PR itself is the notification |
+| Posting status blocks | NOISE - executive summary in chat is sufficient |
+
+### ✅ Chat Output Format
+
 ```
 **Summary:**
 
@@ -268,63 +284,20 @@ Every implementation task MUST be documented with progress comments on the GitHu
 
 **Outcome:** <What changed for stakeholders>
 
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-**Final task or single-task spec:**
-```
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-
-All tasks complete from this specification.
+https://github.com/<owner>/<repo>/compare/dev...<branch>
 
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 ```
 
-**⚠️ CRITICAL: Emoji must be PLAIN TEXT (not inside italic/bold formatting).**
+### When GitHub Comments ARE Required
 
-**Status Emoji Guide:**
-| Status | Emoji | Byline Format |
-|--------|-------|---------------|
-| Task Complete | ✅ | `🤖 ✅ Completed by <AgentName> (<ModelID>)` |
-| In Progress | ↻ | `🤖 ↻ Working by <AgentName> (<ModelID>)` |
-| Created | ✨ | `🤖 ✨ Created by <AgentName> (<ModelID>)[: Issue #N]` |
-| Updated | 📝 | `🤖 📝 Updated by <AgentName> (<ModelID>)[: description]` |
-| Completed | ✅ | `🤖 ✅ Completed by <AgentName> (<ModelID>)` |
-| Rejected | ❌ | `🤖 ❌ Rejected by <AgentName> (<ModelID>): <reason>` |
-
-**When to include context in byline:**
-- **Progress comments**: No context (content already describes the work)
-- **Issue creation**: Optional — add issue number if useful
-- **Rejection/Superseded**: Always include reason or replacement reference
-
-### 🚫 FORBIDDEN in Progress Comments
-
-- **File lists** — Redundant (visible in git commits)
-- **"Next" field** — Dialog prompt (violates `AGENTS.md` § 125)
-- **Punch-list format** — Use executive summary paragraphs
-- **"Awaiting authorization"** — Use HALT protocol, not comments
-- **Technical changelog** — Focus on impact, not file-by-file changes
-
-### ⚠️ Chat Output Rule (CRITICAL)
-
-**Progress executive summaries go to BOTH GitHub comments AND chat.**
-
-| Location | Content |
-|----------|---------|
-| **GitHub Issue Comment** | Full executive summary (summary, outcome) |
-| **Chat Output** | Same executive summary (summary, outcome) |
-
-**Why:** Both GitHub history AND chat transcript should show progress. GitHub preserves long-term history; chat maintains session context.
-
-**✅ DO:** Post executive summary to GitHub, then provide SAME summary in chat
-**🚫 NEVER:** Skip either location
-**🚫 NEVER:** Put full summary in chat but skip GitHub comment
+| Event | Why |
+|-------|-----|
+| Issue closure after merge | Historical record for future maintainers |
+| Spec revision | Document what changed and why |
+| Answering user question | User cannot see internal reasoning |
+| Blocking issue | Explain blocker and await clarification |
 
 **See `github-comments` skill for complete requirements.**
 

--- a/.opencode/guidelines/085-engineering-approach.md
+++ b/.opencode/guidelines/085-engineering-approach.md
@@ -10,7 +10,7 @@
 
 3. **Verify Before Declaring Complete** — Run all tests manually. Check for edge cases. Verify against all success criteria. Update documentation.
 
-4. **Communicate Changes** — Post comments when changes happen (PR created, task completed). DO NOT post comments when creating issues. DO NOT post comments for non-substantive updates (cross-references, origin links, STATUS updates).
+4. **Communicate Changes** — Provide updates in CHAT when changes happen (PR created, task completed). DO NOT post comments to GitHub for implementation progress. DO NOT post comments for non-substantive updates (cross-references, origin links, STATUS updates).
 
 ## Scope Discipline (Critical)
 

--- a/.opencode/guidelines/120-github-issue-first.md
+++ b/.opencode/guidelines/120-github-issue-first.md
@@ -118,11 +118,15 @@ Titles that describe specific concerns or features:
 
 ---
 
-## 5. Progress Comments (MANDATORY)
+## 5. Chat Updates for Implementation Progress
 
-**Every implementation step MUST be documented with a comment on the associated issue.**
+**Implementation progress goes to CHAT ONLY — NOT GitHub Issues.**
 
-**See `github-comments` skill for complete progress comment requirements.**
+- GitHub Issue comments are for historical record (closure summaries, spec revisions, user questions)
+- The PR is the notification — no need to post "PR created" to GitHub
+- The compare URL in chat is the progress update — no need to post progress to GitHub
+
+**See `000-critical-rules.md` "GitHub Progress Comments Are NOISE" for complete requirements.**
 
 ### Prompt Preservation (MANDATORY)
 
@@ -145,49 +149,6 @@ The user's prompt contains nuanced context about:
    - Include both the new prompt and any additional context
 
 3. **See `140-planning-spec-creation.md` "User Prompt Preservation" for complete requirements.**
-
----
-
-### Quick Reference
-
-**Post progress comments after EACH task completion:**
-- Executive summary describing impact and stakeholder value
-- NO file lists (redundant with git)
-- NO "Next" field (dialog prompts prohibited)
-
-**Post progress comments after ANY file change:**
-- Brief narrative describing impact
-- Focus on why the change matters
-
-### Executive Summary Format
-
-**Intermediate task (multi-task spec):**
-```
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-**Final task or single-task spec:**
-```
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-
-All tasks complete from this specification.
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-**⚠️ FAILURE TO POST PROGRESS COMMENTS IS A CRITICAL GUIDELINE VIOLATION.**
 
 ---
 

--- a/.opencode/guidelines/123-github-ai-identity.md
+++ b/.opencode/guidelines/123-github-ai-identity.md
@@ -146,18 +146,15 @@ ALL comments on issues and PRs MUST have a SINGLE byline at the END combining st
 
 | Violation | Consequence |
 |-----------|--------------|
-| Missing progress comments after task completion | CRITICAL — implementation incomplete |
 | Ignoring user comments without posting response | CRITICAL — user cannot see your reasoning |
 | Closing issue without explanation comment | CRITICAL — no audit trail |
 | Editing issue body to add "CLOSED" text | CRITICAL — destroys history |
-| Proceeding to next task without posting comment | CRITICAL — breaks workflow |
 | Using PREFIX for comment attribution | CRITICAL — wrong position |
 | Replacing existing attribution (not appending) | CRITICAL — destroys history |
 | Wrapping emoji in italic/bold | CRITICAL — render failure |
 
 **See `github-comments` skill for:**
 - Complete comment format rules
-- Progress comment format and timing
 - Issue body update rules
 - Closure comment format
 - When NOT to comment

--- a/.opencode/guidelines/125-github-issue-comments.md
+++ b/.opencode/guidelines/125-github-issue-comments.md
@@ -58,11 +58,12 @@ The HALT protocol (see `010-approval-gate.md`) is the correct mechanism for auth
 
 | Situation | Action |
 |-----------|--------|
-| Completed a task | Post progress comment, then HALT |
+| Completed a task | Provide executive summary in CHAT ONLY, then HALT |
 | User asked a question | Respond via comment addressing the question |
 | Reached decision point | HALT silently, wait for user |
-| Changed files | Comment documenting the change |
+| Changed files | Provide executive summary in CHAT ONLY, then HALT |
 | Need clarification | Post question in comment, then HALT |
+| Issue closed AFTER MERGE | Post closure summary to GitHub (historical record) |
 
 ## Anti-Patterns to Avoid
 

--- a/.opencode/guidelines/143-planning-spec-templates.md
+++ b/.opencode/guidelines/143-planning-spec-templates.md
@@ -429,15 +429,6 @@ CREATED: YYYY-MM-DD
 
 ---
 
-## Phase 3: Human Approval (Gated)
-
-### Steps
-
-1. ☐ Human review of changes
-2. ☐ Approve or request revisions
-
----
-
 > **Approval Tracking**: Approvals are tracked via GitHub Issue comments (e.g., `AI: <Agent> ✅ Approved: Phase 1`), NOT in the issue body. Issue body edits destroy history.
 ```
 

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -35,9 +35,10 @@ Implementation task:
 
 Review-prep task:
   1. Verify branch is pushed
-  2. Generate compare URL
-  3. Post completion comment
-  4. HALT
+  2. Clear TODO list
+  3. Generate compare URL
+  4. Post completion comment (chat only)
+  5. HALT
 ```
 
 **If this task is invoked and branch is NOT pushed:**
@@ -70,7 +71,7 @@ When implementation determines "no file changes needed":
 
 ### ⚠️ CRITICAL: Model ID Detection
 
-**When posting completion comment (Step 3):**
+**When posting completion comment (Step 5):**
 
 - **MUST dynamically detect model ID** - NEVER use hardcoded `ollama-cloud/glm-5`
 - **MUST detect actual runtime identity** from environment/MCP tools
@@ -158,7 +159,21 @@ If review-prep is invoked but branch is NOT pushed:
 
 **This violation indicates implementation task did NOT follow Pre-HALT Verification Checklist.**
 
-### Step 2: Generate Compare URL
+### Step 2: Clear TODO List (MANDATORY)
+
+**Before generating compare URL, clear any active todos to ensure clean workflow state.**
+
+```bash
+# Clear todo list to prevent stale state from affecting subsequent phases
+todowrite todos=[]
+```
+
+**Why this matters:**
+- Prevents stale todos from previous phases
+- Ensures clean state before developer review
+- Removes distraction from completed work
+
+### Step 3: Generate Compare URL
 
 Using session values (GIT_OWNER, GIT_REPO):
 
@@ -166,7 +181,7 @@ Using session values (GIT_OWNER, GIT_REPO):
 https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 ```
 
-### Step 2: Pre-Post Verification (MANDATORY GATE)
+### Step 4: Pre-Post Verification (MANDATORY GATE)
 
 **⚠️ CRITICAL: You MUST verify format BEFORE generating the completion comment.**
 
@@ -205,21 +220,9 @@ https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 - Catches format errors before they're posted
 - Forces procedural verification, not informational
 
-### Step 3: Report Completion (SEPARATE Formats for Issue vs Chat)
+### Step 5: Report Completion (Chat ONLY)
 
-**⚠️ CRITICAL: Different formats for GitHub issue vs chat.**
-
-**GitHub Issue Comment Format:**
-
-```markdown
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-```
+**⚠️ CRITICAL: Progress goes to CHAT ONLY - NOT GitHub Issues.**
 
 **Chat Output Format:**
 
@@ -236,22 +239,15 @@ https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 ```
 
-**Key Differences:**
+**Why chat only:**
+- GitHub Issues are historical records - no need for compare URLs
+- Chat provides immediate visibility for developer review
+- URLs clutter issue history unnecessarily
 
-| Location | Contains | Does NOT Contain |
-|----------|----------|------------------|
-| GitHub Issue | Summary, Outcome, byline | Compare URL |
-| Chat | Summary, Outcome, byline, URL | — |
-
-**Why separate formats:**
-- GitHub issues are persistent records - no need for compare URLs (visible via PR)
-- Chat is immediate - developers need quick access to compare URL for review
-- URLs are long and clutter issue history unnecessarily
-
-**Post summary to GitHub issue.**
 **Post summary + URL to chat.**
+**DO NOT post to GitHub issue.**
 
-### Step 4: HALT (MANDATORY - NO EXCEPTIONS)
+### Step 6: HALT (MANDATORY - NO EXCEPTIONS)
 
 **🚫 CRITICAL VIOLATION: Proceeding past this point without explicit "create a PR" is a CRITICAL GUIDELINE VIOLATION.**
 


### PR DESCRIPTION
## Summary

Removed ALL progress comments from GitHub Issues (chat-only now) and enforced mandatory review-prep skill invocation with TODO clearing. GitHub Issues now serve as historical records only (closure summaries after merge), not implementation progress tracking.

## Changes

### Issue #390 - Remove Verbose Status Blocks
- Removed "Human Review" phase from spec templates
- `.opencode/guidelines/143-planning-spec-templates.md`: Removed Phase 3: "Human Approval (Gated)"
- `.opencode/guidelines/113-git-pr-workflow.md`: Removed "Human review required" from PR workflow (implicit)

### Issue #391 - Enforce Mandatory Review-Prep Invocation
- Added TODO list clearing as Step 2 in review-prep
- `.opencode/skills/git-workflow/tasks/review-prep.md`: Added mandatory `todowrite todos=[]` before generating compare URL
- Updated step numbers to account for new TODO clearing step

### Issue #393 - Remove Progress Comments from GitHub
- `.opencode/guidelines/000-critical-rules.md`: Changed "Missing Progress Comments" violation to "GitHub Progress Comments Are NOISE — CHAT ONLY"
- `.opencode/guidelines/085-engineering-approach.md`: Changed "Post comments" to "Provide updates in CHAT"
- `.opencode/guidelines/120-github-issue-first.md`: Replaced "Progress Comments (MANDATORY)" with "Chat Updates for Implementation Progress"
- `.opencode/guidelines/123-github-ai-identity.md`: Removed "Missing progress comments" from critical violations
- `.opencode/guidelines/125-github-issue-comments.md`: Updated "When to Comment vs. HALT" table, clarified progress comments are NOISE

### Cross-Cutting Changes
- All executive summaries and compare URLs now go to CHAT ONLY
- GitHub comments reserved for historical record (closure summaries after merge)
- Authorization cleanup (label removal, STATUS clearing) is SILENT (no comments)

Fixes #390
Fixes #391
Fixes #393