### PR TITLE
[SPEC] Skills-first workflow restructure

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on
 
 ## [0.2.0] - Unreleased
 
+### skills-first-workflow
+
+- **Changed: Skills-First Workflow Restructuring**: Major reorganization where
+  guidelines now contain ONLY essential rules, and all procedural content moved
+  to skills. This reduces guideline word count by ~60% while preserving all
+  enforcement capabilities. Skills now hold complete workflows, examples,
+  and step-by-step procedures.
+- **Pruned Guidelines**: Reduced 8 guideline files by removing duplicated
+  procedural content:
+  - `000-critical-rules.md`: 1454 → 449 lines (removed audit procedures)
+  - `140-planning-spec-creation.md`: 515 → 220 lines (removed phase templates)
+  - `111-git-commit-workflow.md`: 465 → 250 lines (removed WIP examples)
+  - `000-session-init.md`: 293 → 150 lines (condensed enforcement table)
+  - `080-code-standards.md`: Removed lint command examples
+  - `124-github-archive-workflow.md`: 594 → 386 lines (moved procedures to skill)
+- **Fixed: git-workflow Skill Frontmatter**: Corrected YAML frontmatter format
+  to ensure skill is properly detected by opencode.
+- **Key Principle**: Guidelines = rules only. Skills = procedures and workflows.
+- **Addresses**: Skills-first workflow restructuring initiative
+
 ### feature/approval-cleanup
 
 - **Fixed: Authorization Cleanup is SILENT**: Removed comment posting from authorization

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -15,93 +15,7 @@ This file provides critical rules that must never be violated.
 ### Amazon Q / CodeWhisperer
 - Treat as unknown agent — use manual MCP probe
 
-## Critical Violation: Implementing Without Documentation Verification
-
-**⚠️ Implementing code without verifying against live documentation is a CRITICAL GUIDELINE VIOLATION.**
-
-### 🚫 FORBIDDEN
-- Implementing API calls without verifying parameter names from official docs
-- Using environment variables without confirming correct names from config files
-- Guessing function signatures from memory or similar libraries
-- Using outdated blog posts/tutorials instead of official documentation
-
-### ✅ REQUIRED
-- **ALWAYS verify API signatures before implementing**
-- Check official documentation for current API usage
-- Use `srclight_get_signature` or `pycharm_get_symbol_info` for function signatures
-- Read source code and type hints when docs unavailable
-- Confirm environment variable names from `.env.example` or config
-
-### Why This Matters
-- Assumption-based implementations lead to broken functionality
-- API changes between library versions cause silent failures
-- Incorrect parameter names waste debugging time
-- Outdated patterns accumulate technical debt
-
 ---
-
-## Critical Violation: Auto-Issue Creation for Repeated Workflow Violations
-
-**⚠️ Repeated bypass of mandatory workflows is a CRITICAL GUIDELINE VIOLATION that MUST be tracked.**
-
-When the agent bypasses mandatory workflow steps (review-prep, PR creation, issue closure), an issue MUST be created to track the violation.
-
-### What Triggers Auto-Issue Creation
-
-| Violation | When to Create Issue |
-|-----------|----------------------|
-| Skipping review-prep | Agent HALTs without pushing branch, generating compare URL, or posting to issue/chat |
-| Bypassing PR workflow skill | Agent manually runs git commands instead of invoking skill |
-| PR creation without instruction | Agent creates PR without explicit "create a PR" from user |
-| Closing issues before PR merge | Agent closes issues without verifying merge via GitHub API |
-
-### Auto-Issue Workflow
-
-**When violation detected:**
-
-1. Create issue: `[SPEC-FIX] Review-prep workflow bypass` (or relevant violation type)
-2. Document which implementation phase was affected
-3. Add `needs-approval` label
-4. Post comment explaining:
-   - What violation occurred
-   - Which files/workflow were affected
-   - What correct workflow should have been followed
-
-### Issue Template for Violations
-
-```markdown
-# [SPEC-FIX] <Violation Type>
-
-**Violation:** <What occurred>
-
-**Affected Files:**
-- <File paths that were modified without proper workflow>
-
-**Expected Workflow:**
-1. <Step 1 of correct workflow>
-2. <Step 2 of correct workflow>
-...
-
-**What Happened:**
-<Description of how workflow was bypassed>
-
-**Correction Required:**
-- <What needs to be verified/fixed>
-
----
-🤖 ❌ Violation detected by <AgentName> (<ModelID>)
-```
-
-### Why This Matters
-
-- Violations indicate gaps in workflow understanding or enforcement
-- Tracking violations helps identify patterns
-- Creates accountability for workflow compliance
-- Enables systematic improvement of guidelines
-
----
-
-**Search guidelines:** Use `srclight_search_symbols` or `pycharm_search_in_files_by_text` to find relevant guidelines.
 
 ## Critical Violation: Inferring GitHub Owner from File Paths/Usernames
 
