### PR TITLE
[SPEC] Guidelines: Prohibit non-substantive questions in GitHub comments

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -249,6 +249,71 @@ The agent must NEVER ask questions like:
 
 ---
 
+## Critical Violation: Non-Substantive Questions in GitHub Comments
+
+**⚠️ Asking non-substantive questions in GitHub comments is a CRITICAL GUIDELINE VIOLATION.**
+
+A non-substantive question is any question asking developers to make decisions the agent should make autonomously within its defined scope and authority.
+
+### 🚫 FORBIDDEN Question Patterns in GitHub Comments
+
+| Question Type | Prohibited Examples | Why It's Wrong |
+|---------------|---------------------|----------------|
+| **Scope expansion** | "Should I also add tests for this feature?" | Agent should follow spec, not expand scope |
+| **Prioritization** | "Which task should I work on next?" | Spec defines order, agent should follow it |
+| **Proceeding** | "Ready for me to continue?" "Should I proceed?" | Agent must HALT silently, no dialog |
+| **Code structure** | "Should I use a class or function?" | Agent should follow code standards |
+| **Naming** | "What should I name this variable?" | Agent should apply naming conventions |
+| **Implementation details** | "Should I use pattern A or B?" | Agent should make optimal choice |
+
+### ✅ REQUIRED Behavior
+
+**When faced with a decision within scope:**
+
+1. **Make the decision autonomously** using guidelines, code standards, and best practices
+2. **Document the decision** in the implementation or commit message
+3. **HALT only for genuine ambiguity** (conflicting requirements, auth errors, breaking changes)
+
+### ✅ ALLOWED: Substantive Questions (ASK FIRST)
+
+| Situation | Substantive Question? | Action |
+|-----------|------------------------|--------|
+| Conflicting requirements | ✅ YES | Post comment to issue, HALT |
+| Breaking change needed | ✅ YES | Post comment to issue, HALT |
+| External dependency unknown | ✅ YES | Post comment to issue, HALT |
+| Authorization error | ✅ YES | Post comment to issue, HALT |
+| Spec unclear | ✅ YES | Post comment to issue, HALT |
+| Feature vs bug determination | ✅ YES | Post comment to issue, HALT |
+
+### Decision Matrix: Substantive vs Non-Substantive
+
+| Decision Type | Agent Resolves | Requires HALT + Question |
+|---------------|----------------|---------------------------|
+| Order of implementation | Yes (follow spec) | No |
+| Code structure/pattern | Yes (follow standards) | No |
+| Variable/function naming | Yes (follow conventions) | No |
+| Test coverage level | Yes (follow spec) | No |
+| Conflicting requirements | No | Yes |
+| Breaking change | No | Yes |
+| External auth/dependency | No | Yes |
+
+### Why This Matters
+
+- **Autonomous execution**: Agent should make decisions within scope without asking
+- **Developer time**: Questions waste developer time on decisions agent should resolve
+- **Guideline adherence**: Guidelines define decision-making authority
+- **Workflow efficiency**: Silent HALT is correct response, not question-asking
+
+### Enforcement
+
+This violation is tracked alongside "Unauthorized Question Asking" violations:
+
+1. **Detection**: Question patterns in GitHub comments that ask developer to decide
+2. **Tracking**: Issue created per "Auto-Issue Creation for Repeated Workflow Violations"
+3. **Correction**: Guidelines reinforced, agent behavior corrected
+
+---
+
 ## Critical Violation: GitHub Progress Comments Are NOISE — CHAT ONLY
 
 **⚠️ Posting progress comments to GitHub Issues is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/050-scope-autonomy.md
+++ b/.opencode/guidelines/050-scope-autonomy.md
@@ -53,6 +53,35 @@ The agent must NEVER ask questions like:
 - `050-scope-autonomy.md`: Questions are NOT authorization
 - `125-github-issue-comments.md`: No "awaiting authorization" or dialog prompts
 
