### PR TITLE
[SPEC] Enforce GitHub closing keywords in PR descriptions

### DIFF
--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -1,9 +1,6 @@
----
-name: git-workflow
-description: Git Workflow Enforcer ensuring all git operations follow the repository's strict branch-first, stash-first, squash-merge workflow. Invoked automatically before implementation and when PR creation is requested.
-license: MIT
-compatibility: opencode
----
+______________________________________________________________________
+
+## name: git-workflow description: Git Workflow Enforcer ensuring all git operations follow the repository's strict branch-first, stash-first, squash-merge workflow. Invoked automatically before implementation and when PR creation is requested. license: MIT compatibility: opencode
 
 # Skill: git-workflow
 
@@ -16,6 +13,7 @@ Git Workflow Enforcer ensuring all git operations follow the repository's strict
 At workflow trigger points, the agent MUST invoke this skill - NOT run git commands manually.
 
 **🚫 NEVER BYPASS:**
+
 - Run `git checkout -b` manually → MUST invoke `pre-work` task
 - Stop after reading files → MUST invoke `review-prep` task
 - Squash/push/create PR manually → MUST invoke `pr-creation` task
@@ -23,7 +21,7 @@ At workflow trigger points, the agent MUST invoke this skill - NOT run git comma
 
 **Manual operations at these points = CRITICAL VIOLATION.**
 
----
+______________________________________________________________________
 
 ## When to Invoke
 
@@ -137,6 +135,7 @@ Subtasks may use `todowrite` tool for progress tracking, but this is internal to
 4. `commit-prep` (optional) → Prepare commit message
 5. `pr-creation` (user-initiated) → Squash, push, create PR, HALT
 6. `cleanup` (after merge) → Close issues, delete branches
+
 - `/skill git-workflow --task review-prep` - **AFTER implementation done** (automatic, no decision point)
 - `/skill git-workflow --task commit-prep` - When user says "commit"
 - `/skill git-workflow --task pr-creation` - When user says "create a PR" or "pr"
@@ -147,10 +146,10 @@ Subtasks may use `todowrite` tool for progress tracking, but this is internal to
 
 **Invoke this skill at these triggers:**
 
-   - User says `approved`, `go`, or similar authorization
-   - User says `create a PR`, `pr`, or similar PR request
-   - Implementation completes (invoke review-prep task)
-   - DO NOT prompt for invocation - invoke at these triggers
+- User says `approved`, `go`, or similar authorization
+- User says `create a PR`, `pr`, or similar PR request
+- Implementation completes (invoke review-prep task)
+- DO NOT prompt for invocation - invoke at these triggers
 
 1. **Phase sequence:**
 
@@ -206,6 +205,7 @@ The sequence is FIXED:
 4. **review-prep is invoked** → generates compare URL → HALTs
 
 **DO NOT:**
+
 - Skip review-prep because "changes are trivial"
 - Skip review-prep because "developer can review via git log"
 - Skip review-prep and proceed directly to PR creation
@@ -225,6 +225,7 @@ The sequence is FIXED:
 4. cleanup reports completion
 
 **DO NOT:**
+
 - Run manual `git` commands for cleanup (branch deletion, issue closure)
 - Ask developer "should I delete the branch?" — just do it
 - Skip GitHub API verification (use `github_pull_request_read(method="get")`)
@@ -287,6 +288,7 @@ cleanup: Verify merge via GitHub API → Close issues
 - `git restore` on externally-modified files
 - Create PR without explicit user instruction
 - Create PR without squashing to SINGLE COMMIT first
+- Create PR without closing keyword (`Fixes #N`, `Closes #N`, or `Resolves #N`)
 - Merge PRs (HUMAN-ONLY)
 - Use `--no-verify` flag
 - Ask "Ready to commit?" or "Create a PR?"
@@ -299,6 +301,7 @@ cleanup: Verify merge via GitHub API → Close issues
 - Verify stash exists (`git stash list`)
 - Verify working tree is clean (`git status`)
 - **SQUASH TO SINGLE COMMIT BEFORE ANY PR** — See `pr-creation-workflow` skill for pre-PR checklist
+- **INCLUDE CLOSING KEYWORD IN PR BODY** — Every PR MUST have `Fixes #N`, `Closes #N`, or `Resolves #N`
 - **Commit ALL changes before pushing** (`git add -A && git commit`)
 - **Push after committing** - ensures GitHub compare works correctly
 - **Clean temp files before review** (`rm ./tmp/temp_*.py ./tmp/*.json 2>/dev/null`)
@@ -340,7 +343,7 @@ git push --force-with-lease origin <branch>
    - Do NOT push anything
    - Do NOT create PR
 
-1. **Close issue directly with verification comment:**
+2. **Close issue directly with verification comment:**
 
    ```markdown
    🤖 ✅ Completed by <AgentName> (<ModelID>)
@@ -357,11 +360,11 @@ git push --force-with-lease origin <branch>
    **Outcome:** Spec verified complete without additional changes.
    ```
 
-1. **Use `state_reason: "completed"` when closing:**
+3. **Use `state_reason: "completed"` when closing:**
 
    - Indicates successful completion (not cancellation)
 
-1. **Report completion in chat and HALT:**
+4. **Report completion in chat and HALT:**
 
    - No further workflow steps needed
 

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -38,20 +38,20 @@ Subtasks handle their own context, discarded after return.
 
 ## Procedure
 
