### PR TITLE
[Spec #402] Fix compare URL base branch from main to dev

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on
 
 ## [0.2.0] - Unreleased
 
+### spec/git-workflow-compare-url-fix
+
+- **Fixed: Compare URL Base Branch**: Corrected compare URL generation in
+  git-workflow skills and guidelines to use `dev` as base branch for
+  feature branches instead of `main`. Feature branches merge to `dev`
+  first, then `dev` merges to `main` via release PRs. Updated 6 files:
+  `000-critical-rules.md`, `125-github-issue-comments.md`,
+  `approval-gate/SKILL.md`, `approval-gate/tasks/post-implementation.md`,
+  `git-workflow/tasks/review-prep.md`,
+  `implementation-quality/tasks/post-implementation.md`.
+
 ### skill/wording-remediation
 
 - **Changed: Standardized Skill Trigger Format**: All 29 skills now use explicit

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -348,7 +348,7 @@ When URLs are needed (e.g., code compare links, PR links, issue links):
 
 - **GitHub Issues are historical records**: Future maintainers read comments for context, not navigation
 - **URLs become outdated**: Branches get deleted, repos move, links break
-- **Context is what persists**: "The rate limiting was added to prevent API quota exhaustion" survives; `https://github.com/.../compare/main...branch` does not
+- **Context is what persists**: "The rate limiting was added to prevent API quota exhaustion" survives; `https://github.com/.../compare/dev...branch` does not
 - **Chat is for immediate action**: Developers in the current session need clickable links to navigate
 
 ### Examples
@@ -358,7 +358,7 @@ When URLs are needed (e.g., code compare links, PR links, issue links):
 ```markdown
 Phase 1 complete: Added rate limiting to PubMed client.
 
-https://github.com/owner/repo/compare/main...feature-branch
+https://github.com/owner/repo/compare/dev...feature-branch
 ```
 
 **✅ CORRECT (Context in GitHub Issue, URL in Chat):**
@@ -381,7 +381,7 @@ Added rate limiting middleware to PubMed client to prevent API quota exhaustion.
 
 **Outcome:** PubMed API calls now respect rate limits, preventing quota exhaustion errors.
 
-https://github.com/owner/repo/compare/main...feature-branch
+https://github.com/owner/repo/compare/dev...feature-branch
 
 ---
 🤖 ✅ Completed by OpenCode (ollama-cloud/glm-5)

--- a/.opencode/guidelines/125-github-issue-comments.md
+++ b/.opencode/guidelines/125-github-issue-comments.md
@@ -217,7 +217,7 @@ When a comment includes a URL (issue link, PR link, code compare link, etc.), th
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-https://github.com/<owner>/<repo>/compare/main...<branch>
+https://github.com/<owner>/<repo>/compare/dev...<branch>
 ```
 
 ### Why URL Last
@@ -246,7 +246,7 @@ Skills imported from external repository. Parent issue #149 tracks overall progr
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-https://github.com/<owner>/<repo>/compare/main...<branch>
+https://github.com/<owner>/<repo>/compare/dev...<branch>
 ```
 
 ### No URLs

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -117,7 +117,7 @@ Before reporting completion, the agent MUST verify:
 | Verification Step | Required Action |
 |-------------------|-----------------|
 | Branch pushed? | `git log origin/<branch>..HEAD --oneline` must show commits OR be empty (already pushed) |
-| Compare URL generated? | `https://github.com/<owner>/<repo>/compare/main...<branch>` |
+| Compare URL generated? | `https://github.com/<owner>/<repo>/compare/dev...<branch>` |
 | GitHub comment posted? | Executive summary + compare URL to GitHub issue |
 | Chat output posted? | Executive summary + compare URL to chat (BOTH locations required) |
 
@@ -140,7 +140,7 @@ Before reporting completion, the agent MUST verify:
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-https://github.com/<owner>/<repo>/compare/main...<branch>
+https://github.com/<owner>/<repo>/compare/dev...<branch>
 ```
 
 **The review-prep task provides MANDATORY developer visibility before PR creation.**

--- a/.opencode/skills/approval-gate/tasks/post-implementation.md
+++ b/.opencode/skills/approval-gate/tasks/post-implementation.md
@@ -98,7 +98,7 @@ This pushes the branch WITHOUT creating a PR.
 Using session values (GIT_OWNER, GIT_REPO):
 
 ```
-https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
+https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
 ```
 
 ### Step 3: Report Completion
@@ -117,7 +117,7 @@ Format for issue and chat:
 
 **Ready for Review:**
 
-https://github.com/<owner>/<repo>/compare/main...<branch-name>
+https://github.com/<owner>/<repo>/compare/dev...<branch-name>
 ```
 
 ### Step 4: HALT

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -178,7 +178,7 @@ todowrite todos=[]
 Using session values (GIT_OWNER, GIT_REPO):
 
 ```
-https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
+https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
 ```
 
 ### Step 4: Pre-Post Verification (MANDATORY GATE)
@@ -209,7 +209,7 @@ https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
+https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
 ```
 
 **If ANY check fails:** STOP. Fix the format BEFORE continuing to Step 3.
@@ -236,7 +236,7 @@ https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
+https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
 ```
 
 **Why chat only:**
@@ -393,5 +393,5 @@ Updated git-workflow skill to push feature branches after implementation and pro
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-https://github.com/<owner>/<repo>/compare/main...<branch-name>
+https://github.com/<owner>/<repo>/compare/dev...<branch-name>
 ```

--- a/.opencode/skills/implementation-quality/tasks/post-implementation.md
+++ b/.opencode/skills/implementation-quality/tasks/post-implementation.md
@@ -52,7 +52,7 @@ owner="<GIT_OWNER>"
 repo="<GIT_REPO>"
 
 # Generate compare URL
-compare_url="https://github.com/${owner}/${repo}/compare/main...${branch}"
+compare_url="https://github.com/${owner}/${repo}/compare/dev...${branch}"
 ```
 
 ### Step 3: Post Executive Summary
@@ -76,7 +76,7 @@ compare_url="https://github.com/${owner}/${repo}/compare/main...${branch}"
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-https://github.com/<owner>/<repo>/compare/main...<branch>
+https://github.com/<owner>/<repo>/compare/dev...<branch>
 ```
 
 **Critical: Emoji must be PLAIN TEXT (not inside italic/bold formatting).**
@@ -107,7 +107,7 @@ After posting to both locations:
 | Check | Command | Expected |
 |-------|---------|----------|
 | Branch pushed? | `git log origin/<branch>..HEAD --oneline` | Empty (already pushed) |
-| Compare URL? | `https://github.com/<owner>/<repo>/compare/main...<branch>` | Valid URL |
+| Compare URL? | `https://github.com/<owner>/<repo>/compare/dev...<branch>` | Valid URL |
 | Posted to issue? | Check comment exists | Executive summary visible |
 | Posted to chat? | Check chat output | Executive summary visible |
 


### PR DESCRIPTION
## Summary

Fixed compare URL generation in git-workflow skills and guidelines to use `dev` as base branch for feature branches, correcting a mismatch where URLs targeted `main` instead of the actual merge target.

## Changes

- Fixed compare URL base branch from `main` to `dev` in 6 documentation files
- Feature branches merge to `dev` first, then `dev` merges to `main` via release PRs
- Updated files:
  - `.opencode/guidelines/000-critical-rules.md`: Review-prep completion workflow
  - `.opencode/guidelines/125-github-issue-comments.md`: Context-based summary examples
  - `.opencode/skills/approval-gate/SKILL.md`: Multi-task completion flow
  - `.opencode/skills/approval-gate/tasks/post-implementation.md`: Sub-issue workflow
  - `.opencode/skills/git-workflow/tasks/review-prep.md`: Compare URL generation
  - `.opencode/skills/implementation-quality/tasks/post-implementation.md`: Completion workflow
- Updated `CHANGELOG.md` with change documentation

Fixes #402