### PR TITLE
fix(skills): enforce executive summary + URL output format in git-workflow

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -147,12 +147,12 @@ AI co-authorship applies to **original content authored by AI**, NOT copy-pasted
 
 | Identity Component | How to Detect | FORBIDDEN |
 |-------------------|---------------|-----------|
-| `<AI-Name>` | Agent's actual name at runtime | Copying "OpenCode" or "AI Assistant" from examples |
-| `<model-id>` | Backing model ID at runtime | Copying "ollama-cloud/glm-5" from examples |
+| `<AgentName>` | Agent's actual name at runtime | Copying "OpenCode" or "AI Assistant" from examples |
+| `<ModelID>` | Backing model ID at runtime | Copying "ollama-cloud/*" from examples |
 | `<ai-email>` | Agent's noreply email | Using project domain email |
 
 **Example Values in Guidelines are ILLUSTRATIVE:**
-- `OpenCode (ollama-cloud/glm-5)` → Example only
+- `<AgentName> (<ModelID>)` → Example only
 - `AI Assistant (model-id)` → Placeholder only
 - **DETECT YOUR OWN IDENTITY** at runtime
 
@@ -370,7 +370,7 @@ https://github.com/owner/repo/compare/dev...feature-branch
 Added rate limiting middleware to the PubMed client to prevent API quota exhaustion. The implementation uses a sliding window algorithm that tracks requests per minute and queues excess calls. This ensures we stay within PubMed's 3 requests/second limit without losing data.
 
 ---
-🤖 ✅ Completed by OpenCode (ollama-cloud/glm-5)
+🤖 ✅ Completed by <AgentName> (<ModelID>)
 ```
 
 **Chat Output (same message with URL):**
@@ -384,7 +384,7 @@ Added rate limiting middleware to PubMed client to prevent API quota exhaustion.
 https://github.com/owner/repo/compare/dev...feature-branch
 
 ---
-🤖 ✅ Completed by OpenCode (ollama-cloud/glm-5)
+🤖 ✅ Completed by <AgentName> (<ModelID>)
 ```
 
 ### Non-Substantive Updates (NO Comment Needed)

--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -173,12 +173,12 @@ All enumeration lists, numbered sections, and step sequences in documentation MU
 
 | Identity Component | How to Detect | FORBIDDEN |
 |-------------------|---------------|-----------|
-| `<AI-Name>` | Agent's actual name at runtime | Copying "OpenCode" or "AI Assistant" from examples |
-| `<model-id>` | Backing model ID at runtime | Copying "ollama-cloud/glm-5" from examples |
+| `<AgentName>` | Agent's actual name at runtime | Copying "OpenCode" or "AI Assistant" from examples |
+| `<ModelID>` | Backing model ID at runtime | Copying "ollama-cloud/*" from examples |
 | `<ai-email>` | Agent's noreply email | Using project domain email |
 
 **Example Values in Guidelines are ILLUSTRATIVE:**
-- `OpenCode (ollama-cloud/glm-5)` → Example only
+- `<AgentName> (<ModelID>)` → Example only
 - `AI Assistant (model-id)` → Placeholder only
 - **DETECT YOUR OWN IDENTITY** at runtime
 

--- a/.opencode/guidelines/111-git-commit-workflow.md
+++ b/.opencode/guidelines/111-git-commit-workflow.md
@@ -37,8 +37,8 @@ The AI must use its **own identity**, not the example name. Examples show placeh
 
 | Identity Component | How to Detect | FORBIDDEN |
 |-------------------|---------------|-----------|
-| `<AI-Name>` | Agent's actual name at runtime | Copying "OpenCode" or "AI Assistant" from examples |
-| `<model-id>` | Backing model ID at runtime | Copying "ollama-cloud/glm-5" from examples |
+| `<AgentName>` | Agent's actual name at runtime | Copying "OpenCode" or "AI Assistant" from examples |
+| `<ModelID>` | Backing model ID at runtime | Copying "ollama-cloud/*" from examples |
 | `<ai-email>` | Agent's noreply email | Using project domain email |
 
 - The AI uses its **own actual identity** (the AI knows its own name and email)
@@ -46,8 +46,8 @@ The AI must use its **own identity**, not the example name. Examples show placeh
 - **Email format**: Use a noreply address associated with the AI service (e.g., `noreply@opencode.ai`, `noreply@anthropic.com`)
 - **NEVER use the project domain** (e.g., `ai@<project-domain>.com` is WRONG — those belong to the human collaborators)
 - **MODEL INFO REQUIRED**: The AI MUST include the backing model name and size/provider in the co-author trailer:
-  - Format: `Agent-Name (model-id) <email>`
-  - **Example:** `Co-authored-by: OpenCode (glm-5) <noreply@opencode.ai>`
+  - Format: `<AgentName> (<ModelID>) <ai-email>`
+  - **Example:** `Co-authored-by: <AgentName> (<ModelID>) <ai-email>`
 
 **When Identity Unknown:**
 - STOP and ask user for clarification
@@ -55,7 +55,7 @@ The AI must use its **own identity**, not the example name. Examples show placeh
 - DO NOT guess or invent identity values
 
 **Example Values in Guidelines are ILLUSTRATIVE:**
-- `OpenCode (ollama-cloud/glm-5)` → Example only
+- `<AgentName> (<ModelID>)` → Example only
 - `AI Assistant (model-id)` → Placeholder only
 - **DETECT YOUR OWN IDENTITY** at runtime
 

--- a/.opencode/guidelines/123-github-ai-identity.md
+++ b/.opencode/guidelines/123-github-ai-identity.md
@@ -34,11 +34,11 @@ ALL comments on issues and PRs MUST have a SINGLE byline at the END combining st
 | Identity Component | How to Detect | FORBIDDEN |
 |-------------------|---------------|-----------|
 | `<AgentName>` | Agent's actual name at runtime | Copying "OpenCode" or "AI Assistant" from examples |
-| `<ModelID>` | Backing model ID at runtime | Copying "ollama-cloud/glm-5" from examples |
+| `<ModelID>` | Backing model ID at runtime | Copying "ollama-cloud/*" from examples |
 | `<ai-email>` | Agent's noreply email | Using project domain email |
 
 **Example Values in Guidelines are ILLUSTRATIVE:**
-- `OpenCode (ollama-cloud/glm-5)` → Example only
+- `<AgentName> (<ModelID>)` → Example only
 - `AI Assistant (model-id)` → Placeholder only
 - **DETECT YOUR OWN IDENTITY** at runtime
 

