### PR TITLE
[SPEC] Guidelines: GitHub comments only for historical record, not progress

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on
 
 ## [0.2.0] - Unreleased
 
+### fix/github-comments-noise
+
+- **Clarified: GitHub Comments Only for Historical Record**: Authorization cleanup,
+  implementation progress, and PR creation are SILENT - no GitHub comments. GitHub
+  comments are only for issue closure (historical record), spec revisions, and
+  answering user questions. Implementation progress goes to CHAT ONLY with URLs.
+- **Changed Files**:
+  - `CHANGELOG.md`: Added clarification entry
+  - `123-github-ai-identity.md`: Added cross-reference to 010-approval-gate for SILENT cleanup
+- **Key Distinction**:
+  - Authorization cleanup (state management) = NO GitHub comment, NO chat (not implementation)
+  - Implementation progress (review-prep) = NO GitHub comment, YES chat with compare URL
+  - PR creation = NO GitHub comment, YES chat with PR URL
+  - Issue closure after merge = YES GitHub comment (historical record), YES chat
+- **URL Placement**: URLs belong in chat output, NOT in GitHub comments. GitHub
+  comments are for future maintainers who need context, not developers who need
+  clickable links.
+- **Addresses**: GitHub issue #382, #384
+
 ### skill/todowrite-progress-tracking
 
 - **Added: Progress Tracking to Git Workflow Tasks**: All git workflow

--- a/.opencode/guidelines/123-github-ai-identity.md
+++ b/.opencode/guidelines/123-github-ai-identity.md
@@ -237,6 +237,7 @@ If unsure, ask: "Did the human provide the core ideas, or did the AI generate th
 |-----------|---------|
 | `120-github-issue-first.md` | Issue workflow, sub-issues |
 | `000-critical-rules.md` | Critical violation enforcement |
+| `010-approval-gate.md` | Authorization cleanup (SILENT - no comments) |
 | `github-comments` skill | Complete comment protocol |
 
 ---


### PR DESCRIPTION
## Summary

GitHub comments are NOISE for implementation progress, review-prep, and PR creation. These events should ONLY post to chat with URLs - NOT to GitHub Issues.

## Key Clarification

| Event | GitHub Comment? | Chat Update? | Why |
|-------|-----------------|--------------|-----|
| Authorization cleanup (state management) | ❌ NO | ❌ NO | Not implementation - just state cleanup |
| Implementation progress (review-prep) | ❌ NO | ✅ YES | Progress update - belongs in chat |
| PR creation | ❌ NO | ✅ YES | PR is the notification - belongs in chat |
| Issue closure after merge | ✅ YES | ✅ YES | Historical record for future maintainers |

## URL Placement

URLs (compare URLs, PR URLs) belong in **chat output**, NOT in GitHub comments:
- **Chat**: For developers in current session who need clickable links
- **GitHub comments**: For future maintainers who need context (WHAT changed and WHY)

## Changes

### .opencode/CHANGELOG.md
- Added `fix/github-comments-noise` entry clarifying SILENT operations
- Clarified that authorization cleanup, implementation progress, and PR creation have NO GitHub comments

### .opencode/guidelines/123-github-ai-identity.md
- Added cross-reference to `010-approval-gate.md` for SILENT cleanup workflow

## Why This Matters

- GitHub comments are for historical record (WHAT changed and WHY for future maintainers)
- Chat is for current session (developers who need clickable navigation)
- Posting compare URLs to GitHub comments is NOISE - URLs become outdated, context persists
- Posting "PR created" to GitHub is NOISE - the PR itself is the notification

## Fixes

Fixes #382
Fixes #384

## Supersedes

This PR supersedes:
- PR #392 (had merge conflicts and incorrect content)
- PR #495 (had incorrect summary table)</