### PR TITLE
[SPEC] Guidelines: Clear Approval Markers When Authorization Received

### DIFF
--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -179,6 +179,54 @@ When a spec is modified:
 - Progress comments added to issue
 - Bug report additions (separate from spec content changes)
 
+### Authorization Cleanup Workflow (SILENT — No Comments)
+
+**When authorization is received AND workflow was interrupted, clean up approval markers BEFORE proceeding.**
+
+**The Problem:**
+
+When workflow is interrupted (for clarification questions, spec revisions, context switching, error recovery, or investigation), stale markers accumulate:
+
+- `needs-approval` label remains on issue
+- `STATUS: N.M (REVISED - NEEDS APPROVAL)` suffix remains in STATUS field
+- Todo list shows stale tasks from interrupted workflow
+
+**The Solution:**
+
+When authorization is received after interruption:
+
+1. **Remove `needs-approval` label** (if present)
+2. **Clear STATUS suffix** (`N.M (REVISED - NEEDS APPROVAL)` → `N.M`)
+3. **Clear todo list** (if workflow was interrupted — see detection below)
+4. **Proceed with implementation**
+
+**⚠️ CRITICAL: Cleanup is SILENT — NO comments posted.**
+
+- Authorization cleanup is administrative, not post-implementation review information
+- GitHub comments are for implementation results, not status notifications
+- The issue state (label, STATUS) IS the record — no duplicate notification needed
+
+#### Workflow Interruption Detection
+
+**Clear todos if ANY interruption occurred since last authorization:**
+
+| Interruption Type | Detection |
+|------------------|-----------|
+| Developer conversation | Agent asked clarification question and received answer |
+| Spec revision | Agent revised spec (added/changed content) |
+| Error recovery | Agent encountered error and investigated |
+| Context switch | Agent switched to different task/issue |
+| Investigation phase | Agent performed investigation before implementation |
+
+**Action:** If ANY interruption, CLEAR the todo list before implementation.
+
+| Edge Case | Action |
+|-----------|--------|
+| No interruption (immediate auth) | Skip todo clearing (todos still valid) |
+| Todo list already empty | Skip todo clearing (no-op) |
+| Label already removed | Skip label removal (no-op) |
+| STATUS has no suffix | Skip STATUS edit (no-op) |
+
 ### Label Handling
 
 **The `needs-approval` label is informational when explicit authorization is present.**
@@ -191,7 +239,7 @@ When a spec is modified:
 | No authorization AND no label | Check for other blockers; proceed if clear. |
 
 **Workflow:**
-1. **Explicit authorization received** → Proceed (label status is informational)
+1. **Explicit authorization received** → Clean up markers (label, STATUS, todos) → Proceed (label status is informational)
 2. **No explicit authorization** → Check for `needs-approval` label
 3. **Label present without authorization** → HALT and wait for user to authorize
 

--- a/.opencode/guidelines/141-planning-status-tracking.md
+++ b/.opencode/guidelines/141-planning-status-tracking.md
@@ -52,6 +52,54 @@ STATUS: 1.1 (REVISED - NEEDS APPROVAL)
 - Progress comments added to issue
 - Bug report additions to existing spec
 
