### PR TITLE
[SPEC] Guidelines: State tracking uses labels, comments for substance

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -21,6 +21,25 @@ The format is based on
   Implementation progress = comments go to chat only, not GitHub.
 - **Addresses**: GitHub issues #382, #384
 
+### spec/github-comments-state-tracking
+
+- **Fixed: Three-Tier Principle for GitHub Comments**: Established clear rules
+  for what content goes in GitHub comments vs. labels vs. chat.
+- **Tier 1 (NEVER)**: State tracking, progress notifications, routine updates.
+  Use labels for state tracking instead.
+- **Tier 2 (ALWAYS)**: Answering questions asked via GitHub, executive summary
+  when issue closes.
+- **Tier 3 (AI INTELLIGENCE)**: Bug identification, design decisions, architectural
+  warnings, edge case documentation. AI agent determines if substantive content
+  warrants GitHub comment.
+- **Changed Files**:
+  - `000-critical-rules.md`: Added three-tier principle for GitHub comments
+  - `125-github-issue-comments.md`: Defined three tiers with examples
+  - `124-github-archive-workflow.md`: Added executive summary to closure
+- **Key Distinction**: Labels are permitted for state tracking. Comments are for
+  substantive content. PR creation/progress goes to chat only.
+- **Addresses**: GitHub issue #497
+
 ### skill/todowrite-progress-tracking
 
 - **Added: Progress Tracking to Git Workflow Tasks**: All git workflow

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -253,9 +253,29 @@ The agent must NEVER ask questions like:
 
 **⚠️ Posting progress comments to GitHub Issues is a CRITICAL GUIDELINE VIOLATION.**
 
-GitHub Issue comments are for **historical record (closure summaries)**, NOT for implementation progress.
+GitHub Issue comments are for **substantive content (historic context, questions, closure summaries)**, NOT for state tracking or progress notifications.
 
-**The PR itself is the notification. The compare URL in chat is the progress update.**
+**State tracking uses LABELS. Progress notifications go to CHAT.**
+
+### Three-Tier Principle (MANDATORY)
+
+**Tier 1: NEVER acceptable for GitHub comments**
+- State tracking (STATUS updates, progress blocks)
+- Progress notifications (implementation, review-prep, PR creation)
+- Routine updates (file changes, test results, lint)
+
+**Tier 2: ALWAYS acceptable for GitHub comments**
+- Answering questions asked via GitHub comments
+- Executive summary when issue closes (historical record)
+
+**Tier 3: AI AGENT INTELLIGENCE determines**
+- Bug identification that needs recording
+- Design decisions needing context
+- Architectural warnings
+- Edge case documentation
+- Security observations
+- Data integrity concerns
+- Any substantive information for future readers
 
 ### ✅ REQUIRED Behavior
 
@@ -265,6 +285,8 @@ GitHub Issue comments are for **historical record (closure summaries)**, NOT for
 | Review-prep done | ❌ NO | ✅ YES - compare URL |
 | PR created | ❌ NO | ✅ YES - PR URL |
 | Issue closed AFTER MERGE | ✅ YES - closure summary | ✅ YES - completion notice |
+| User asked question via GitHub | ✅ YES - answer the question | ❌ NO - GitHub only |
+| AI identifies substantive bug/design | AI DETERMINES | ❌ NO - GitHub if substantive |
 
 ### 🚫 FORBIDDEN
 
@@ -274,6 +296,7 @@ GitHub Issue comments are for **historical record (closure summaries)**, NOT for
 | Posting progress after review-prep | NOISE - developer can view GitHub diff |
 | Posting "PR created" to GitHub | NOISE - PR itself is the notification |
 | Posting status blocks | NOISE - executive summary in chat is sufficient |
+| Using comments for state tracking | Labels are the proper mechanism |
 
 ### ✅ Chat Output Format
 
@@ -298,8 +321,9 @@ https://github.com/<owner>/<repo>/compare/dev...<branch>
 | Spec revision | Document what changed and why |
 | Answering user question | User cannot see internal reasoning |
 | Blocking issue | Explain blocker and await clarification |
+| Substantive bug/design issue | AI determines if content worthy of recording |
 
-**See `github-comments` skill for complete requirements.**
+**Labels are PERMITTED for state tracking.** Use labels for workflow state (`needs-approval`, `in-progress`, `blocked`) instead of comments. Custom labels are encouraged.
 
 ---
 

--- a/.opencode/guidelines/125-github-issue-comments.md
+++ b/.opencode/guidelines/125-github-issue-comments.md
@@ -1,5 +1,40 @@
 # Issue Comment Protocol
 
+## Three-Tier Principle (MANDATORY)
+
+**GitHub Issue comments are for substantive content, NOT for state tracking or progress notifications.**
+
+**State tracking uses LABELS. Progress notifications go to CHAT.**
+
+### Tier 1: NEVER Acceptable for GitHub Comments
+
+These are CRITICAL VIOLATIONS:
+
+- State tracking (STATUS updates, progress blocks)
+- Progress notifications (implementation progress, review-prep, PR creation)
+- Routine updates (file changes, test results, lint)
+
+**Use labels for state tracking:** `needs-approval`, `in-progress`, `blocked`, or custom labels.
+
+### Tier 2: ALWAYS Acceptable for GitHub Comments
+
+- Answering questions asked via GitHub comments
+- Executive summary when issue closes (historical record for future maintainers)
+
+### Tier 3: AI Agent Intelligence Determines
+
+AI agent MAY post to GitHub when substantive content warrants recording:
+
+- Bug identification that needs recording
+- Design decisions needing context for future maintainers
+- Architectural warnings about long-term implications
+- Edge case documentation for future reference
+- Security observations requiring permanent record
+- Data integrity concerns
+- Any substantive information for future readers
+
+**When in doubt:** Ask "Would a future maintainer need this context?" If yes → post to GitHub. If no → chat only.
+
 ## NEVER Use Issue Comments as Dialog Prompts
 
 GitHub issue comments are **general comments**, NOT interactive dialogs.


### PR DESCRIPTION
## Summary

Implemented three-tier principle for GitHub comments to clarify what content goes where.

## Three-Tier Principle

| Tier | Content | Location |
|------|---------|----------|
| **Tier 1 (NEVER)** | State tracking, progress, routine updates | Use labels |
| **Tier 2 (ALWAYS)** | Questions, closure summaries | GitHub comments |
| **Tier 3 (AI DETERMINES)** | Bug ID, design decisions, architecture | AI discretion |

## Key Distinctions

- **Labels are for state tracking**: `needs-approval`, `in-progress`, `blocked`, custom labels
- **GitHub comments are for substantive content**: Questions, closure summaries, bug reports, design decisions
- **Progress goes to chat**: Implementation progress, review-prep, PR creation

## Changes

### `.opencode/guidelines/000-critical-rules.md`
- Added three-tier principle with examples
- Clarified labels are permitted for state tracking
- Added AI agent intelligence allowance for substantive content

### `.opencode/guidelines/125-github-issue-comments.md`
- Added three-tier principle at top of file
- Defined each tier with examples
- Clarified labels are proper for state tracking

### `.opencode/CHANGELOG.md`
- Added `spec/github-comments-state-tracking` entry

## Success Criteria

✅ Three-tier principle defined: NEVER, ALWAYS, AI INTELLIGENCE
✅ State tracking clearly directed to labels (permitted)
✅ GitHub comments clearly for substantive content
✅ AI agents have discretion for substantive determinations

Fixes #497