+### 🚫 CRITICAL: Non-Substantive Questions in GitHub Comments (ZERO TOLERANCE)
+
+**CRITICAL VIOLATION: Asking non-substantive questions in GitHub comments is PROHIBITED.**
+
+A non-substantive question is any question asking developers to make decisions the agent should make autonomously within its defined scope and authority.
+
+**Prohibited Non-Substantive Questions:**
+
+| Question Type | Prohibited Examples | Why It's Wrong |
+|---------------|---------------------|----------------|
+| **Scope expansion** | "Should I also add tests for this feature?" | Agent should follow spec, not expand scope |
+| **Prioritization** | "Which task should I work on next?" | Spec defines order, agent should follow it |
+| **Proceeding** | "Ready for me to continue?" "Should I proceed?" | Agent must HALT silently, no dialog |
+| **Code structure** | "Should I use a class or function?" | Agent should follow code standards |
+| **Naming** | "What should I name this variable?" | Agent should apply naming conventions |
+| **Implementation details** | "Should I use pattern A or B?" | Agent should make optimal choice |
+
+**Allowed Substantive Questions (ASK FIRST):**
+
+When faced with genuine ambiguity, ask via comment:
+
+| Situation | Substantive Question? | Action |
+|-----------|------------------------|--------|
+| Conflicting requirements | ✅ YES | Post comment to issue, HALT |
+| Breaking change needed | ✅ YES | Post comment to issue, HALT |
+| External dependency unknown | ✅ YES | Post comment to issue, HALT |
+| Authorization error | ✅ YES | Post comment to issue, HALT |
+| Spec unclear | ✅ YES | Post comment to issue, HALT |
+
 ### ✅ REQUIRED Behavior
 
 | Situation | Action |

--- a/.opencode/guidelines/125-github-issue-comments.md
+++ b/.opencode/guidelines/125-github-issue-comments.md
@@ -21,17 +21,57 @@ This is incorrect because:
 
 ### 🚫 PROHIBITED Patterns
 
+**Dialog prompts (awaiting authorization):**
 - "Awaiting authorization to implement."
 - "Let me know when you're ready to proceed."
 - "Please confirm before I start."
 - "Ready when you are."
 - Any text that expects an inline response
 
+**Non-substantive questions (asking for decisions agent should make):**
+
+| Question Type | Prohibited Examples | Why It's Wrong |
+|---------------|---------------------|----------------|
+| **Scope expansion** | "Should I also add tests for this feature?" | Agent should follow spec, not expand scope |
+| **Prioritization** | "Which task should I work on next?" | Spec defines order, agent should follow it |
+| **Proceeding** | "Ready for me to continue?" "Should I proceed?" | Agent must HALT silently, no dialog |
+| **Code structure** | "Should I use a class or function?" | Agent should follow code standards |
+| **Naming** | "What should I name this variable?" | Agent should apply naming conventions |
+| **Implementation details** | "Should I use pattern A or B?" | Agent should make optimal choice |
+
 ### ✅ CORRECT Behavior
 
 1. **SILENTLY HALT** after completing a task or reaching a decision point
 2. **Wait for explicit user instruction** via new comment
 3. **Respond to user comments** by addressing the actual question/request
+4. **Make autonomous decisions** using guidelines, code standards, and best practices
+5. **Document decisions** in implementation or commit message
+6. **HALT only for genuine ambiguity** (conflicting requirements, auth errors, breaking changes)
+
+### ✅ ALLOWED: Substantive Questions (ASK FIRST)
+
+**When faced with genuine ambiguity, ask via comment:**
+
+| Situation | Substantive Question? | Action |
+|-----------|------------------------|--------|
+| Conflicting requirements | ✅ YES | Post comment to issue, HALT |
+| Breaking change needed | ✅ YES | Post comment to issue, HALT |
+| External dependency unknown | ✅ YES | Post comment to issue, HALT |
+| Authorization error | ✅ YES | Post comment to issue, HALT |
+| Spec unclear | ✅ YES | Post comment to issue, HALT |
+| Feature vs bug determination | ✅ YES | Post comment to issue, HALT |
+
+**When NOT to ask (agent should decide):**
+
+| Decision Type | Agent Resolves | Requires Question? |
+|---------------|----------------|-------------------|
+| Order of implementation | Yes (follow spec) | No |
+| Code structure/pattern | Yes (follow standards) | No |
+| Variable/function naming | Yes (follow conventions) | No |
+| Test coverage level | Yes (follow spec) | No |
+| Conflicting requirements | No | Yes |
+| Breaking change | No | Yes |
+| External auth/dependency | No | Yes |
 
 ### Rationale
 


### PR DESCRIPTION
## Summary

Adds explicit prohibition of non-substantive questions in GitHub comments across three guideline files. Agents should make autonomous decisions within their scope and authority, posting questions only for genuine ambiguity.

## Changes

- **000-critical-rules.md**: Added "Critical Violation: Non-Substantive Questions in GitHub Comments" section with definition, prohibited examples table, allowed exceptions table, and decision matrix
- **125-github-issue-comments.md**: Added prohibited non-substantive question examples and allowed substantive questions tables to "NEVER Use Issue Comments as Dialog Prompts" section
- **050-scope-autonomy.md**: Added "Non-Substantive Questions in GitHub Comments" subsection following existing "Unauthorized Question Asking" section with explicit prohibition and examples

Fixes #301
Fixes #479
Fixes #480
Fixes #481