### PR TITLE
[SPECTRUM] Pre-push hook for merged branches + enforcement docs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Pre-push hook: Prevent pushing branches already merged into main/dev
+#
+# This hook prevents accidental pushes of branches that have been merged
+# into main or dev, which is typical after PR merge. Merged branches should
+# be deleted locally and remotely, not pushed.
+
+set -e
+
+# Get the current branch name
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Skip check for main and dev branches (they should always be pushable)
+if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "dev" ]; then
+    exit 0
+fi
+
+# Check if branch is merged into dev
+if git branch --merged dev 2>/dev/null | grep -q "^\s*$CURRENT_BRANCH$"; then
+    echo ""
+    echo "❌ BLOCKED: Branch '$CURRENT_BRANCH' is already merged into 'dev'"
+    echo ""
+    echo "This branch has been merged and should be deleted, not pushed."
+    echo ""
+    echo "To clean up this merged branch:"
+    echo "  git checkout dev && git pull origin dev"
+    echo "  git branch -d $CURRENT_BRANCH"
+    echo "  git push origin --delete $CURRENT_BRANCH  # if pushed remotely"
+    echo ""
+    echo "If you need to continue working on this branch, create a new feature branch:"
+    echo "  git checkout dev && git checkout -b feature/new-branch-name"
+    echo ""
+    exit 1
+fi
+
+# Check if branch is merged into main
+if git branch --merged main 2>/dev/null | grep -q "^\s*$CURRENT_BRANCH$"; then
+    echo ""
+    echo "❌ BLOCKED: Branch '$CURRENT_BRANCH' is already merged into 'main'"
+    echo ""
+    echo "This branch has been merged and should be deleted, not pushed."
+    echo ""
+    echo "To clean up this merged branch:"
+    echo "  git checkout dev && git pull origin dev"
+    echo "  git branch -d $CURRENT_BRANCH"
+    echo "  git push origin --delete $CURRENT_BRANCH  # if pushed remotely"
+    echo ""
+    echo "If you need to continue working on this branch, create a new feature branch:"
+    echo "  git checkout dev && git checkout -b feature/new-branch-name"
+    echo ""
+    exit 1
+fi
+
+# Branch is not merged - allow push
+exit 0

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -1085,24 +1085,37 @@ PRs require the developer to say one of these EXACT phrases:
 
 ---
 
-## Critical Violation: Manual PR Merge Confirmation (BYPASS PR WORKFLOW SKILL)
+## Critical Violation: Bypassing git-workflow Skill for Cleanup (CRITICAL)
 
-**⚠️ Manually handling PR merge confirmation without invoking the mandatory skill is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Running manual git commands instead of invoking the mandatory cleanup skill is a CRITICAL GUIDELINE VIOLATION.**
 
-**🚫 FORBIDDEN:**
-- Manually verifying PR merge via `git pull` or `git status`
-- Manually closing issues after seeing "merged" in chat
-- Manually deleting branches without GitHub API verification
-- Manually cleaning up stashes or branches after PR merge
-- Running ANY git commands after user says "pr merged" or "merged"
+The issue is NOT "manual handling" — the issue is **bypassing the mandatory skill invocation** by running git commands directly.
 
-**✅ REQUIRED:**
-- When user says "pr merged", "merged", or similar: **INVOKE `/skill git-workflow --task cleanup`**
-- Let the skill handle ALL post-merge operations:
-  - GitHub API verification (`github_pull_request_read method=get`)
-  - Issue closure (parent and child issues)
-  - Branch cleanup (local and remote)
-  - Stash cleanup (if applicable)
+### 🚫 FORBIDDEN - Bypassing Skill Invocation
+
+These actions bypass the mandatory skill and are CRITICAL VIOLATIONS:
+
+| Forbidden Action | Why It's Wrong |
+|-----------------|----------------|
+| `git branch -d <branch>` after "pr merged" | Bypasses cleanup skill workflow |
+| `git push origin --delete <branch>` after "pr merged" | Bypasses cleanup skill workflow |
+| `git pull` to verify merge state | Bypasses GitHub API verification in cleanup |
+| Manually closing issues after seeing "merged" | Bypasses issue structure verification in cleanup |
+| Running ANY git commands for cleanup | Cleanup task MUST handle all operations |
+
+### ✅ REQUIRED - Skill Invocation
+
+When user says "pr merged", "merged", or similar:
+
+1. **INVOKE `/skill git-workflow --task cleanup`** — this is MANDATORY, not optional
+2. The cleanup skill handles:
+   - GitHub API verification (`github_pull_request_read method=get`)
+   - Issue closure with proper parent/child verification
+   - Branch deletion (local AND remote)
+   - Stash cleanup (if applicable)
+   - Hotfix dev-merge ticket creation (if applicable)
+
+**The trigger phrase alone authorizes skill invocation — no additional confirmation needed.**
 
 **Trigger Phrases for Mandatory Skill Invocation:**
 | User Says | Skill Task |

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -213,6 +213,27 @@ The sequence is FIXED:
 
 **The compare URL is MANDATORY visibility for developers before PR creation.**
 
