### PR TITLE
fix(guidelines): add todo list cleanup at workflow transitions

### DIFF
--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -381,6 +381,34 @@ When authorization is received after interruption:
 2. **No explicit authorization** → Check for `needs-approval` label
 3. **Label present without authorization** → HALT and wait for user to authorize
 
+### Todo List Cleanup (MANDATORY)
+
+**When authorization received after workflow interruption:**
+
+Workflow interruptions include:
+- Developer conversation (clarification questions)
+- Spec revision
+- Context switch to different issue/task
+- Error recovery
+- Session boundary
+
+**Action:** Clear todo list BEFORE starting implementation:
+
+```python
+todowrite(todos=[])
+```
+
+**Edge cases:**
+
+| Scenario | Action |
+|----------|--------|
+| No interruption (immediate auth) | Skip todo clearing (todos still valid) |
+| Todo list already empty | Skip todo clearing (no-op) |
+| Clarification question answered | Clear todos (workflow restarted) |
+| Spec revised | Clear todos (scope changed) |
+
+**Rationale:** Todos track progress within a workflow. Workflow interruption invalidates that progress tracking - the new implementation starts fresh.
+
 ### Bug Report Response
 
 When bug report requires code changes:

--- a/.opencode/guidelines/111-git-commit-workflow.md
+++ b/.opencode/guidelines/111-git-commit-workflow.md
@@ -186,6 +186,68 @@ git log -1 --oneline
 
 ______________________________________________________________________
 
+## 5.5. Todo Lifecycle During Workflow Transitions (MANDATORY)
+
+**Clear todos at these transition points:**
+
+| Transition Point | Action |
+|------------------|--------|
+| Implementation → PR creation | Clear implementation todos (no todo needed for PR steps) |
+| After PR creation | Clear PR workflow todos (waiting for human merge) |
+| After cleanup | Clear all todos (workflow complete) |
+
+**Why:** Each workflow phase has explicit steps in skills. Todo lists track implementation progress, not procedural steps.
+
+### When to Clear Todos
+
+**After authorization received (before implementation starts):**
+
+If workflow was interrupted by clarification, revision, context switch, or error:
+
+```python
+todowrite(todos=[])
+```
+
+**Workflow interruptions include:**
+
+- Developer conversation (clarification questions)
+- Spec revision
+- Context switch to different issue/task
+- Error recovery
+- Session boundary
+
+**Edge cases:**
+
+| Scenario | Action |
+|----------|--------|
+| No interruption (immediate auth) | Skip todo clearing (todos still valid) |
+| Todo list already empty | Skip todo clearing (no-op) |
+| Clarification question answered | Clear todos (workflow restarted) |
+| Spec revised | Clear todos (scope changed) |
+
+**Before PR creation workflow:**
+
+```python
+# See git-workflow skill pr-creation task
+todowrite(todos=[])
+```
+
+**After cleanup workflow:**
+
+```python
+# See git-workflow skill cleanup task
+todowrite(todos=[])
+```
+
+### Why Todo Clearing Matters
+
+- Implementation todos track progress within a workflow
+- PR creation has explicit procedural steps - no todo needed
+- Stale todos cause confusion about "X of Y complete"
+- Clean state on completion prevents confusion in next session
+
+______________________________________________________________________
+
 ______________________________________________________________________
 
 ## 6. Grouped-Step Commit Strategy

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -155,6 +155,21 @@ git status --porcelain  # Must be empty
 git branch -vv          # Should show minimal branches
 ```
 
+---
+
+### Step 6: Clear Workflow Todos
+
+**After cleanup complete:**
+
+```python
+# Clear any remaining workflow todos
+todowrite(todos=[])
+```
+
+**Why:** Ensures clean state for next work session. Todo lists track progress within workflows - once workflow completes, todos are no longer needed.
+
+---
+
 ## Context Required
 
 - Guidelines: `114-git-branch-cleanup.md`, `124-github-archive-workflow.md`

--- a/.opencode/skills/git-workflow/tasks/implementation.md
+++ b/.opencode/skills/git-workflow/tasks/implementation.md
@@ -33,6 +33,24 @@ todowrite([
 
 See `020-go-prohibitions.md` Section 6 for unqualified approval scope.
 
+### Todo Clearing at Workflow Transitions
+
+**Clear todos at these transition points:**
+
+| Transition Point | Action |
+|------------------|--------|
+| Implementation → PR creation | Clear implementation todos (no todo needed for PR steps) |
+| After PR creation | Clear PR workflow todos (waiting for human merge) |
+| After cleanup | Clear all todos (workflow complete) |
+
+**Why:** Each workflow phase has explicit steps in skills. Todo lists track implementation progress, not procedural steps.
+
+**When to Clear:**
+
+- **Before PR creation workflow:** `todowrite(todos=[])`
+- **After cleanup workflow:** `todowrite(todos=[])`
+- **After authorization (if interrupted):** `todowrite(todos=[])`
+
 ## Workflow
 
 1. **User-driven work:** The agent performs approved implementation tasks

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -38,6 +38,21 @@ Subtasks handle their own context, discarded after return.
 
 ## Procedure
 
+### Step 0: Clear Implementation Todos (MANDATORY)
+
+**Before PR creation workflow begins:**
+
+```python
+# Clear any stale implementation todos
+todowrite(todos=[])
+```
+
+**Why:** Implementation todos are for tracking work progress. PR creation has explicit procedural steps in this task - no todo list needed. Clearing prevents confusion about stale "X of Y complete" status.
+
+**CRITICAL:** This step runs BEFORE checking PR state, collecting sub-issues, or any other PR workflow steps.
+
+---
+
 ### Step 1: Check PR State (Subtask)
 
 **Invoke subtask to determine if PR already exists:**


### PR DESCRIPTION
## Summary

Added todo list cleanup at workflow transition points to prevent stale todos from causing confusion during implementation phases. Updated pr-creation.md, cleanup.md, implementation.md, 010-approval-gate.md, and 111-git-commit-workflow.md with explicit todo clearing steps.

## Changes

- **pr-creation.md**: Added Step 0 to clear implementation todos before PR workflow
- **cleanup.md**: Added Step 6 to clear all todos after cleanup workflow
- **implementation.md**: Added Todo Clearing at Workflow Transitions section
- **010-approval-gate.md**: Added Todo List Cleanup section to Authorization Cleanup Workflow with edge cases
- **111-git-commit-workflow.md**: Added section 5.5 for Todo Lifecycle During Workflow Transitions

Fixes #433
Fixes #434