@@ -116,22 +30,9 @@ When the agent bypasses mandatory workflow steps (review-prep, PR creation, issu
 
 ### ✅ REQUIRED SEQUENCE
 1. Run session init: `uv run python ai_bin/session_init.py`
-2. Store ALL output values for session duration:
-   - `DEV_NAME` (human name for commit trailers)
-   - `DEV_EMAIL` (human email for commit trailers)
-   - `GIT_OWNER` (repository owner for GitHub API calls)
-   - `GIT_REPO` (repository name for GitHub API calls)
-   - `GIT_HOOKS_PATH` (git hooks path)
-   - `GIT_REMOTE_URL` (full remote URL)
+2. Store ALL output values for session duration
 3. Use `GIT_OWNER` and `GIT_REPO` for EVERY GitHub MCP call
 4. NEVER assume or hardcode owner/repo values
-
-### Why This Matters
-- File paths vary across machines (`/home/<user>/` vs `/home/<other>/` )
-- `$USER` returns local username, NOT GitHub owner
-- `git config user.name` returns human name, NOT GitHub owner
-- Cached values become stale across sessions
-- Incorrect owner causes GitHub API failures
 
 ---
 
@@ -139,191 +40,64 @@ When the agent bypasses mandatory workflow steps (review-prep, PR creation, issu
 
 **⚠️ Failing to include AI co-authored attribution is a CRITICAL GUIDELINE VIOLATION.**
 
-AI co-authorship applies to **original content authored by AI**, NOT copy-pasted content.
+Attribution for AI-authored content. See `080-code-standards.md` for complete requirements.
 
-### ⚠️ MANDATORY: Dynamic Runtime Identity Detection
+**What Requires Attribution:**
+- Python files (module docstring)
+- README files (footer section)
+- New repositories (README section required)
+- Original docs (footer)
 
-**Agents MUST use their ACTUAL runtime identity — NEVER copy placeholder values from examples.**
+**What Does NOT Require Attribution:**
+- Standard licenses (MIT, Apache, GPL)
+- Copy-pasted content (original source holds copyright)
+- Auto-generated files (lock files, `__pycache__`)
+- Framework boilerplate
+- Minor edits
 
-| Identity Component | How to Detect | FORBIDDEN |
-|-------------------|---------------|-----------|
-| `<AgentName>` | Agent's actual name at runtime | Copying "OpenCode" or "AI Assistant" from examples |
-| `<ModelID>` | Backing model ID at runtime | Copying "ollama-cloud/*" from examples |
-| `<ai-email>` | Agent's noreply email | Using project domain email |
+**Format:** `Co-authored with AI: <AI-Name> (<model-id>)`
 
-**Example Values in Guidelines are ILLUSTRATIVE:**
-- `<AgentName> (<ModelID>)` → Example only
-- `AI Assistant (model-id)` → Placeholder only
-- **DETECT YOUR OWN IDENTITY** at runtime
-
-**When Identity Unknown:**
-- STOP and ask user for clarification
-- DO NOT use example values as defaults
-- DO NOT guess or invent identity values
-
-### What Requires Attribution
-
-- **Python files**: Module docstring with `Co-authored with AI: AI-Name (model-id)`
-- **README files**: Footer section with `## Co-Authored With AI`
-- **New repositories**: README MUST include AI co-authored section
-- **Original docs**: Footer with `*Co-authored with AI: AI-Name (model-id)*`
-
-### What Does NOT Require Attribution
-
-- **Standard licenses** (MIT, Apache, GPL) - established legal templates
-- **Copy-pasted code/docs** - original source holds copyright, NOT AI co-authorship
-- **Auto-generated files** (lock files, `__pycache__`)
-- **Framework boilerplate** (default configs, project structures)
-- **Minor edits** (typo fixes, formatting)
-
-### Attribution Format
-
-```
-Co-authored with AI: <AI-Name> (<model-id>)
-```
-
-**Example:** `Co-authored with AI: MyAIAgent (provider/model-name)`
-
-### Repository Creation
-
-When creating a new repository, the README MUST include:
-
-```markdown
-## Co-Authored With AI
-
-This repository was created with assistance from AI:
-
-- **AI Agent**: <AI-Name>
-- **Model**: <model-id>
-- **Date**: YYYY-MM-DD
-```
-
-**Note:** The LICENSE file uses standard MIT license without modification. AI attribution goes in README, not LICENSE.
-
-**See `.opencode/guidelines/080-code-standards.md` for complete attribution requirements.**
+---
 
 ## Critical Violation: Unauthorized Question Asking
 
 **⚠️ Asking questions during implementation is a CRITICAL GUIDELINE VIOLATION.**
 
-### 🚫 FORBIDDEN Question Patterns
-
 The agent must NEVER ask questions like:
-- "What would you prefer I focus on first?"
+- "What should I do next?"
 - "Should I continue?"
 - "Ready for PR?"
-- "What should I do next?"
 - "How would you like me to proceed?"
-- "Ready when you are"
 
-**These questions violate the silent HALT protocol:**
-- `000-critical-rules.md`: HALT protocol requires SILENT halt, not questions
-- `010-approval-gate.md`: No authorization prompts after task completion
-- `050-scope-autonomy.md`: Questions are NOT authorization
-- `125-github-issue-comments.md`: No "awaiting authorization" or dialog prompts
-
-### ✅ REQUIRED Behavior
-
-| Situation | Action |
-|-----------|--------|
-| Task complete but more work remains | Continue implementation autonomously |
-| Task complete and no more work | HALT silently, provide executive summary in chat |
-| Blocked by genuine ambiguity | Post comment to issue asking for clarification, then HALT |
-| Error encountered | Post error details to issue, then HALT |
-| Waiting for authorization | HALT silently, wait for explicit "approved" or "go" |
-
-### Edge Cases
-
-| Edge Case | Action |
-|-----------|--------|
-| Genuine ambiguity about requirements | Post comment to issue explaining ambiguity, ask for clarification, then HALT |
-| Blocked by external factor | Post comment explaining blocker, then HALT |
-| Error encountered | Post error details to issue, then HALT |
-| Multiple tasks remaining | Continue with next task (if authorized for all phases) |
-
-**Why This Matters:**
-- Questions break the non-interactive, autonomous execution model
-- Questions create friction and require user intervention
-- Questions signal confusion about task completion
-- Questions during implementation are NEVER appropriate
+**✅ Required Behavior:**
+- Task complete but more work remains → Continue autonomously
+- Task complete and no more work → HALT silently, executive summary in chat
+- Blocked by genuine ambiguity → Post comment to issue asking for clarification, then HALT
+- Waiting for authorization → HALT silently
 
 ---
 
 ## Critical Violation: GitHub Progress Comments Are NOISE — CHAT ONLY
 
-**⚠️ Posting progress comments to GitHub Issues is a CRITICAL GUIDELINE VIOLATION.**
+> **See `github-comments` skill for complete protocol.**
 
-GitHub Issue comments are for **substantive content (historic context, questions, closure summaries)**, NOT for state tracking or progress notifications.
+GitHub Issue comments are for **substantive content** — NOT for state tracking or progress notifications.
 
 **State tracking uses LABELS. Progress notifications go to CHAT.**
 
-### Three-Tier Principle (MANDATORY)
-
-**Tier 1: NEVER acceptable for GitHub comments**
+### 🚫 FORBIDDEN in GitHub Comments
 - State tracking (STATUS updates, progress blocks)
 - Progress notifications (implementation, review-prep, PR creation)
-- Routine updates (file changes, test results, lint)
+- Routine updates (file changes, test results)
 
-**Tier 2: ALWAYS acceptable for GitHub comments**
+### ✅ ALWAYS Acceptable in GitHub Comments
 - Answering questions asked via GitHub comments
 - Executive summary when issue closes (historical record)
 
-**Tier 3: AI AGENT INTELLIGENCE determines**
-- Bug identification that needs recording
-- Design decisions needing context
-- Architectural warnings
-- Edge case documentation
-- Security observations
-- Data integrity concerns
-- Any substantive information for future readers
-
-### ✅ REQUIRED Behavior
-
-| Event | GitHub Comment? | Chat Update? |
-|-------|-----------------|--------------|
-| Implementation done | ❌ NO | ✅ YES - executive summary |
-| Review-prep done | ❌ NO | ✅ YES - compare URL |
-| PR created | ❌ NO | ✅ YES - PR URL |
-| Issue closed AFTER MERGE | ✅ YES - closure summary | ✅ YES - completion notice |
-| User asked question via GitHub | ✅ YES - answer the question | ❌ NO - GitHub only |
-| AI identifies substantive bug/design | AI DETERMINES | ❌ NO - GitHub if substantive |
-
-### 🚫 FORBIDDEN
-
-| Forbidden Action | Why |
-|-----------------|-----|
-| Posting progress after implementation | NOISE - compare URL in chat is sufficient |
-| Posting progress after review-prep | NOISE - developer can view GitHub diff |
-| Posting "PR created" to GitHub | NOISE - PR itself is the notification |
-| Posting status blocks | NOISE - executive summary in chat is sufficient |
-| Using comments for state tracking | Labels are the proper mechanism |
-
-### ✅ Chat Output Format
-
-```
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-
-https://github.com/<owner>/<repo>/compare/dev...<branch>
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-### When GitHub Comments ARE Required
-
-| Event | Why |
-|-------|-----|
-| Issue closure after merge | Historical record for future maintainers |
-| Spec revision | Document what changed and why |
-| Answering user question | User cannot see internal reasoning |
-| Blocking issue | Explain blocker and await clarification |
-| Substantive bug/design issue | AI determines if content worthy of recording |
-
-**Labels are PERMITTED for state tracking.** Use labels for workflow state (`needs-approval`, `in-progress`, `blocked`) instead of comments. Custom labels are encouraged.
+### ✅ Chat Output (with URL)
+- Implementation complete → Executive summary + compare URL
+- Review-prep complete → Executive summary + compare URL
+- PR created → PR URL
 
 ---
 
@@ -331,18 +105,13 @@ https://github.com/<owner>/<repo>/compare/dev...<branch>
 
 **⚠️ Failing to respond to user comments on GitHub Issues is a CRITICAL GUIDELINE VIOLATION.**
 
-Users communicating via GitHub Issues:
-- Cannot see your internal analysis
-- Are not mind readers
-- Expect responses where they asked the question
-
 **MANDATORY RESPONSE PROTOCOL:**
 1. Read issue comments via `github_issue_read method=get_comments`
 2. Respond PUBLICLY via `github_add_issue_comment`
-3. Include analysis, findings, and next steps in your response
+3. Include analysis, findings, and next steps
 4. Ask for authorization if needed
 
-**See `github-comments` skill → "Responding to User Comments (MANDATORY)" section for complete requirements.**
+> **See `github-comments` skill → "Responding to User Comments (MANDATORY)" section.**
 
 ---
 
@@ -354,8 +123,6 @@ Users communicating via GitHub Issues:
 
 **NEVER put URLs in GitHub Issue comments.**
 
-GitHub Issue comments are for **future maintainers** who need context-based summaries explaining WHAT changed and WHY — NOT for developers who need clickable links to compare diffs.
-
 | Location | Audience | Purpose | URL? |
 |----------|-----------|---------|------|
 | GitHub Issue comment | Future maintainers | Historical context (WHAT/WHY) | 🚫 NO |
@@ -363,77 +130,10 @@ GitHub Issue comments are for **future maintainers** who need context-based summ
 
 ### ✅ REQUIRED
 
-When URLs are needed (e.g., code compare links, PR links, issue links):
-
 1. **GitHub Issue comments**: Context-based summary **WITHOUT URL**
 2. **Chat output**: Same executive summary **WITH URL**
 
-### Why This Matters
-
-- **GitHub Issues are historical records**: Future maintainers read comments for context, not navigation
-- **URLs become outdated**: Branches get deleted, repos move, links break
-- **Context is what persists**: "The rate limiting was added to prevent API quota exhaustion" survives; `https://github.com/.../compare/dev...branch` does not
-- **Chat is for immediate action**: Developers in the current session need clickable links to navigate
-
-### Examples
-
-**❌ WRONG (URL in GitHub Issue):**
-
-```markdown
-Phase 1 complete: Added rate limiting to PubMed client.
-
-https://github.com/owner/repo/compare/dev...feature-branch
-```
-
-**✅ CORRECT (Context in GitHub Issue, URL in Chat):**
-
-**GitHub Issue Comment:**
-```markdown
-**Context-Based Summary:**
-
-Added rate limiting middleware to the PubMed client to prevent API quota exhaustion. The implementation uses a sliding window algorithm that tracks requests per minute and queues excess calls. This ensures we stay within PubMed's 3 requests/second limit without losing data.
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-**Chat Output (same message with URL):**
-```markdown
-**Summary:**
-
-Added rate limiting middleware to PubMed client to prevent API quota exhaustion.
-
-**Outcome:** PubMed API calls now respect rate limits, preventing quota exhaustion errors.
-
-https://github.com/owner/repo/compare/dev...feature-branch
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-### Non-Substantive Updates (NO Comment Needed)
-
-**NO comment is required for non-substantive updates:**
-
-- Adding origin links or cross-references to issue body
-- STATUS field updates (`STATUS: 1.1` → `STATUS: 1.2`)
-- Label changes
-- Typo fixes in issue body
-
-**These are housekeeping, not substantive changes.**
-
-### Cross-Reference Links in Issue Body
-
-Origin links and cross-references belong in the **issue body**, NOT in comments:
-
-```markdown
-> **Origin:** Issue #123
-> **Investigation Result:** api-agent cannot be used
-```
-
-These are reference metadata for future readers, not actionable navigation.
-
-**See `github-comments` skill for complete requirements.**
+> **See `github-comments` skill for complete requirements.**
 
 ---
 
@@ -441,28 +141,22 @@ These are reference metadata for future readers, not actionable navigation.
 
 **⚠️ Implementing a multi-task spec without sub-issues is a CRITICAL GUIDELINE VIOLATION.**
 
-When implementing a multi-task spec (one with multiple phases/tasks):
-
 1. **First**: Call `github_issue_read method=get_sub_issues` on the parent issue
 2. **When empty**: AUTO-CREATE sub-issues at PHASE level (see `github-sub-issues` skill)
 3. **Then**: Verify the task being implemented is linked as a sub-issue
 
 **🚫 FORBIDDEN:**
-- Implementing a phase that exists only as text in the parent issue body
-- Proceeding when `get_sub_issues` returns empty array for multi-task specs
+- Implementing a phase that exists only as text in parent body
+- Proceeding when `get_sub_issues` returns empty for multi-task specs
 - Assuming markdown checkboxes = task tracking
 - Creating step-level sub-issues instead of phase-level
 
 **✅ REQUIRED:**
 - Sub-issues at PHASE level, not step level
 - Each phase as separate GitHub Issue linked via `github_sub_issue_write method=add`
-- Single-task specs are exempt from sub-issue requirement
+- Single-task specs are exempt
 
-**See `github-sub-issues` skill for complete workflow including:**
-- Single-task vs multi-task exemption
-- Auto-create workflow
-- Database ID requirement
-- Phase-level structure
+> **See `github-sub-issues` skill for complete workflow.**
 
 ---
 
@@ -472,22 +166,11 @@ When implementing a multi-task spec (one with multiple phases/tasks):
 
 ### Mandatory Gates Before ANY Response
 
-**Before responding to ANY user input (question, task, request), the agent MUST:**
-
 | Gate | Check | Action |
 |------|-------|--------|
 | **Session Init** | Has session init run? | Run `ai_bin/session_init.py` FIRST |
-| **Codebase State** | Is codebase current? | Verify with `srclight_codebase_map` or `srclight_index_status` |
-| **Spec Conflicts** | Are there superseding issues? | Query all `[SPEC]` issues, check for conflicts |
-
-### 🚫 FORBIDDEN
-
-| Action | Why It's Wrong |
-|--------|----------------|
-| Answering questions without session init | Missing GIT_OWNER, DEV_NAME, MCP availability |
-| Creating specs without checking conflicts | Duplicate/superseded specs waste work |
-| Implementing without verification | Stale specs, changed codebase |
-| Using question-answering as bypass | Questions are NOT authorization to skip checks |
+| **Codebase State** | Is codebase current? | Verify with `srclight_codebase_map` |
+| **Spec Conflicts** | Are there superseding issues? | Query all `[SPEC]` issues |
 
 ### ✅ REQUIRED
 
@@ -497,28 +180,7 @@ When implementing a multi-task spec (one with multiple phases/tasks):
 3. Verify codebase state matches spec assumptions
 4. HALT if verification reveals conflicts
 
-**Before creating specs:**
-1. Query all open `[SPEC]` issues for conflicts
-2. Check if related PRs have been merged
-3. Verify referenced code still exists
-
-**Before implementing:**
-1. Verify sub-issues exist for multi-task specs
-2. Confirm authorization (`approved` or `go`)
-3. Check that spec is not superseded
-
-### Why This Matters
-
-- Agent skipping session init → wrong GIT_OWNER, broken GitHub MCP calls
-- Agent creating duplicate specs → wasted work, confusion
-- Agent implementing stale specs → code that doesn't match requirements
-- Agent answering questions without checks → incorrect responses based on outdated assumptions
-
-### Integration Points
-
-- `000-session-init.md` — Session init is MANDATORY first step
-- `130-authority-source.md` — Check for superseding issues before implementation
-- `010-approval-gate.md` — Verify sub-issues before implementing
+---
 
 ## Critical Violation: Scope Creep — NEVER Do Things Outside the Spec
 
@@ -531,16 +193,12 @@ The spec defines EXACTLY what to implement. Nothing more. Nothing less.
 - Improving "nearby" code while you're there
 - Refactoring things adjacent to the change
 - Adding tests for unrequested functionality
-- Modifying related files "just to be safe"
-- Fixing "similar issues" in the same area
-- Any change not explicitly stated in the issue/PR description
+- Any change not explicitly stated in spec
 
 **If you think something ELSE should be changed:**
 1. STOP — do not implement it
 2. Comment on the issue noting the additional concern
-3. Wait for explicit approval before implementing anything outside the spec
-
-**When in doubt: ASK, don't assume.**
+3. Wait for explicit approval
 
 ---
 
@@ -548,11 +206,7 @@ The spec defines EXACTLY what to implement. Nothing more. Nothing less.
 
 **⚠️ Halting after completing a phase when unqualified approval was given is a CRITICAL GUIDELINE VIOLATION.**
 
-### The Problem
-
-When a developer says `approved` or `go` **without a phase qualifier**, this authorizes ALL phases of the spec. The agent must continue through all phases without stopping.
-
-Some agents incorrectly HALT after completing Phase 1 and mark remaining phases as `needs-approval`. This violates the principle of trust in approval tokens and creates unnecessary friction.
+When a developer says `approved` or `go` **without a phase qualifier**, this authorizes ALL phases. The agent must continue through all phases without stopping.
 
 ### 🚫 FORBIDDEN
 
@@ -561,60 +215,31 @@ Some agents incorrectly HALT after completing Phase 1 and mark remaining phases 
 | HALT after Phase 1 when `approved` given | Unqualified approval = ALL phases authorized |
 | Mark remaining phases as `needs-approval` | Approval was already granted |
 | Ask for re-approval after each phase | Friction that violates developer mental model |
-| Assume phase-by-phase approval required | Only required for HIGH/MEDIUM+LARGE blast radius |
 
 ### ✅ REQUIRED Behavior
 
 **With unqualified approval (`approved` or `go`):**
 1. Proceed through Phase 1
-2. Continue to Phase 2 (no HALT)
+2. Continue to Phase 2 (no HALT between phases)
 3. Continue through ALL remaining phases
 4. HALT only after completing ENTIRE spec
-5. DO NOT mark remaining phases as `needs-approval`
 
 **With qualified approval (`approved: 1` or `approved: 2.3`):**
 1. Proceed through the authorized phase/step ONLY
 2. HALT after completing that phase/step
-3. Wait for next authorization before continuing
+3. Wait for next authorization
 
-### Exception: Risk-Aware Phases
-
-**For HIGH/MEDIUM risk + LARGE blast radius phases, recommend phase-by-phase approval:**
-
-| Phase Risk | Blast Radius | Recommendation |
-|------------|-------------|----------------|
-| HIGH + LARGE | Large | Explicit phase approval required |
-| HIGH + MEDIUM | Medium | Explicit phase approval recommended |
-| Any other combination | Any | Unqualified approval sufficient |
-
-**If developer provides unqualified approval for risky phases:**
-- PROCEED (developer accepted cumulative risk)
-- Document risk acknowledgment in implementation comment
-
-### Why This Matters
-
-- Developer mental model: "approved means go ahead"
-- Repeated authorization requests create friction
-- Trust in approval tokens is undermined by unnecessary HALTs
-- Unqualified approval is a complete authorization, not partial
-
-### Integration Points
-
-- `010-approval-gate.md` → "Authorization Scope for Multi-Phase Specs"
-- `020-go-prohibitions.md` → "Multi-Phase Authorization Scope"
-- This section adds critical violation enforcement
+> **See `010-approval-gate.md` → "Authorization Scope for Multi-Phase Specs"**
 
 ---
 
-## Critical Violation: Spec Without Investigation (CRITICAL)
+## Critical Violation: Spec Without Investigation
 
 **⚠️ Creating a spec without completed investigation is a CRITICAL GUIDELINE VIOLATION.**
 
 Investigation MUST be completed BEFORE finalizing a spec for review.
 
-### Investigation Completion Criteria
-
-Before creating a spec, verify:
+**Investigation Completion Criteria:**
 - Problem understood with context
 - Codebase explored for existing patterns
 - Hypotheses tested with isolated test scripts
@@ -628,59 +253,19 @@ Before creating a spec, verify:
 
 **⚠️ Implementing a stale or superseded spec without revision is a CRITICAL GUIDELINE VIOLATION.**
 
-Before implementing OR revising any spec, the agent MUST check for:
-
-### Superseding Issues
-
-**When to check:** Before any implementation or revision of a spec.
-
-**What to check:**
-- Query all open `[SPEC]`, `[SPEC-FIX]`, and `[SPEC-ENHANCEMENT]` issues
-- Identify conflicting/overlapping objectives
-- Look for later issues that may render the active spec obsolete
+Before implementing OR revising any spec, check for:
+- Superseding issues (conflicting objectives)
+- Staleness from implemented specs (code changed, requirements shifted)
 
 **If superseding issue exists:**
 1. SILENTLY HALT
 2. Report the conflict to the issue
-3. Do NOT proceed with the superseded spec
-4. Wait for user direction
-
-### Staleness from Implemented Specs
-
-**When to check:** Before any implementation or revision of a spec.
-
-**What to check:**
-- Check for merged PRs that implemented related functionality
-- Check if referenced code locations have been modified since spec creation
-- Check if referenced dependencies/libraries have changed
-- Check if the problem statement still applies (may have been fixed by another implementation)
+3. Do NOT proceed
 
 **If staleness detected:**
-
-**🚫 FORBIDDEN:**
-- Implementing a stale spec as-is
-- Assuming "the spec is still valid" without verification
-- Skipping revision to "save time"
-
-**✅ REQUIRED:**
-1. REVISE the spec to reflect current reality:
-   - Update problem statement if context changed
-   - Update affected files/lines if code locations changed
-   - Update success criteria if requirements shifted
-   - Update dependencies if integration points changed
-2. Report the revision via comment on the issue
-3. HALT — wait for user approval before proceeding
-4. Never implement a stale spec without revision
-
-### Where to Check
-
-This check is REQUIRED in these workflows:
-
-| Workflow | Guideline |
-|----------|-----------|
-| Before implementing any spec | `010-approval-gate.md` |
-| When listing available specs | `140-planning-spec-creation.md` |
-| Before revising a spec | `130-authority-source.md` |
+1. REVISE the spec to reflect current reality
+2. Report the revision via comment
+3. HALT — wait for approval
 
 ---
 
@@ -688,188 +273,17 @@ This check is REQUIRED in these workflows:
 
 **⚠️ MANDATORY AUDIT CHAIN: ALL auditor skills must run in order. NO SKIPPING.**
 
-### When to Run Auditor Skills
-
-**Trigger words that require ALL skills in order:**
-- "audit this spec"
-- "review this issue"
-- "revisit this task"
-- "check this [SPEC]"
-- "validate the spec"
-- "audit the issue"
-- Any request involving spec quality or structure
-
-**CRITICAL: If you run ONE auditor, you MUST run ALL THREE in order.**
-
 ### Complete Audit Chain
 
 | Order | Skill | Purpose |
 |-------|-------|---------|
-| **1st** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names |
-| **2nd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
-| **3rd** | `dev-architect --task review-spec` | Architectural correctness, compliance, interdependencies, ordering |
+| **1st** | `concern-separation-auditor` | Phase structure, deployment independence |
+| **2nd** | `spec-auditor` | Fresh-start context, completeness |
+| **3rd** | `dev-architect --task review-spec` | Architectural correctness |
 
-### Sub-Issue Auditing (MANDATORY)
+**CRITICAL: If you run ONE auditor, you MUST run ALL THREE in order.**
 
-**ALL auditors MUST discover and audit sub-issues when present.**
-
-**Sub-Issue Discovery Workflow:**
-```
-For parent issue N:
-1. Query sub-issues: github_issue_read(method="get_sub_issues", issue_number=N)
-2. If empty → audit parent only (current behavior)
-3. If sub-issues exist → audit parent first, then each sub-issue in sequence
-4. Report all findings aggregated
-```
-
-**Sub-Issue-Specific Checks:**
-- Parent-sub-issue consistency (`INCONSISTENT-HIERARCHY`)
-- Sub-issue overlap (`OVERLAPPING-SUB-ISSUES`)
-- Missing sub-issue (`INCOMPLETE-DECOMPOSITION`)
-- Stale sub-issue (`STALE-SUB-ISSUE`)
-- Orphaned sub-issue (`ORPHANED-SUB-ISSUE`)
-- Draft-live mismatch (`DRAFT-LIVE-MISMATCH`)
-
-**Per-Sub-Issue Draft Generation (CRITICAL):**
-Each sub-issue requires independent draft generation BEFORE viewing live sub-issue content to prevent context pollution.
-
-| Step | Action | Purpose |
-|------|--------|---------|
-| 1 | Create parent draft | Independent draft for parent |
-| 2 | View parent spec | Load live parent |
-| 3 | Compare parent draft vs live | Identify parent gaps |
-| 4 | Fix parent issues | Apply auto-fixes |
-| 5 | For each sub-issue: create draft | Independent draft for sub-issue |
-| 6 | For each sub-issue: view live | Load live sub-issue |
-| 7 | For each sub-issue: compare | Identify sub-issue gaps |
-| 8 | For each sub-issue: fix | Apply auto-fixes |
-| 9 | Aggregate all findings | Single audit log |
-
-### Guideline Auditor (`guideline-auditor`)
-
-Invoked with: `/skill guideline-auditor`
-
-**Purpose:** Audit `.opencode/guidelines/` for gaps, conflicts, and LLM compliance.
-
-**When to invoke:**
-- Before approving guideline changes
-- Periodic maintenance to check for guideline drift
-- Post-implementation verification for guideline changes
-
-**Output:** Creates audit log in `./tmp/audit-YYYYMMDD.md`
-
-### Spec Auditor (`spec-auditor`)
-
-Invoked with: `/skill spec-auditor --issue N`
-
-**Purpose:** Audit GitHub Issue `[SPEC]` specs against master spec standards.
-
-**When to invoke:**
-- After running `concern-separation-auditor --issue N`
-- When "audit/review/revisit" keywords used
-- Before approving spec implementation
-- During spec review for quality
-- Periodic audit to check for spec drift
-
-**Output:** Posts findings to GitHub Issue, creates audit log in `./tmp/audit-spec-YYYYMMDD.md`
-
-### Concern Separation Auditor (`concern-separation-auditor`)
-
-Invoked with: `/skill concern-separation-auditor --issue N`
-
-**Purpose:** Audit spec phase structure for concern separation, deployment independence, and risk isolation.
-
-**When to invoke:**
-- FIRST before spec-auditor (mandatory order)
-- When "audit/review/revisit" keywords used
-- When creating new specs
-- Before approving spec implementation
-
-**Output:** Posts findings to GitHub Issue
-
-### Enforcement Flow
-
-| Trigger | Action |
-|---------|--------|
-| Spec created | REQUIRED: Run BOTH auditors in order (concern-separation FIRST, then spec-auditor) |
-| "Audit/review/revisit this spec" | REQUIRED: Run BOTH auditors in order |
-| Before implementation approval | REQUIRED: Verify both auditors passed |
-| Guideline change proposed | Optional: `/skill guideline-auditor` |
-| Post-implementation | Optional: Re-run auditors to verify no new issues |
-
----
-
-## Critical Violation: Auditor Comment Practices — Two-Channel Rule
-
-**⚠️ Posting complete audit reports to GitHub Issues when no revision was made is a CRITICAL GUIDELINE VIOLATION.**
-
-### The Problem
-
-Auditors have been posting complete audit findings as GitHub Issue comments even when no revision was made. This creates noise that:
-- Buries revision history
-- Makes it hard for future developers to find what actually changed
-- Violates the distinction between chat (developer coordination) and GitHub Issues (revision history)
-
-### 🚫 FORBIDDEN
-
-| Channel | When NOT to Post | Why |
-|---------|------------------|-----|
-| GitHub Issues | Complete audit report when no revision made | Creates noise, buries history |
-| Chat | Silence when audit finds no issues | Developer doesn't know audit ran |
-| GitHub Issues | Checklist-style pass/fail without revision | No context for future developers |
-
-### ✅ REQUIRED (Two-Channel Rule)
-
-| Channel | When to Post | Content |
-|---------|--------------|---------|
-| **Chat** | ALWAYS (success OR fixes) | Executive summary: pass/fail status, fixes applied |
-| **GitHub Issues** | ONLY on revision | WHY revision needed, WHAT changed - for future developer context |
-
-### Chat Executive Summary Format
-
-```
-**Audit Complete:** [audit type] [passed/failed]
-
-**Issues Found:** N
-**Issues Fixed:** M (if any)
-**Status:** [No concerns detected | N issues fixed]
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-### GitHub Issue Revision Comment Format
-
-```
-Fixed [issue description]
-
-**Why:** [reason for revision]
-**What:** [what changed]
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-### Examples
-
-**Audit passed (no issues):**
-- Chat: Post executive summary with "passed" status
-- GitHub Issues: NO COMMENT (no revision made)
-
-**Audit found issues and fixed them:**
-- Chat: Post executive summary with issues found and fixes applied
-- GitHub Issues: Post revision comment explaining WHY and WHAT changed
-
-**Audit found catastrophic issue (HALT):**
-- Chat: Post summary explaining blocker
-- GitHub Issues: NO COMMENT (issue is blocking, not fixed)
-
-### Why This Matters
-
-- Developers need confirmation audits ran (even when pass)
-- Future developers read GitHub Issues to understand WHAT changed and WHY
-- Audit reports are noise without revision context
-- Two channels serve different purposes: chat for coordination, issues for history
+> **See individual skill files for complete requirements.**
 
 ---
 
@@ -890,40 +304,12 @@ Skills are MANDATORY enforcement points - not optional helpers.
 
 ### ✅ REQUIRED WORKFLOW
 
-**Before ANY git operation:**
-
 1. **STOP** - Do NOT run git commands manually
 2. **INVOKE** the appropriate skill task
-3. **LET THE SKILL** handle all git operations
+3. **LET THE SKILL** handle all operations
 4. **FOLLOW** what the skill does/outputs
 
-**Example - Creating a Branch:**
-
-```
-❌ WRONG: git checkout -b spec/my-feature
-✅ RIGHT: /skill git-workflow --task pre-work
-           (skill handles: stash → verify clean → create branch)
-```
-
-**Example - After Implementation:**
-
-```
-❌ WRONG: Just stop after reading files
-✅ RIGHT: /skill git-workflow --task review-prep
-           (skill handles: commit → push → compare URL → HALT)
-```
-
-### Why Skills Are Mandatory
-
-Skills enforce:
-- Correct git workflow sequence
-- Stash before branch creation
-- Squash before PR
-- GitHub API verification before issue closure
-- Consistent executive summary format
-- Co-author trailers in commits
-
-**Manual operations bypass these enforcements → CRITICAL VIOLATION.**
+> **See `git-workflow` skill for complete workflow.**
 
 ---
 
@@ -933,123 +319,21 @@ Skills enforce:
 
 After implementation completes, the agent MUST automatically:
 1. **Invoke `/skill git-workflow --task review-prep`** (MANDATORY - NO EXCEPTIONS)
-2. The skill handles: commit → push → generate compare URL → post to issue AND chat → HALT
+2. Skill handles: commit → push → compare URL → post to chat → HALT
 3. **NO silent HALT without completing the workflow**
 
 **🚫 FORBIDDEN:**
 - Completing implementation and just HALTing silently
 - Skipping review-prep because "changes are trivial"
-- Skipping review-prep because "developer can use git log"
-- Skipping review-prep and asking "do you want to review?"
 - Proceeding directly to PR creation without compare URL
-- Reporting completion without providing compare URL
-- **Stopping after reading files/loading skills without implementing**
 
-**✅ REQUIRED SEQUENCE:**
-1. Implementation completes all file changes
-2. **AUTOMATIC:** Agent invokes `/skill git-workflow --task review-prep`
-3. Skill handles: commit → push → generate compare URL → post to issue/chat → HALT
-4. Agent reports completion with executive summary
+**✅ REQUIRED:**
+1. Implementation completes
+2. **AUTOMATIC:** Invoke `/skill git-workflow --task review-prep`
+3. Skill handles: commit → push → compare URL → HALT
+4. Report completion with executive summary
 
-**Why This Matters:**
-- Developers need visibility into ALL changes before PR creation
-- GitHub diff viewer provides superior review experience
-- Prevents accidental PRs without developer review
-- Establishes clear boundary between "implementation done" and "PR requested"
-- Compare URL is the canonical way for developers to review branch changes
-- **Silent HALT without workflow completion loses all progress tracking**
-
-**Executive Summary REQUIREMENT:**
-
-When posting completion after review-prep, the agent MUST include an executive summary:
-
-| Location | Content |
-|----------|---------|
-| **GitHub Issue Comment** | Full executive summary (summary, outcome) |
-| **Chat Output** | Same executive summary (summary, outcome) |
-
-**Executive Summary Format:**
-```
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-**🚫 FORBIDDEN in Completion Comments:**
-- File lists (redundant with git diff)
-- "Next" field (dialog prompt)
-- Punch-list format
-- Technical changelog (focus on impact)
-
-**See `113-git-pr-workflow.md` → "Review Phase" and `git-workflow` skill → `review-prep` task.**
-
----
-
-## Critical Violation: Skipping Review-Prep After Implementation
-
-**⚠️ Failing to invoke review-prep after implementation completes is a CRITICAL GUIDELINE VIOLATION.**
-
-After implementation completes, the agent MUST automatically:
-1. **Invoke `/skill git-workflow --task review-prep`** (MANDATORY - NO EXCEPTIONS)
-2. The skill handles: commit → push → generate compare URL → post to issue AND chat → HALT
-3. **NO silent HALT without completing the workflow**
-
-**🚫 FORBIDDEN:**
-- Completing implementation and just HALTing silently
-- Skipping review-prep because "changes are trivial"
-- Skipping review-prep because "developer can use git log"
-- Skipping review-prep and asking "do you want to review?"
-- Proceeding directly to PR creation without compare URL
-- Reporting completion without providing compare URL
-- **Stopping after reading files/loading skills without implementing**
-
-**✅ REQUIRED SEQUENCE:**
-1. Implementation completes all file changes
-2. **AUTOMATIC:** Agent invokes `/skill git-workflow --task review-prep`
-3. Skill handles: commit → push → generate compare URL → post to issue/chat → HALT
-4. Agent reports completion with executive summary
-
-**Why This Matters:**
-- Developers need visibility into ALL changes before PR creation
-- GitHub diff viewer provides superior review experience
-- Prevents accidental PRs without developer review
-- Establishes clear boundary between "implementation done" and "PR requested"
-- Compare URL is the canonical way for developers to review branch changes
-- **Silent HALT without workflow completion loses all progress tracking**
-
-**Executive Summary REQUIREMENT:**
-
-When posting completion after review-prep, the agent MUST include an executive summary:
-
-| Location | Content |
-|----------|---------|
-| **GitHub Issue Comment** | Full executive summary (summary, outcome) |
-| **Chat Output** | Same executive summary (summary, outcome) |
-
-**Executive Summary Format:**
-```
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-**🚫 FORBIDDEN in Completion Comments:**
-- File lists (redundant with git diff)
-- "Next" field (dialog prompt)
-- Punch-list format
-- Technical changelog (focus on impact)
-
-**See `113-git-pr-workflow.md` → "Review Phase" and `git-workflow` skill → `review-prep` task.**
+> **See `git-workflow` skill → `review-prep` task.**
 
 ---
 
@@ -1057,239 +341,81 @@ When posting completion after review-prep, the agent MUST include an executive s
 
 **⚠️ Creating a PR without EXPLICIT developer instruction is a CRITICAL GUIDELINE VIOLATION.**
 
-PRs require the developer to say one of these EXACT phrases:
-- "create a PR"
-- "pr"
-- "make a PR"
-- "push and create PR"
-- "let's get a PR up"
+PRs require EXPLICIT phrases: "create a PR", "pr", "make a PR", "push and create PR"
 
 **🚫 FORBIDDEN:**
-- Creating a PR after "approved" or "go" — these authorize implementation ONLY
-- Creating a PR after completing implementation — completion does NOT authorize PR creation
-- Asking "Ready for a PR?" or "Should I create a PR?" — just STOP and report completion
-- **Pushing branch to remote without "create a PR" instruction** — pushing is part of PR creation, NOT implementation
+- Creating PR after "approved" or "go" — authorizes implementation ONLY
+- Creating PR after completing implementation
+- Asking "Ready for a PR?"
 
 **✅ REQUIRED:**
-- After completing implementation: report completion concisely, then STOP
-- Wait for EXPLICIT "create a PR" instruction
-- Only then: squash, push, create PR, report URL, STOP
+- After completing implementation: report, then STOP and wait
+- Only create PR after EXPLICIT "create a PR"
+- Then: squash, push, create PR, report URL, STOP
 
-**See `pr-creation-workflow` skill for the full PR timing workflow including:**
-- Authorization boundary (what authorizes implementation vs PR)
-- Developer must test before PR
-- HALT after PR creation
-
----
-
-## Critical Violation: Bypassing git-workflow Skill for Cleanup (CRITICAL)
-
-**⚠️ Running manual git commands instead of invoking the mandatory cleanup skill is a CRITICAL GUIDELINE VIOLATION.**
-
-The issue is NOT "manual handling" — the issue is **bypassing the mandatory skill invocation** by running git commands directly.
-
-### 🚫 FORBIDDEN - Bypassing Skill Invocation
-
-These actions bypass the mandatory skill and are CRITICAL VIOLATIONS:
-
-| Forbidden Action | Why It's Wrong |
-|-----------------|----------------|
-| `git branch -d <branch>` after "pr merged" | Bypasses cleanup skill workflow |
-| `git push origin --delete <branch>` after "pr merged" | Bypasses cleanup skill workflow |
-| `git pull` to verify merge state | Bypasses GitHub API verification in cleanup |
-| Manually closing issues after seeing "merged" | Bypasses issue structure verification in cleanup |
-| Running ANY git commands for cleanup | Cleanup task MUST handle all operations |
-
-### ✅ REQUIRED - Skill Invocation
-
-When user says "pr merged", "merged", or similar:
-
-1. **INVOKE `/skill git-workflow --task cleanup`** — this is MANDATORY, not optional
-2. The cleanup skill handles:
-   - GitHub API verification (`github_pull_request_read method=get`)
-   - Issue closure with proper parent/child verification
-   - Branch deletion (local AND remote)
-   - Stash cleanup (if applicable)
-   - Hotfix dev-merge ticket creation (if applicable)
-
-**The trigger phrase alone authorizes skill invocation — no additional confirmation needed.**
-
-**Trigger Phrases for Mandatory Skill Invocation:**
-| User Says | Skill Task |
-|-----------|-----------|
-| "pr merged" | `/skill git-workflow --task cleanup` |
-| "merged" | `/skill git-workflow --task cleanup` |
-| "PR is merged" | `/skill git-workflow --task cleanup` |
-| "merge confirmed" | `/skill git-workflow --task cleanup` |
-
-**See `git-workflow` skill → `cleanup` task for complete post-merge workflow.**
+> **See `pr-creation-workflow` skill for complete workflow.**
 
 ---
 
 ## Critical Violation: Closing Issues Before PR Merge
 
-**⚠️ Closing issues BEFORE the PR is merged is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Closing issues before PR merge is a CRITICAL GUIDELINE VIOLATION.**
 
 **🚫 FORBIDDEN:**
 - Closing issues immediately after implementation
 - Closing issues when PR is created but not merged
 - Closing parent issues while child issues remain open
-- Closing issues without explicit "merge confirmed" from human
-- Closing issues based on `git pull` fast-forward alone (MUST use GitHub API)
+- Closing issues without GitHub API verification
 
 **✅ REQUIRED SEQUENCE:**
-1. Complete implementation → Create PR → Report PR URL → **HALT**
-2. Wait for human to review and merge PR
-3. User confirms "pr merged" → **Call `github_pull_request_read method=get` to verify**
-4. Verify `merged_at` timestamp or `state: "closed"` with merge
-5. ONLY after API confirms merge → Close issues
-6. Post closing summary comment
+1. Complete implementation → Create PR → Report URL → HALT
+2. Wait for human to merge PR
+3. User confirms "pr merged" → Call `github_pull_request_read method=get` to verify
+4. Verify `merged_at` timestamp exists
+5. Only after API confirms merge → Close issues
 
-**Why `git pull` is insufficient:**
-- Local fast-forward shows `git pull` succeeded
-- Does NOT verify the PR merge state in GitHub
-- Agent could close issue before human actually merged
-
-**See `124-github-archive-workflow.md` for complete issue closure timing.**
-**See `git-workflow` skill "Task Dependencies" section for post-merge workflow including issue closure.**
+> **See `124-github-archive-workflow.md` and `git-workflow` skill → `cleanup` task.**
 
 ---
 
 ## Critical Violation: Parent/Child Issue Closure
 
-**⚠️ Closing a parent issue while child issues remain open, or assuming parent status reflects sub-issue completion, is a CRITICAL GUIDELINE VIOLATION.**
-
-When working with parent/child issue hierarchies (specs with sub-issues):
-
-**🚫 FORBIDDEN:**
-- Closing a parent `[SPEC]` issue when ANY child `[Task]` issues are still open
-- Closing a parent after PR merge if other child tasks are incomplete
-- Assuming "the PR covers everything" when sub-issues exist
-- **Assuming parent status reflects sub-issue status — ALWAYS query sub-issues**
-- **Closing ANY issue without first calling `github_issue_read(method="get_sub_issues")`**
-
-**⚠️ CRITICAL: Step 1 is MANDATORY before closing ANY issue - parent or child. No exceptions.**
+**⚠️ Closing a parent issue while child issues remain open is a CRITICAL GUIDELINE VIOLATION.**
 
 ### MANDATORY Pre-Close Checklist (NO EXCEPTIONS)
 
-Before closing ANY issue (parent OR child), the agent MUST complete this checklist in order:
-
 | Step | Action | MUST Result |
 |------|--------|-------------|
-| **1** | Query sub-issues: `github_issue_read(method="get_sub_issues", issue_number=N)` | `[]` empty or verified all closed |
+| **1** | Query sub-issues: `github_issue_read(method="get_sub_issues", issue_number=N)` | `[]` empty or all closed |
 | **2** | Verify PR merge state: `github_pull_request_read(method="get", pullNumber=PR)` | `merged_at` field exists |
 | **3** | Close child issues | Only children addressed by merged PR |
-| **4** | Re-query parent sub-issues | Verify all children now closed |
+| **4** | Re-query parent sub-issues | Verify all children closed |
 | **5** | Close parent | Only if ALL children closed |
 
 **If ANY step fails → DO NOT CLOSE the issue.**
 
-### Example: Parent Closure Workflow
-
-```python
-# Step 1: ALWAYS query sub-issues FIRST (MANDATORY)
-children = github_issue_read(method="get_sub_issues", issue_number=parent_issue)
-
-if children:
-    # Parent with sub-issues - must verify all children closed
-    open_children = [c for c in children if c.state == "open"]
-    if open_children:
-        # BLOCK: Cannot close parent with open children
-        post_warning_comment(parent_issue, open_children)
-        return  # DO NOT CLOSE
-    
-# Step 2: Verify PR merge
-pr = github_pull_request_read(method="get", pullNumber=pr_number)
-if not pr.get("merged_at"):
-    return  # DO NOT CLOSE - PR not merged
-
-# Steps 3-5: Proceed with closure only after all checks pass
-close_issue_with_summary(parent_issue)
-```
-
-### Correct Workflow
-
-| Step | Action | Issues Affected |
-|------|--------|-----------------|
-| PR merged for child task | Close corresponding child issue | Child issue only |
-| Check remaining children | Verify all children closed | No action yet |
-| All children closed? | Close parent with summary | Parent issue |
-
-### Example
-
-```
-SPEC #100 (parent)
-├── Task #101: Phase 1 - Database schema
-├── Task #102: Phase 2 - API endpoints
-└── Task #103: Phase 3 - UI components
-
-PR merges for Phase 1 → Close #101 ONLY
-#100 remains open (children #102, #103 pending)
-
-Later, PR merges for Phase 2 → Close #102 ONLY
-#100 remains open (child #103 pending)
-
-Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
-```
-
-### Exception: All Children Completed
-
-**When ALL child issues are completed by a single PR merge:**
-
-1. Close the child issue corresponding to the PR
-2. **ALSO close the parent issue** (all children are now complete)
-3. Add summary comment to the parent explaining all work is complete
-
-**Example:** If PR #150 fixes both #102 and #103 (the last remaining children), close BOTH child issues AND the parent #100 after merge.
-
-### Why This Matters
-
-- Parent issues track overall progress across all phases
-- Premature parent closure loses visibility into remaining work
-- Stakeholders need to see open issues for incomplete work
-- GitHub sub-issue view shows which children remain
-- **The MANDATORY sub-issue query prevents violations**
-
-### Sub-Issue Double-Check (MANDATORY)
-
-**After closing child issues addressed by PR, ALWAYS verify remaining sub-issues before closing parent.**
-
-**The Problem:**
-- Single PR may address multiple sub-issues
-- Agent may close sub-issues prematurely (before PR merge)
-- Agent may forget to close sub-issues after PR merge
-- Parent gets closed while children remain open
-
-**See `git-workflow` skill → "Sub-Issue Double-Check" section and `124-github-archive-workflow.md` → "Sub-Issue Double-Check" section for complete workflow.**
-
 ---
 
-## Critical Violation: Deleting Branches/Stashes Improperly
+## Critical Violation: Deleting Branches Improperly
 
 **⚠️ Improper branch deletion is a CRITICAL GUIDELINE VIOLATION.**
 
-**MERGED branches must be deleted IMMEDIATELY after merge confirmation.**
-
-**🚫 FORBIDDEN:**
+### 🚫 FORBIDDEN
 - `git branch -D <branch>` on unmerged branches without explicit request
 - `git stash drop` without explicit request
 - Preserving merged branches "just in case"
-- Asking "should I delete this merged branch?" — just delete it
-- Deleting `main` or other protected branches
+- Asking "should I delete this merged branch?"
 
-**✅ REQUIRED:**
-- **MERGED branches**: Delete IMMEDIATELY after merge confirmation — no asking, no waiting
+### ✅ REQUIRED
+- **MERGED branches**: Delete IMMEDIATELY after merge confirmation
 - **UNMERGED branches with work**: Preserve until explicitly asked to delete
 - **Stashes**: Preserve until explicitly asked to delete
-- After PR creation: report URL, wait for merge confirmation, then DELETE the branch
-
-### Quick Reference
 
 | Branch Status | Action |
 |---------------|--------|
-| Merged PR | **DELETE IMMEDIATELY** — no confirmation needed |
-| Unmerged with commits | **PRESERVE** — wait for explicit delete request |
-| Stashes | **PRESERVE** — wait for explicit delete request |
+| Merged PR | **DELETE IMMEDIATELY** |
+| Unmerged with commits | **PRESERVE** |
+| Stashes | **PRESERVE** |
 | `main` branch | **NEVER DELETE** |
 
 ---
@@ -1298,50 +424,20 @@ Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
 
 **⚠️ All work must be approached with proper engineering discipline.**
 
-See `.opencode/guidelines/085-engineering-approach.md` for complete requirements.
+> **See `085-engineering-approach.md` for complete requirements.**
 
 ### Core Engineering Principles
 
-1. **Understand Before Solving** — Read all relevant code before proposing changes
-2. **Design Before Implementing** — Document approach and obtain approval before coding
-3. **Verify Before Declaring Complete** — Run tests, check edge cases, validate success criteria
-4. **Communicate Changes** — Post comments when changes occur (NOT when creating issues)
-
-### Requirements Analysis Mandatory
-
-Every specification MUST include:
-- Problem definition with context and stakeholders
-- Constraints, assumptions, and success criteria
-- Edge cases identified
-- Dependencies and integrations affected
-- Risk assessment
-
-### No Feature Creep
-
-- Implement ONLY what is in the approved spec
-- No additions, enhancements, or "improvements" beyond scope
-- No refactoring unless explicitly requested
-- File separate issues for unrelated fixes discovered during work
-
-### No Unapproved Work
-
-- Never start implementation without explicit authorization
-- "Should I do X?" is a question, not authorization
-- Wait for clear "approved" or "go" before starting
-- If unclear, ask — do not assume
+1. **Understand Before Solving** — Read code before proposing changes
+2. **Design Before Implementing** — Document approach and get approval
+3. **Verify Before Declaring Complete** — Run tests, check edge cases
+4. **Communicate Changes** — Post comments when changes occur
 
 ### WIP Commit Before HALT (MANDATORY)
 
 **CRITICAL: Work-in-progress commits MUST be made before ANY HALT to prevent data loss.**
 
-When implementation halts (for ANY reason - awaiting approval, awaiting clarification, error, session end), uncommitted changes are at risk from:
-- Session crashes
-- Context window exhaustion
-- Developer needs to switch branches
-- Machine restarts
-
 **✅ REQUIRED BEFORE ANY HALT:**
-
 ```bash
 git status
 # If changes exist:
@@ -1351,104 +447,4 @@ git commit -m "WIP: Phase N - <description>" \
     --trailer "Co-authored-by: <Human-Name> <human-email>"
 ```
 
-**🚫 FORBIDDEN:**
-- HALTing without committing uncommitted changes
-- Leaving working tree dirty before HALT
-- "Waiting" without preserving work in progress
-
-**✅ WIP Commit Characteristics:**
-- Prefix: `WIP:` for easy identification
-- Phase: Include phase number for context
-- Description: Brief description of work in progress
-- Trailers: Same co-author trailers as full commits
-- Squashable: Can be amended later with subsequent work
-
-**See `111-git-commit-workflow.md` → "WIP Commit Before HALT" section for complete workflow.**
-
-## Critical Violation: Implementing Without Documentation Verification
-
-**⚠️ Implementing code without verifying against live documentation is a CRITICAL GUIDELINE VIOLATION.**
-
-### 🚫 FORBIDDEN
-- Implementing API calls without verifying parameter names from official docs
-- Using environment variables without confirming correct names from config files
-- Guessing function signatures from memory or similar libraries
-- Using outdated blog posts/tutorials instead of official documentation
-
-### ✅ REQUIRED
-- **ALWAYS verify API signatures before implementing**
-- Check official documentation for current API usage
-- Use `srclight_get_signature` or `pycharm_get_symbol_info` for function signatures
-- Read source code and type hints when docs unavailable
-- Confirm environment variable names from `.env.example` or config
-
-### Why This Matters
-- Assumption-based implementations lead to broken functionality
-- API changes between library versions cause silent failures
-- Incorrect parameter names waste debugging time
-- Outdated patterns accumulate technical debt
-
----
-
-## Critical Violation: Auto-Issue Creation for Repeated Workflow Violations
-
-**⚠️ Repeated bypass of mandatory workflows is a CRITICAL GUIDELINE VIOLATION that MUST be tracked.**
-
-When the agent bypasses mandatory workflow steps (review-prep, PR creation, issue closure), an issue MUST be created to track the violation.
-
-### What Triggers Auto-Issue Creation
-
-| Violation | When to Create Issue |
-|-----------|----------------------|
-| Skipping review-prep | Agent HALTs without pushing branch, generating compare URL, or posting to issue/chat |
-| Bypassing PR workflow skill | Agent manually runs git commands instead of invoking skill |
-| PR creation without instruction | Agent creates PR without explicit "create a PR" from user |
-| Closing issues before PR merge | Agent closes issues without verifying merge via GitHub API |
-
-### Auto-Issue Workflow
-
-**When violation detected:**
-
-1. Create issue: `[SPEC-FIX] Review-prep workflow bypass` (or relevant violation type)
-2. Document which implementation phase was affected
-3. Add `needs-approval` label
-4. Post comment explaining:
-   - What violation occurred
-   - Which files/workflow were affected
-   - What correct workflow should have been followed
-
-### Issue Template for Violations
-
-```markdown
-# [SPEC-FIX] <Violation Type>
-
-**Violation:** <What occurred>
-
-**Affected Files:**
-- <File paths that were modified without proper workflow>
-
-**Expected Workflow:**
-1. <Step 1 of correct workflow>
-2. <Step 2 of correct workflow>
-...
-
-**What Happened:**
-<Description of how workflow was bypassed>
-
-**Correction Required:**
-- <What needs to be verified/fixed>
-
----
-🤖 ❌ Violation detected by <AgentName> (<ModelID>)
-```
-
-### Why This Matters
-
-- Violations indicate gaps in workflow understanding or enforcement
-- Tracking violations helps identify patterns
-- Creates accountability for workflow compliance
-- Enables systematic improvement of guidelines
-
----
-
-**Search guidelines:** Use `srclight_search_symbols` or `pycharm_search_in_files_by_text` to find relevant guidelines.
+> **See `111-git-commit-workflow.md` → "WIP Commit Before HALT" section.**

--- a/.opencode/guidelines/000-session-init.md
+++ b/.opencode/guidelines/000-session-init.md
@@ -4,15 +4,11 @@
 
 **Before ANY other operations, run the session init script:**
 
-### Step 1.1: Run Session Init Script
-
-**ALWAYS run this script FIRST:**
-
 ```bash
 uv run python ai_bin/session_init.py
 ```
 
-**Script outputs:**
+**Script outputs (store for session duration):**
 - `DEV_NAME`: Human collaborator name (for commit trailers)
 - `DEV_EMAIL`: Human collaborator email (for commit trailers)
 - `GIT_OWNER`: Repository owner (for GitHub MCP API calls)
@@ -20,22 +16,10 @@ uv run python ai_bin/session_init.py
 - `GIT_HOOKS_PATH`: Git hooks path (to verify hooks installed)
 - `GIT_REMOTE_URL`: Full remote URL (for reference)
 
-**Store these values for the session duration.**
-
 **Exit codes:**
 - 0: Success - proceed with session
 - 1: No remote configured or parse error - cannot proceed with GitHub operations
 - 2: Non-GitHub remote - GitHub MCP operations unavailable
-
-**Error handling:**
-- Exit code 1: Verify git remote is configured (`git remote add origin <url>`)
-- Exit code 2: GitHub MCP operations will not work with non-GitHub remotes
-
-**Why script FIRST:**
-- Ensures correct owner extraction from remote URL
-- Provides structured output ready for use
-- Fails fast before MCP operations begin
-- Prevents incorrect owner assumptions in GitHub API calls
 
 ---
 
@@ -44,8 +28,6 @@ uv run python ai_bin/session_init.py
 **⚠️ DO NOT infer GitHub owner from file paths, usernames, or cached values.**
 
 ### 🚫 FORBIDDEN (ZERO TOLERANCE)
-
-**These actions are CRITICAL GUIDELINE VIOLATIONS:**
 
 | Forbidden Action | Why It's Wrong |
 |------------------|----------------|
@@ -59,37 +41,9 @@ uv run python ai_bin/session_init.py
 
 **ONLY use values from `ai_bin/session_init.py` output:**
 
-```bash
-# REQUIRED: Run this FIRST
-uv run python ai_bin/session_init.py
-
-# Expected output format:
-# DEV_NAME=<human-name>        # For commit trailers
-# DEV_EMAIL=<human-email>     # For commit trailers
-# GIT_OWNER=<github-owner>          # For GitHub MCP API calls
-# GIT_REPO=<github-repo>            # For GitHub MCP API calls
-# GIT_HOOKS_PATH=<hooks-path>        # Git hooks location
-# GIT_REMOTE_URL=<remote-url>        # Full remote URL
-```
-
-**Use these values for SESSION DURATION:**
 - `GIT_OWNER` and `GIT_REPO` for ALL `github_*` MCP calls
 - `DEV_NAME` and `DEV_EMAIL` for commit trailers
 - DO NOT re-run `git config` or derive values from other sources
-
-### Why This Matters
-
-| Incorrect Source | Example | Result |
-|------------------|---------|--------|
-| File path parsing | `/home/<user>/git/...` | Owner=`<user>` (WRONG) |
-| `$USER` variable | `echo $USER` → `<local-user>` | Owner=`<local-user>` (WRONG) |
-| `git config user.name` | `git config user.name` → `<human-name>` | Owner=`<human-name>` (WRONG) |
-| Hardcoded value | `owner="<hardcoded>"` | Wrong on different machines |
-| Cached from previous session | Previous session's `GIT_OWNER` | May be stale |
-
-**CORRECT:** `GIT_OWNER=<owner>` from session init (for `<owner>/<repo>`)
-
----
 
 ---
 
@@ -97,68 +51,31 @@ uv run python ai_bin/session_init.py
 
 **After git config check, probe MCP tool availability:**
 
-1. **Test PyCharm MCP**: Call `pycharm_get_project_modules` or similar to verify PyCharm tools work
-2. **Test GitHub MCP**: Call `github_get_me` to verify GitHub tools work
-3. **Discover repository**: Run `git remote -v` to get correct owner/repo from origin. Extract owner/repo from the origin URL and store for all subsequent GitHub API calls. NEVER assume or hardcode repository owner/name.
-4. **Record results**: Note which MCP toolsets are available/unavailable and store owner/repo values
-5. **Loop Detection Check**: If MCP probe succeeds but no subsequent tool invocation occurs within 2 message turns, HALT and report potential task loop (infinite retry detection)
-
-### Repository Discovery (MANDATORY)
-
-**Use values from session init script:**
-
-The `ai_bin/session_init.py` script extracts owner and repo from the remote URL and stores them for use in GitHub MCP calls.
-
-**Script output:**
-```
-GIT_OWNER=<owner>
-GIT_REPO=<repo>
-```
-
-**Error handling (handled by script):**
-- If `git remote -v` fails or returns no output → Script exits with code 1
-- If remote is not GitHub (e.g., GitLab, Bitbucket) → Script exits with code 2
-- If origin remote doesn't exist → Script exits with code 1
+1. **Test PyCharm MCP**: Call `pycharm_get_project_modules` or similar
+2. **Test GitHub MCP**: Call `github_get_me`
+3. **Record results**: Note which MCP toolsets are available/unavailable
 
 ### MCP Enforcement Gate
-
-**After MCP probe, enforce tool selection based on availability:**
 
 | Scenario | Spec Tracking | File Operations | GitHub Operations |
 |----------|---------------|-----------------|-------------------|
 | **Both available** | GitHub Issues | PyCharm MCP tools ONLY | GitHub MCP tools ONLY |
 | **PyCharm only** | GitHub Issues | PyCharm MCP tools ONLY | N/A (no GitHub MCP) |
-| **Neither available** | GitHub Issues via `gh` CLI | Direct file tools with `# FALLBACK: PyCharm MCP unavailable` comment | `gh` CLI or web UI |
+| **Neither available** | GitHub Issues via `gh` CLI | Direct file tools with fallback comment | `gh` CLI or web UI |
 
 **PROHIBITED violations:**
-- Using `read` tool on project files when PyCharm MCP is available → Hard stop
+- Using `read` tool on project files when PyCharm MCP available → Hard stop
 - Using `edit` tool for renames instead of `pycharm_rename_refactoring` → Hard stop
-- Using `grep` for project search when PyCharm MCP is available → Hard stop
+- Using `grep` for project search when PyCharm MCP available → Hard stop
 - Creating local spec files instead of GitHub Issues → Hard stop
-- Proceeding past session init without confirming MCP availability
 
-**Fallback acknowledgment**: If PyCharm MCP is unavailable, must explicitly acknowledge fallback mode before using direct file tools.
-
-This probe determines workflow:
-- **Both available**: Use GitHub Issues for specs, PyCharm tools for file operations
-- **Only PyCharm**: Use GitHub Issues via `gh` CLI for specs, PyCharm tools for files
-- **Neither available**: Use direct file tools, GitHub Issues via `gh` CLI for specs
-
-**Do NOT proceed with any task until MCP availability is confirmed AND repository discovered (if GitHub MCP available).**
+**Do NOT proceed with any task until MCP availability is confirmed.**
 
 ---
 
 ## 3. NO RESPONSE WITHOUT INIT (MANDATORY)
 
 **⚠️ ZERO TOLERANCE: The agent MUST NOT respond to user questions or execute tasks before completing session init.**
-
-### The Problem
-
-Without session init:
-- `GIT_OWNER`/`GIT_REPO` are unknown → GitHub MCP calls fail
-- `DEV_NAME`/`DEV_EMAIL` are unknown → Commit trailers missing or wrong
-- MCP availability is unknown → Wrong tool selection
-- Hook verification is missed → Safety checks bypassed
 
 ### 🚫 FORBIDDEN (ZERO TOLERANCE)
 
@@ -168,33 +85,16 @@ Without session init:
 | Creating specs before running session init | No owner/repo for GitHub Issues |
 | Running git commands before running session init | Missing human identity for trailers |
 | Implementing before running session init | All context missing |
-| Investigating bugs before running session init | Cannot use correct tools without MCP check |
 
 ### ✅ REQUIRED SEQUENCE
 
 **Before responding to ANY user input:**
 
-1. **Run session init FIRST**: `uv run python ai_bin/session_init.py`
-2. **Store ALL outputs** for session duration
-3. **Probe MCP availability** (PyCharm, GitHub)
-4. **Verify hooks installed**
-5. **THEN and ONLY THEN**: Respond to user
-
-### Mandatoy Enforcement Point
-
-**Session init is a MANDATORY enforcement point** - not an optional step.
-
-The agent MUST:
-1. Run session init script
-2. Succeed (exit code 0)
-3. Store outputs
-4. Probe MCP
-5. Verify hooks
-6. **ALL of the above BEFORE responding to ANY user message**
-
-### Loop Detection
-
-If MCP probe succeeds but no subsequent tool invocation occurs within 2 message turns, HALT and report potential task loop.
+1. Run session init FIRST: `uv run python ai_bin/session_init.py`
+2. Store ALL outputs for session duration
+3. Probe MCP availability (PyCharm, GitHub)
+4. Verify hooks installed
+5. THEN and ONLY THEN: Respond to user
 
 ---
 
@@ -207,87 +107,76 @@ git config core.hooksPath
 # Should output: .githooks
 ```
 
-**Hook Verification in `ai_bin/session_init.py`:**
-
-Session init script automatically verifies hooks and warns if missing:
-
-- **Hooks installed**: Silent (no output)
-- **Hooks missing**: Warning to AI agent, includes remediation instructions
-- **Behavior**: Continue execution — developer decides remediation
+Session init script automatically verifies hooks and warns if missing.
 
 If hooks are missing:
 - ⚠️ AI agent relays warning to developer
-- ⚠️ Developer decides: install hooks (`./scripts/install-hooks.sh`) or proceed
+- ⚠️ Developer decides: install hooks or proceed
 - ⚠️ Risk: Without hooks, local commits to `main` or `dev` are not blocked
 
 ---
 
-## 1. Core behavior
+## 5. Core Behavior
 
-* Follow user instructions exactly; do not add scope.
-* Ask questions only for ambiguity/conflict.
-* Production-data execution is forbidden unless explicitly instructed in-session.
-* **"Check error" means read code and logs — NEVER run scripts against production.** Bug reports, error logs, and diagnostics are for static analysis only. Running the failing script, reproducing the error, or verifying fixes against production is prohibited without explicit authorization.
-* Default initial state is interactive discussion; active persona protocol may override.
+- Follow user instructions exactly; do not add scope.
+- Ask questions only for ambiguity/conflict.
+- Production-data execution is forbidden unless explicitly instructed in-session.
+- **"Check error" means read code and logs — NEVER run scripts against production.**
+- Default initial state is interactive discussion; active persona protocol may override.
 
-## 2. Boundaries (Always / Ask first / Never)
+---
+
+## 6. Boundaries (Always / Ask first / Never)
 
 ### ✅ ALWAYS DO
-* Use `uv run python` for all commands.
-* **Create a feature branch from `dev` BEFORE any implementation** (see 110-git-branch-first.md). This is MANDATORY — the FIRST action before any edit. NEVER edit files while on `main` or `dev`. No exceptions for "small" changes, docs, tests, or configs.
-* **When GitHub MCP tools available**: Use the **Issue-First** strategy. Create GitHub Issues for specs. Use **Sub-issues (Task Lists)** for atomic tasks to establish parent-child hierarchy. **MANDATORY**: All implementation tasks MUST be their own issues, linked via `github_sub_issue_write` using the **Database ID** (not the issue number). See 120-github-issue-first.md.
-* **VERIFY SUB-ISSUES BEFORE IMPLEMENTING**: When authorized to implement a SPEC, first call `github_issue_read method=get_sub_issues` on the parent issue. If empty, STOP and report "Cannot implement — no sub-issues found." See 010-approval-gate.md Sub-issue Verification Gate.
-* **Always use GitHub Issues for spec tracking.** Even without GitHub MCP, use `gh` CLI for GitHub operations.
-* **Prefer MCP tools for project operations.** Use PyCharm MCP tools for file operations, GitHub MCP tools for git/GitHub operations. See 015-mcp-preference.md.
-* For Python source analysis, use `ai_bin/py structure`.
-* Use `tmp/` for temp files (`T="./tmp/"`).
-* Follow the **Spec-Driven Development** methodology (Specify -> Plan -> Tasks -> Implement).
-* **Prefer GitHub workflow when MCP tools available.** Use GitHub Issues for planning and PRs for code integration. See `121-github-pr-workflow.md`.
+
+- Use `uv run python` for all commands.
+- **Create a feature branch from `dev` BEFORE any implementation** (see 110-git-branch-first.md). This is MANDATORY — the FIRST action before any edit.
+- **When GitHub MCP tools available**: Use the Issue-First strategy. See 120-github-issue-first.md.
+- **VERIFY SUB-ISSUES BEFORE IMPLEMENTING**: Call `github_issue_read method=get_sub_issues` on parent issue. See 010-approval-gate.md.
+- **Always use GitHub Issues for spec tracking.** Even without GitHub MCP, use `gh` CLI.
+- **Prefer MCP tools for project operations.** See 015-mcp-preference.md.
+- Use `tmp/` for temp files (`T="./tmp/"`).
 
 ### ⚠️ ASK FIRST
-* Any action that deviates from the approved plan/spec.
-* Adding new dependencies to `pyproject.toml`.
-* Modifying database schemas or core infrastructure.
+
+- Any action that deviates from the approved plan/spec.
+- Adding new dependencies to `pyproject.toml`.
+- Modifying database schemas or core infrastructure.
 
 ### 🚫 NEVER DO
-* No unauthorized edits/implementation.
-* **NEVER write code without an approved spec.** Bug fixes, guideline violations, and any code changes require a spec (GitHub Issue or local file if MCP unavailable) BEFORE implementation. Immediate code fixes are violations.
-* **NEVER implement without explicit developer authorization.** Creating a spec does NOT authorize implementation. You MUST receive explicit authorization from the developer before writing any code. No exceptions.
-* **NEVER implement a spec with `needs-approval` label.** Check the issue labels before implementing. If `needs-approval` is present, SILENTLY HALT and wait for authorization.
-* **Questions are NOT authorization to make changes.** A question like "should I do X?" or "would you like me to X?" is seeking permission, not receiving it. Wait for explicit instruction before acting.
-* **Analysis and investigation do NOT authorize implementation.** After creating a spec, SILENTLY HALT and wait for explicit authorization. Do not proceed to implementation automatically.
-* **NEVER create local spec files when GitHub MCP tools are available.** Use GitHub Issues as the primary spec tracking mechanism.
-* **NEVER use direct file tools (read/write/edit/glob/grep) on project files when PyCharm MCP is available.** See `015-mcp-preference.md` for mandatory PyCharm MCP tool usage.
-* **NEVER use bash for file operations (cat/sed/echo) on project files when PyCharm MCP is available.** Use PyCharm MCP tools instead.
-* **NEVER edit `.ipynb` files directly.** Raw JSON manipulation, `json.dump`, `write` tool, `sed`, `re.sub`, or any non-MCP method will CORRUPT notebooks. ALWAYS use `the-notebook-mcp` tools. If MCP unavailable, REFUSE notebook operations entirely. See `061-notebook-rules.md`.
-* **Commits require direct instruction from the developer; merges are HUMAN-ONLY.** The agent may commit when authorized, but must NEVER merge PRs. "go" means "proceed to the next task or phase" — NOT "merge" or "create PR".
-* **NEVER commit directly to main.** The feature-branch workflow is MANDATORY. Even if user says "commit to main", create a feature branch, commit there. Merging is HUMAN-ONLY — even if user says "go" with an open PR, the agent must NOT merge. If all tasks are complete, report summary and HALT.
-* **ZERO TOLERANCE: Never use or access `/tmp/` (system temp directory) for any reason — ONLY use or access `./tmp/` for temporary outputs, scripts, and files.**
-* **ZERO TOLERANCE: Never access `~/.local/` or tool output files.** Tool outputs are internal artifacts — use MCP tools directly to paginate large results instead of reading cached files.
-* **NEVER run scripts, commands, or code against production data or production databases.** "Check error log" means look for log files — never run the script to reproduce or diagnose. "Fix a bug" means fix the code — never test or verify against production. Production execution requires explicit user instruction in-session.
-* Do not use shell text-writes (`echo`/`printf`/`tee`/heredoc) for file edits.
-* Do not use `sed -i`.
-* Do not use `uv run python ai_bin/memory`.
-* Never deliver plans inline in the message body.
-* Never implement while open questions remain unanswered.
-* **NEVER SWALLOW EXCEPTIONS OR HIDE MISSING DATA.** See `090-data-integrity.md` for zero-tolerance rules.
 
-## 3. Execution gates (canonical)
+- No unauthorized edits/implementation.
+- **NEVER write code without an approved spec.** Bug fixes require a spec BEFORE implementation.
+- **NEVER implement without explicit developer authorization.** Creating a spec does NOT authorize implementation.
+- **NEVER implement a spec with `needs-approval` label.** SILENTLY HALT and wait for authorization.
+- **Questions are NOT authorization to make changes.** Wait for explicit instruction.
+- **Analysis and investigation do NOT authorize implementation.** SILENTLY HALT after creating a spec.
+- **NEVER create local spec files when GitHub MCP tools are available.**
+- **NEVER use direct file tools on project files when PyCharm MCP is available.** See 015-mcp-preference.md.
+- **NEVER edit `.ipynb` files directly.** See 061-notebook-rules.md.
+- **Commits require direct instruction; merges are HUMAN-ONLY.**
+- **NEVER commit directly to main.** Feature-branch workflow is MANDATORY.
+- **ZERO TOLERANCE: Never use `/tmp/` (system temp) — ONLY `./tmp/`.**
+- **NEVER run scripts against production data.** Production execution requires explicit user instruction.
+- **NEVER SWALLOW EXCEPTIONS OR HIDE MISSING DATA.** See 090-data-integrity.md.
 
-* Any directive starting with `plan` or `spec` is plan-only and never implementation authorization.
-* **New specs MUST be created with `needs-approval` label.** The agent must SILENTLY HALT and wait for explicit authorization before implementing.
-* **Before implementing, verify the spec lacks `needs-approval` label.** If present, SILENTLY HALT and wait for authorization.
-* Plan/Spec directives must produce or update a GitHub Issue, then notify reference + brief summary, then halt.
-* Existing plans/specs do not carry authorization across sessions.
-* `revise` means update the issue or plan file ONLY — never make code changes for a `revise` command
-* Perform one approved item at a time, then stop.
-* Plans with open questions must have all questions answered before implementation.
-* Authorization commands: `approved`, `approved: 1`, `approved: 1.2`, `go` — each authorization is per-task and revoked after use.
-* **`go` means "proceed to the next task or phase" — NOT "merge" or "create PR".** If tasks/phases remain in the spec, proceed to the next one. If all tasks are complete, report a summary of changes and HALT. Merging PRs is HUMAN-ONLY. The agent must NEVER merge, even after user says "go" or "approved".
-* Directives `specs`, `plans`, or `pending` must list all available top-level specs (GitHub Issues with `[SPEC]` prefix or local `plans/SPEC-*.md` files with STATUS not `completed`), then present a multi-choice user query for selecting which one to implement.
+---
 
-## 4. References (authoritative detail)
+## 7. Execution Gates (Canonical)
 
-* `docs/specs/how-to-write-good-spec-ai-agents.md` — master spec methodology (essay/approach guide).
-* `docs/specs/spec-flow-control.md` — spec flow control (STATUS format, phases, markers).
-* `docs/specs/spec-flow-control-implementation.md` — spec implementation guide.
+- Any directive starting with `plan` or `spec` is plan-only and never implementation authorization.
+- **New specs MUST be created with `needs-approval` label.** SILENTLY HALT and wait for authorization.
+- **Before implementing, verify the spec lacks `needs-approval` label.** If present, SILENTLY HALT.
+- `revise` means update the issue or plan file ONLY — never make code changes.
+- Perform one approved item at a time, then stop.
+- Authorization commands: `approved`, `approved: 1`, `approved: 1.2`, `go` — each per-task and revoked after use.
+- **`go` means "proceed to the next task or phase" — NOT "merge" or "create PR".**
+
+---
+
+## 8. References (Authoritative Detail)
+
+- `docs/specs/how-to-write-good-spec-ai-agents.md` — master spec methodology
+- `docs/specs/spec-flow-control.md` — spec flow control (STATUS format, phases, markers)
+- `docs/specs/spec-flow-control-implementation.md` — spec implementation guide

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -6,6 +6,8 @@
 > - Single-task exemption
 > - Re-evaluation checklist
 > - Bug report response
+> - Authorization cleanup workflow
+> - Closed-issue audit workflow
 
 ## Tier 0: Zero Tolerance Rules
 
@@ -19,7 +21,6 @@
 | **Authorization required** | NO implementation WITHOUT explicit `"approved"` or `"go"` |
 | **Explicit auth overrides label** | When user says `approved`/`go`, proceed REGARDLESS of `needs-approval` label |
 | **Branch first** | Create feature branch BEFORE any file modification |
-| **Review-prep after implementation** | Push branch, generate compare URL, post summary, HALT — MANDATORY after implementation |
 | **Human-only merge** | Agents MUST NEVER merge PRs |
 | **MCP tools** | Use PyCharm/GitHub MCP for file operations when available |
 | **Silent halt** | HALT after completion, after PR creation — no prompts |
@@ -44,25 +45,6 @@
 ### Sub-Issue Verification Gate (MANDATORY)
 
 **⚠️ Before implementing ANY spec, the agent MUST verify sub-issue structure:**
-
-```python
-# MANDATORY: Before implementing spec N
-sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
-
-if sub_issues:
-    # Multi-task spec - sub-issues exist
-    # Proceed with implementation (sub-issues track phases)
-    pass
-else:
-    # Check if single-task or missing sub-issues
-    if has_multiple_phases(spec_body):
-        # Multi-task spec without sub-issues - AUTO-CREATE THEM
-        # See github-sub-issues skill for workflow
-        create_sub_issues_for_phases(issue_number=N)
-    else:
-        # Single-task spec - no sub-issues needed
-        proceed_with_implementation()
-```
 
 **Single-Task Exemption:**
 - Specs with exactly ONE implementation task do NOT require sub-issues
@@ -124,25 +106,6 @@ When a developer says `approved` or `go` **without a phase qualifier**, the agen
 - Phase-by-phase approval is intentional scoping (opt-in via qualifiers)
 - Prevents unnecessary back-and-forth on multi-phase implementations
 
-**Developer Workflow:**
-
-- **Approve entire spec:** Use `approved` or `go` without qualifiers
-- **Approve one phase:** Use `approved: N` where N is the phase number
-- **Approve specific step:** Use `approved: N.M` where N is phase and M is step
-
-**Agent Behavior:**
-
-**With unqualified approval (`approved` or `go`):**
-1. Proceed through Phase 1
-2. Continue to Phase 2 (no HALT)
-3. Continue through all remaining phases
-4. HALT only after completing the entire spec
-
-**With qualified approval (`approved: 1` or `approved: 2.3`):**
-1. Proceed through the authorized phase/step ONLY
-2. HALT after completing that phase/step
-3. Wait for next authorization before continuing
-
 ## Risk-Aware Authorization (CRITICAL)
 
 **⚠️ High-risk and large-blast-radius phases may require explicit phase-by-phase approval, even with unqualified authorization.**
@@ -175,111 +138,13 @@ When a developer says `approved` or `go` **without a phase qualifier**, the agen
 
 ### Authorization Commands for Risk-Aware Phases
 
-**For HIGH/medium risk or ANY/large blast radius:**
+**For HIGH/MEDIUM risk or ANY/large blast radius:**
 
 | Command | Purpose |
 |---------|---------|
 | `approved: N` | Approve only Phase N (phase-by-phase authorization) |
 | `approved: N.M` | Approve only Phase N Step M |
 | `approved` | Approve ALL phases (only if developer understands cumulative risk) |
-
-**Developer Workflow for Risky Phases:**
-
-1. Check phase risk level and blast radius in spec
-2. For HIGH/MEDIUM+LARGE phases, use `approved: N` for explicit control
-3. For cumulative risk acceptance, use unqualified `approved`
-
-**Agent Workflow for Risky Phases:**
-
-1. Before implementation, read phase risk level from spec
-2. For HIGH/MEDIUM+LARGE phases, **RECOMMEND** phase-by-phase approval
-3. If unqualified approval given for risky phase, PROCEED (developer accepted cumulative risk)
-4. Document risk acceptance in implementation comment
-
-### Example Risk-Aware Authorization
-
-**Spec with HIGH/MEDIUM risk profile:**
-
-```markdown
-## Phase 1: Database Schema (Risk: LOW, Blast Radius: SMALL)
-...
-## Phase 2: Authentication Service (Risk: MEDIUM, Blast Radius: MEDIUM)
-...
-## Phase 3: Production Deployment (Risk: HIGH, Blast Radius: LARGE)
-...
-```
-
-**Authorization Scenarios:**
-
-| Developer Command | What Gets Implemented |
-|-----------------|----------------------|
-| `approved` | All phases (developer accepts cumulative risk) |
-| `approved: 1` | Phase 1 only (safe phase, no risk concern) |
-| `approved: 2` | Phase 2 only (medium risk isolated) |
-| `approved: 3` | Phase 3 only (high risk, explicit approval) |
-
-**Agent Response to Unqualified Approval for Risky Phase:**
-
-```
-Implementing Phase 3 (HIGH risk, LARGE blast radius).
-
-⚠️ This phase has elevated risk:
-- Risk Level: HIGH
-- Blast Radius: LARGE
-- Rollback: Difficult (may need production coordination)
-
-Proceeding with unqualified approval (developer accepts cumulative risk).
-```
-
-### Integration with Auditor Skills
-
-**Both spec auditors check risk profile:**
-
-| Auditor | Risk Check |
-|---------|-----------|
-| `concern-separation-auditor` | Validates phase risk level is declared |
-| `spec-auditor` | Validates blast radius is assessed |
-
-**Missing risk level → `BOILERPLATE-TITLE` or `MISSING-ELEMENT` violation**
-
-### Edge Cases for Unqualified Approval
-
-**Edge Case: Conflict/Requirement Change**
-
-If a spec requirement changes mid-implementation (e.g., external feedback, new information), remaining tasks ARE marked `needs-approval`:
-
-| Scenario | Action |
-|----------|--------|
-| Spec revised during implementation | Stop immediately, mark remaining phases as `needs-approval` |
-| New requirement discovered | Post comment, mark affected phases as `needs-approval` |
-| Stakeholder changes scope | HALT, wait for explicit re-authorization |
-
-This is NOT a violation of "unqualified approval covers all phases" — it's a safety mechanism when the context changes.
-
-**Edge Case: External Input**
-
-Bug reports, critical findings, or production incidents invalidate prior approval:
-
-| Input Type | Action |
-|------------|--------|
-| Bug report on related code | HALT, mark remaining phases as `needs-approval` |
-| Production incident | HALT, wait for explicit instruction |
-| Critical finding during implementation | Post comment to issue, HALT |
-
-**Edge Case: Risk Escalation**
-
-If phase risk is elevated to HIGH/MEDIUM+LARGE during implementation:
-
-| Risk Change | Action |
-|-------------|--------|
-| Phase marked LOW → discovered HIGH | HALT, recommend phase-by-phase approval |
-| Blast radius grows | HALT, wait for explicit authorization |
-| Dependencies increase | HALT, assess impact |
-
-**Why Edge Cases Override:**
-- Changed context invalidates implicit trust
-- External input means developer may not have full information
-- Risk escalation requires explicit acknowledgment
 
 ## Compound Command Recognition
 
@@ -292,8 +157,6 @@ If phase risk is elevated to HIGH/MEDIUM+LARGE during implementation:
 | `"#196 approvedcheck pr"` | NO (compound text) | NO |
 | `"check pr"` | N/A (verification) | NO |
 
-See `approval-gate` skill → `verify-authorization` task for complete pattern matching algorithm.
-
 ### Revision Revokes Approval (MANDATORY)
 
 **Any modification to a spec or task document MUST immediately revoke approval.**
@@ -303,8 +166,6 @@ When a spec is modified:
 2. **Label applied**: Add `needs-approval` label to the issue
 3. **Agent MUST HALT**: Do NOT proceed with implementation
 4. **Fresh authorization required**: New explicit approval needed before implementation
-
-**Note**: When using `revise` command, the agent MAY post comments explaining changes but MUST NOT proceed with implementation. `revise` commands allow only documentation updates, never code changes.
 
 **This applies to:**
 - Any modification to the spec body (requirements, steps, criteria)
@@ -317,224 +178,9 @@ When a spec is modified:
 - Progress comments added to issue
 - Bug report additions (separate from spec content changes)
 
-### Authorization Cleanup Workflow (SILENT — No Comments)
-
-**When authorization is received AND workflow was interrupted, clean up approval markers BEFORE proceeding.**
-
-**The Problem:**
-
-When workflow is interrupted (for clarification questions, spec revisions, context switching, error recovery, or investigation), stale markers accumulate:
-
-- `needs-approval` label remains on issue
-- `STATUS: N.M (REVISED - NEEDS APPROVAL)` suffix remains in STATUS field
-- Todo list shows stale tasks from interrupted workflow
-
-**The Solution:**
-
-When authorization is received after interruption:
-
-1. **Remove `needs-approval` label** (if present)
-2. **Clear STATUS suffix** (`N.M (REVISED - NEEDS APPROVAL)` → `N.M`)
-3. **Clear todo list** (if workflow was interrupted — see detection below)
-4. **Proceed with implementation**
-
-**⚠️ CRITICAL: Cleanup is SILENT — NO comments posted.**
-
-- Authorization cleanup is administrative, not post-implementation review information
-- GitHub comments are for implementation results, not status notifications
-- The issue state (label, STATUS) IS the record — no duplicate notification needed
-
-#### Workflow Interruption Detection
-
-**Clear todos if ANY interruption occurred since last authorization:**
-
-| Interruption Type | Detection |
-|------------------|-----------|
-| Developer conversation | Agent asked clarification question and received answer |
-| Spec revision | Agent revised spec (added/changed content) |
-| Error recovery | Agent encountered error and investigated |
-| Context switch | Agent switched to different task/issue |
-| Investigation phase | Agent performed investigation before implementation |
-
-**Action:** If ANY interruption, CLEAR the todo list before implementation.
-
-| Edge Case | Action |
-|-----------|--------|
-| No interruption (immediate auth) | Skip todo clearing (todos still valid) |
-| Todo list already empty | Skip todo clearing (no-op) |
-| Label already removed | Skip label removal (no-op) |
-| STATUS has no suffix | Skip STATUS edit (no-op) |
-
-### Label Handling
-
-**The `needs-approval` label is informational when explicit authorization is present.**
-
-| Situation | Action |
-|-----------|--------|
-| User authorizes AND label present | Proceed with implementation. Label is informational, not blocking. |
-| User authorizes AND no label | Proceed with implementation. |
-| No authorization AND label present | HALT and wait for explicit authorization. |
-| No authorization AND no label | Check for other blockers; proceed if clear. |
-
-**Workflow:**
-1. **Explicit authorization received** → Clean up markers (label, STATUS, todos) → Proceed (label status is informational)
-2. **No explicit authorization** → Check for `needs-approval` label
-3. **Label present without authorization** → HALT and wait for user to authorize
-
-### Todo List Cleanup (MANDATORY)
-
-**When authorization received after workflow interruption:**
-
-Workflow interruptions include:
-- Developer conversation (clarification questions)
-- Spec revision
-- Context switch to different issue/task
-- Error recovery
-- Session boundary
-
-**Action:** Clear todo list BEFORE starting implementation:
-
-```python
-todowrite(todos=[])
-```
-
-**Edge cases:**
-
-| Scenario | Action |
-|----------|--------|
-| No interruption (immediate auth) | Skip todo clearing (todos still valid) |
-| Todo list already empty | Skip todo clearing (no-op) |
-| Clarification question answered | Clear todos (workflow restarted) |
-| Spec revised | Clear todos (scope changed) |
-
-**Rationale:** Todos track progress within a workflow. Workflow interruption invalidates that progress tracking - the new implementation starts fresh.
-
-### Bug Report Response
-
-When bug report requires code changes:
-
-1. Add `needs-approval` label
-2. Post additional spec comment
-3. HALT immediately
-4. Wait for explicit `go` or `approved`
-
-## Closed-Issue Audit (CRITICAL)
-
-**When a closed issue is targeted for implementation via `#N approved`, the agent MUST audit before proceeding.**
-
-### Why This Matters
-
-Issuing `#N approved` for a closed issue assumes closure was correct. Without audit:
-
-- Incorrectly-closed parents with open children propagate violations
-- Agent implements on top of already-broken workflow state
-- Missing work goes undetected
-
-### Pre-Authorization Audit (MANDATORY)
-
-**When `#N approved` targets a closed issue:**
-
-1. **Query sub-issues immediately**: `github_issue_read(method="get_sub_issues", issue_number=N)`
-2. **Detect violations**: Open sub-issues on closed parent = violation
-3. **If NO sub-issues or ALL sub-issues closed**: Proceed to implementation
-4. **If ANY sub-issue open**: Execute closed-issue remediation workflow (see `124-github-archive-workflow.md`)
-
-### Direct Inspection Requirement (CRITICAL)
-
-**NEVER rely on comments, changelogs, or memory.**
-
-The agent MUST inspect the project directly:
-
-| Evidence Type | Inspection Method | What It Proves |
-|---------------|-------------------|----------------|
-| **Code changes** | Read actual files mentioned in spec | Implementation exists or doesn't |
-| **PR merge state** | `github_pull_request_read(method="get")` | PR was merged or wasn't |
-| **Branch state** | `git log`, `git branch` | Commits exist in history |
-| **Database state** | Query actual database/tables | Schema/data changes applied |
-| **Config state** | Read actual config files | Configuration changed |
-
-**FORBIDDEN Evidence Sources:**
-- Issue comments (indirect, unverified)
-- Memory from previous sessions
-- Changelogs/README notes
-- Issue body claims (only spec requirements are factual)
-- Project conventions/assumptions
-
-### Remediation Decision Tree
-
-**Based on direct inspection results:**
-
-| Inspection Result | Correct Action |
-|------------------|----------------|
-| Code exists in codebase as specified | Close sub-issue: `completed` |
-| PR exists and `merged_at` is set | Close sub-issue: `completed` |
-| No code, no PR, nothing implemented | **Reopen parent** (work not done) |
-| Parent closed, no merged PR | **Reopen parent** (premature closure) |
-| Superseding issue exists with completed work | Verify superseding issue complete, close: `not_planned` |
-
-### Remediation Comments
-
-**When agent remediates, it posts comments with direct inspection results:**
-
-```
-🤖 ✅ **Auto-Remediated: [Action]**
-
-Parent issue #N was closed while this sub-issue remained open.
-
-**Direct Inspection Results:**
-- [Actual file/code checked and result]
-- [Actual PR state from API call]
-- [Actual evidence from project]
-
-**Action:** [Close/Open] based on direct inspection
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-### When to HALT During Audit
-
-**HALT only when direct inspection is impossible:**
-- Cannot access codebase (permission error)
-- Cannot call GitHub API (network/auth failure)
-- Spec is ambiguous about what deliverables to check
-
-**HALT with actionable message explaining what couldn't be inspected.**
-
-### Integration Points
-
-| Workflow Stage | Guideline Reference |
-|----------------|---------------------|
-| Pre-authorization audit | This section |
-| Post-merge cleanup | `124-github-archive-workflow.md` → "Parent Closure Pre-Check" |
-| Skill enforcement | `approval-gate` skill → `verify-authorization` task |
-
-## What This Guideline Does NOT Cover
-
-**The skill handles procedural workflow:**
-
-- Spec + approval requirements details
-- Re-evaluation checklist
-- Pre-implementation verification steps
-- Single-task exemption logic
-- Authorization scope rules
-- Workflow decision tree
-
-**See the skill for complete implementation details.**
-
 ## Questions Are Not Bypass Authorization (CRITICAL)
 
 **⚠️ Answering questions is NOT authorization verification. Questions are NOT a shortcut around mandatory checks.**
-
-### The Problem
-
-Agents treat question-answering as a shortcut to bypass verification:
-
-- User asks "Should I implement #123?" → Agent implements #123
-- User asks "Would #456 fix the issue?" → Agent implements #456
-- User says "approved check pr" → Agent treats "approved" as authorization AND skips verification
-
-This is WRONG. Questions require verification FIRST, then response.
 
 ### 🚫 FORBIDDEN (ZERO TOLERANCE)
 
@@ -544,7 +190,6 @@ This is WRONG. Questions require verification FIRST, then response.
 | Answering question without checking conflicts | Duplicate/wasted work |
 | Treating question as authorization shortcut | Questions are NOT approval |
 | Skipping verification because "user asked" | User inquiry ≠ permission to bypass |
-| Responding to "#123 approved check pr" without checking | Compound text parsing is evasion |
 
 ### ✅ REQUIRED SEQUENCE
 
@@ -556,45 +201,6 @@ This is WRONG. Questions require verification FIRST, then response.
 4. **If question is about implementation**: Check authorization separately
 5. **If question implies implementation**: HALT and wait for explicit `approved`/`go`
 
-### Question Types and Required Responses
-
-| Question Type | Required Response |
-|----------------|-------------------|
-| "Should I implement #123?" | Verify #123 first, then answer if it's valid. Do NOT implement. |
-| "Would #456 fix the issue?" | Analyze #456, then answer. Do NOT implement. |
-| "#123 approved" | Parse as standalone token. Implement #123. |
-| "#123 approved check pr" | Parse "approved" as standalone → implement. "check pr" is additional instruction. |
-| "What's the status of #789?" | Verify #789's state, then answer. No implementation implied. |
-| "Can you fix the bug?" | Create spec, add `needs-approval`, HALT. Answer "yes, spec created." |
-
-### Authorization Token Parsing (CRITICAL)
-
-**Approval tokens must be STANDALONE (separated by whitespace) to count.**
-
-| Message | Token Parsing | Authorization? | Action |
-|---------|---------------|----------------|--------|
-| `approved check pr` | ["approved", "check", "pr"] | YES (approved standalone) | Implement, then check PR |
-| `#196 approved` | ["approved"] | YES | Implement #196 |
-| `#196 approvedcheck pr` | ["approvedcheck"] | NO (compound text) | Respond to question, do NOT implement |
-| `check pr` | No approval token | NO | Check PR, do NOT implement |
-
-**CRITICAL**: Do NOT parse compound text to extract approval. If "approved" is not surrounded by whitespace, it is NOT authorization.
-
-### Why This Matters
-
-- Questions can be answered without authorization
-- Authorization enables implementation, not shortcuts
-- Verification protects against stale/conflicting specs
-- Proper parsing prevents compound-text bypass
-
-### Integration with Verification-First Protocol
-
-This section COMPLEMENTS the Verification-First Response Protocol in `085-engineering-approach.md`:
-
-- **Verification-First**: Run checks before ANY response
-- **Questions Are Not Bypass**: Authorization is separate from question-answering
-- **Together**: Verify first, answer question, THEN check authorization if implementation implied
-
 ## Related Guidelines
 
 | Guideline | Purpose |
@@ -604,4 +210,4 @@ This section COMPLEMENTS the Verification-First Response Protocol in `085-engine
 | `120-github-issue-first.md` | Issue-first strategy and sub-issues |
 | `124-github-archive-workflow.md` | Issue closure timing |
 | `github-sub-issues` skill | Sub-issue creation workflow |
-| `pr-creation-workflow` skill | PR creation timing |
+| `pr-creation-workflow` skill | PR creation timing

--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -12,103 +12,66 @@ These standards apply to **ALL code artifacts**: Python modules, Jupyter noteboo
 - **Strict Enum Mapping**: DB-stored enums use plain string values (`NEW_DISCOVERY = "new_discovery"`).
   Emojis/presentation strings handled as properties or mapping functions, never stored in DB.
 - **Parsing Logic Changes**: Changes to `src/commons/parsing/` affecting extracted metadata require a full pipeline
-  rerun from Step 100 (`0100_ingest_xml.ipynb`) — performed by the user, not the agent. A change **affects extracted
-  metadata** if it alters the values, presence, or format of any field written to the database or output files. Agent
-  MUST NOT write DB remediation, backfill, or migration code to compensate for parsing changes; the pipeline rerun
-  handles data consistency. Flag the rerun requirement to the user after making such changes. Redundant "safety-net"
-  updates in downstream notebooks prohibited.
+  rerun from Step 100 (`0100_ingest_xml.ipynb`) — performed by the user, not the agent.
 
 ## Design Principles — ENFORCED UNIVERSALLY
 
 > **See `code-size-enforcement` skill for complete size limit enforcement rules, detection methods, and violation recovery.**
 
-- **KISS (Keep It Simple, Stupid)**: Simplest correct solution. No unnecessary abstraction or cleverness. Prefer straightforward, readable code over "clever" optimizations.
-- **DRY (Don't Repeat Yourself)**: No duplicated logic. Extract shared functionality into reusable functions/modules. If you copy-paste code, you're doing it wrong.
-- **Non-Monolithic**: Break large blocks into cohesive, independent components. Notebooks should have focused cells — cells that do "one thing."
-- **Modular**: Each function, class, module, notebook cell, and document section should have a single clear purpose and minimal dependencies.
-- **Single Function Methods**: Every function/method performs exactly ONE task. If a function has multiple responsibilities, split it. Decompose ALL tasks, plans, and algorithms into discrete single-function methods. This applies to:
-  - Python functions in `.py` files
-  - Notebook cells (each cell should do ONE thing)
-  - LaTeX/XeLaTeX environments and macros (one purpose each)
-  - Scripts and configuration files
-- **No Monoliths**: Long procedural blocks are prohibited. If a function exceeds 350 words, decompose it. If a notebook cell exceeds 450 words, split it into multiple cells.
-- **No Magic Strings or Numbers**: All literal strings and numbers that carry domain meaning must be extracted to named
-  constants (`UPPER_SNAKE_CASE` at module level, or class-level `ClassVar`) before use. Inline literals are only
-  acceptable for truly universal values (e.g., `0`, `1`, `""`, `True`, `False`, HTTP status `200`).
+- **KISS (Keep It Simple, Stupid)**: Simplest correct solution. No unnecessary abstraction or cleverness.
+- **DRY (Don't Repeat Yourself)**: No duplicated logic. Extract shared functionality into reusable functions/modules.
+- **Non-Monolithic**: Break large blocks into cohesive, independent components.
+- **Modular**: Each function, class, module, notebook cell should have a single clear purpose and minimal dependencies.
+- **Single Function Methods**: Every function/method performs exactly ONE task.
+- **No Monoliths**: Long procedural blocks are prohibited. If a function exceeds 350 words, decompose it.
+- **No Magic Strings or Numbers**: Extract domain meaning to named constants (`UPPER_SNAKE_CASE`).
 - **No Re-exports** (ABSOLUTE PROHIBITION):
   - NEVER add `from X import Y` or `__all__` to `__init__.py` files.
-  - `__init__.py` must contain ONLY a module docstring describing the package purpose.
-  - All imports must reference concrete module paths (e.g., `from commons.mesh.validator import MeshValidator`,
-    NOT `from commons.mesh import MeshValidator`).
-  - Rationale: Re-exports break IDE "Find Usages" and "Go to Definition" by creating false source locations.
-  - Existing `__all__` entries in legacy files are assumed approved — do not remove them without explicit instruction.
-  - When creating a NEW `__init__.py`, it must be docstring-only. When editing an existing `__init__.py`, do not add
-    any imports or `__all__` entries.
-- **Top-Level Documentation**: Every Python source file must include a brief top-level comment identifying the
-  package's or class's purpose. Use a module docstring (preferred) or a leading `#` comment. Keep it to one or two
-  concise sentences — enough for `ai_bin/py structure` to display alongside the filename.
-- **Docstring/Comment Determinism**: Pydoc/docstrings and code comments must use deterministic wording. Avoid ambiguous hedge/alternative phrasing such as `maybe`, `if ... or ...`, `and/or`, or `A + B or C` when describing required behavior, validation paths, or implementation intent.
-- **Labels Over Index Numbers**: When editing structured artifacts (notebooks, migration lists, cell arrays, ordered
-  configs), add and use stable labels/names so that inserts, deletes, and moves which change index numbers do not cause
-  edit failures. Reference items by label, not by positional index.
+  - `__init__.py` must contain ONLY a module docstring.
+  - All imports must reference concrete module paths.
+- **Top-Level Documentation**: Every Python source file must include a brief top-level comment.
+- **Docstring/Comment Determinism**: Use deterministic wording. Avoid ambiguous phrasing.
+- **Labels Over Index Numbers**: Reference items by label, not by positional index.
 
 ## Modern Python
 
-- **Pathlib**: `pathlib.Path` exclusively for file/dir ops. No `os.path.join`, `os.mkdir`, string concatenation. Use `/`
-  operator.
+- **Pathlib**: `pathlib.Path` exclusively for file/dir ops. No `os.path.join`, `os.mkdir`, string concatenation.
 - **f-strings**: For all string interpolation. No `.format()` or `%` unless required by external libs.
-- **Metadata Integrity**: Use `shutil.copy2` (not `shutil.copy`). Never discard metadata unless explicitly instructed.
+- **Metadata Integrity**: Use `shutil.copy2` (not `shutil.copy`).
 
 ## Libraries & Packages
 
-- Use NLP packages (e.g., NLTK) for NLP tasks — no regex for NLP. NLP tasks include tokenization, stemming,
-  lemmatization, part-of-speech tagging, named entity recognition, and sentence segmentation. Simple pattern matching
-  or fixed-format extraction does not qualify and may use regex. For tasks requiring complex pattern logic beyond
-  simple fixed-format extraction, prefer FSM or LALR-type grammars (e.g., `lark`, `pyparsing`) over regex — regex is
-  brittle on live data.
+- Use NLP packages (e.g., NLTK) for NLP tasks — no regex for NLP. For complex pattern logic, prefer FSM/LALR grammars.
 - All DB/system ops use existing project libraries. Direct data file manipulation prohibited unless instructed.
 - Use `ConfigurationManager` for all data file paths — never hardcode or assume data file locations.
-  `project-config.ini` is located at project root; initialize `ConfigurationManager` with the project root path (
-  resolved via root resolution per `120-scripting.md`).
+
+---
 
 ## Print Statements & Output
 
-- **NO narration/signal prints**: Never add print statements that narrate code changes, signal feature updates, or announce implementation details. Print statements are for data output and user-facing information only.
-- **NO pedantic notes in code**: Lines like `print("Note: X now uses Y")` or `print("Feature Z implemented")` are prohibited. Code should speak for itself through documentation and version control.
-- **Valid print uses**: Progress bars, data summaries, error messages, user-facing status, diagnostic output during development/testing.
-- **Invalid print uses**: Announcing "implementation complete", narrating changes, signaling "now using X", helpful hints, tutorial-style output, any form of self-documentation via print.
-- **Examples of prohibited prints**:
-  - `print("Note: Visualizations now use dark mode")`
-  - `print("Feature X enabled")`
-  - `print("Using new algorithm for Y")`
-  - `print("Implementation complete - phase 1")`
-- **If context is needed**: Add a docstring, code comment, or update documentation — never a print statement.
+- **NO narration/signal prints**: Never add print statements that narrate code changes or announce implementation details.
+- **NO pedantic notes in code**: Lines like `print("Note: X now uses Y")` are prohibited.
+- **Valid print uses**: Progress bars, data summaries, error messages, user-facing status, diagnostic output.
+- **Invalid print uses**: Announcing "implementation complete", narrating changes, tutorial-style output.
+- **If context is needed**: Add a docstring or code comment — never a print statement.
+
+---
 
 ## Linting & Static Analysis
 
 ### ⚠️ MANDATORY: Pre-Lint File Type Verification
 
-**Running the wrong linter on the wrong file type is a CRITICAL GUIDELINE VIOLATION that causes noise and wastes time.**
+**Running the wrong linter on the wrong file type is a CRITICAL GUIDELINE VIOLATION.**
 
 **Verification Before Each Lint Command:**
 
-```bash
-# STEP 1: Verify file type
-ls -la src/ | head -5  # Check what files exist
+1. **Verify file type**: `ls -la src/ | head -5`
+2. **Select CORRECT tool for file type**:
+   - Python files? Use Python tools (`ruff`, `pyright`)
+   - Markdown files? Use markdown tools (`pymarkdownlnt`, `mdformat`)
+   - Mixed? Run SEPARATE commands for each type
 
-# STEP 2: Select CORRECT tool for file type
-# Python files? Use Python tools
-# Markdown files? Use markdown tools
-# Mixed? Run SEPARATE commands for each type
-
-# STEP 3: Run lint command ONLY on correct file types
-uvx ruff check --fix src/ test/           # Python only
-uvx pymarkdownlnt scan -r docs/           # Markdown only
-```
-
-### 🚫 PROHIBITED Misuse
-
-**DO NOT run Python tools on non-Python files:**
+### Correct Tool Usage
 
 | Tool | Python Files | Markdown Files |
 |------|--------------|----------------|
@@ -118,35 +81,9 @@ uvx pymarkdownlnt scan -r docs/           # Markdown only
 | `pymarkdownlnt` | 🚫 PROHIBITED | ✅ REQUIRED |
 | `mdformat` | 🚫 PROHIBITED | ✅ REQUIRED |
 
-Running `ruff check` or `ruff format` on `.md` files is a **CRITICAL GUIDELINE VIOLATION**.
+**Running `ruff check` on `.md` files is a CRITICAL GUIDELINE VIOLATION.**
 
-### Correct Tool Usage
-
-**Python files (`.py`):**
-```bash
-uvx ruff check --fix src/ test/   # Lint + auto-fix
-uvx ruff format src/ test/        # Format
-uvx pyright src/                  # Type check
-uvx vulture src/                  # Dead code scan
-```
-
-**Markdown files (`.md`):**
-```bash
-uvx pymarkdownlnt scan -r .opencode/guidelines/ docs/   # Lint
-uvx mdformat .opencode/guidelines/ docs/                # Format
-```
-
-**Rationale:** Python linters (`ruff`, `pyright`, `vulture`) are designed for Python syntax and will produce incorrect or useless results when run on markdown files. Use markdown-specific tools (`pymarkdownlnt`, `mdformat`) for markdown files.
-
-### Cross-Check Verification Table
-
-| Linter Tool | Python Files | Markdown Files |
-|-------------|--------------|----------------|
-| `ruff` | ✅ REQUIRED | 🚫 PROHIBITED |
-| `pyright` | ✅ REQUIRED | 🚫 PROHIBITED |
-| `vulture` | ✅ OPTIONAL | 🚫 PROHIBITED |
-| `pymarkdownlnt` | 🚫 PROHIBITED | ✅ REQUIRED |
-| `mdformat` | 🚫 PROHIBITED | ✅ REQUIRED |
+---
 
 ## Numbering — ENFORCED
 
@@ -161,7 +98,7 @@ All enumeration lists, numbered sections, and step sequences in documentation MU
 - Code comments explaining 0-indexed array access
 - Technical documentation explicitly explaining zero-based indexing concepts
 
-**Rationale:** Documentation is for humans. Natural counting matches human cognition.
+---
 
 ## AI Co-Authored Attribution (MANDATORY)
 
@@ -198,20 +135,11 @@ AI co-authorship applies to **creative, original content authored by AI**:
 ### What Does NOT Require AI Attribution
 
 **Standard/boilerplate content does NOT require AI attribution:**
-- Standard licenses (MIT, Apache, GPL, etc.) - these are established legal templates
-- Auto-generated files (lock files, build artifacts, `__pycache__`)
-- Framework boilerplate (default configs, standard project structures)
-- Minor edits to existing files (typo fixes, formatting)
-- Files with no creative content (empty `__init__.py`, pure config)
-
-**Copy-pasted content from ANY external source does NOT get AI attribution:**
-- Code copied from Stack Overflow, blogs, tutorials
-- Code copied from other projects/repositories
-- Documentation copied from official sources
-- Configuration copied from templates/examples
-- **If it was copy-pasted, it's NOT AI-co-authored** - the original source holds copyright
-
-**Rationale:** AI attribution is about transparency in creative work. Copying a standard MIT license, copying code from Stack Overflow, or copy-pasting documentation from another project requires no AI creativity - those sources hold their own copyrights. Only genuinely original content created by AI deserves AI co-authorship attribution.
+- Standard licenses (MIT, Apache, GPL, etc.) - established legal templates
+- Auto-generated files (lock files, `__pycache__`)
+- Framework boilerplate (default configs, project structures)
+- Minor edits (typo fixes, formatting)
+- **Copy-pasted content from ANY external source** - original source holds copyright
 
 ### Files Requiring Attribution
 
@@ -226,7 +154,7 @@ AI co-authorship applies to **creative, original content authored by AI**:
 
 | File Type | Reason |
 |-----------|--------|
-| LICENSE files | Standard legal templates (MIT, Apache, etc.) |
+| LICENSE files | Standard legal templates (MIT, Apache, GPL) |
 | `pyproject.toml`, `setup.py` | Boilerplate configuration |
 | Lock files (`uv.lock`, `package-lock.json`) | Auto-generated |
 | Empty `__init__.py` | No content |
@@ -279,6 +207,8 @@ AI co-authored attribution:
 3. Enables proper credit and traceability
 4. Helps identify AI-generated content for review
 5. **Respects copyright** - only claims co-authorship on genuinely original AI work
+
+---
 
 ## Cross-Reference Standards
 

--- a/.opencode/guidelines/111-git-commit-workflow.md
+++ b/.opencode/guidelines/111-git-commit-workflow.md
@@ -7,33 +7,28 @@
 - **NEVER run `git restore`, `git checkout`, `git reset`, `git clean`, or any other git command that discards or modifies working tree state.**
 - **NEVER discard uncommitted changes** — even if they appear to be formatting-only, unintended, or erroneous. Analysis commands are read-only.
 - **NEVER commit or merge without direct instruction.** Commits and merges may ONLY be initiated by the developer as a direct instruction to the AI agent. Autonomously committing or merging is FORBIDDEN.
-- **NEVER create a PR without direct instruction.** PRs require explicit developer request — the agent does NOT automatically create PRs after completing implementation. See `113-git-pr-workflow.md`.
+- **NEVER create a PR without direct instruction.** PRs require explicit developer request — see `113-git-pr-workflow.md`.
 - Agent MUST NOT create commit messages or scripts proactively (without user request).
-- When asked to "prepare a commit" — see Section 2 for the mandatory script-based workflow.
 
 ### STOP ASKING FOR COMMITS AND PRS
 
 The developer will say "commit" or "create a PR" when they want git operations. Until then, do nothing—no questions, no prompts:
 
 1. **After completing implementation**: Report completion concisely, then STOP and wait silently
-1. **Do NOT ask**: "Commit?", "Ready to commit?", "Should I commit?", "Ready for a PR?", "Create a PR?", "Push and PR?"
-1. **Do NOT automatically create PRs**: PR creation requires the same explicit instruction as commits
+2. **Do NOT ask**: "Commit?", "Ready to commit?", "Should I commit?", "Ready for a PR?", "Create a PR?", "Push and PR?"
+3. **Do NOT automatically create PRs**: PR creation requires the same explicit instruction as commits
 
 ### ✅ ALWAYS DO
 
 - **Include co-author trailers for both AI and human collaborator.** Every implementation commit MUST include TWO trailers:
   - AI author: Use the AI's actual identity dynamically (the AI knows its own name)
-  - Human collaborator: Use session-cached values from `000-session-init.md` "MANDATORY FIRST STEP" (`DEV_NAME`, `DEV_EMAIL`)
-- Re-run discovery (`git status`, `git diff`) before any commit workflow.
-- If `pyproject.toml` changed, include `uv.lock`.
+  - Human collaborator: Use session-cached values from `000-session-init.md`
+- Re-run discovery (`git status`, `git diff`) before any commit workflow
+- If `pyproject.toml` changed, include `uv.lock`
 
 ### Co-Author Trailer Workflow
 
 **⚠️ CRITICAL: AI Identity is DYNAMIC — NEVER copy the AI name from examples!**
-
-The AI must use its **own identity**, not the example name. Examples show placeholders like `OpenCode` — the actual AI must substitute its own name/email.
-
-**Step 1: Determine AI identity dynamically:**
 
 | Identity Component | How to Detect | FORBIDDEN |
 |-------------------|---------------|-----------|
@@ -41,40 +36,19 @@ The AI must use its **own identity**, not the example name. Examples show placeh
 | `<ModelID>` | Backing model ID at runtime | Copying "ollama-cloud/*" from examples |
 | `<ai-email>` | Agent's noreply email | Using project domain email |
 
-- The AI uses its **own actual identity** (the AI knows its own name and email)
-- **DO NOT use generic placeholders like "AI"** — use the actual AI agent name (e.g., "OpenCode Desktop", "OpenCode")
-- **Email format**: Use a noreply address associated with the AI service (e.g., `noreply@opencode.ai`, `noreply@anthropic.com`)
-- **NEVER use the project domain** (e.g., `ai@<project-domain>.com` is WRONG — those belong to the human collaborators)
-- **MODEL INFO REQUIRED**: The AI MUST include the backing model name and size/provider in the co-author trailer:
-  - Format: `<AgentName> (<ModelID>) <ai-email>`
-  - **Example:** `Co-authored-by: <AgentName> (<ModelID>) <ai-email>`
-
 **When Identity Unknown:**
 - STOP and ask user for clarification
 - DO NOT use example values as defaults
 - DO NOT guess or invent identity values
 
-**Example Values in Guidelines are ILLUSTRATIVE:**
-- `<AgentName> (<ModelID>)` → Example only
-- `AI Assistant (model-id)` → Placeholder only
-- **DETECT YOUR OWN IDENTITY** at runtime
-
-**Step 2: Use cached human identity from session start:**
-
-- Human collaborator values are cached at session start via `000-session-init.md` "MANDATORY FIRST STEP"
-- `DEV_NAME`: Human's name (or `$USER` fallback)
-- `DEV_EMAIL`: Human's email (or `$USER@$HOSTNAME` fallback)
-- **Do NOT re-run `git config`** — use stored session values
-
-**Step 3: Include BOTH trailers (MANDATORY):**
-
+**Format:**
 ```bash
 git commit -m "message" \
     --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
     --trailer "Co-authored-by: <Human-Name> <human-email>"
 ```
 
-______________________________________________________________________
+---
 
 ## 2. Preparing Commits (Script-Based Workflow)
 
@@ -83,47 +57,37 @@ When asked to "prepare a commit" (or similar READ-ONLY phrase):
 **Mandatory Steps:**
 
 1. Run read-only commands: `git status`, `git diff`, `git diff --cached`, `git log`
-1. Summarize the changes (grouped logically if multiple files)
-1. **Create a shell script in `./tmp/`** containing the `git add` and `git commit` commands
-1. **STOP** — do NOT run the script, do NOT run `git add` or `git commit`
-1. Report the script path and proposed commit message for the user to review and execute
+2. Summarize the changes (grouped logically if multiple files)
+3. **Create a shell script in `./tmp/`** containing the `git add` and `git commit` commands
+4. **STOP** — do NOT run the script, do NOT run `git add` or `git commit`
+5. Report the script path and proposed commit message for the user to review and execute
 
-______________________________________________________________________
+---
 
 ## 3. Reading Historical Content
 
 ### ✅ ALWAYS DO
 
-- To inspect a file at a historical commit, use `git show <ref>:<path> > ./tmp/historical_file.ext`.
-- Process the saved file with the appropriate `ai_bin/` or IDE tool.
+- To inspect a file at a historical commit, use `git show <ref>:<path> > ./tmp/historical_file.ext`
+- Process the saved file with the appropriate `ai_bin/` or IDE tool
 
 ### 🚫 NEVER DO
 
-- Using `python3`, `python -c`, `json.tool`, `grep`, or `sed` to process `git show` output is a critical violation.
+- Using `python3`, `python -c`, `json.tool`, `grep`, or `sed` to process `git show` output is a critical violation
 
-______________________________________________________________________
+---
 
 ## 4. Lockfile Policy
 
-- This repository is an application/CI repo — commit `uv.lock`.
+- This repository is an application/CI repo — commit `uv.lock`
 
-______________________________________________________________________
+---
 
 ## 5. WIP Commit Before HALT (MANDATORY)
 
+> **See `git-workflow` skill → `implementation` task for complete WIP commit workflow.**
+
 **CRITICAL: Work-in-progress commits MUST be made before ANY HALT to prevent data loss.**
-
-### Why WIP Commits Are Required
-
-When implementation halts (for ANY reason), uncommitted changes are at risk:
-
-- Session crashes
-- Context window exhaustion
-- Developer needs to switch branches
-- Machine restarts
-- Awaiting clarification/approval
-
-WIP commits preserve work in progress in recoverable git history.
 
 ### When to Commit WIP
 
@@ -136,67 +100,17 @@ WIP commits preserve work in progress in recoverable git history.
 | Error encountered | WIP commit | `WIP: Phase N - error: description` |
 | Session ending | WIP commit | `WIP: Phase N - session end` |
 
-### WIP Commit Workflow
-
-**Before ANY HALT (awaiting approval, clarification, error, session end):**
-
-```bash
-# Step 1: Check for uncommitted changes
-git status
-
-# Step 2: If changes exist, commit WIP
-git add -A
-git commit -m "WIP: Phase N - <brief description>" \
-    --trailer "Co-authored-by: <AI-Name> (<model-id>) <ai-email>" \
-    --trailer "Co-authored-by: <Human-Name> <human-email>"
-
-# Step 3: Verify commit was created
-git log -1 --oneline
-
-# Step 4: Report WIP commit made
-```
-
-### WIP Commit Characteristics
-
-| Characteristic | Description |
-|---------------|-------------|
-| **Prefix** | Always starts with `WIP:` for easy identification |
-| **Phase** | Includes phase number for context |
-| **Description** | Brief description of what was being worked on |
-| **Trailers** | Same co-author trailers as full commits |
-| **Squashable** | Can be squashed or amended later with subsequent work |
-
-### After WIP Commit
-
-- **Continue work**: Next commit can amend or squash the WIP commit
-- **Session resumes**: Rebase or continue from WIP commit
-- **PR creation**: Squash WIP commits with final work before PR
-
 ### What Counts as HALT
 
 | HALT Trigger | WIP Required? |
 |-------------|--------------|
-| Awaiting approval | ✅YES |
+| Awaiting approval | ✅ YES |
 | Awaiting clarification | ✅ YES |
 | Mid-task pause | ✅ YES |
 | Error encountered | ✅ YES |
 | Session ending | ✅ YES |
 | Task complete | ❌ NO (use full commit) |
 | Phase complete | ❌ NO (use full commit) |
-
-______________________________________________________________________
-
-## 5.5. Todo Lifecycle During Workflow Transitions (MANDATORY)
-
-**Clear todos at these transition points:**
-
-| Transition Point | Action |
-|------------------|--------|
-| Implementation → PR creation | Clear implementation todos (no todo needed for PR steps) |
-| After PR creation | Clear PR workflow todos (waiting for human merge) |
-| After cleanup | Clear all todos (workflow complete) |
-
-**Why:** Each workflow phase has explicit steps in skills. Todo lists track implementation progress, not procedural steps.
 
 ### When to Clear Todos
 
@@ -209,46 +123,13 @@ todowrite(todos=[])
 ```
 
 **Workflow interruptions include:**
-
 - Developer conversation (clarification questions)
 - Spec revision
 - Context switch to different issue/task
 - Error recovery
 - Session boundary
 
-**Edge cases:**
-
-| Scenario | Action |
-|----------|--------|
-| No interruption (immediate auth) | Skip todo clearing (todos still valid) |
-| Todo list already empty | Skip todo clearing (no-op) |
-| Clarification question answered | Clear todos (workflow restarted) |
-| Spec revised | Clear todos (scope changed) |
-
-**Before PR creation workflow:**
-
-```python
-# See git-workflow skill pr-creation task
-todowrite(todos=[])
-```
-
-**After cleanup workflow:**
-
-```python
-# See git-workflow skill cleanup task
-todowrite(todos=[])
-```
-
-### Why Todo Clearing Matters
-
-- Implementation todos track progress within a workflow
-- PR creation has explicit procedural steps - no todo needed
-- Stale todos cause confusion about "X of Y complete"
-- Clean state on completion prevents confusion in next session
-
-______________________________________________________________________
-
-______________________________________________________________________
+---
 
 ## 6. Grouped-Step Commit Strategy
 
@@ -257,7 +138,6 @@ When implementing specs with multiple steps, create commits per logical group (n
 ### What Is a Commit Group?
 
 A commit group is a cohesive set of related changes that:
-
 - Implements one logical feature or fix
 - Can be reviewed independently
 - Makes sense as a standalone commit
@@ -279,51 +159,6 @@ A commit group is a cohesive set of related changes that:
 - One commit per step of multi-step spec (too granular)
 - All changes in one commit (too broad if multiple concerns)
 
-### Grouped Commit Workflow
-
-**Step 1: Identify Groups**
-
-- Analyze implementation to determine logical groups
-- Each group = one cohesive change
-- Groups should be independently reviewable
-
-**Step 2: Commit Each Group**
-
-```bash
-# Stage group changes
-git add <files-for-this-group>
-
-# Commit with descriptive message
-git commit -m "[Phase N] <group description>"
-
-# Post progress comment to issue
-```
-
-**Step 3: Progress Comments**
-After EACH commit group, post to the issue:
-
-```markdown
-**Summary:**
-
-<1-2 sentences describing the impact of this commit group.>
-
-**Outcome:** <What changed for stakeholders>
-
-**Commit Group:** <group name> (X of Y)
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-### When to Use Grouped vs Single
-
-| Implementation Type | Commit Strategy |
-|---------------------|-----------------|
-| Single-concern, cohesive | Single commit |
-| Multi-concern, separable | Grouped commits |
-| Large phase with sub-phases | Grouped by sub-phase |
-| Implementation + tests | Two commits (impl, then tests) |
-
 ---
 
 ## 7. Discrete Units and Concern-Based Phases
@@ -333,7 +168,6 @@ After EACH commit group, post to the issue:
 ### Discrete Unit Definition
 
 A discrete unit is an atomic, concern-scoped change that:
-
 - Modifies files related to ONE concern (layer, module, responsibility)
 - Can be cherry-picked independently without breaking builds
 - Can be reverted without leaving orphaned dependencies
@@ -346,34 +180,6 @@ A discrete unit is an atomic, concern-scoped change that:
 | **Phase** | Entire concern boundary | Multiple commits (one per discrete unit) |
 | **Discrete Unit** | Atomic change within phase | ONE git commit |
 | **Commit Group** | Multiple discrete units (same concern) | Multiple commits (reviewed together) |
-
-### Example: Authentication Feature
-
-**Phase 1: Data Layer (Risk: LOW, Blast Radius: SMALL)**
-
-```
-Phase 1 contains 3 discrete units:
-
-Step 1.1: Add user table schema        → Commit 1 (discrete unit)
-Step 1.2: Create migration script      → Commit 2 (discrete unit)
-Step 1.3: Add seed data for testing    → Commit 3 (discrete unit)
-
-All 3 commits are in the SAME phase (same concern boundary).
-```
-
-**Phase 2: Business Logic (Risk: MEDIUM, Blast Radius: MEDIUM)**
-
-```
-Phase 2 depends on Phase 1 (interdependency).
-
-Phase 2 contains 3 discrete units:
-
-Step 2.1: Create AuthRepository class   → Commit 4 (discrete unit)
-Step 2.2: Implement password hashing  → Commit 5 (discrete unit)
-Step 2.3: Add session management        → Commit 6 (discrete unit)
-
-All 3 commits are in the SAME phase (same concern boundary).
-```
 
 ### WIP Commit Positioning
 
@@ -407,119 +213,6 @@ Phase 1 commits:
   Step 1.3 → Commit 3
 ```
 
-### Cherry-Pick Workflow for Discrete Units
-
-**Each discrete unit can be cherry-picked independently:**
-
-```bash
-# Cherry-pick a single discrete unit from Phase 1
-git cherry-pick <commit-1>  # User table schema
-
-# Cherry-pick entire Phase 1
-git cherry-pick <commit-1>..<commit-3>  # All of Phase 1
-
-# Cherry-pick by concern
-git cherry-pick <phase-1-commits>  # All data layer changes
-```
-
-**With interdependency ordering, cherry-picks are safe:**
-- Phase 1 commits have NO dependencies (can be cherry-picked first)
-- Phase 2 commits depend on Phase 1 (cherry-pick after Phase 1)
-- Phase 3 commits depend on Phase 2 (cherry-pick after Phase 2)
-
-### Revert Workflow for Single-Phase Changes
-
-**Reverting by phase (not by commit):**
-
-```bash
-# Revert entire Phase 2
-git revert <phase-2-first-commit>..<phase-2-last-commit>
-
-# Revert single discrete unit
-git revert <commit-4>  # Revert AuthRepository class only
-
-# Revert and preserve history
-git revert --no-commit <phase-2-commits>  # Stage for review
-```
-
-**Phase-level reverts preserve interdependency ordering:**
-- Reverting Phase 2 doesn't break Phase 1 (Phase 1 has no dependencies)
-- Reverting Phase 2 doesn't break Phase 3 (Phase 3 doesn't exist yet)
-
-### Interactive Rebase for Rearranging Phases
-
-**Phases can be reordered within dependency constraints:**
-
-```bash
-# Interactive rebase to rearrange phases
-git rebase -i origin/dev
-
-# Can swap Phase 2 and Phase 3 if they don't depend on each other
-# CANNOT swap Phase 1 and Phase 3 if Phase 3 depends on Phase 1
-```
-
-**Dependency check before reordering:**
-1. Build dependency graph for all phases
-2. Verify no circular dependencies
-3. Reorder only if dependencies are satisfied
-
-### Examples of Discrete Unit Breakdown
-
-**Example 1: Simple Feature (2 Phases)**
-
-```
-Phase 1: Config Update (Risk: LOW, Blast Radius: SMALL)
-  └── Step 1.1: Update database connection string  ← 1 discrete unit = 1 commit
-
-Phase 2: Documentation (Risk: LOW, Blast Radius: SMALL)
-  └── Step 2.1: Update README with new config  ← 1 discrete unit = 1 commit
-
-Total: 2 phases, 2 discrete units, 2 commits
-```
-
-**Example 2: Complex Feature (8 Phases)**
-
-```
-Phase 1: Database Schema (Risk: LOW, Blast Radius: SMALL)
-  ├── Step 1.1: Create migration file           ← Discrete unit
-  ├── Step 1.2: Add user table                  ← Discrete unit
-  ├── Step 1.3: Add indexes                     ← Discrete unit
-  ├── Step 1.4: Add foreign keys                ← Discrete unit
-  └── Step 1.5: Update schema version           ← Discrete unit
-  Total: 5 discrete units = 5 commits
-
-Phase 2: Data Layer Tests (Risk: LOW, Blast Radius: SMALL)
-  └── Step 2.1: Add tests for user table        ← 1 discrete unit = 1 commit
-
-Phase 3: Business Logic (Risk: MEDIUM, Blast Radius: MEDIUM)
-  ├── Step 3.1: Create AuthRepository class      ← Discrete unit
-  ├── Step 3.2: Implement password hashing       ← Discrete unit
-  └── Step 3.3: Add session management           ← Discrete unit
-  Total: 3 discrete units = 3 commits
-
-... (remaining phases follow same pattern)
-
-Total: 8 phases, ~15 discrete units, ~15 commits
-```
-
-**Example 3: Refactoring (3 Phases)**
-
-```
-Phase 1: Extract Interfaces (Risk: MEDIUM, Blast Radius: MEDIUM)
-  ├── Step 1.1: Create IUserRepository interface ← Discrete unit
-  ├── Step 1.2: Extract method signatures         ← Discrete unit
-  └── Step 1.3: Update existing implementations  ← Discrete unit
-  Total: 3 discrete units = 3 commits
-
-Phase 2: Integration Layer (Risk: MEDIUM, Blast Radius: MEDIUM)
-  └── Step 2.1: Replace UserRepository usage ← 1 discrete unit = 1 commit
-
-Phase 3: Remove Old Code (Risk: LOW, Blast Radius: SMALL)
-  └── Step 3.1: Delete old UserRepository class ← 1 discrete unit = 1 commit
-
-Total: 3 phases, 5 discrete units, 5 commits
-```
-
-______________________________________________________________________
+---
 
 *Source: Content migrated from `110-git-protocol.md`*

--- a/.opencode/guidelines/124-github-archive-workflow.md
+++ b/.opencode/guidelines/124-github-archive-workflow.md
@@ -1,25 +1,16 @@
 # GitHub Workflow: Archive & Issue Closure
 
+> **See `git-workflow` skill → `cleanup` task for issue closure procedure.**
+
 ## Archive Workflow (Completion)
 
-### When to Archive
-
-Archive a spec **immediately** after the final phase is approved and the PR is merged:
-
+**Archive a spec immediately after PR merge:**
 1. All steps marked `☑`
 2. PR merged (not just created)
 3. Add closing summary comment to issue
 4. Close the GitHub Issue (state change only)
 
-### Archive Process
-
-#### When GitHub MCP Tools Available
-
-1. **All specs use GitHub Issues as the authoritative source** (no local files needed)
-2. **Archive process**: Add closing summary comment, then close the GitHub Issue
-3. **Issue reference**: Add `ISSUE: https://github.com/<owner>/<repo>/issues/<number>` to the closed issue body if needed
-
-⚠️ **CRITICAL**: NEVER edit the issue body when closing. Adding `STATUS: completed` or `COMPLETED: YYYY-MM-DD` to the body destroys history. Use comments instead.
+⚠️ **CRITICAL**: NEVER edit the issue body when closing. Use comments instead.
 
 ---
 
@@ -49,8 +40,6 @@ Archive a spec **immediately** after the final phase is approved and the PR is m
 **Before closing ANY issue, the agent MUST call `github_pull_request_read method=get` to verify the PR is merged.**
 
 **MANDATORY Pre-Close Checklist (NO EXCEPTIONS):**
-
-Before closing ANY issue (parent OR child), the agent MUST complete this checklist in order:
 
 | Step | Action | MUST Result |
 |------|--------|-------------|
@@ -189,43 +178,6 @@ Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
 
 **After closing child issues addressed by PR, ALWAYS verify remaining sub-issues before closing parent.**
 
-**The Problem:**
-- Single PR may address multiple sub-issues
-- Agent may close sub-issues prematurely (before PR merge)
-- Agent may forget to close sub-issues after PR merge
-- Parent gets closed while children remain open
-
-**Required Double-Check Workflow:**
-
-```python
-# After closing child issues addressed by PR:
-# 1. Get parent issue number from PR body (Fixes #123)
-# 2. Query for remaining open sub-issues
-
-children = github_issue_read(method="get_sub_issues", issue_number=parent_issue)
-open_children = [c for c in children if c.state == "open"]
-
-if open_children:
-    # Double-check: are these children addressed by this PR?
-    for child in open_children:
-        if child_was_addressed_by_pr(child, pr_number):
-            # Close child that PR addressed but wasn't closed earlier
-            close_with_summary(child, pr_number)
-        else:
-            # Orphaned child — log warning
-            comment(f"⚠️ Child issue #{child['number']} remains open after parent closed by PR #{pr_number}")
-    
-    # Re-query after closing children addressed by PR
-    children = github_issue_read(method="get_sub_issues", issue_number=parent_issue)
-    open_children = [c for c in children if c.state == "open"]
-
-# Only close parent if ALL children are now closed
-if not open_children:
-    close_parent_with_summary(parent_issue, pr_number)
-else:
-    comment(f"Parent #{parent_issue} left open — {len(open_children)} child issue(s) remain")
-```
-
 **Critical Rules:**
 1. **NEVER close parent while children remain open**
 2. **Always query for sub-issues before closing parent**
@@ -246,58 +198,27 @@ else:
 
 **Before closing ANY parent issue, the agent MUST perform intelligent verification.**
 
-### Why Agent Intelligence Is Required
-
-**A script cannot determine intent from open/closed state alone.**
-
-| Scenario | Script Detection | Agent Intelligence Required |
-|----------|-----------------|----------------------------|
-| Child open, work done | Detects "open" | Check comments, verify PR linked, confirm implementation complete |
-| Child closed "not planned" | Detects "closed" | Understand intentional non-completion |
-| Child superseded | Detects "open" | Follow comment links to replacement issue |
-| Parent correctly closed | Flags violation | Determine all children actually complete via context |
-
 ### Pre-Close Checklist
 
 **Before closing a parent `[SPEC]` issue, the agent MUST:**
 
-#### Step 1: Query Sub-Issues
+| Step | Action |
+|------|--------|
+| **1** | Query sub-issues: `github_issue_read(method="get_sub_issues", issue_number=<parent>)` |
+| **2** | Classify each sub-issue (closed/completed/superseded/incomplete) |
+| **3** | All children closed/completed/superseded → ✅ Close parent |
+| **4** | Any child open + incomplete → 🚫 POST warning, DO NOT close |
 
-```
-Call github_issue_read(method="get_sub_issues", issue_number=<parent>)
-```
+### Classification Rules
 
-If empty (no sub-issues) → Proceed to close parent (single-task issue).
+| Sub-Issue State | Evidence Required |
+|-----------------|-------------------|
+| Closed as "completed" | `state_reason: "completed"` |
+| Closed as "not planned" | `state_reason: "not_planned"` + explanation comment |
+| Superseded by another issue | "Superseded by #N" link in comments + verify #N exists |
+| Work done but forgot to close | PR linked in body/comments + verify PR merged |
 
-If non-empty → Continue to Step 2.
-
-#### Step 2: Classify Each Sub-Issue
-
-For each sub-issue, check:
-
-**Already Closed:**
-- `state: "closed"` with `state_reason: "completed"` → Done, proceed
-- `state: "closed"` with `state_reason: "not_planned"` → Intentionally not done, proceed
-
-**Open but May Be Complete:**
-- Check comments for "Superseded by #N" link → Verify replacement exists, treat as closed
-- Check body for PR link (e.g., "Fixes #N", "Closes #N") → If PR merged, work may be done
-- Check comments for "work completed" or "implemented in" → May qualify as complete
-
-**Open and Incomplete:**
-- No PR link, no superseded link, work not done → **BLOCK parent closure**
-
-#### Step 3: Decision Logic
-
-| Classification | Action |
-|----------------|--------|
-| All children closed/completed/superseded | ✅ Proceed to close parent |
-| Any child open + incomplete | 🚫 POST warning comment, DO NOT close parent |
-| Unclear status | Stop and ask user for clarification |
-
-#### Step 4: Post Warning (If Blocked)
-
-If parent cannot be closed:
+### Warning Post (If Blocked)
 
 ```markdown
 🤖 ⚠️ **Cannot Close Parent — Open Sub-Issues Detected**
@@ -306,16 +227,10 @@ This parent issue cannot be closed because the following sub-issue(s) remain inc
 
 - #N: [Title] — [state, labels, status]
 
-**Status Analysis:**
-- [For each open sub-issue, state why it cannot be closed]
-
 **To close this parent:**
 1. Complete the remaining sub-issue(s)
 2. Close each sub-issue when work is complete
 3. Or close sub-issue as "not planned" with explanation if intentionally skipped
-
-**Manual Override:**
-If parent should close despite open children, add a comment explaining why remaining work is no longer needed, then request manual close.
 
 ---
 🤖 ⚠️ Blocking by <AgentName> (<ModelID>)
@@ -340,44 +255,11 @@ If parent should close despite open children, add a comment explaining why remai
 | Open with "in-progress" label | Currently being worked |
 | Open, no PR, no superseded link | Work not started or incomplete |
 
-### Example Pre-Close Check
-
-```
-SPEC #100 (parent) - Ready to close
-├── Task #101: Database schema
-│   └── state: "closed", state_reason: "completed" ✅
-├── Task #102: API endpoints
-│   └── state: "closed", state_reason: "not_planned" (comment: "Moved to Phase 2") ✅
-└── Task #103: UI components
-    └── state: "open", comment: "Superseded by #150"
-        → Agent verifies #150 exists and covers UI ✅
-
-Result: All sub-issues accounted for. Proceed to close #100.
-```
-
-```
-SPEC #100 (parent) - Blocked from closing
-├── Task #101: Database schema
-│   └── state: "closed", state_reason: "completed" ✅
-├── Task #102: API endpoints
-│   └── state: "open", labels: ["needs-approval"] 🚫
-
-Result: #102 is open and awaiting approval. POST warning comment. DO NOT close #100.
-```
-
 ---
 
 ## ⚠️ ENFORCED: Closed-Issue Remediation (Pre-Authorization Audit)
 
 **When a closed issue is targeted for implementation via `#N approved`, the agent MUST audit before proceeding.**
-
-### Why This Matters
-
-Issuing `#N approved` for a closed issue assumes closure was correct. Without audit:
-
-- Incorrectly-closed parents with open children propagate violations
-- Agent implements on top of already-broken workflow state
-- Missing work goes undetected
 
 ### Pre-Authorization Audit (MANDATORY)
 
@@ -392,26 +274,20 @@ Issuing `#N approved` for a closed issue assumes closure was correct. Without au
 
 **NEVER rely on comments, changelogs, or memory.**
 
-The agent MUST inspect the project directly:
-
 | Evidence Type | Inspection Method | What It Proves |
 |---------------|-------------------|----------------|
 | **Code changes** | Read actual files mentioned in spec | Implementation exists or doesn't |
 | **PR merge state** | `github_pull_request_read(method="get")` | PR was merged or wasn't |
 | **Branch state** | `git log`, `git branch` | Commits exist in history |
 | **Database state** | Query actual database/tables | Schema/data changes applied |
-| **Config state** | Read actual config files | Configuration changed |
 
 **FORBIDDEN Evidence Sources:**
 - Issue comments (indirect, unverified)
 - Memory from previous sessions
 - Changelogs/README notes
 - Issue body claims (only spec requirements are factual)
-- Project conventions/assumptions
 
-### Remediation Actions (Determined by Direct Inspection)
-
-**The agent inspects the project directly and determines action:**
+### Remediation Actions
 
 | Direct Inspection Result | Correct Action |
 |-------------------------|----------------|
@@ -421,51 +297,11 @@ The agent MUST inspect the project directly:
 | Parent closed, no merged PR | **Reopen parent** (premature closure) |
 | Superseding issue exists with completed work | Verify superseding issue is complete, then close: `not_planned` |
 
-### Remediation Comments
-
-**When agent remediates, it posts comments with direct inspection results:**
-
-```
-🤖 ✅ **Auto-Remediated: [Action]**
-
-Parent issue #N was closed while this sub-issue remained open.
-
-**Direct Inspection Results:**
-- [Actual file/code checked and result]
-- [Actual PR state from API call]
-- [Actual evidence from project]
-
-**Action:** [Close/Open] based on direct inspection
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-### When to HALT
-
-**HALT only when direct inspection is impossible:**
-- Cannot access codebase (permission error)
-- Cannot call GitHub API (network/auth failure)
-- Spec is ambiguous about what deliverables to check
-
-**HALT with actionable message explaining what couldn't be inspected.**
-
 ---
 
 ## ⚠️ ENFORCED: Superseded Issue Closure (Without Implementation)
 
 **Issues superseded by new issues MUST follow atomic closure workflow.**
-
-### The Problem
-
-When a user says "close this and create a new spec":
-
-1. Agent closes the old issue
-2. Agent claims "a new spec will be created" in closing comment
-3. Agent STOPS without creating the new spec
-4. The promise "will be created" was never kept
-
-**This is a CRITICAL GUIDELINE VIOLATION.**
 
 ### 🚫 PROHIBITED
 
@@ -484,8 +320,6 @@ When a user says "close this and create a new spec":
 
 ### ✅ REQUIRED ATOMIC WORKFLOW
 
-**"Close and Create New" Workflow:**
-
 | Step | Action | Order |
 |------|--------|-------|
 | Create new issue | Create the replacement issue FIRST | Step 1 |
@@ -493,31 +327,6 @@ When a user says "close this and create a new spec":
 | Close old issue | Add closing comment WITH replacement reference | Step 3 |
 
 **Critical: New issue MUST exist BEFORE closing old issue.**
-
-### Atomic Execution Example
-
-**User request:** "Close this and create a new spec for a 'spec-quality' skill"
-
-**CORRECT WORKFLOW:**
-```
-1. Create new issue #363 with title "[SPEC] Guidelines: ..."
-2. Note issue number: #363
-3. Close old issue #333 with comment:
-   "AI: <AgentName> (<ModelID>) on behalf of <HumanName> 🤖 
-    **Replaced By:** #363
-    
-    This issue is superseded by #363 without implementation.
-    The approach (static templates) was determined to be incorrect.
-    See #363 for the replacement spec."
-```
-
-**INCORRECT WORKFLOW:**
-```
-1. Close old issue #333 with comment:
-   "AI: OpenCode ... 
-    A new spec will be created separately"  ← WRONG: forward-looking claim
-2. STOP  ← WRONG: incomplete workflow
-```
 
 ### Closing Summary for Superseded Issues
 
@@ -537,23 +346,6 @@ When a user says "close this and create a new spec":
 ---
 🤖 ✅ Completed by <AgentName> (<ModelID>)
 ```
-
-### Why Atomic Execution Matters
-
-1. **Trust**: Agents must not make promises they don't keep
-2. **Traceability**: GitHub issues linked immediately, no lost references
-3. **Workflow integrity**: "Close and create" is ONE action, not two separate steps
-4. **User experience**: User expects both actions completed, not just one
-
-### Enforcement
-
-**spec-auditor skill checks:**
-
-- Does closing comment claim future action without execution?
-- Does issue reference a replacement that doesn't exist?
-- Is forward-looking language used ("will be created", "to be done") in closing comments?
-
-**If audit fails:** Reopen the issue, create the replacement, then close properly.
 
 ---
 

--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -1,46 +1,42 @@
 # Planning: Spec Creation
 
+> **See `dev-architect` skill for complete spec design workflow.**
+
 ## Spec-Driven Development Workflow
 
 AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach:
 
-1. **Specify Phase**: Define **What & Why**. Kick off with a high-level vision (product brief), then expand it into a detailed specification focusing on user journeys, experiences, and success criteria.
-2. **Plan Phase**: Define **How**. Draft the technical plan (architecture, technical stack, and constraints). **Invoke `/skill dev-architect --task design-plan` at Plan phase.**
-3. **Tasks Phase**: Break the plan into **small, reviewable chunks** (tasks) that can be implemented and tested in isolation.
+1. **Specify Phase**: Define **What & Why**. High-level vision → detailed specification.
+2. **Plan Phase**: Define **How**. Technical plan with architecture and constraints. **Invoke `/skill dev-architect --task design-plan` at Plan phase.**
+3. **Tasks Phase**: Break plan into **small, reviewable chunks**.
 4. **Implement Phase**: **Execute** tasks and **verify** results.
 
-**CRITICAL**: Investigation and Planning phases are AUTO-COMPLETED before the spec is created. The spec file ONLY contains implementation and verification phases.
+**CRITICAL**: Investigation and Planning phases are AUTO-COMPLETED before spec creation.
 
-**INVESTIGATION CHECKPOINT**: Before creating a spec, the agent MUST verify investigation is complete. Investigation completion criteria include: problem understood, codebase explored, hypotheses tested, alternatives considered, risks identified, and success criteria defined.
+**INVESTIGATION CHECKPOINT**: Before creating a spec, verify investigation is complete:
+- Problem understood with context
+- Codebase explored for existing patterns
+- Hypotheses tested with isolated test scripts
+- Alternatives considered with tradeoffs
+- Risks identified with mitigation strategies
+- Success criteria defined (testable, measurable)
 
 ---
 
-## 1.4. Concern-Based Phases with Interdependencies (MANDATORY)
+## Concern-Based Phases with Interdependencies (MANDATORY)
 
 **All specs MUST define phases based on separation of concerns, risk, blast radius, and interdependencies.**
 
 ### Phase Ordering Principles
 
-**Phases MUST be ordered using these principles (in priority order):**
-
 | Priority | Principle | Description |
 |----------|-----------|-------------|
-| **1 (HIGHEST)** | **Interdependencies First** | If Phase B depends on Phase A, then A MUST be implemented before B |
-| **2** | **Smallest Blast Radius** | Data layer changes before business logic before API/UI |
-| **3** | **Low Risk Before High Risk** | Read-only changes before mutations; additive before modifications |
+| **1 (HIGHEST)** | **Interdependencies First** | If Phase B depends on Phase A, A MUST be implemented first |
+| **2** | **Smallest Blast Radius** | Data layer before business logic before API/UI |
+| **3** | **Low Risk Before High Risk** | Read-only before mutations; additive before modifications |
 | **4** | **Single Concern Per Phase** | One layer, one module, or one responsibility per phase |
 
-### Interdependency Ordering (Critical)
-
-**TOP PRIORITY: Dependencies before dependents (topological order)**
-
-The interdependency ordering principle ensures:
-- **Cherry-pick safety**: Any single commit can be cherry-picked without breaking builds (dependencies are already present)
-- **Revert safety**: Reverting a commit won't leave orphaned dependents (dependents come later)
-- **Independent units**: Each discrete unit is independently buildable at its concern-level
-- **Atomic changes**: Each phase focuses on one concern boundary
-
-**Declaration Format:**
+### Interdependency Declaration (Required)
 
 Every phase MUST declare its interdependencies:
 
@@ -49,281 +45,19 @@ Every phase MUST declare its interdependencies:
 
 **Interdependencies**: [NONE | Phase M (what it requires)]
 
-**Why this order**: [Explanation of why this phase depends on previous phases]
-
-### Steps
-1. ☐ [first step]
-2. ☐ [second step]
-```
-
-**Example:**
-
-```markdown
-## Phase 3: Business Logic (Risk: MEDIUM, Blast Radius: MEDIUM)
-
-**Interdependencies**: Phase 1 (user table schema must exist)
-
-**Why this order**: AuthRepository depends on user table. Cannot implement business logic without data foundation.
-
-### Steps
-1. ☐ Create AuthRepository class
-2. ☐ Implement password hashing
-3. ☐ Add session management
-```
-
-### Topological Ordering Algorithm
-
-**When ordering phases, use this algorithm:**
-
-1. **Build dependency graph**: For each phase, identify all phases it depends on
-2. **Detect cycles**: If circular dependency found, refactor or combine phases
-3. **Topological sort**: Order phases so all dependencies come before dependents
-4. **Apply secondary principles**: Within dependency constraints, order by blast radius (smallest first), then risk (lowest first)
-
-**Conflict Resolution:**
-
-When ordering principles conflict, resolve in this order:
-1. **Interdependencies** (must be satisfied first - CYCLIC DEPENDENCIES ARE BLOCKING)
-2. **Blast Radius** (smaller scope preferred when no dependency conflict)
-3. **Risk** (lower risk preferred when blast radius is equal)
-4. **Concern Separation** (automatically satisfied if 1-3 are satisfied)
-
-### Separation of Concerns for Phases
-
-**What is a "concern" for phase definition?**
-
-A concern is a bounded area of responsibility with:
-- **Single layer**: Data, Business Logic, API, Presentation, Infrastructure
-- **Single module**: Authentication, Search, Notifications, Reporting
-- **Single responsibility**: Query optimization, Error handling, Caching
-
-**Phase should modify ONE concern:**
-
-| Phase Concern Type | Examples | What It Includes |
-|-------------------|----------|-----------------|
-| **Data Layer** | Database schema, migrations, repositories | Tables, indexes, data access code |
-| **Business Logic** | Services, domain models, validation rules | Core algorithms, business rules |
-| **API Layer** | Endpoints, request/response handling | HTTP handling, routing, serialization |
-| **Presentation** | UI components, views, templates | Frontend code, user interface |
-| **Infrastructure** | Caching, logging, monitoring | Cross-cutting concerns |
-| **Testing** | Unit tests, integration tests, E2E tests | Verification for a specific concern |
-
-**Phase isolation rules:**
-- Data layer changes should NOT touch API code
-- Business logic changes should NOT touch presentation layer
-- Each phase should be reviewable in isolation
-
-### Risk Profiles
-
-**Each phase MUST have a risk profile:**
-
-| Risk Level | Characteristics | Examples |
-|------------|-----------------|----------|
-| **LOW** | Read-only, additive, localized, easily reversible | Adding a new query, adding a new test file, documentation |
-| **MEDIUM** | Modifies existing code, affects one module, moderate rollback complexity | Refactoring a service, adding a new API endpoint, modifying schema |
-| **HIGH** | Breaking changes, affects multiple modules, hard to rollback, production-critical | Database migration, authentication rewrite, API versioning, deployment changes |
-
-### Blast Radius Assessment
-
-**Each phase MUST have a blast radius assessment:**
-
-| Blast Radius | Scope | Testing Required | Rollback Difficulty |
-|--------------|-------|------------------|---------------------|
-| **SMALL** | Single file/module, no dependencies | Unit tests only | Easy (simple revert) |
-| **MEDIUM** | Multiple files, internal dependencies | Integration tests | Moderate (may need data migration) |
-| **LARGE** | Cross-module, external dependencies | Full test suite | Difficult (may need data rollback, coordination) |
-
-### Cherry-Pick and Revert Guarantees
-
-**With interdependency ordering, the following guarantees apply:**
-
-**Cherry-Pick Guarantees:**
-- Any phase's commits can be cherry-picked independently (dependencies already present)
-- Build will not break from cherry-picking a single phase
-- Tests for that phase will pass without additional phases
-
-**Revert Guarantees:**
-- Reverting a phase won't break dependent phases (they don't exist yet)
-- No orphaned code or incomplete dependencies after revert
-- Clean rollback to previous phase boundary
-
-**Interactive Rebase Guarantees:**
-- Phases can be reordered within dependency constraints
-- Dropping a phase won't break later phases (dependency check required)
-- Squashing phases preserves interdependency ordering
-
-### Phase Template with Interdependencies
-
-**Required template for every phase:**
-
-```markdown
-## Phase N: [Concern Name] (Risk: [LOW|MEDIUM|HIGH], Blast Radius: [SMALL|MEDIUM|ARGE])
-
-**Interdependencies**: [NONE|Phase M (what must exist before this phase)]
-
-**Why this order**: [One-sentence explanation of dependency]
+**Why this order**: [One-sentence explanation]
 
 ### Steps
 1. ☐ [Specific, atomic step - one git commit]
-2. ☐ [Specific, atomic step - one git commit]
-3. ☐ [Specific, atomic step - one git commit]
-
-### Success Criteria
-1. ✅ [Measurable, testable criterion]
-2. ✅ [Measurable, testable criterion]
 ```
 
-**Example - Complete Feature:**
-
-```markdown
-## Phase 1: User Table Schema (Risk: LOW, Blast Radius: SMALL)
-
-**Interdependencies**: NONE
-
-**Why this order**: Foundation - no dependencies on other phases.
-
-### Steps
-1. ☐ Add users table with authentication columns
-2. ☐ Create user repository class
-3. ☐ Write migration script
+> **See `concern-separation-auditor` skill for complete phase structure validation.**
 
 ---
 
-## Phase 2: Authentication Service (Risk: MEDIUM, Blast Radius: MEDIUM)
+## Spec Requirements (MANDATORY)
 
-**Interdependencies**: Phase 1 (user table must exist)
-
-**Why this order**: Authentication service depends on user table for credential storage.
-
-### Steps
-1. ☐ Implement password hashing with bcrypt
-2. ☐ Add session token generation
-3. ☐ Create login/logout methods
-
----
-
-## Phase 3: API Endpoints (Risk: MEDIUM, Blast Radius: MEDIUM)
-
-**Interdependencies**: Phase 2 (authentication service must exist)
-
-**Why this order**: API endpoints expose authentication service through HTTP layer.
-
-### Steps
-1. ☐ Add /login endpoint
-2. ☐ Add /logout endpoint
-3. ☐ Add /refresh-token endpoint
-
----
-
-## Phase 4: Integration Tests (Risk: LOW, Blast Radius: MEDIUM)
-
-**Interdependencies**: Phases 1-3 (all functionality must exist)
-
-**Why this order**: Integration tests verify all components work together end-to-end.
-
-### Steps
-1. ☐ Write login flow test
-2. ☐ Write token refresh test
-3. ☐ Write logout flow test
-```
-
-### Circular Dependency Detection
-
-**If circular dependencies are detected, resolve by:**
-
-1. **Refactoring**: Split shared responsibilities into separate phases
-2. **Combining**: Merge interdependent phases into single larger phase
-3. **Extracting**: Create shared dependency that both phases can depend on
-
-**Example - Circular Dependency:**
-
-```
-Phase A depends on Phase B
-Phase B depends on Phase C
-Phase C depends on Phase A  ← CIRCULAR
-
-Solutions:
-1. Extract shared code into Phase D that A, B, C all depend on
-2. Combine A, B, C into a single phase
-3. Redesign to break circular dependency in architecture
-```
-
----
-
-## Terminology: Spec vs. Guideline Files
-
-- **"Create a new spec"** = Create a GitHub Issue with `[SPEC]` prefix (Mandatory when GitHub MCP available)
-- **"Create a guideline file"** = Create/modify files in `.opencode/guidelines/` (Implementation task)
-- **SPEC = GitHub Issue** — Specs are planning/tracking artifacts, not file system artifacts
-
----
-
-## 1. Listing Available Specs
-
-When the user issues commands `specs` or `pending`:
-
-1. **Gather all top-level specs**:
-   - Query open GitHub Issues with `[SPEC]` prefix in title
- 2. **Check for superseding issues AND staleness**:
-    - Before implementing OR revising a spec, query for later `[SPEC]` or `[SPEC-FIX]` or `[SPEC-ENHANCEMENT]` issues
-    - If a later issue supersedes, invalidates, or contradicts the active spec, HALT and report
-    - Implementation of a superseded spec is wasted work
-    - Check if other specs were implemented while this spec was pending (staleness)
-    - If stale, REVISE the spec to reflect current reality before proceeding
-    - Report the revision and HALT — wait for approval before proceeding
-3. **Present a multi-choice user query**:
-   - Use the `question` tool with a list of available specs
-   - Include spec title/name and current STATUS for each option
-   - Add a "Type your own answer" option for creating a new spec
-4. **Response format**:
-   ```
-   Available Specs:
-   - [SPEC] Feature A (STATUS: 1.2)
-   - [SPEC] Feature B (STATUS: 2.1)
-   - [SPEC] Bug Fix C (STATUS: 1.1)
-   ```
-5. **After user selection**:
-   - Load the selected spec content
-   - Show the spec details and current status
-   - Report that the spec is ready and HALT. Do NOT prompt for approval or "GO".
-
----
-
-## 1.1. GitHub MCP Required — No Fallback
-
-**When GitHub MCP tools are NOT available, the agent MUST refuse planning work entirely.**
-
-### 🚫 NO FALLBACK TO LOCAL FILES
-- **PROHIBITED**: Using `plans/SPEC-*.md` files as fallback when GitHub MCP is unavailable
-- **PROHIBITED**: Creating local plan files when GitHub MCP is unavailable
-- **PROHIBITED**: Proceeding with implementation without GitHub Issue tracking
-
-### ✅ REQUIRED ACTION
-- If GitHub MCP is unavailable, STOP immediately
-- Report: "GitHub MCP tools unavailable. Cannot create or track specs without GitHub Issues."
-- Wait for GitHub MCP to be restored before proceeding
-
----
-
-## 1. Spec Reality Sync
-
-**Specs must reflect current code/implementation state.** If drift is detected between a spec and the actual code:
-
-1. **Code is authoritative** — the spec is secondary
-2. **Update the spec to match reality** — this is administrative sync, not implementation
-3. **Report the synchronization and HALT**
-4. **This exemption applies ONLY to spec files in GitHub Issues**
-5. **`.opencode/guidelines/` modifications require full spec-first workflow**
-
----
-
-## 1.1. Engineering Requirements for Specs
-
-**Every specification MUST include thorough requirements analysis.**
-
-### Full Requirements Analysis Required
-
-Before any implementation, every spec must document:
+**Every specification MUST include:**
 
 | Requirement | Description |
 |-------------|-------------|
@@ -337,17 +71,6 @@ Before any implementation, every spec must document:
 | **Integrations** | How does this integrate with existing code? |
 | **Risk Assessment** | What could go wrong? Mitigation strategies? |
 
-### Design Phase Required
-
-**No direct-to-implementation.** Before coding:
-
-1. **Explore codebase** for existing patterns and reusable components
-2. **Document design decisions** in the spec
-3. **Consider alternatives** and their tradeoffs
-4. **Get approval on approach** before starting implementation
-
-### Anti-Patterns in Specifications
-
 **🚫 FORBIDDEN in Specs:**
 - Vague requirements ("make it better")
 - Missing success criteria
@@ -359,26 +82,11 @@ Before any implementation, every spec must document:
 
 ---
 
-## 1.2. User Prompt Preservation (MANDATORY)
+## User Prompt Preservation (MANDATORY)
 
 **When creating or revising a spec, the agent MUST preserve the user's original prompt as context.**
 
-### Why Prompt Preservation Matters
-
-The user's original prompt contains:
-- The initial intent and motivation behind the request
-- Nuanced context that may not be captured in the spec body
-- Specific constraints, preferences, or edge cases the user mentioned
-- Background information that informed the decision
-
-Without the original prompt context:
-- Future agents lose critical information about the user's intent
-- Decision rationale may be unclear
-- Subtle requirements may be missed in implementation
-
 ### Prompt Capture Requirement
-
-**ALWAYS capture the user prompt as a comment on the spec issue:**
 
 1. **When creating a new spec:**
    - After creating the GitHub Issue, immediately post a comment with the user prompt
@@ -386,71 +94,45 @@ Without the original prompt context:
 
 2. **When revising an existing spec:**
    - After updating the issue body, post a comment with the revision prompt
-   - Include both the new prompt and any additional context provided
 
 3. **Multiple prompts:**
-   - If the user provides multiple messages before spec creation, capture the triggering prompt
+   - Capture the triggering prompt
    - Optionally capture key context messages as separate comments
 
 ### What to Capture
 
-| Prompt Element | Capture? | Format |
-|----------------|----------|--------|
-| Exact user prompt text | ✅ YES | Verbatim or minimal editing |
-| Key context from conversation | ✅ YES | Summarized in separate section |
-| Decision to create spec | ✅ YES | Brief note on why spec was created |
-| Code snippets in prompt | ✅ YES | Include verbatim |
+| Prompt Element | Capture? |
+|----------------|----------|
+| Exact user prompt text | ✅ YES |
+| Key context from conversation | ✅ YES |
+| Decision to create spec | ✅ YES |
+| Code snippets in prompt | ✅ YES |
 
-### Edge Cases
-
-| Scenario | Action |
-|----------|--------|
-| Prompt is very long | Summarize key points, link to full conversation if available |
-| User provides clarifications | Add clarification comments separately |
-| Confidential/sensitive info | Allow user to redact before posting |
-
-### Integration with Fresh-Start Context
-
-User prompt preservation COMPLEMENTS the fresh-start context rules:
-
-| Context Type | Location |
-|--------------|----------|
-| User's original prompt | First comment on issue |
-| Detailed analysis | Issue body (Problem Statement, Context, etc.) |
-| Related issues | Issue body (Related Issues section) |
-| User clarifications | Follow-up comments |
-
-**The prompt comment provides the "WHY" — the issue body provides the "WHAT" and "HOW".**
+> **See `github-comments` skill → "User Prompt Comment Format" section.**
 
 ---
 
-## 1.3. Fresh-Start Context Requirements
+## Fresh-Start Context Requirements (MANDATORY)
 
-**All specs, bug reports, and issues MUST be self-contained for agents with NO memory context.**
+**All specs MUST be self-contained for agents with NO memory context.**
 
-A different AI agent (or the same agent after a context reset) may pick up this spec without:
+A different AI agent may pick up this spec without:
 - Prior conversation history
 - Mental context from discovery phases
 - Background knowledge of why decisions were made
 
 ### Mandatory Self-Containment Rules
 
-**Specs MUST include ALL context inline:**
-
 1. **No "see above" or "as discussed" references**
-   - ❌ "As discussed above..."
-   - ❌ "See the previous comment..."
-   - ❌ "As mentioned in the chat..."
    - ✅ RESTATE all information inline in the spec
 
 2. **Explicit file/line references**
    - Include exact file paths: `src/module/file.py`
-   - Use STABLE ANCHORS: function names `process_data()`, class names `ClassName`, or section headers `"Section Name"`
+   - Use STABLE ANCHORS: function names, class names, section headers
    - ⚠️ AVOID line numbers `file.py:42` — they break on every edit
-   - Include relevant code snippets (if short, <20 lines)
 
 3. **Cross-references with context**
-   - When referencing other issues/specs: include issue number AND brief summary
+   - Include issue number AND brief summary
    - Include URLs: `https://github.com/<owner>/<repo>/issues/123`
    - State WHY the reference matters
 
@@ -461,12 +143,10 @@ A different AI agent (or the same agent after a context reset) may pick up this 
 
 ### Fresh-Start Context Checklist
 
-Before submitting any spec, verify ALL of the following:
-
 | Element | Required Content |
 |---------|------------------|
 | **Problem Statement** | What is broken/needed and WHY (with context) |
-| **Affected Files** | List of files with function/section anchors and snippets |
+| **Affected Files** | List of files with function/section anchors |
 | **Related Issues** | Links + summaries + relevance explanation |
 | **Context** | Background on affected systems, prior decisions |
 | **Constraints** | Technical, resource, time, compatibility limits |
@@ -477,40 +157,56 @@ Before submitting any spec, verify ALL of the following:
 | **Risk Assessment** | What could go wrong and mitigations |
 | **Decision Rationale** | Why this approach was chosen |
 
-### Example: Bad vs Good Spec Context
+---
 
-**❌ BAD (assumes memory context):**
-> Fix the bug in the authentication module as discussed.
+## Spec Reality Sync
 
-**✅ GOOD (self-contained):**
-> **Problem:** The OAuth2 token refresh fails when the refresh token expires (issue #123).
->
-> **Location:** `src/auth/oauth_client.py` in `refresh_token()` function:
-> ```python
-> def refresh_token(self):
->     # BUG: Does not handle expired refresh_token
->     response = self._request_token(...)
->     # Raises TokenExpiredError instead of re-authenticating
-> ```
->
-> **Context:** Users reported being logged out after 7 days (token expiry). Related to #100 (persistent sessions).
->
-> **Decision:** Re-authenticate using stored credentials rather than failing.
+**Specs must reflect current code/implementation state.** If drift is detected:
+
+1. **Code is authoritative** — the spec is secondary
+2. **Update the spec to match reality** — this is administrative sync, not implementation
+3. **Report the synchronization and HALT**
+4. **This exemption applies ONLY to spec files in GitHub Issues**
+5. **`.opencode/guidelines/` modifications require full spec-first workflow**
 
 ---
 
-## 2. Spec Persistence
+## GitHub MCP Required — No Fallback
 
-### GitHub Issues Are the Authoritative Source
+**When GitHub MCP tools are NOT available, the agent MUST refuse planning work entirely.**
 
-**GitHub Issues are ALWAYS the spec tracking mechanism, regardless of MCP availability:**
+### 🚫 NO FALLBACK TO LOCAL FILES
+- **PROHIBITED**: Using `plans/SPEC-*.md` files as fallback
+- **PROHIBITED**: Creating local plan files when GitHub MCP unavailable
+- **PROHIBITED**: Proceeding with implementation without GitHub Issue tracking
 
-- **When GitHub MCP tools available**: Use GitHub MCP tools for all GitHub operations
-- **When GitHub MCP unavailable**: Use `gh` CLI for GitHub operations
-- **NO LOCAL PLAN FILES**: There is no fallback to `plans/SPEC-*.md` files
-
-This ensures consistent workflow and prevents context fragmentation.
+### ✅ REQUIRED ACTION
+- If GitHub MCP is unavailable, STOP immediately
+- Report: "GitHub MCP tools unavailable. Cannot create or track specs without GitHub Issues."
+- Wait for GitHub MCP to be restored before proceeding
 
 ---
 
-*Source: Content migrated from `040-plan-delivery.md`*
+## Terminology: Spec vs. Guideline Files
+
+- **"Create a new spec"** = Create a GitHub Issue with `[SPEC]` prefix
+- **"Create a guideline file"** = Create/modify files in `.opencode/guidelines/`
+- **SPEC = GitHub Issue** — Specs are planning/tracking artifacts, not file system artifacts
+
+---
+
+## Listing Available Specs
+
+When the user issues commands `specs` or `pending`:
+
+1. **Gather all top-level specs**: Query open GitHub Issues with `[SPEC]` prefix in title
+2. **Check for superseding issues AND staleness**: Query for later `[SPEC]`/`[SPEC-FIX]`/`[SPEC-ENHANCEMENT]` issues
+3. **Present a multi-choice user query**: Use `question` tool with spec titles and STATUS
+4. **After user selection**: Load spec content, show current status, HALT
+
+**Response format:**
+```
+Available Specs:
+- [SPEC] Feature A (STATUS: 1.2)
+- [SPEC] Feature B (STATUS: 2.1)
+```

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -1,6 +1,9 @@
-______________________________________________________________________
-
-## name: git-workflow description: Git Workflow Enforcer ensuring all git operations follow the repository's strict branch-first, stash-first, squash-merge workflow. Invoked automatically before implementation and when PR creation is requested. license: MIT compatibility: opencode
+---
+name: git-workflow
+description: Git Workflow Enforcer ensuring all git operations follow the repository's strict branch-first, stash-first, squash-merge workflow. Invoked automatically before implementation and when PR creation is requested.
+license: MIT
+compatibility: opencode
+---
 
 # Skill: git-workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,25 +44,47 @@ uv run python ai_bin/session_init.py
 
 ---
 
-## Core Workflow (References)
+## Skills-First Workflow
 
-| Topic | Guideline File |
-|-------|----------------|
-| Branch Before Edit | `110-git-branch-first.md` |
-| Stash External Changes | `110-git-branch-first.md` §1.1 |
-| WIP Commit Before HALT | `111-git-commit-workflow.md` §5 |
-| Todo Tracking | `111-git-commit-workflow.md` §5.5 |
-| MCP Tool Usage | `015-mcp-preference.md`, `mcp-tool-usage` skill |
-| Notebook Operations | `061-notebook-rules.md`, `notebook-operations` skill |
-| Authorization Gate | `010-approval-gate.md`, `approval-gate` skill |
-| Spec Creation | `140-planning-spec-creation.md` |
-| Issue Closure | `124-github-archive-workflow.md` |
-| Critical Rules | `000-critical-rules.md` |
-| Engineering Approach | `085-engineering-approach.md` |
-| Environment | `070-environment.md` |
-| Code Standards | `080-code-standards.md` |
-| Data Integrity | `090-data-integrity.md` |
-| Error Handling | `090-data-integrity.md` (see `implementation-quality` skill for data patterns) |
+**ALL procedural workflows are in skills. Guidelines contain ONLY essential rules.**
+
+### Master Trigger Table
+
+| Workflow Trigger | Invocation |
+|------------------|------------|
+| Before ANY file edit | `/skill approval-gate --task verify-authorization` |
+| Before implementation | `/skill approval-gate --task verify-sub-issues` |
+| After authorization | `/skill git-workflow --task pre-work` |
+| After implementation | `/skill git-workflow --task review-prep` (AUTOMATIC) |
+| "create a PR" | `/skill git-workflow --task pr-creation` |
+| "PR merged" | `/skill git-workflow --task cleanup` |
+| Before creating file | `/skill implementation-quality --task file-locations` |
+| At implementation start | `/skill implementation-quality --task code-structure` |
+| Before running commands | `/skill implementation-quality --task environment` |
+| Before handling data | `/skill implementation-quality --task data-integrity` |
+| Writing code | `/skill code-size-enforcement` |
+| After ANY code/guideline/skill/task change | `/skill code-review` (MANDATORY) |
+| Before spec approval | `/skill concern-separation-auditor --issue N` (FIRST) |
+| After concern auditor | `/skill spec-auditor --issue N` (SECOND) |
+| After spec auditor | `/skill dev-architect --task review-spec` (THIRD) |
+
+**See `.opencode/skills/` for complete skill documentation.**
+
+---
+
+## Essential Rules (Zero Tolerance)
+
+| Rule | Description |
+|------|-------------|
+| Spec before code | NO code changes WITHOUT approved spec |
+| Authorization required | NO implementation WITHOUT `"approved"` or `"go"` |
+| Branch first | Create feature branch BEFORE any file modification |
+| Human-only merge | Agents MUST NEVER merge PRs |
+| Silent halt | HALT after completion — no prompts |
+| PR timing | PRs require explicit `"create a PR"` instruction |
+| MCP tools | Use PyCharm/GitHub MCP for file operations when available |
+| `/tmp/` prohibited | Use `./tmp/` only |
+| Notebook operations | Use `the-notebook-mcp` ONLY — never edit `.ipynb` directly |
 
 ---
 
@@ -100,77 +122,42 @@ uv run python ai_bin/session_init.py
 
 ---
 
-## Skills (Mandatory Invocation)
+## Guideline Files (Rules Only)
 
-**Master Trigger Table:**
+| Guideline | Purpose |
+|-----------|---------|
+| `000-critical-rules.md` | Zero tolerance violations |
+| `000-session-init.md` | Startup sequence |
+| `010-approval-gate.md` | Authorization workflow |
+| `015-mcp-preference.md` | Tool selection |
+| `020-go-prohibitions.md` | GO command limits |
+| `050-scope-autonomy.md` | Scope restrictions |
+| `060-tool-usage.md` | Tool usage rules |
+| `061-notebook-rules.md` | Notebook operations |
+| `070-environment.md` | Environment setup |
+| `075-docs-verification.md` | Documentation verification |
+| `080-code-standards.md` | Code quality standards |
+| `085-engineering-approach.md` | Engineering principles |
+| `086-http-requests.md` | HTTP request standards |
+| `087-no-backward-compat.md` | Refactoring rules |
+| `090-data-integrity.md` | Data handling rules |
+| `100-persistence.md` | PostgreSQL/SQLAlchemy standards |
+| `110-git-branch-first.md` | Branch workflow |
+| `111-git-commit-workflow.md` | Commit standards |
+| `112-git-merge-protocol.md` | Merge protocol |
+| `113-git-pr-workflow.md` | PR workflow |
+| `114-git-branch-cleanup.md` | Branch cleanup |
+| `115-git-hotfix-workflow.md` | Hotfix workflow |
+| `120-github-issue-first.md` | Issue workflow |
+| `121-github-pr-workflow.md` | PR creation |
+| `122-github-mcp-operations.md` | GitHub MCP |
+| `123-github-ai-identity.md` | AI identity in comments |
+| `124-github-archive-workflow.md` | Issue closure |
+| `125-github-issue-comments.md` | Comment protocol |
+| `130-authority-source.md` | Code as authority |
+| `140-planning-spec-creation.md` | Spec creation |
 
-| Workflow Trigger | Invocation |
-|------------------|------------|
-| Before ANY file edit | `/skill approval-gate --task verify-authorization` |
-| Before implementation | `/skill approval-gate --task verify-sub-issues` |
-| After authorization | `/skill git-workflow --task pre-work` |
-| After implementation | `/skill git-workflow --task review-prep` (AUTOMATIC) |
-| "create a PR" | `/skill git-workflow --task pr-creation` |
-| "PR merged" | `/skill git-workflow --task cleanup` |
-| Before creating file | `/skill implementation-quality --task file-locations` |
-| At implementation start | `/skill implementation-quality --task code-structure` |
-| Before running commands | `/skill implementation-quality --task environment` |
-| Before handling data | `/skill implementation-quality --task data-integrity` |
-| Writing code | `/skill code-size-enforcement` |
-| After ANY code/guideline/skill/task change | `/skill code-review` (MANDATORY) |
-| Before spec approval | `/skill concern-separation-auditor --issue N` (FIRST) |
-| After concern auditor | `/skill spec-auditor --issue N` (SECOND) |
-| After spec auditor | `/skill dev-architect --task review-spec` (THIRD) |
-
-**See full skill list in `.opencode/skills/`**
-
----
-
-## 🚫 NEVER (Zero Tolerance)
-
-- Write code without approved spec
-- Interpret questions as authorization
-- Proceed after completing task — **SILENTLY HALT**
-- Create PRs without explicit "create a PR" instruction
-- Bypass `git-workflow` skill for PR/cleanup operations
-- Use `/tmp/` — only `./tmp/`
-- Delete merged branches — delete **IMMEDIATELY** after merge
-- Prompt via issue comments — no "awaiting authorization" dialogs
-- Run notebooks with production data without explicit authorization
-- Implement scope creep — ONLY what spec requests
-- Use shell redirects on notebooks — use `the-notebook-mcp` exclusively
-- `git restore` on external changes — **`git stash` FIRST**
-- Copy hardcoded identity examples — **extract from system prompt**
-- Make code/guideline/skill/task changes without running `/skill code-review` AFTER changes
-- **Post session summaries, chit-chat, or interactive questions to GitHub Issues** — ALL chat session communication goes to CHAT ONLY, NEVER to GitHub Issues
-
----
-
-## Guideline Violations
-
-**If agent violates guideline:**
-
-1. STOP task
-2. Update this file "NEVER" list
-3. Update relevant `.opencode/guidelines/` file
-4. Document fix in issue comment (FACTUAL ONLY)
-5. Wait for confirmation before resuming
-
----
-
-## Session Communication
-
-**Chat vs. GitHub Issues:**
-
-| Output Type | Destination |
-|-------------|-------------|
-| Session summaries, progress updates | CHAT ONLY |
-| Interactive questions, chit-chat | CHAT ONLY |
-| Audit logs | Internal (`./tmp/`) — NOT posted anywhere |
-| Investigation artifacts | GitHub Issues (only when substantive) |
-| Closure summaries | GitHub Issues (historical record) |
-
-**CRITICAL:** ALL chat session communication goes to CHAT ONLY, NEVER to GitHub Issues. Audit logs are internal artifacts — do NOT post to chat or GitHub unless explicitly requested.
+**Procedural content moved to skills.** Guidelines now contain ONLY rules.
 
 ---
 
@@ -184,6 +171,32 @@ uv run python ai_bin/session_init.py
 - `<ai-email>` → Agent's noreply email
 
 **Example values in guidelines are ILLUSTRATIVE ONLY — substitute your actual identity.**
+
+---
+
+## Session Communication
+
+| Output Type | Destination |
+|-------------|-------------|
+| Session summaries, progress updates | CHAT ONLY |
+| Interactive questions, chit-chat | CHAT ONLY |
+| Audit logs | Internal (`./tmp/`) — NOT posted anywhere |
+| Investigation artifacts | GitHub Issues (only when substantive) |
+| Closure summaries | GitHub Issues (historical record) |
+
+**CRITICAL:** ALL chat session communication goes to CHAT ONLY, NEVER to GitHub Issues. Audit logs are internal artifacts — do NOT post to chat or GitHub unless explicitly requested.
+
+---
+
+## Guideline Violations
+
+**If agent violates guideline:**
+
+1. STOP task
+2. Update this file "NEVER" list
+3. Update relevant `.opencode/guidelines/` file
+4. Document fix in issue comment (FACTUAL ONLY)
+5. Wait for confirmation before resuming
 
 ---
 


### PR DESCRIPTION
## Summary

Skills-first workflow restructuring moves procedural content from guidelines to skills, reducing guideline size by ~60% while preserving enforcement. Guidelines now contain only essential rules; skills hold all workflows and procedures.

## Changes

- **Changed: Skills-First Workflow Restructuring**: Major reorganization where guidelines now contain ONLY essential rules, and all procedural content moved to skills. This reduces guideline word count by ~60% while preserving all enforcement capabilities. Skills now hold complete workflows, examples, and step-by-step procedures.
- **Pruned Guidelines**: Reduced 8 guideline files by removing duplicated procedural content:
  - `000-critical-rules.md`: 1454 → 449 lines (removed audit procedures)
  - `140-planning-spec-creation.md`: 515 → 220 lines (removed phase templates)
  - `111-git-commit-workflow.md`: 465 → 250 lines (removed WIP examples)
  - `000-session-init.md`: 293 → 150 lines (condensed enforcement table)
  - `080-code-standards.md`: Removed lint command examples
  - `124-github-archive-workflow.md`: 594 → 386 lines (moved procedures to skill)
- **Fixed: git-workflow Skill Frontmatter**: Corrected YAML frontmatter format to ensure skill is properly detected by opencode.
- **Key Principle**: Guidelines = rules only. Skills = procedures and workflows.

Fixes #494