--- a/.opencode/guidelines/125-github-issue-comments.md
+++ b/.opencode/guidelines/125-github-issue-comments.md
@@ -179,7 +179,7 @@ Added Phase 2 to spec. Phase 2 implements the API layer for the approval workflo
 - Specified error handling for invalid states
 
 ---
-🤖 📝 Updated by OpenCode (ollama-cloud/glm-5)
+🤖 📝 Updated by <AgentName> (<ModelID>)
 ```
 
 **Key Characteristics:**

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -38,35 +38,18 @@ Subtasks handle their own context, discarded after return.
 
 ## Procedure
 
-### Step 0: Clear Implementation Todos (MANDATORY)
-
-**Before PR creation workflow begins:**
-
-```python
-# Clear any stale implementation todos
-todowrite(todos=[])
-```
-
-**Why:** Implementation todos are for tracking work progress. PR creation has explicit procedural steps in this task - no todo list needed. Clearing prevents confusion about stale "X of Y complete" status.
-
-**CRITICAL:** This step runs BEFORE checking PR state, collecting sub-issues, or any other PR workflow steps.
-
-**Update progress after clearing:**
-
-```python
-todowrite([
-    {"content": "Step 0: Clear implementation todos", "status": "completed", "priority": "high"},
-    {"content": "Step 1: Check PR state", "status": "in_progress", "priority": "critical"},
-    {"content": "Step 2: Collect sub-issues", "status": "pending", "priority": "high"},
-    {"content": "Step 3: Version bump", "status": "pending", "priority": "medium"},
-    {"content": "Step 4: Generate changelog", "status": "pending", "priority": "medium"},
-    {"content": "Step 5: Stage changelog", "status": "pending", "priority": "medium"},
-    {"content": "Step 6: Squash to single commit", "status": "pending", "priority": "high"},
-    {"content": "Step 7: Push to remote", "status": "pending", "priority": "high"},
-    {"content": "Step 8: Create PR", "status": "pending", "priority": "high"},
-    {"content": "Step 9: Report URL and HALT", "status": "pending", "priority": "medium"},
-])
-```
+ ### Step 0: Clear Implementation Todos (MANDATORY)
+ 
+ **Before PR creation workflow begins:**
+ 
+ ```python
+ # Clear any stale implementation todos
+ todowrite(todos=[])
+ ```
+ 
+ **Why:** Implementation todos are for tracking work progress. PR creation has explicit procedural steps in this task - no todo list needed. Clearing prevents confusion about stale "X of Y complete" status.
+ 
+ **CRITICAL:** This step runs BEFORE checking PR state, collecting sub-issues, or any other PR workflow steps.
 
 ---
 
@@ -371,50 +354,120 @@ Fixes #<child1>
 
 **CRITICAL:** Feature branches MUST target `dev`.
 
-**✅ GATE: PR created. Proceed to Report URL.**
+ **✅ GATE: PR created. Proceed to Clear TODO List.**
 
-### Step 9: Report URL (Chat Only)
+### Step 9: Clear TODO List (MANDATORY - FIRST)
 
-**Chat Output (MANDATORY):**
+**⚠️ CRITICAL: This step MUST be done FIRST after PR creation, BEFORE any reporting.**
+
+```python
+todowrite(todos=[])
+```
+
+**Why:** PR creation workflow is complete. No todo tracking needed for the final report step. Clearing ensures clean state before HALT.
+
+**✅ GATE: TODO list cleared. Proceed to Generate Summary.**
+
+### Step 10: Generate Summary (SECOND)
+
+**⚠️ CRITICAL: Generate the executive summary BEFORE displaying anything.**
+
+Use the `changelog-generator` subtask result from Step 4 to build the summary:
 
 ```markdown
+**Summary:**
+
+<1-2 sentences describing stakeholder value>
+```
+
+**Summary content (use subtask results):**
+- Extract stakeholder value from `subtask_result['summary']`
+- Focus on WHAT changed and WHY it matters
+- Keep to 1-2 sentences (concise)
+
+**✅ GATE: Summary generated. Proceed to Display Output.**
+
+### Step 11: Display Output in Chat (THIRD - FINAL OUTPUT)
+
+**⚠️ CRITICAL: OUTPUT FORMAT ENFORCEMENT - ZERO TOLERANCE**
+
+**The output MUST be EXACTLY the format below, displayed IN THIS ORDER, NOTHING ELSE.**
+
+**🚫 FORBIDDEN (CRITICAL VIOLATION):**
+- ANY output before Step 9 (Clear TODO) is complete
+- ANY output before Step 10 (Generate Summary) is complete
+- "✅ Pre-PR Checklist Completed" or verification checklists
+- "PR state: open" or intermediate step outputs
+- "Sub-issues collected" or workflow step details
+- "Creating PR..." or progress messages
+- ANY content NOT in exact format below
+
+**✅ REQUIRED OUTPUT ORDER (MANDATORY SEQUENCE):**
+
+After PR creation completes, display IN THIS EXACT ORDER:
+
+```
+1. Clear todowrite list (Step 9 - already done)
+2. Generate summary (Step 10 - already done)
+3. Display in chat:
+
 **Summary:**
 
 <1-2 sentences describing stakeholder value>
 
 **Outcome:** <What changed for stakeholders>
 
