### PR TITLE
[SPEC-FIX] Automate hotfix dev-merge ticket creation

### DIFF
--- a/.opencode/guidelines/115-git-hotfix-workflow.md
+++ b/.opencode/guidelines/115-git-hotfix-workflow.md
@@ -82,9 +82,16 @@ Create PR:
 
 ### Step 4: After Merge to main
 
-**After human merges the hotfix PR to `main`:**
+**After human merges the hotfix PR to `main`, the agent MUST:**
 
-1. **Sync to `dev`:**
+1. **Verify PR merge via GitHub API** (see `cleanup.md` Step 1)
+2. **Create dev merge ticket:**
+   - Title: `[SPEC] Merge main to dev - Hotfix: <description>`
+   - Body: Reference to hotfix PR, commit hashes, affected files
+   - Labels: `hotfix`, `needs-approval`
+   - Post chat message: "Hotfix merged to main. Ticket #N created for dev merge."
+
+3. **Sync to `dev`:**
    ```bash
    git checkout dev
    git merge main
@@ -93,11 +100,26 @@ Create PR:
    
    Or create a PR from `main` to `dev` if preferred.
 
-2. **Delete hotfix branch:**
+4. **Delete hotfix branch:**
    ```bash
    git branch -d hotfix/urgent-fix
    git push origin --delete hotfix/urgent-fix
    ```
+
+**Hotfix Detection:**
+
+The cleanup task detects hotfix PRs by:
+- PR target branch is `main` (not `dev`)
+- PR has `hotfix` label (or was created from `hotfix/*` branch)
+
+**Edge Cases:**
+
+| Scenario | Action |
+|----------|--------|
+| PR rejected/abandoned | No ticket created (PR not merged) |
+| PR merged via GitHub UI (no agent) | User must manually create ticket |
+| Direct commits to main (no PR) | No ticket created (hotfix workflow requires PR) |
+| Hotfix PR targeting dev | No ticket created (wrong target branch) |
 
 ---
 

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -47,7 +47,7 @@ This skill is invoked at these workflow triggers:
 | `review-prep` | Push branch, generate compare URL, post to issue AND chat | ~250 | — |
 | `commit-prep` | Prepare squash commit message (read-only) | ~480 | — |
 | `pr-creation` | Squash, push, create PR with changelog | ~220 | `check-pr-state`, `collect-sub-issues` |
-| `cleanup` | Delete merged branches, verify issue structure | ~150 | `verify-sub-issues` |
+| `cleanup` | Delete merged branches, verify issue structure, hotfix dev-merge ticket | ~240 | `verify-sub-issues` |
 
 ### Subtask Architecture
 
@@ -125,7 +125,7 @@ Subtasks may use `todowrite` tool for progress tracking, but this is internal to
 
 **`pr-creation`**: Use when user says "create a PR" or "pr". Squashes to single commit, pushes, creates PR with changelog, HALTs.
 
-**`cleanup`**: Use when user says "pr merged" or "merged" (automatic). Verifies merge via GitHub API, closes issues, deletes local and remote branches.
+**`cleanup`**: Use when user says "pr merged" or "merged" (automatic). Verifies merge via GitHub API, creates hotfix dev-merge ticket if applicable, closes issues, deletes local and remote branches.
 
 ## Workflow Context
 

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -52,7 +52,69 @@ proceed_to_close_issues()
 - GitHub API `merged_at` field is the ONLY reliable merge indicator
 - Closing issues without merged PR loses tracking and audit trail
 
-### Step 2: Switch to Dev
+### Step 2: Hotfix Dev-Merge Ticket (Hotfix PRs ONLY)
+
+**If PR targets `main` (hotfix), create a ticket for merging `main` → `dev`:**
+
+```python
+# Detect hotfix PR
+pr_info = github_pull_request_read(method="get", owner=..., repo=..., pullNumber=...)
+
+is_hotfix = (
+    pr_info["base"]["ref"] == "main" and
+    ("hotfix" in pr_info.get("labels", []) or 
+     pr_info["head"]["ref"].startswith("hotfix/"))
+)
+
+if is_hotfix and pr_info.get("merged_at"):
+    # Create ticket for dev merge
+    ticket = github_issue_write(
+        method="create",
+        owner=...,
+        repo=...,
+        title=f"[SPEC] Merge main to dev - Hotfix: {pr_info['title']}",
+        body=f"""# Dev Merge Required for Hotfix
+
+**Hotfix PR:** #{pr_info['number']}
+**Merged to main:** {pr_info['merged_at']}
+**Hotfix description:** {pr_info['body']}
+
+## Affected Files
+
+{chr(10).join(pr_info.get('files', []))}
+
+## Action Required
+
+Merge `main` → `dev` to propagate hotfix to integration branch.
+
+```bash
+git checkout dev
+git merge main
+git push origin dev
+```
+
+---
+🤖 Auto-created by cleanup task after hotfix merge.
+""",
+        labels=["hotfix", "needs-approval"]
+    )
+    
+    # Post chat message
+    print(f"Hotfix merged to main. Ticket #{ticket['number']} created for dev merge.")
+```
+
+**Ticket Format:**
+- Title: `[SPEC] Merge main to dev - Hotfix: <hotfix title>`
+- Labels: `hotfix`, `needs-approval`
+- Body: Hotfix PR reference, commit hashes, affected files
+- Chat message: "Hotfix merged to main. Ticket #N created for dev merge."
+
+**Skip for non-hotfix PRs:**
+- PRs targeting `dev` → no ticket (normal feature workflow)
+- PRs without `hotfix` label targeting `dev` → no ticket
+- Direct commits to `main` (no PR) → no ticket (hotfix workflow requires PR)
+
+### Step 3: Switch to Dev
 
 ```bash
 git checkout dev


### PR DESCRIPTION
## Summary

Automated hotfix dev-merge ticket creation to prevent manual ticket creation errors and ensure proper workflow tracking when hotfixes are merged to production.

## Changes

### Documentation
- Updated `115-git-hotfix-workflow.md` Step 4 with automatic ticket creation procedure
- Added hotfix detection logic to `cleanup.md` Step 2 (checks PR target branch and labels)
- Updated SKILL.md cleanup task description to reflect enhancements

### Workflow Improvements
- After hotfix PR merge to `main`, agent now automatically creates dev-merge ticket
- Agent verifies PR merge via GitHub API before creating ticket
- Edge cases documented: rejected PR, direct commit, wrong target branch
- Hotfix cleanup now includes ticket creation for traceability

Fixes #420