### PR TITLE
[SPEC-FIX] Add .opencode/.gitignore for Node.js/Bun files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,6 @@ env/
 # uv
 .uv/
 
-# Node.js / Bun (not used in this Python project)
-/bun.lock
-/node_modules/
-/package-lock.json
-/package.json
-
 # PyCharm / JetBrains
 .idea/
 *.iws

--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,0 +1,5 @@
+# Node.js / Bun files (not used in this Python project)
+bun.lock
+node_modules/
+package-lock.json
+package.json


### PR DESCRIPTION
# Fix .gitignore for Node.js/Bun Files

Fixes #417

## Problem

The hotfix PR #416 incorrectly added Node.js/Bun ignore patterns to the root `.gitignore` with leading slashes (`/bun.lock`), which only ignores files at the repository root level. The files in `.opencode/` directory are still tracked.

## Solution

1. **Created `.opencode/.gitignore`** - proper location for subdirectory-specific ignores
2. **Reverted root `.gitignore`** - removed the incorrect patterns

## Files Changed

| File | Change |
|------|--------|
| `.opencode/.gitignore` | Created - ignores `bun.lock`, `node_modules/`, `package.json`, `package-lock.json` |
| `.gitignore` | Reverted - removed Node.js patterns |

## Why `.opencode/.gitignore`

- Node.js/Bun files are only used by AI tooling in `.opencode/`
- Subdirectory `.gitignore` is the standard approach
- Root `.gitignore` should be project-level only
- Patterns without leading slashes work anywhere in the directory tree

## Related

- Created issue #417 to track this fix
- Hotfix #416 has already merged to main with incorrect patterns