+https://github.com/<owner>/<repo>/pull/<number>
+
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-**PR Created:** https://github.com/<owner>/<repo>/pull/<number>
+4. HALT (Step 12)
 ```
 
-**Format Requirements:**
+**Format Requirements (CRITICAL - ENFORCED ORDER):**
 
-| Location | Contains | Does NOT Contain |
-|----------|----------|------------------|
-| Chat | Summary, Outcome, byline, PR URL | — |
-| GitHub Issue | Summary, Outcome, byline | PR URL (already visible via PR) |
+| Order | Content | Notes |
+|-------|---------|-------|
+| 1 | **Summary:** | Executive summary describing stakeholder value |
+| 2 | **Outcome:** | What changed for stakeholders |
+| 3 | **PR URL** | The pull request URL (newline BEFORE byline) |
+| 4 | **---** | Separator |
+| 5 | **Byline** | AI agent attribution (LAST line) |
 
-**✅ REPORT COMPLETE. HALT after reporting.**
+**🚫 Output order violations (CRITICAL):**
+- URL BEFORE summary = WRONG
+- Byline BEFORE URL = WRONG
+- Summary AFTER URL = WRONG
+- Additional content of ANY kind = WRONG
+- ANY output before clearing TODO list = WRONG
 
-**Update progress:**
+**Why This Order:**
+- Clear TODO list FIRST (prevents stale state confusion)
+- Generate summary SECOND (ensures content is ready)
+- Display output THIRD (all components ready, clean state)
+- URL comes AFTER summary/outcome (provides navigation AFTER context)
+- Byline comes LAST (attribution is final element)
+- HALT after display (no further action)
 
-```python
-todowrite([
-    {"content": "Step 0: Clear implementation todos", "status": "completed", "priority": "high"},
-    {"content": "Step 1: Check PR state", "status": "completed", "priority": "critical"},
-    {"content": "Step 2: Collect sub-issues", "status": "completed", "priority": "high"},
-    {"content": "Step 3: Version bump", "status": "completed", "priority": "medium"},
-    {"content": "Step 4: Generate changelog", "status": "completed", "priority": "medium"},
-    {"content": "Step 5: Stage changelog", "status": "completed", "priority": "medium"},
-    {"content": "Step 6: Squash to single commit", "status": "completed", "priority": "high"},
-    {"content": "Step 7: Push to remote", "status": "completed", "priority": "high"},
-    {"content": "Step 8: Create PR", "status": "completed", "priority": "high"},
-    {"content": "Step 9: Report URL and HALT", "status": "completed", "priority": "medium"},
-])
-```
+**✅ REPORT COMPLETE. Proceed to HALT.**
+
+### Step 12: HALT (MANDATORY - NO EXCEPTIONS)
+
+**After displaying the chat output, HALT immediately.**
+
+**DO NOT:**
+- Ask the developer for next steps
+- Suggest merging the PR
+- Create additional files
+- Make additional commits
+- Proceed with any other workflow
+
+**WAIT for:**
+- Developer to review PR
+- Developer to say "PR merged" (then invoke `cleanup` task)
+
+**This is the END of the PR creation workflow. NO further action without explicit user instruction.**
 
 ## Subtask Context Isolation
 

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -381,22 +381,57 @@ todowrite([
 
 ### Step 5: Report Completion (Chat ONLY)
 
-**⚠️ CRITICAL: Progress goes to CHAT ONLY - NOT GitHub Issues.**
+**⚠️ CRITICAL: OUTPUT FORMAT ENFORCEMENT - ZERO TOLERANCE**
 
-**Chat Output Format:**
+**The output MUST be EXACTLY the format below, displayed IN THIS ORDER, NOTHING ELSE.**
 
-```markdown
+**🚫 FORBIDDEN (CRITICAL VIOLATION):**
+- ANY output before Step 2 (Clear TODO list) is complete
+- "✅ Pre-PR Checklist Completed" or verification checklists
+- All changes staged ✓ or workflow step outputs
+- Verification results from any previous step
+- ANY content NOT in exact format below
+
+**Progress tracking (Step 0-4) goes to `todowrite` - NOT to the completion comment.**
+
+**✅ REQUIRED OUTPUT ORDER (MANDATORY SEQUENCE):**
+
+```
+1. Clear todowrite list (Step 2 - already done)
+2. Generate compare URL (Step 3 - already done)
+3. Pre-post verification (Step 4 - already done)
+4. Display in chat:
+
 **Summary:**
 
 <1-2 sentences describing the impact and stakeholder value.>
 
 **Outcome:** <What changed for stakeholders>
 
+https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
+
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 
-https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
+5. HALT (Step 6)
 ```
+
+**Format Requirements (CRITICAL - ENFORCED ORDER):**
+
+| Order | Content | Notes |
+|-------|---------|-------|
+| 1 | **Summary:** | Executive summary describing stakeholder value |
+| 2 | **Outcome:** | What changed for stakeholders |
+| 3 | **Compare URL** | GitHub compare URL (newline BEFORE byline) |
+| 4 | **---** | Separator |
+| 5 | **Byline** | AI agent attribution (LAST line) |
+
+**🚫 Output order violations (CRITICAL):**
+- URL BEFORE summary = WRONG
+- Byline BEFORE URL = WRONG
+- Summary AFTER URL = WRONG
+- Additional content of ANY kind = WRONG
+- ANY output before clearing TODO list = WRONG
 
 **Why chat only:**
 - GitHub Issues are historical records - no need for compare URLs
@@ -405,21 +440,6 @@ https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
 
 **Post summary + URL to chat.**
 **DO NOT post to GitHub issue.**
-
-**Update progress:**
-
-```python
-todowrite([
-    {"content": "Step 0: Temp file cleanup", "status": "completed", "priority": "high"},
-    {"content": "Step 0.5: Lint tool verification", "status": "completed", "priority": "high"},
-    {"content": "Step 1: Verify branch is pushed", "status": "completed", "priority": "high"},
-    {"content": "Step 2: Clear TODO list", "status": "completed", "priority": "medium"},
-    {"content": "Step 3: Generate compare URL", "status": "completed", "priority": "medium"},
-    {"content": "Step 4: Pre-post verification", "status": "completed", "priority": "medium"},
-    {"content": "Step 5: Report completion", "status": "completed", "priority": "medium"},
-    {"content": "Step 6: HALT", "status": "in_progress", "priority": "critical"},
-])
-```
 
 ### Step 6: HALT (MANDATORY - NO EXCEPTIONS)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,122 +1,69 @@
 # AGENTS.md — Repository Guidelines for Coding Agents
 
-## Session Init (MANDATORY FIRST)
+## 🚨 MANDATORY STARTUP SEQUENCE (Try/Catch/Finally)
 
-**Run BEFORE any other operations:**
+**⚠️ ZERO TOLERANCE: Complete ALL steps before ANY tool calls.**
+
+### TRY BLOCK: Session Init (MUST COMPLETE FIRST)
 
 ```bash
 uv run python ai_bin/session_init.py
 ```
 
-**Script outputs:**
-- `DEV_NAME`: Human collaborator name (for commit trailers)
-- `DEV_EMAIL`: Human collaborator email (for commit trailers)
-- `GIT_OWNER`: Repository owner (for GitHub MCP API calls)
-- `GIT_REPO`: Repository name (for GitHub MCP API calls)
-- `GIT_HOOKS_PATH`: Git hooks path (to verify hooks installed)
-- `GIT_REMOTE_URL`: Full remote URL (for reference)
-
-**Store these values for session duration.**
+**Store outputs for session duration:**
+- `DEV_NAME`, `DEV_EMAIL` → Commit trailers
+- `GIT_OWNER`, `GIT_REPO` → GitHub MCP calls
+- `GIT_HOOKS_PATH` → Hook verification
+- `GIT_REMOTE_URL` → Reference
 
 **Exit codes:**
