### PR TITLE
[SPEC] Clarify unqualified approval covers all phases

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -520,6 +520,68 @@ The spec defines EXACTLY what to implement. Nothing more. Nothing less.
 
 ---
 
+## Critical Violation: Incorrect HALT After Phase Completion — Unqualified Approval
+
+**⚠️ Halting after completing a phase when unqualified approval was given is a CRITICAL GUIDELINE VIOLATION.**
+
+### The Problem
+
+When a developer says `approved` or `go` **without a phase qualifier**, this authorizes ALL phases of the spec. The agent must continue through all phases without stopping.
+
+Some agents incorrectly HALT after completing Phase 1 and mark remaining phases as `needs-approval`. This violates the principle of trust in approval tokens and creates unnecessary friction.
+
+### 🚫 FORBIDDEN
+
+| Forbidden Pattern | Why It's Wrong |
+|-------------------|-----------------|
+| HALT after Phase 1 when `approved` given | Unqualified approval = ALL phases authorized |
+| Mark remaining phases as `needs-approval` | Approval was already granted |
+| Ask for re-approval after each phase | Friction that violates developer mental model |
+| Assume phase-by-phase approval required | Only required for HIGH/MEDIUM+LARGE blast radius |
+
+### ✅ REQUIRED Behavior
+
+**With unqualified approval (`approved` or `go`):**
+1. Proceed through Phase 1
+2. Continue to Phase 2 (no HALT)
+3. Continue through ALL remaining phases
+4. HALT only after completing ENTIRE spec
+5. DO NOT mark remaining phases as `needs-approval`
+
+**With qualified approval (`approved: 1` or `approved: 2.3`):**
+1. Proceed through the authorized phase/step ONLY
+2. HALT after completing that phase/step
+3. Wait for next authorization before continuing
+
+### Exception: Risk-Aware Phases
+
+**For HIGH/MEDIUM risk + LARGE blast radius phases, recommend phase-by-phase approval:**
+
+| Phase Risk | Blast Radius | Recommendation |
+|------------|-------------|----------------|
+| HIGH + LARGE | Large | Explicit phase approval required |
+| HIGH + MEDIUM | Medium | Explicit phase approval recommended |
+| Any other combination | Any | Unqualified approval sufficient |
+
+**If developer provides unqualified approval for risky phases:**
+- PROCEED (developer accepted cumulative risk)
+- Document risk acknowledgment in implementation comment
+
+### Why This Matters
+
+- Developer mental model: "approved means go ahead"
+- Repeated authorization requests create friction
+- Trust in approval tokens is undermined by unnecessary HALTs
+- Unqualified approval is a complete authorization, not partial
+
+### Integration Points
+
+- `010-approval-gate.md` → "Authorization Scope for Multi-Phase Specs"
+- `020-go-prohibitions.md` → "Multi-Phase Authorization Scope"
+- This section adds critical violation enforcement
+
+---
+
 ## Critical Violation: Spec Without Investigation
 
 **⚠️ Creating a spec without completed investigation is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -242,6 +242,45 @@ Proceeding with unqualified approval (developer accepts cumulative risk).
 
 **Missing risk level → `BOILERPLATE-TITLE` or `MISSING-ELEMENT` violation**
 
+### Edge Cases for Unqualified Approval
+
+**Edge Case: Conflict/Requirement Change**
+
+If a spec requirement changes mid-implementation (e.g., external feedback, new information), remaining tasks ARE marked `needs-approval`:
+
+| Scenario | Action |
+|----------|--------|
+| Spec revised during implementation | Stop immediately, mark remaining phases as `needs-approval` |
+| New requirement discovered | Post comment, mark affected phases as `needs-approval` |
+| Stakeholder changes scope | HALT, wait for explicit re-authorization |
+
+This is NOT a violation of "unqualified approval covers all phases" — it's a safety mechanism when the context changes.
+
+**Edge Case: External Input**
+
+Bug reports, critical findings, or production incidents invalidate prior approval:
+
+| Input Type | Action |
+|------------|--------|
+| Bug report on related code | HALT, mark remaining phases as `needs-approval` |
+| Production incident | HALT, wait for explicit instruction |
+| Critical finding during implementation | Post comment to issue, HALT |
+
+**Edge Case: Risk Escalation**
+
+If phase risk is elevated to HIGH/MEDIUM+LARGE during implementation:
+
+| Risk Change | Action |
+|-------------|--------|
+| Phase marked LOW → discovered HIGH | HALT, recommend phase-by-phase approval |
+| Blast radius grows | HALT, wait for explicit authorization |
+| Dependencies increase | HALT, assess impact |
+
+**Why Edge Cases Override:**
+- Changed context invalidates implicit trust
+- External input means developer may not have full information
+- Risk escalation requires explicit acknowledgment
+
 ## Compound Command Recognition
 
 **Approval tokens must be STANDALONE (separated by whitespace) to constitute valid authorization.**


### PR DESCRIPTION
## Summary

Enhanced approval scope guidelines to clarify that unqualified approval (`approved` or `go` without phase qualifier) authorizes ALL phases of a spec, preventing agents from incorrectly halting after completing phases and marking remaining phases as `needs-approval`.

## Changes

**Files Modified:**
- `.opencode/guidelines/000-critical-rules.md` - Added critical violation section for incorrect HALT after phase completion
- `.opencode/guidelines/010-approval-gate.md` - Added edge cases for unqualified approval handling

**Key Additions:**

1. **Critical Violation Section (000-critical-rules.md):**
   - Documents forbidden patterns (HALT after Phase 1 when `approved` given)
   - Required behavior (proceed through all phases with unqualified approval)
   - Exception for risk-aware phases (HIGH/MEDIUM+LARGE may need explicit phase approval)
   - Integration points with related guidelines

2. **Edge Cases Section (010-approval-gate.md):**
   - Conflict/requirement change scenarios
   - External input handling (bug reports, production incidents)
   - Risk escalation procedures
   - Why edge cases override unqualified approval

**Impact:**
- Agents will now understand that `approved` or `go` without qualifier authorizes ALL phases
- Developers can use qualified approval (`approved: N`) for phase-by-phase control
- High-risk phases still support explicit approval recommendations
- Clear guidance on when remaining tasks should be marked `needs-approval`

Fixes #412