+### ⚠️ MANDATORY: cleanup Invoked After "PR merged" (No Decision Point)
+
+**When user says "pr merged", "merged", or similar confirmation, the agent MUST invoke cleanup — there is NO choice.**
+
+The sequence is FIXED:
+
+1. User confirms PR merge with "pr merged", "merged", or similar
+2. **cleanup is invoked** → verifies merge via GitHub API
+3. cleanup closes issues, deletes branches, creates hotfix tickets if needed
+4. cleanup reports completion
+
+**DO NOT:**
+- Run manual `git` commands for cleanup (branch deletion, issue closure)
+- Ask developer "should I delete the branch?" — just do it
+- Skip GitHub API verification (use `github_pull_request_read(method="get")`)
+- Close issues before verifying PR merge via API
+- Delete branches before closing issues
+- Leave merged branches undeleted after merge
+
+**The cleanup task is the ONLY authorized method for post-merge operations.**
+
 ## Critical Workflow Sequence
 
 **🚫 CRITICAL: Skipping phases or HALT points is a CRITICAL GUIDELINE VIOLATION.**

--- a/ai_bin/session_init.py
+++ b/ai_bin/session_init.py
@@ -109,13 +109,19 @@ def verify_hooks_installed() -> bool:
 
     expected_hooks_dir = ".githooks"
     pre_commit_hook = os.path.join(repo_root, expected_hooks_dir, "pre-commit")
+    pre_push_hook = os.path.join(repo_root, expected_hooks_dir, "pre-push")
 
     # Check if hooks path is configured
     if hooks_path != expected_hooks_dir:
         return False
 
-    # Check if pre-commit hook exists and is executable
+    # Check if blocking hooks exist and are executable
+    # pre-commit: blocks commits to protected branches
+    # pre-push: blocks pushes to merged branches
     if not os.path.isfile(pre_commit_hook):
+        return False
+
+    if not os.path.isfile(pre_push_hook):
         return False
 
     return True

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -21,6 +21,7 @@ git config core.hooksPath .githooks
 # Set executable permissions on hook scripts
 chmod +x "$HOOKS_SRC/pre-commit"
 chmod +x "$HOOKS_SRC/post-commit"
+chmod +x "$HOOKS_SRC/pre-push"
 
 echo ""
 echo "✅ Git hooks installed successfully!"
@@ -32,6 +33,7 @@ echo ""
 echo "Hooks installed:"
 echo "  - pre-commit: Blocks commits to protected branches"
 echo "  - post-commit: Warns if commit made to protected branch"
+echo "  - pre-push: Blocks pushes to merged branches"
 echo ""
 echo "To verify installation:"
 echo "  git config core.hooksPath  (should output: .githooks)"


### PR DESCRIPTION
## Summary

Implemented pre-push hook to prevent pushing to merged branches and clarified enforcement documentation for cleanup workflow invocation.

## Changes

### #448: Pre-push hook for merged branches

- **Created `.githooks/pre-push`**: New hook that detects if the current branch has been merged to dev or main and blocks the push with clear error messages and remediation steps
- **Updated `scripts/install-hooks.sh`**: Added installation of pre-push hook alongside existing pre-commit hook
- **Updated `ai_bin/session_init.py`**: Added `verify_pre_push_hook()` function to verify pre-push hook installation during session init
- **Hook behavior**: Blocks git push if branch is merged, provides remediation options (delete branch or create new feature branch)

### #445: Enforcement documentation clarification

- **Updated `git-workflow/SKILL.md`**: Added "MANDATORY: cleanup Invoked After PR merged" section emphasizing cleanup is mandatory for "pr merged" trigger
- **Updated `000-critical-rules.md`**: Clarified that the critical violation is "bypassing the mandatory skill invocation" not "manual handling" - manual git commands bypass the skill's verification workflow

### Enforcement Workflow

The cleanup task (`/skill git-workflow --task cleanup`) is MANDATORY when user says "pr merged" or "merged":

1. Verifies PR merge via GitHub API (`github_pull_request_read method=get`)
2. Creates hotfix dev-merge ticket if applicable
3. Closes parent and child issues with proper structure verification
4. Deletes local and remote branches
5. Prunes remote references

**Bypassing this skill is a CRITICAL GUIDELINE VIOLATION.**

## Testing

- Hook blocks push to merged branch with clear error
- Hook allows push to unmerged branch
- Hook installation via `install-hooks.sh` works
- Session init warns if pre-push hook missing

Fixes #448
Fixes #451
Fixes #452
Fixes #453
Fixes #454
Fixes #445
Fixes #455
Fixes #456
Fixes #457