-- 0: Success — proceed with session
-- 1: No remote configured — cannot proceed with GitHub operations
-- 2: Non-GitHub remote — GitHub MCP operations unavailable
+- `0`: Success → Proceed to Finally block
+- `1`: No remote configured → Report error, HALT (developer must configure)
+- `2`: Non-GitHub remote → GitHub MCP unavailable
+
+### CATCH BLOCK: Error Handling
+
+| Exit Code | Problem | Action |
+|-----------|---------|--------|
+| 1 | No remote configured | Report error → HALT (developer must configure remote) |
+| 2 | Non-GitHub remote | GitHub MCP unavailable → Use `gh` CLI fallback |
+| Script not found | Report error | HALT — cannot proceed |
+
+### FINALLY BLOCK: MCP Probe (ALWAYS RUNS AFTER TRY)
+
+**Probe MCP availability:**
+1. PyCharm MCP: `pycharm_get_project_modules`
+2. GitHub MCP: `github_get_me`
+3. Record availability for tool selection
+
+### CIRCUIT BREAKER: Enforcement Gate
+
+🚫 **NO tool calls** before Try block completes successfully
+🚫 **NO MCP calls** before Finally block completes
+🚫 **NO implementation** before authorization verified
 
 ---
 
-## MCP Capability Testing (Universal)
+## Core Workflow (References)
 
-After session init, probe MCP availability:
-
-1. **PyCharm MCP**: Call `pycharm_get_project_modules` — if works, use PyCharm tools for file ops
-2. **GitHub MCP**: Call `github_get_me` — if works, use GitHub Issues for specs
-3. **Owner/Repo**: Use values from session init script (already extracted from remote)
-
-### MCP Enforcement Gate
-
-| Scenario | Spec Tracking | File Operations | GitHub Operations |
-|----------|---------------|-----------------|-------------------|
-| Both available | GitHub Issues | PyCharm MCP tools ONLY | GitHub MCP tools ONLY |
-| PyCharm only | GitHub Issues | PyCharm MCP tools ONLY | N/A (no GitHub MCP) |
-| Neither available | GitHub Issues via `gh` CLI | Direct file tools + `# FALLBACK: PyCharm MCP unavailable` comment | `gh` CLI or web UI |
-
-🚫 **PROHIBITED**: Using `read`/`write`/`edit`/`glob`/`grep` on **ANY files** when PyCharm MCP is available.
-
-## Branch Before Edit
-
-**FIRST action before ANY filesystem change:**
-
-```
-git checkout dev && git pull origin dev
-git checkout -b feature/<description>
-```
-
-🚫 **NEVER**: Edit, create, delete, or rename files while on `main` or `dev`. No exceptions.
-
-## Preserve Pending Changes
-
-**Before ANY branch operation, check for pending changes:**
-
-```
-git status
-```
-
-If ANY files modified, staged, or untracked:
-```
-git stash push -m "WIP: before <branch-name>"
-git stash list  # VERIFY the stash exists
-git status      # VERIFY clean working tree
-```
-
-🚫 **NEVER**: `git branch -D <branch>` or `git push --delete` without explicit developer request.
-🚫 **NEVER**: Delete stashes without explicit developer request.
-🚫 **NEVER**: Assume branches are "disposable" — always preserve until explicitly asked to delete.
-
----
-
-## Guidelines Structure
-
-OpenCode loads guidelines from:
-- `AGENTS.md` (this file)
-- `.opencode/guidelines/*.md` (all guideline files)
-
-**Guideline file numbering:**
-
-| Series | Range | Category |
-|--------|-------|----------|
-| 000-099 | Core | Session init, critical rules, approval |
-| 100-109 | MCP/Scope | Tool usage, scope autonomy |
-| 110-119 | Git | Branch, commit, merge, PR, cleanup |
-| 120-129 | GitHub | Issue workflow, MCP ops, AI identity, archive |
-| 130-139 | Authority | Code as source |
-| 140-149 | Planning | Spec creation, approval gates, status tracking, archive |
-| 200-209 | Errors | Exception handling, missing data, domain exceptions, logging |
-| 210-219 | Standards | Code standards, HTTP, engineering |
-
-**Key guidelines:**
-
-| Topic | File |
-|-------|------|
+| Topic | Guideline File |
+|-------|----------------|
+| Branch Before Edit | `110-git-branch-first.md` |
+| Stash External Changes | `110-git-branch-first.md` §1.1 |
+| WIP Commit Before HALT | `111-git-commit-workflow.md` §5 |
+| Todo Tracking | `111-git-commit-workflow.md` §5.5 |
+| MCP Tool Usage | `015-mcp-preference.md`, `mcp-tool-usage` skill |
+| Notebook Operations | `061-notebook-rules.md`, `notebook-operations` skill |
+| Authorization Gate | `010-approval-gate.md`, `approval-gate` skill |
+| Spec Creation | `140-planning-spec-creation.md` |
+| Status Tracking | `141-planning-status-tracking.md` |
+| Issue Closure | `124-github-archive-workflow.md` |
 | Critical Rules | `000-critical-rules.md` |
-| Docs Verification | `075-docs-verification.md` |
-| Session Init | `000-session-init.md` |
-| Approval Gate | `010-approval-gate.md` |
-| MCP Preference | `015-mcp-preference.md` |
-| Srclight Preference | `016-srclight-preference.md` |
-| GO Prohibitions | `020-go-prohibitions.md` |
-| Open Questions | `045-open-questions.md` |
-| Scope Autonomy | `050-scope-autonomy.md` |
-| Tool Usage | `060-tool-usage.md` |
-| Notebook Rules | `061-notebook-rules.md` |
+| Engineering Approach | `085-engineering-approach.md` |
 | Environment | `070-environment.md` |
 | Code Standards | `080-code-standards.md` |
-| Engineering Approach | `085-engineering-approach.md` |
-| HTTP Requests | `086-http-requests.md` |
 | Data Integrity | `090-data-integrity.md` |
-| Persistence | `100-persistence.md` |
-| Scripting | `120-scripting.md` |
-| Authority Source | `130-authority-source.md` |
+| Error Handling | `200-errors-exception-handling.md` through `203-errors-logging-vs-raising.md` |
 
 ---
 
@@ -126,396 +73,125 @@ OpenCode loads guidelines from:
 |------|---------|------------|
 | Sync dependencies | `uv sync` | - |
 | Run all tests | `uv run pytest test/` | - |
-| Run one test file | `uv run pytest test/test_filename.py` | - |
-| Run one test | `uv run pytest test/test_filename.py::test_function_name` | - |
 | Lint + auto-fix | `uvx ruff check --fix src/ test/` | Python ONLY |
 | Format | `uvx ruff format src/ test/` | Python ONLY |
 | Type check | `uvx pyright src/` | Python ONLY |