+#### Authorization Received Status Transition
+
+**When authorization is received after a revision, clean up approval markers BEFORE proceeding.**
+
+**The Problem:**
+- `needs-approval` label remains on issue after authorization
+- `STATUS: N.M (REVISED - NEEDS APPROVAL)` suffix remains in STATUS field
+- Stale todo list from interrupted workflow
+
+**The Solution:**
+When authorization is received AND workflow was interrupted:
+
+1. **Remove `needs-approval` label** (if present)
+2. **Clear STATUS suffix**: `N.M (REVISED - NEEDS APPROVAL)` → `N.M`
+3. **Clear todo list** (if workflow was interrupted — see detection below)
+4. **Proceed with implementation**
+
+**⚠️ CRITICAL: Cleanup is SILENT — NO comments posted.**
+
+- Authorization cleanup is administrative, not post-implementation review information
+- GitHub comments are for implementation results, not status notifications
+- The issue state (label, STATUS) IS the record — no duplicate notification needed
+
+**Workflow Interruption Detection:**
+
+| Interruption Type | Detection |
+|------------------|-----------|
+| Developer conversation | Agent asked clarification question and received answer |
+| Spec revision | Agent revised spec (added/changed content) |
+| Error recovery | Agent encountered error and investigated |
+| Context switch | Agent switched to different task/issue |
+| Investigation phase | Agent performed investigation before implementation |
+
+**Action:** If ANY interruption occurred since last authorization, CLEAR the todo list before implementation.
+
+| Edge Case | Action |
+|-----------|--------|
+| No interruption (immediate auth) | Skip todo clearing (todos still valid) |
+| Todo list already empty | Skip todo clearing (no-op) |
+| Label already removed | Skip label removal (no-op) |
+| STATUS has no suffix | Skip STATUS edit (no-op) |
+
+**Timeline:** Cleanup happens BEFORE implementation begins — not during, not after.
+
+**See Also:**
+- `010-approval-gate.md` → "Authorization Cleanup Workflow" section for detailed cleanup rules
+- `todowrite` integration for clearing stale todos
+
 ### Status Markers (Visual Icons)
 
 | Marker | Meaning | When to Use |

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -22,6 +22,31 @@ This skill is invoked at these workflow triggers:
 | User says "approved" or "go" | `/skill approval-gate --task verify-authorization` | Verify auth + needs-approval label status |
 | Before implementing any task | `/skill approval-gate --task verify-sub-issues` | Verify sub-issue structure |
 
+## Authorization Cleanup (SILENT)
+
+**When authorization is received after workflow interruption, clean up approval markers BEFORE implementation.**
+
+**Cleanup actions:**
+1. Remove `needs-approval` label (if present)
+2. Clear STATUS suffix (`N.M (REVISED - NEEDS APPROVAL)` → `N.M`)
+3. Clear todo list (if workflow was interrupted)
+
+**Workflow Interruption Detection:**
+
+| Interruption Type | Detection |
+|------------------|-----------|
+| Developer conversation | Agent asked clarification question and received answer |
+| Spec revision | Agent revised spec (added/changed content) |
+| Error recovery | Agent encountered error and investigated |
+| Context switch | Agent switched to different task/issue |
+| Investigation phase | Agent performed investigation before implementation |
+
+**Action:** If ANY interruption, CLEAR the todo list before implementation.
+
+**⚠️ CRITICAL: Cleanup is SILENT — NO comments posted.**
+
+See `010-approval-gate.md` → "Authorization Cleanup Workflow" for full details.
+
 ## Tasks
 
 | Task | Purpose | Words |


### PR DESCRIPTION
## Summary

Added authorization cleanup documentation to ensure stale approval markers (needs-approval label, STATUS suffix, stale todos) are cleaned up when explicit authorization is received after workflow interruptions.

## Changes

### Documentation Updates

- **`.opencode/guidelines/010-approval-gate.md`**: Added "Authorization Cleanup Workflow (SILENT — No Comments)" section after "Revision Revokes Approval" section
- **`.opencode/guidelines/141-planning-status-tracking.md`**: Added "Authorization Received Status Transition" section with STATUS cleanup rules
- **`.opencode/skills/approval-gate/SKILL.md`**: Added "Authorization Cleanup (SILENT)" section with cleanup actions and workflow interruption detection

### Problem Addressed

When authorization is received after workflow interruptions (developer conversation, spec revision, error recovery, context switch, investigation phase), stale markers accumulate:
- `needs-approval` label remains on issue
- STATUS has `(REVISED - NEEDS APPROVAL)` suffix
- Todo list shows stale tasks from interrupted workflow

### Solution

**Authorization Cleanup Workflow (SILENT):**
1. Remove `needs-approval` label (if present)
2. Clear STATUS suffix: `N.M (REVISED - NEEDS APPROVAL)` → `N.M`
3. Clear todo list (if workflow was interrupted)
4. Proceed with implementation (NO comments posted - cleanup is administrative)

**Workflow Interruption Detection:**
- Developer conversation (agent asked clarification question)
- Spec revision (agent revised spec content)
- Error recovery (agent encountered and investigated error)
- Context switch (agent switched to different task/issue)
- Investigation phase (agent performed investigation before implementation)

Fixes #384
Fixes #385
Fixes #386
Fixes #387
Fixes #388
Fixes #389