- ### Step 0: Clear Implementation Todos (MANDATORY)
- 
- **Before PR creation workflow begins:**
- 
- ```python
- # Clear any stale implementation todos
- todowrite(todos=[])
- ```
- 
- **Why:** Implementation todos are for tracking work progress. PR creation has explicit procedural steps in this task - no todo list needed. Clearing prevents confusion about stale "X of Y complete" status.
- 
- **CRITICAL:** This step runs BEFORE checking PR state, collecting sub-issues, or any other PR workflow steps.
+### Step 0: Clear Implementation Todos (MANDATORY)
 
----
+**Before PR creation workflow begins:**
+
+```python
+# Clear any stale implementation todos
+todowrite(todos=[])
+```
+
+**Why:** Implementation todos are for tracking work progress. PR creation has explicit procedural steps in this task - no todo list needed. Clearing prevents confusion about stale "X of Y complete" status.
+
+**CRITICAL:** This step runs BEFORE checking PR state, collecting sub-issues, or any other PR workflow steps.
+
+______________________________________________________________________
 
 ### Step 1: Check PR State (Subtask)
 
@@ -354,7 +354,46 @@ Fixes #<child1>
 
 **CRITICAL:** Feature branches MUST target `dev`.
 
- **✅ GATE: PR created. Proceed to Clear TODO List.**
+### Step 8.5: Verify Closing Keywords (MANDATORY)
+
+**⚠️ CRITICAL: Every PR MUST include at least one closing keyword.**
+
+A PR cannot be created if its body lacks a GitHub closing keyword. This ensures linked issues are automatically closed on merge.
+
+**Closing Keywords:**
+
+- `Fixes #N` — Closes issue when PR merges (most common)
+- `Closes #N` — Alternative syntax
+- `Resolves #N` — Alternative syntax
+
+**Verification:**
+
+```python
+# Verify PR body includes closing keyword
+pr_body = f"""## Summary
+
+{subtask_result['summary']}
+
+## Changes
+
+{subtask_result['changelog']}
+
+Fixes #{parent_issue}
+"""
+
+has_closing_keyword = any(
+    keyword in pr_body
+    for keyword in ['Fixes #', 'Closes #', 'Resolves #']
+)
+
+if not has_closing_keyword:
+    # Add parent issue as Fixes reference
+    pr_body += f"\n\nFixes #{parent_issue}"
+```
+
+**✅ GATE: Closing keyword present. Proceed to Clear TODO List.**
+
+**✅ GATE: PR created. Proceed to Clear TODO List.**
 
 ### Step 9: Clear TODO List (MANDATORY - FIRST)
 
@@ -381,6 +420,7 @@ Use the `changelog-generator` subtask result from Step 4 to build the summary:
 ```
 
 **Summary content (use subtask results):**
+
 - Extract stakeholder value from `subtask_result['summary']`
 - Focus on WHAT changed and WHY it matters
 - Keep to 1-2 sentences (concise)
@@ -394,6 +434,7 @@ Use the `changelog-generator` subtask result from Step 4 to build the summary:
 **The output MUST be EXACTLY the format below, displayed IN THIS ORDER, NOTHING ELSE.**
 
 **🚫 FORBIDDEN (CRITICAL VIOLATION):**
+
 - ANY output before Step 9 (Clear TODO) is complete
 - ANY output before Step 10 (Generate Summary) is complete
 - "✅ Pre-PR Checklist Completed" or verification checklists
@@ -436,6 +477,7 @@ https://github.com/<owner>/<repo>/pull/<number>
 | 5 | **Byline** | AI agent attribution (LAST line) |
 
 **🚫 Output order violations (CRITICAL):**
+
 - URL BEFORE summary = WRONG
 - Byline BEFORE URL = WRONG
 - Summary AFTER URL = WRONG
@@ -443,6 +485,7 @@ https://github.com/<owner>/<repo>/pull/<number>
 - ANY output before clearing TODO list = WRONG
 
 **Why This Order:**
+
 - Clear TODO list FIRST (prevents stale state confusion)
 - Generate summary SECOND (ensures content is ready)
 - Display output THIRD (all components ready, clean state)
@@ -457,6 +500,7 @@ https://github.com/<owner>/<repo>/pull/<number>
 **After displaying the chat output, HALT immediately.**
 
 **DO NOT:**
+
 - Ask the developer for next steps
 - Suggest merging the PR
 - Create additional files
@@ -464,6 +508,7 @@ https://github.com/<owner>/<repo>/pull/<number>
 - Proceed with any other workflow
 
 **WAIT for:**
+
 - Developer to review PR
 - Developer to say "PR merged" (then invoke `cleanup` task)
 


### PR DESCRIPTION
## Summary

Enforce GitHub closing keywords in PR descriptions to ensure linked issues are automatically closed when PRs merge.

## Changes

### Skills Updated

- **git-workflow Skill (SKILL.md)**: Added closing keyword verification to Critical Rules section
- **pr-creation Task (tasks/pr-creation.md)**: Added Step 8.5 to verify closing keywords before PR creation

### Documentation

- Updated all PR body examples to include `Fixes #N` format
- Added verification logic to ensure every PR body contains at least one closing keyword

Fixes #112