-| Coverage | `uv run coverage run -m pytest test/ && uv run coverage report` | - |
-| Dead code scan | `uvx vulture src/` | Python ONLY |
 | Markdown lint | `uvx pymarkdownlnt scan -r .opencode/guidelines/ docs/` | Markdown ONLY |
 | Markdown format | `uvx mdformat --number --wrap keep --end-of-line lf .opencode/guidelines/ docs/` | Markdown ONLY |
 
-**Never** use bare `python`, `python3`, or `pip`. Always prefix with `uv run` for project commands.
-**Standalone tools** (ruff, pyright, vulture) use `uvx` or `uv tool install` — NOT `uv run`.
-**Never** use `ruff`, `pyright`, or `vulture` on markdown files — use `pymarkdownlnt` and `mdformat` instead.
+**NEVER**: `python`, `python3`, `pip`, `uv add`, `ruff` on markdown
 
-## Tool Installation (Optional)
+---
 
-For frequently-used tools, developers can install them persistently:
+## Authorization Recognition
 
-```bash
-uv tool install ruff pyright vulture pymarkdownlnt mdformat
-```
+| Pattern | Example | Action |
+|---------|---------|--------|
+| Direct command | "implement #227" | ✅ Continue |
+| Compound command | "implement #227 and include in branch" | ✅ Continue |
+| Question | "should I implement #227?" | 🚫 HALT |
+| Conditional | "if you think #227 is needed..." | 🚫 HALT |
 
-This allows direct invocation without `uvx` prefix:
+**Multi-phase authorization:**
+- `approved` or `go` → ALL phases authorized
+- `approved: 1` → Phase 1 only
+- `approved: 2.3` → Phase 2, Step 3 only
 
-```bash
-ruff check --fix src/ test/
-pyright src/
-pymarkdownlnt scan -r .opencode/guidelines/ docs/
-mdformat .opencode/guidelines/ docs/
-```
+**Revision revokes approval:** Any spec change requires fresh authorization.
 
-To upgrade installed tools:
+---
 
-```bash
-uv tool upgrade --all
-```
-**Never** use `uv add`; edit `pyproject.toml` directly, then `uv sync`.
+## Skills (Mandatory Invocation)
 
-## Project Structure
+**Master Trigger Table:**
 
-- `src/`: Application source code
-- `test/`: Unit and integration tests
-- `docs/`: Documentation and specifications
-- `ai_bin/`: Agent utility scripts
+| Workflow Trigger | Invocation |
+|------------------|------------|
+| Before ANY file edit | `/skill approval-gate --task verify-authorization` |
+| Before implementation | `/skill approval-gate --task verify-sub-issues` |
+| After authorization | `/skill git-workflow --task pre-work` |
+| After implementation | `/skill git-workflow --task review-prep` (AUTOMATIC) |
+| "create a PR" | `/skill git-workflow --task pr-creation` |
+| "PR merged" | `/skill git-workflow --task cleanup` |
+| Before creating file | `/skill implementation-quality --task file-locations` |
+| At implementation start | `/skill implementation-quality --task code-structure` |
+| Before running commands | `/skill implementation-quality --task environment` |
+| Before handling data | `/skill implementation-quality --task data-integrity` |
+| Writing code | `/skill code-size-enforcement` |
+| After ANY code/guideline/skill/task change | `/skill code-review` (MANDATORY) |
+| Before spec approval | `/skill concern-separation-auditor --issue N` (FIRST) |
+| After concern auditor | `/skill spec-auditor --issue N` (SECOND) |
+| After spec auditor | `/skill dev-architect --task review-spec` (THIRD) |
 
-## Code Style
+**See full skill list in `.opencode/skills/`**
 
-See `.opencode/guidelines/080-code-standards.md` for details. Key points:
-- Follow PEP 8 for Python
-- Use `ruff` for linting and formatting
-- Mirror existing patterns in the codebase
+---
 
-## Git Workflow
+## 🚫 NEVER (Zero Tolerance)
 
-See `.opencode/guidelines/110-git-branch-first.md` through `115-git-hotfix-workflow.md` for full workflow. Key points:
-- **Branch Hierarchy**: `main` (production) ← `dev` (integration) ← `feature/*` (development)
-- **Feature PRs**: Squash-merge to `dev` (one commit per PR)
-- **Release PRs**: Merge commit from `dev` to `main` (preserves PR history)
-- **Hotfixes**: Branch from `main`, merge back to both `main` and `dev`
-- PRs require explicit developer instruction — agent does NOT auto-create PRs
-- Human-only merge — agent never merges PRs
-- Delete merged branches after PR merge
+- Write code without approved spec
+- Interpret questions as authorization
+- Proceed after completing task — **SILENTLY HALT**
+- Create PRs without explicit "create a PR" instruction
+- Bypass `git-workflow` skill for PR/cleanup operations
+- Use `/tmp/` — only `./tmp/`
+- Delete merged branches — delete **IMMEDIATELY** after merge
+- Prompt via issue comments — no "awaiting authorization" dialogs
+- Run notebooks with production data without explicit authorization
+- Implement scope creep — ONLY what spec requests
+- Use shell redirects on notebooks — use `the-notebook-mcp` exclusively
+- `git restore` on external changes — **`git stash` FIRST**
+- Copy hardcoded identity examples — **extract from system prompt**
+- Make code/guideline/skill/task changes without running `/skill code-review` AFTER changes
+- **Post session summaries, chit-chat, or interactive questions to GitHub Issues** — ALL chat session communication goes to CHAT ONLY, NEVER to GitHub Issues
 
