### PR TITLE
[SPEC] Untrack .opencode/package-lock.json from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ out/
 .junie/*.bak
 .junie/cache/
 .junie/memory.md
+.opencode/package-lock.json
 
 # Cloudflare / Wrangler
 .wrangler/


### PR DESCRIPTION
## Summary

Added `.opencode/package-lock.json` to `.gitignore` to prevent OpenCode's auto-generated lockfile from being accidentally committed. This follows the same pattern as other tool-managed lockfiles (npm, yarn, uv).

Fixes #285