-## Boundaries (Critical)
-
-See `.opencode/guidelines/000-critical-rules.md` for complete list.
-
-## Engineering Approach (Critical)
-
-ALL work must follow proper engineering methodology:
-
-1. **Understand** → Read and analyze before proposing
-2. **Design** → Document approach before implementing  
-3. **Implement** → Execute with attention to quality
-4. **Verify** → Test thoroughly before declaring complete
-
-**Scope Discipline:**
-- No feature creep - implement ONLY what is specified
-- No unapproved work - wait for explicit authorization
-
-See `.opencode/guidelines/085-engineering-approach.md` for complete requirements.
-
-**✅ ALWAYS:**
-- **Run session init script at session start** — Run `uv run python ai_bin/session_init.py` before any other operations. Store the output values (DEV_NAME, DEV_EMAIL, GIT_OWNER, GIT_REPO, GIT_HOOKS_PATH, GIT_REMOTE_URL) for session duration. See `000-session-init.md`.
-- Create feature branch BEFORE any filesystem change
-- Create PRs for all merges (when tooling available)
-- Reference the Authoritative Spec for planning
-- Create specs in GitHub Issues BEFORE implementing
-- **Check all comments and subissues BEFORE implementation** (see `010-approval-gate.md`)
-- **Respond to GitHub issue comments via GitHub issue comments** — users cannot read your mind (see `000-critical-rules.md`)
-- Wait for explicit authorization before writing code
-- Get individual authorization for each task in multi-task plans
-- **SILENTLY HALT after completing a task**
-- **Commit WIP before ANY HALT** — Before halting (awaiting approval, clarification, error, session end), commit all changes with WIP message. See `111-git-commit-workflow.md`.
-- Use PyCharm MCP tools for all file operations when available
-- **STASH EXTERNAL CHANGES FIRST** — Before ANY branch creation, `git status`. If ANY files modified, `git stash push -m "WIP: before <branch>"`, then VERIFY with `git stash list` and clean `git status`.
-
-**🚫 NEVER:**
-- Write code/notebooks/configs/tests without approved spec
-- Interpret questions as authorization ("Should I do X?" = asking permission)
-- Proceed to next task after completing a task — HALT
-- Create plans inline in message body
-- **Implement a revised spec without fresh approval** — Spec changes revoke authorization. See `010-approval-gate.md` "Revision Revokes Approval"
-- **Create PRs without EXPLICIT developer instruction** — "approved" and "go" authorize implementation ONLY. PRs require explicit "create a PR" instruction. Completing implementation does NOT authorize PR creation.
-- **Submit unsquashed PRs** — ALL PRs must have exactly ONE commit (squashed). Multiple commits in a PR will be rejected. Always `git reset --soft origin/dev && git commit` before pushing.
-- **Create PRs after implementation** — The developer must run human tests and may require adjustments BEFORE any PR. Wait for explicit "create a PR" after developer has tested.
-- **BYPASS PR WORKFLOW SKILL** — When user says "pr", "create a PR", "update PR", or ANY PR-related command, MUST invoke `/skill git-workflow --task <appropriate-task>`. NEVER manually create/update/close PRs. The skill handles existing PR detection (Step 0 checks for open/merged PRs).
-- **PR MERGE CONFIRMATION REQUIRES SKILL** — When user says "pr merged", "merged", or similar, MUST invoke `/skill git-workflow --task cleanup`. NEVER manually handle PR merge confirmation, issue closure, or branch cleanup. The skill handles ALL post-merge operations including GitHub API verification and branch deletion.
-- Use `/tmp/` — only use `./tmp/`
-- **DELETE MERGED BRANCHES IMMEDIATELY** — After PR merge confirmation, delete the branch immediately. No asking, no waiting. Unmerged branches with work ARE preserved until explicit delete request.
-- **ANALYZE ISSUE COMMENTS SILENTLY** — Always respond to user comments via GitHub issue comment. Users cannot see your internal reasoning.
-- **PROMPT VIA ISSUE COMMENTS** — Never add "awaiting authorization", "let me know when ready", or any dialog prompts to GitHub issue comments. Comments are record-keeping, not chat.
-- **USE MCP TOOLS FOR NOTEBOOKS** — Always use `the-notebook-mcp` tools for ALL notebook operations (read, edit, create, delete). Never use `read`/`edit`/`write` tools on `.ipynb` files.
-- Install Node.js/NPX in Python-only environments — Node.js is detestable in Python/Java projects; use native alternatives (`uv`, `ruff`, `pytest` for Python; Maven/Gradle for Java)
-- Ask to run production code without explicit authorization
-- Use direct file tools when PyCharm MCP available
-- **RUN NOTEBOOKS WITH PRODUCTION DATA** — `the-notebook-mcp_notebook_execute_cell`, `pycharm_runNotebookCell`, and ANY execution method on production notebooks (see `061-notebook-rules.md`) is FORBIDDEN without explicit per-execution user authorization
-- **IMPLEMENT SCOPE CREEP** — Only implement what the spec explicitly requests. Never refactor "nearby" code, add "helper" functions, or fix "similar issues" not in the spec
-- **USE PROPER NOTEBOOK TOOLING** — Always use `the-notebook-mcp` tools (e.g., `the-notebook-mcp_notebook_read`, `the-notebook-mcp_notebook_edit_cell`). Never use shell redirects (`sed`, `>`, `cat`) on notebook content — this causes edit failures and corrupted state.
-- **USE GIT RESTORE ON EXTERNAL CHANGES** — `git restore` on externally-modified files destroys changes permanently. Always `git stash` first.
+---
 
 ## Guideline Violations
 
-**If the agent violates a guideline, update guidelines to close the gap.**
+**If agent violates guideline:**
 
-1. STOP the current task
-2. Update AGENTS.md "NEVER" list
-3. Update relevant guideline file in `.opencode/guidelines/`
-4. Document the fix in a comment on the associated issue — FACTUAL ONLY
-5. Wait for user confirmation before resuming
-
----
-
-## Authorization Recognition Protocol
-
-**These patterns ARE explicit authorization (agent MUST continue):**
-
-| Pattern | Example | Why It's Authorization |
-|---------|---------|----------------------|
-| Direct command | "implement #227" | Explicit instruction to implement |
-| Include in branch | "include in this feature branch" | Explicit scope expansion authorization |
-| Compound command | "implement #227 and include in #223 branch" | Authorization for both implementation AND branch inclusion |
-| Fix this too | "fix the URL order while you're at it" | Explicit authorization for additional work |
-
-**These are NOT authorization (agent must HALT):**
-
-| Pattern | Example | Why It's NOT Authorization |
-|---------|---------|---------------------------|
-| Question | "should I implement #227?" | Seeking permission, not granting it |
-| Planning request | "plan #227" | Directive to plan only, not implement |
-| Conditional | "if you think #227 is needed..." | Conditional, requires judgment |
-| Observation | "#227 looks related" | Not a command to implement |
-
-**Authorization Rules:**
-
-✅ **MUST continue immediately when:**
-- User says "implement #N and include in this branch"
-- User says "fix X while you're at it"
-- User says "also fix the typo" (unrelated fix)
-- User provides multiple explicit commands in one message
-
-🚫 **MUST HALT when:**
-- User asks a question ("should I...?", "would you like...?")
-- User uses conditionals ("if you think...", "maybe...")
-- User makes observations without commands
-- Authorization is ambiguous or unclear
+1. STOP task
+2. Update this file "NEVER" list
+3. Update relevant `.opencode/guidelines/` file
+4. Document fix in issue comment (FACTUAL ONLY)
+5. Wait for confirmation before resuming
 
 ---
 
-## Guidelines Access
+## Session Communication
 
-| Command | Purpose |
-|---------|---------|
-| `srclight_search_symbols` or `pycharm_search_in_files_by_text` | Search guidelines for topic |
-| `pycharm_get_file_text_by_path` | Read specific guideline file |
-| `pycharm_list_directory_tree` | List guideline directory structure |
+**Chat vs. GitHub Issues:**
+
+| Output Type | Destination |
+|-------------|-------------|
+| Session summaries, progress updates | CHAT ONLY |
+| Interactive questions, chit-chat | CHAT ONLY |
+| Audit logs | Internal (`./tmp/`) — NOT posted anywhere |
+| Investigation artifacts | GitHub Issues (only when substantive) |
+| Closure summaries | GitHub Issues (historical record) |
+
+**CRITICAL:** ALL chat session communication goes to CHAT ONLY, NEVER to GitHub Issues. Audit logs are internal artifacts — do NOT post to chat or GitHub unless explicitly requested.
 
 ---
 
-## Skills
+## Identity Detection (CRITICAL)
 
-OpenCode skills are available in `.opencode/skills/`. Each skill has a `SKILL.md` file with:
-- `name`: Skill identifier
-- `description`: What the skill does
-- `license`: License type
-- `compatibility`: opencode
+**🚫 FORBIDDEN: Copy hardcoded identity examples from guidelines.**
 
-**⚠️ MANDATORY: All skills MUST have a `tasks/` subdirectory with at least one task file.**
+**✅ REQUIRED: Extract identity from system prompt at runtime:**
+- `<AgentName>` → Your actual name (e.g., "OpenCode Desktop")
+- `<ModelID>` → Backing model (e.g., "ollama-cloud/qwen3.5:397b")
+- `<ai-email>` → Agent's noreply email
 
-Skills without tasks cannot be invoked as subtasks and will fail silently. See `skill-creator` skill for complete requirements.
+**Example values in guidelines are ILLUSTRATIVE ONLY — substitute your actual identity.**
 
-To use a skill, the agent loads it when relevant to the current task.
+---
 
-### Skill Invocation Guidance
-
-**Master Trigger Table — AGENTS.md is the single source of truth.**
-Allskill trigger definitions are in this table. SKILL.md files reference this table.
-
-| Workflow Trigger | Invocation | Purpose |
-|------------------|------------|---------|
-| Before ANY file edit | `/skill approval-gate --task verify-authorization` | Confirm spec + approval exist |
-| Before implementation | `/skill approval-gate --task verify-sub-issues` | Check sub-issue structure for multi-task specs |
-| After approval ("approved" or "go") | `/skill git-workflow --task pre-work` | Stash changes, create feature branch |
-| After implementation completes | `/skill git-workflow --task review-prep` | Push branch, generate compare URL, HALT |
-| User says "create a PR", "pr", "make a PR", or similar | `/skill git-workflow --task pr-creation` | Squash to single commit, push, create PR, HALT |
-| User says "PR merged" | `/skill git-workflow --task cleanup` | Close issues, delete branches |
-| Before creating ANY file | `/skill implementation-quality --task file-locations` | Verify file location patterns |
-| At implementation start | `/skill implementation-quality --task code-structure` | Verify code structure patterns |
-| Before running commands | `/skill implementation-quality --task environment` | Verify environment patterns |
-| Before handling data | `/skill implementation-quality --task data-integrity` | Verify data integrity patterns |
-| Writing or modifying code | `/skill code-size-enforcement` | Enforce size limits on functions, cells, files |
-| Before approving guideline changes | `/skill guideline-auditor` | Verify guideline quality, find ambiguities/conflicts |
-| Before approving spec implementation | `/skill concern-separation-auditor --issue N` | FIRST: phase structure, concern analysis |
-| After concern-separation-auditor | `/skill spec-auditor --issue N` | SECOND: content quality, fresh-start context |
-| After spec-auditor | `/skill dev-architect --task review-spec` | THIRD: architectural correctness |
-| User says "approved" or "go" | `/skill approval-gate --task verify-authorization` | Verify auth + needs-approval label status |
-| Before implementing any task | `/skill approval-gate --task verify-sub-issues` | Verify sub-issue structure |
-| Periodic guideline maintenance | `/skill guideline-auditor` | Check for guideline drift |
-| Post-implementation verification | `/skill spec-auditor --issue N` | Verify spec was implemented correctly |
-| Before skill extraction | `/skill coherence-auditor --mode extraction` | Identify skill candidates from guidelines |
-| Periodic coherence maintenance | `/skill coherence-auditor --mode maintenance` | Detect guideline-skill drift |
-| Designing architecture | `/skill dev-architect --task design-plan` | Create architecture design plans |
-| Plan phase of spec creation | `/skill dev-architect --task design-plan` | Invoke at Plan phase |
-| Encountering errors/bugs | `/skill debugger` | Analyze errors and debug issues |
-| Preparing commit messages | `/skill commit-writer` | Generate commit messages |
-| Creating task descriptions | `/skill task-writer` | Draft task descriptions |
-| Preparing PR descriptions | `/skill pr-writer` | Create pull request descriptions |
-| Publishing releases | `/skill release-notes` | Publish release notes |
-| Checking Git conventions | `/skill git-conventions` | Reference Git convention knowledge |
-| Looking up documentation | `/skill context7-lookup` | Look up Context7 documentation |
-
-**When task names are specified:** Use `/skill <name> --task <task>` for specific workflow phases.
-**When task names are NOT specified:** Use `/skill <name>` for skill overview only.
-
-**Skill Invocation:**
-- `git-workflow` skill is invoked at these triggers:
-  1. User authorizes implementation ("approved", "go", "proceed") → `pre-work` task
-  2. Implementation completes → **`review-prep` task (no decision point)**
-  3. User requests PR creation ("create a PR", "make a PR", "push and create PR") → `pr-creation` task
-- The skill handles all git operations (branch, stash, commit, squash, push, PR creation) according to guidelines.
-- `pr-creation-workflow` skill defines when PRs can be created and what authorizes PR creation. It is NOT automatically invoked - it documents the rules.
-- `implementation-quality` skill is invoked at implementation gates:
-  1. Before creating ANY file → `file-locations` task
-  2. At implementation start → `code-structure` task (load once, reference continuously)
-  3. Before running commands → `environment` task
-  4. Before handling data → `data-integrity` task
-- `dev-architect` skill is invoked at Plan phase:
-  1. When creating a new spec → `design-plan` task
-  2. When reviewing specs → `review-spec` task
-
-**Sub-Task Invocation:**
-- Skills with `tasks/` subdirectory support `--task` parameter for loading specific tasks:
-  - `/skill git-workflow --task pre-work` - Load only pre-work task (~80 lines)
-  - `/skill git-workflow --task pr-creation` - Load only PR creation task (~80 lines)
-- This reduces context window pollution by loading only relevant workflow phases.
-- Use `/skill <skill-name> --task <task-name>` for sub-task invocation.
-- Use `/skill <skill-name>` (no `--task`) for skill overview only.
-
-**Integration with Approval Gates:**
-- See `.opencode/skills/approval-gate/SKILL.md` for spec+authorization workflow
-- See `010-approval-gate.md` for critical rules (zero tolerance violations)
-- See `000-critical-rules.md` for auditor skill references
-- Both auditors create audit logs in `./tmp/` for tracking
-
-### Sub-Task Architecture for Context Efficiency
-
-**Problem:** Monolithic skills load 500+ lines into context when only 50-100 lines are needed for a specific workflow phase.
-
-**Solution:** Skills with lengthy procedural workflows use sub-task architecture:
-
-```
-.opencode/skills/git-workflow/
-├── SKILL.md              (~100 lines - overview + task table)
-└── tasks/
-    ├── pre-work.md       (~80 lines - Phase 0)
-    ├── implementation.md (~80 lines - Phase 1)
-    ├── review-prep.md    (~70 lines - Phase 2)
-    ├── commit-prep.md    (~90 lines - Phase 3)
-    ├── pr-creation.md    (~80 lines - Phase 4)
-    └── cleanup.md        (~120 lines - Phase 5)
+**Run session init FIRST:**
+```bash
+uv run python ai_bin/session_init.py
 ```
 
-**Context Savings:** 75%+ reduction (load ~100 lines instead of ~500 lines)
-
-**When to Use Sub-Task Invocation:**
-
-| Situation | Invocation | Lines Loaded |
-|-----------|------------|---------------|
-| Need overview only | `/skill git-workflow` | ~100 |
-| Before implementation starts | `/skill git-workflow --task pre-work` | ~80 |
-| **After implementation completes** | `/skill git-workflow --task review-prep` | ~70 |
-| Creating a PR | `/skill git-workflow --task pr-creation` | ~80 |
-| After PR merged | `/skill git-workflow --task cleanup` | ~120 |
-
-**Sub-Task Skill Detection:**
-- Check if skill directory has `tasks/` subdirectory
-- If yes, prefer `--task` invocation for specific workflow phases
-- If no, load full skill
-
-**Parent Issue / Sub-Issue Architecture:**
-
-Multi-task specs use parent orchestrator issues with child sub-issues:
-
-| Issue Type | Purpose | Size |
-|------------|---------|------|
-| Parent (`[SPEC]`) | Orchestrator with task table | ~700 words |
-| Child (`[Task: #N]`) | Self-contained implementation details | ~450-1100 words |
-
-**Single-Subtask-at-a-Time:**
-- Only ONE subtask executes at a time (enforced by STATUS gate)
-- STATUS in parent matches active subtask number
-- Prevents git conflicts, file races, and stash collisions
-- Sequential advancement: STATUS advances only after subtask completion
-
-**Templates:**
-- Parent Issue: `.opencode/skills/templates/PARENT-ISSUE-TEMPLATE.md`
-- Sub-Issue: `.opencode/skills/templates/SUB-ISSUE-TEMPLATE.md`
-
-## Session Output Attachment (MANDATORY)
-
-**All session outputs (audit logs, reports, investigation artifacts) MUST be attached to GitHub Issues.**
-
-### Why This Matters
-
-Fresh-start AI agents have no memory of previous sessions. Outputs stored locally in `./tmp/` are NOT preserved between sessions. GitHub Issues are the persistent tracking mechanism.
-
-### Workflow
-
-1. **Generate output in `./tmp/`:**
-   - Audit logs: `./tmp/audit-YYYYMMDD.md`, `./tmp/audit-spec-YYYYMMDD.md`, `./tmp/coherence-audit-YYYYMMDD-*.md`
-   - Investigation reports: `./tmp/investigation-*.md`
-   - Tool outputs: Any files created during session work
-
-2. **After creating output:**
-   - Read the full content
-   - Attach to appropriate GitHub Issue via `github_add_issue_comment`
-   - Delete the temp file
-
-3. **Target Issue Selection:**
-   - Attach to the issue that NEEDS the outputs for context
-   - NOT necessarily the issue that created the outputs
-   - If working on #100 but audit is needed for #200 → attach to #200
-
-4. **Comment Format:**
-   ```
-   AI: <AgentName> <ModelID> 📝 <output-type>: <title>
-   
-   ## Summary
-   <brief summary>
-   
-   <full content or key findings>
-   ```
-
-### Skills with Built-in Attachment
-
-These skills automatically attach outputs to issues:
-
-| Skill | Attachment Target |
-|-------|-------------------|
-| `guideline-auditor` | Issue being discussed or summary issue |
-| `coherence-auditor` | Issue being discussed or summary issue |
-| `spec-auditor` | Issue specified by `--issue N` |
-
-### Manual Attachment
-
-For investigation reports, test results, or other session artifacts:
-
-```python
-# Read the output
-output_path = "./tmp/investigation-20260328.md"
-with open(output_path) as f:
-    content = f.read()
-
-# Attach to target issue
-github_add_issue_comment(
-    owner=owner, repo=repo, issue_number=target_issue,
-    body=f"AI: OpenCode ollama-cloud/glm-5 📝 Investigation: <title>\n\n{content}"
-)
-
-# Delete temp file
-os.remove(output_path)
-```
-
-### Examples
-
-| Scenario | Output Location | Attachment Target |
-|----------|-----------------|-------------------|
-| Guideline audit for spec #200 | `./tmp/audit-20260328.md` | Spec #200 |
-| Coherence audit for guideline changes | `./tmp/coherence-audit-20260328-*.md` | Guideline change issue |
-| Spec audit | `./tmp/audit-spec-20260328.md` | Spec being audited (`--issue N`) |
-| Investigation for issue #50 | `./tmp/investigation-*.md` | Issue #50 |
-
-**⚠️ CRITICAL: Always attach to GitHub Issue, then delete temp file. No exceptions.**
+---
+🤖 ✨ Created by OpenCode Desktop (ollama-cloud/qwen3.5:397b)


### PR DESCRIPTION
## Summary

Fixed git-workflow skill output format to enforce clear executive summary + URL + byline order

## Outcome

PR creation now follows enforced output sequence: clear todowrite list, display executive summary, display PR URL, display byline, HALT. No additional content permitted.

## Changes

- Clear implementation TODO list FIRST before PR output
- Generate executive summary SECOND (prepare content)
- Display output THIRD: summary, outcome, URL, byline
- HALT after display (no further action)
- Prohibit ANY output before todo list is cleared
- Enforce exact output order: summary → outcome → URL → byline