### PR TITLE
[SPEC] Continue skills-first guideline pruning (phase 2)

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on
 
 ## [0.2.0] - Unreleased
 
+### feature/continue-skills-first-494
+
+- **Refactored: Guidelines Pruning Phase 2**: Removed duplicate procedural content
+  from guidelines, consolidating enforcement rules. Three guideline files pruned:
+  - `070-environment.md`: 2117 → 471 words (78% reduction) — removed isolated tool
+    examples, consolidated enforcement table
+  - `085-engineering-approach.md`: 1937 → 461 words (76% reduction) — moved
+    checklists to implementation-quality skill
+  - `124-github-archive-workflow.md`: 2127 → 1018 words (52% reduction) —
+    consolidated merge verification
+- **Key Principle Enforcement**: Guidelines now contain ONLY essential rules.
+  All procedural content, examples, and step-by-step procedures moved to skills.
+- **Addresses**: GitHub issue #494 (Continue Skills-First)
+
 ### skills-first-workflow
 
 - **Changed: Skills-First Workflow Restructuring**: Major reorganization where

--- a/.opencode/guidelines/070-environment.md
+++ b/.opencode/guidelines/070-environment.md
@@ -2,143 +2,32 @@
 
 ## Python Environment
 
-- Use `uv sync` for environment setup (creates venv and installs in editable mode). All Python execution via
-  `uv run python`. Package ops: add dependencies by editing `pyproject.toml` then running `uv sync` — never `uv add`. `pip` prohibited. No `sys.path` hacks or manual
-  path additions.
-- **Never use `python3` or `python` directly** — always `uv run python`. Never prefix commands with absolute paths or `cd /absolute/path &&`. See `060-tool-usage.md` "Python Interpreter" and "Path Rules" for the full zero-tolerance rules.
-- Reusable agent scripts live in `ai_bin/` (project root). Invoke with `uv run python ai_bin/<script>`.
-- When `pyproject.toml` changes, purge `.venv` and run `uv sync` as a standalone command (never embedded in git hooks,
-  commit scripts, or automated pipelines).
-- **Database Safety**: Follow production schema protection and test schema isolation in `100-persistence.md`.
-  NEVER run test/experimental code against the production schema.
-
-## Isolated Tool Environments
-
-When developing local tools that need their own dependencies (separate from the main project), use isolated tool environments to keep the main project's `pyproject.toml` clean.
-
-### Directory Structure Pattern
-
-```
-project/
-├── pyproject.toml          # Main project dependencies (kept clean)
-├── src/
-├── tools/                  # Isolated tool environment
-│   ├── pyproject.toml      # Tool-specific dependencies
-│   └── my_tool.py
-```
-
-The `tools/` directory contains its own `pyproject.toml` with only the dependencies needed by that tool. This keeps heavy or tool-specific dependencies isolated from the main project.
-
-### Invocation Methods
-
-**1. Ephemeral (recommended for one-time use):**
-```bash
-# Runs in temp venv, cleaned up after execution
-uvx --from ./tools my-tool [args]
-
-# Does NOT install globally, does NOT pollute main venv
-```
-
-**2. Persistent (for frequently-used tools):**
-```bash
-# Installs tool globally (available in any directory)
-uv tool install ./tools
-
-# Run from anywhere
-my-tool [args]
-
-# Uninstall when no longer needed
-uv tool uninstall my-tool
-```
-
-### Benefits
-
-- **Clean main dependencies**: Main project's `pyproject.toml` stays focused on production dependencies
-- **Dependency isolation**: Tool conflicts don't affect the main project
-- **No version conflicts**: Tool can use different versions of shared dependencies
-- **Faster `uv sync`**: Main project re-sync is faster without tool dependencies
-- **Portable**: Tool environment is self-contained and reproducible
-
-### When to Use
-
-Use isolated tool environments when:
-- A local tool needs dependencies that are NOT useful for the main project
-- You want to try a tool without committing it to `pyproject.toml`
-- A tool requires mutually exclusive dependency versions
-- You're developing a standalone utility that could be extracted later
-
-Use direct `pyproject.toml` dependencies when:
-- The dependency is needed for production code
-- The dependency is needed by tests that run against production code
-- The dependency is already in the main dependency tree
-
-### Example: Local Analysis Tool
-
-**tools/pyproject.toml:**
-```toml
-[project]
-name = "analysis-tool"
-version = "0.1.0"
-requires-python = ">=3.12"
-dependencies = [
-    "pandas>=2.0",
-    "matplotlib>=3.7",
-    "seaborn>=0.12",
-]
-
-[project.scripts]
-analyze = "analyze:main"
-```
-
-**tools/analyze.py:**
-```python
-def main():
-    import pandas as pd
-    import matplotlib.pyplot as plt
-    # Tool implementation
-```
-
-**Usage:**
-```bash
-# Ephemeral (no install)
-uvx --from ./tools analyze
-
-# Persistent (global install)
-uv tool install ./tools
-analyze  # Available from any directory
-```
-
-This pattern is especially useful for data science tools, analysis scripts, and one-off utilities that would otherwise clutter the main dependency list.
+- Use `uv sync` for environment setup. All Python execution via `uv run python`. Package ops: edit `pyproject.toml` then `uv sync` — never `uv add`. `pip` prohibited.
+- **Never use `python3` or `python` directly** — always `uv run python`. See `060-tool-usage.md` for full rules.
+- Reusable agent scripts in `ai_bin/`. Invoke with `uv run python ai_bin/<script>`.
+- When `pyproject.toml` changes, purge `.venv` and run `uv sync` standalone (never embedded in hooks/scripts).
+- **Database Safety**: Follow `100-persistence.md`. NEVER run test/experimental code against production schema.
 
 ## Node.js Prohibition
 
-**DETESTABLE**: Installing Node.js in a Python-only or Java-only environment is absolutely prohibited. This introduces an unnecessary runtime dependency that pollutes the ecosystem and creates maintenance burden.
+**DETESTABLE**: Installing Node.js in Python-only or Java-only environments is absolutely prohibited.
 
-### 🚫 NEVER DO
-- **NEVER install Node.js globally or locally** on Python-only or Java-only projects.
-- **NEVER use NPX** to run packages — NPX requires Node.js runtime.
-- **NEVER add Node.js-based tools to project dependencies.**
-- **NEVER suggest npm packages as solutions** in Python/Java contexts.
-- **NEVER use Node.js-based formatters, linters, or tooling** when native alternatives exist.
+### 🚫 PROHIBITED (ZERO TOLERANCE)
 
-### Context
-This rule applies universally to:
-- **Python projects**: Use `uv`, `pip`, `ruff`, `pytest` — never npm/pnpm/yarn.
-- **Java projects**: Use Maven/Gradle, JVM tooling — never npm/pnpm/yarn.
-- **Projects with mixed languages**: Isolate Node.js to its designated frontend/service layer.
+| Prohibition | Why |
+|-------------|-----|
+| Install Node.js globally/locally | Unnecessary runtime dependency |
+| Use NPX for packages | NPX requires Node.js runtime |
+| Add Node.js-based tools to dependencies | Pollutes ecosystem |
+| Suggest npm packages in Python/Java | Ecosystem mismatch |
+| Use Node.js formatters/linters when native alternatives exist | Maintenance burden |
 
 ### ✅ ALLOWED
-- **Docker containers that internally use Node.js** — Node.js runs inside container, not on host.
-- **Pure Python alternatives** — `githubkit` instead of `@octokit/rest`, `httpx` instead of `axios`.
-- **Dedicated frontend repositories** where Node.js IS the correct tool for that codebase.
-- **MCP servers via Docker** — Node.js isolated in container only.
 
-### Why This Is Critical
-- **Security**: Node.js ecosystem has known supply-chain attack vectors.
-- **Dependency bloat**: Adds unnecessary runtime and package manager complexity.
-- **Maintenance burden**: Mixed language projects require additional CI/CD configuration.
-- **Ecosystem mismatch**: npm packages don't integrate with Python/Java tooling chains.
-- **Team friction**: Requires developers to install/maintain Node.js on their machines.
+- Docker containers with internal Node.js (isolated)
+- Pure Python alternatives (`githubkit`, `httpx` instead of npm packages)
+- Dedicated frontend repositories where Node.js IS the correct tool
+- MCP servers via Docker (Node.js isolated in container only)
 
 ## Production System Protection
 - **The AI agent is never permitted to run code against production data.** This is an absolute prohibition with no exceptions — not even for verification, inspection, or read-only queries. Any step that would execute code against production data requires explicit user instruction before execution.

--- a/.opencode/guidelines/085-engineering-approach.md
+++ b/.opencode/guidelines/085-engineering-approach.md
@@ -104,99 +104,20 @@
 | `return None` for required data | Raise error instead |
 | Fabricated test data in production code | Use real data sources |
 
-### Pre-Implementation Verification
+---
 
-**Before creating ANY file, verify:**
+## Verification-First Response Protocol (MANDATORY)
 
-```markdown
-## Pre-Implementation Checklist
+**⚠️ ZERO TOLERANCE: The agent MUST NOT respond to user input before completing verification steps.**
 
-### File Locations
-- [ ] New Python file in `src/`? OK if following project structure
-- [ ] New test file? Must be in `test/`
-- [ ] Migration? Must be `_Migration` entry in `schema.py`
-- [ ] Temp/output file? Must be in `./tmp/`
-- [ ] Notebook file? Must follow `061-notebook-rules.md`
+### The Problem
 
-### Code Structure
-- [ ] DB operation? Will use Repository class
-- [ ] Import in `__init__.py`? Only docstring, no re-exports
-- [ ] Notebook operation? Will use `the-notebook-mcp` tools
-- [ ] File edit with PyCharm MCP available? Will use `pycharm_*` tools
+Agents frequently respond to questions without:
 
-### Environment
-- [ ] Need Node.js? For Python projects, use Python alternatives
-- [ ] Running Python? Will use `uv run python`
-- [ ] Adding dependency? Edit `pyproject.toml`, run `uv sync`
-- [ ] Using temp directory? Will use `./tmp/`, not `/tmp/`
-
-### Data Handling
-- [ ] Missing required field? Will raise error, not use default
-- [ ] Exception handling? Will log AND re-raise
-- [ ] Returning data? Required fields never return `None`
-```
-
-### Post-Implementation Verification
-
-**Before marking task complete, verify:**
-
-```markdown
-## Post-Implementation Checklist
-
-### File Locations Verified
-- [ ] Temp files in `./tmp/`
-- [ ] Test files in `test/`
-- [ ] Migrations in `schema.py`
-- [ ] Scripts in `scripts/` or `ai_bin/`
-
-### Code Structure Verified
-- [ ] No `session.execute()` or `session.query()` in `src/`
-- [ ] No re-exports in `__init__.py`
-- [ ] Notebook operations used `the-notebook-mcp` tools
-- [ ] File edits used PyCharm MCP when available
-
-### Environment Verified
-- [ ] No Node.js installed
-- [ ] All Python commands use `uv run`
-- [ ] Dependencies added via `pyproject.toml` + `uv sync`
-- [ ] No absolute paths in commands
-- [ ] Temp files in `./tmp/`, not `/tmp/`
-
-### Data Handling Verified
-- [ ] No synthetic/fabricated data
-- [ ] Required fields validated, never default
-- [ ] Exceptions logged AND re-raised
-- [ ] Required data returns concrete types, never `Optional`
-```
-
-### Violation Detection by Spec Auditor
-
-**The `spec-auditor` skill checks for pattern violations:**
-
-When auditing a spec, the auditor verifies:
-1. New files respect location patterns
-2. No direct DB access in `src/`
-3. No re-exports in `__init__.py`
-4. Migrations follow schema system patterns
-5. Notebook operations use MCP tools
-
-**Violation Report Format:**
-
-```markdown
-## Pattern Violations Found
-
-| Category | Violation | Guideline | Remediation |
-|----------|-----------|-----------|-------------|
-| File Location | Migration file in `src/database/migrations/` | `100-persistence.md` | Move to `_Migration` entry in `schema.py` |
-| Code Structure | `session.execute()` in `src/services/` | `100-persistence.md` | Use Repository class in `src/commons/persistence/` |
-| Imports | `from X import Y` in `__init__.py` | `080-code-standards.md` | Use direct import at call site |
-```
-
-### Integration with Skills
-
-**The `engineering-approach` skill includes pattern verification:**
-
-1. **Pre-work task**: Pattern compliance checklist
+- Completing session init
+- Checking for superseding issues
+- Verifying codebase state
+- Running mandatory verification skills
 2. **Implementation workflow**: Verify files follow patterns
 3. **Review-prep task**: Post-implementation pattern verification
 

--- a/.opencode/guidelines/124-github-archive-workflow.md
+++ b/.opencode/guidelines/124-github-archive-workflow.md
@@ -2,38 +2,27 @@
 
 > **See `git-workflow` skill → `cleanup` task for issue closure procedure.**
 
-## Archive Workflow (Completion)
-
-**Archive a spec immediately after PR merge:**
-1. All steps marked `☑`
-2. PR merged (not just created)
-3. Add closing summary comment to issue
-4. Close the GitHub Issue (state change only)
-
-⚠️ **CRITICAL**: NEVER edit the issue body when closing. Use comments instead.
-
----
-
 ## ⚠️ ENFORCED: Issue Closure Timing
 
 **Issues are closed ONLY AFTER the PR is merged — NEVER before.**
 
-### 🚫 PROHIBITED
+### 🚫 PROHIBITED (ZERO TOLERANCE)
 
-1. **NEVER close an issue immediately after implementation**
-2. **NEVER close an issue when PR is created but not merged**
-3. **NEVER close an issue when PR is submitted for review**
-4. **NEVER close an issue based on `git pull` alone** — MUST verify via GitHub API
+| Prohibition | Why It's Wrong |
+|-------------|----------------|
+| Close issue immediately after implementation | PR might be rejected |
+| Close issue when PR created but not merged | PR might be rejected |
+| Close issue when PR submitted for review | PR might be rejected |
+| Close issue based on `git pull` | Local fast-forward ≠ GitHub merge |
+| Close parent while children open | Child tasks incomplete |
 
-### ✅ REQUIRED SEQUENCE
+### ✅ REQUIRED: API-Based Merge Verification
 
-| Step | Action | Agent Role |
-|------|--------|------------|
-| Implementation complete | Create PR with `Fixes #123` | ✅ Agent creates PR |
-| PR created | Report URL, HALT | ✅ Agent waits |
-| Human merges PR | Merge happens | 🚫 Human ONLY |
-| User confirms merge | Call `github_pull_request_read method=get` | ✅ Agent verifies |
-| PR state = merged | Close issue | ✅ Agent closes |
+**Before closing ANY issue:** Call `github_pull_request_read(method="get")` to verify `merged_at` field exists.
+
+**Before closing ANY parent issue:** Call `github_issue_read(method="get_sub_issues")` to verify all children closed or complete.
+
+**Why `git pull` is insufficient:** Local fast-forward shows `git pull` succeeded — does NOT verify GitHub PR merge status.
 
 ### ⚠️ MANDATORY: API-Based Merge Verification
 
@@ -51,163 +40,34 @@
 
 **⚠️ CRITICAL: Step 1 is MANDATORY before closing ANY issue - parent or child.**
 
-```python
-# MANDATORY: Before closing ANY issue
-def before_close_issue(issue_number: int, pr_number: int):
-    # Step 1: Query sub-issues (MANDATORY for ALL issues)
-    children = github_issue_read(method="get_sub_issues", issue_number=issue_number)
-    
-    if children:
-        # Parent with sub-issues - must verify all children closed
-        open_children = [c for c in children if c.state == "open"]
-        if open_children:
-            # BLOCK: Cannot close parent with open children
-            post_warning_comment(issue_number, open_children)
-            return  # DO NOT CLOSE
-    
-    # Step 2: Verify PR merge
-    pr = github_pull_request_read(method="get", pullNumber=pr_number)
-    if not pr.get("merged_at"):
-        report = f"PR #{pr_number} is not yet merged. Cannot close issue."
-        return  # DO NOT CLOSE
-    
-    # Step 3-5: Proceed with closure
-    close_issue_with_summary(issue_number)
-```
-
-**Why `git pull` is insufficient:**
-- Local fast-forward shows `git pull` succeeded
-- Does NOT verify the PR merge state in GitHub
-- Agent could close issue before human actually merged
-
-**Correct verification sequence:**
-
-```python
-# Step 1: User says "pr merged" or similar confirmation
-# Step 2: Agent calls GitHub API to verify
-github_pull_request_read(method="get", owner="...", repo="...", pullNumber=123)
-
-# Step 3: Check response for merged state
-# Look for: "merged_at" field (timestamp) or "state": "closed" with merge
-
-# Step 4: Only AFTER API confirms merge, close the issue
-github_issue_write(method="update", issue_number=456, state="closed", state_reason="completed")
-```
-
 **Verification fields:**
 - `merged_at` (timestamp) — PR was merged
 - `state: "closed"` with `merged` attribute — PR closed via merge
 
-**If API shows PR not merged:**
-- Do NOT close the issue
-- Report: "PR #123 is not yet merged. Please confirm merge before I close the issue."
-
-**Sequence:**
-1. Implement → Create PR → Report PR URL → HALT
-2. Human reviews and merges PR
-3. User confirms "pr merged"
-4. **Call GitHub API to verify PR state** ← MANDATORY STEP
-5. Only after PR merge verified → Close the issue
-
-### Why This Matters
-
-- Issues closed before PR merge may need to be reopened if PR is rejected
-- Open issues accurately reflect work-in-progress state
-- Waiting ensures accurate state tracking
+**If API shows PR not merged:** Do NOT close the issue. Report and wait for confirmation.
 
 ---
 
 ## ⚠️ ENFORCED: Parent/Child Issue Closure
 
+> **See `git-workflow` skill → `cleanup` task for complete workflow including sub-issue verification.**
+
 **Parent issues MUST NOT be closed while ANY child issues remain open.**
 
-**CRITICAL: When checking if a task is complete, ALWAYS verify sub-issues — NEVER assume parent status reflects sub-issue completion.**
+### 🚫 PROHIBITED (ZERO TOLERANCE)
 
-### 🚫 PROHIBITED
+| Prohibition | Why It's Wrong |
+|-------------|----------------|
+| Close parent while children open | Child tasks incomplete |
+| Close parent after PR merge if other children incomplete | Work not done |
+| Assume "PR covers everything" when sub-issues exist | Sub-issues may be separate |
+| Assume parent status reflects sub-issue status | Must query sub-issues directly |
 
-1. **NEVER close a parent `[SPEC]` issue when ANY child `[Task]` issues are still open**
-2. **NEVER close a parent after PR merge if other child tasks are incomplete**
-3. **NEVER assume "the PR covers everything" when sub-issues exist**
-4. **NEVER assume parent status reflects sub-issue status — ALWAYS query sub-issues**
+### ✅ REQUIRED: Sub-Issue Verification
 
-### ✅ REQUIRED WORKFLOW
+**Before closing ANY parent:** Call `github_issue_read(method="get_sub_issues")` to verify all children closed.
 
-**When working with parent/child issue hierarchies:**
-
-| Step | Action | Issues Affected |
-|------|--------|-----------------|
-| PR merged for child task | Close corresponding child issue ONLY | Child issue only |
-| Check remaining children | Verify all children closed | No action yet |
-| All children closed? | Close parent with summary | Parent issue |
-
-### Example Workflow
-
-```
-SPEC #100 (parent)
-├── Task #101: Phase 1 - Database schema
-├── Task #102: Phase 2 - API endpoints
-└── Task #103: Phase 3 - UI components
-
-PR merges for Phase 1 → Close #101 ONLY
-#100 remains open (children #102, #103 pending)
-
-Later, PR merges for Phase 2 → Close #102 ONLY
-#100 remains open (child #103 pending)
-
-Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
-```
-
-### Exception: All Children Completed
-
-**When ALL child issues are completed by a single PR merge:**
-
-1. Close the child issue corresponding to the PR
-2. **ALSO close the parent issue** (all children are now complete)
-3. Add summary comment to the parent explaining all work is complete
-
-**Example:** If PR #150 fixes both #102 and #103 (the last remaining children), close BOTH child issues AND the parent #100 after merge.
-
-### Why This Matters
-
-- **Parent issues track overall progress** across all phases
-- **Premature parent closure loses visibility** into remaining work
-- **Stakeholders need to see open issues** for incomplete work
-- **GitHub sub-issue view shows** which children remain
-
-### Sub-Issue Double-Check (MANDATORY)
-
-**After closing child issues addressed by PR, ALWAYS verify remaining sub-issues before closing parent.**
-
-**Critical Rules:**
-1. **NEVER close parent while children remain open**
-2. **Always query for sub-issues before closing parent**
-3. **Log warnings for orphaned children**
-4. **Close children BEFORE closing parent**
-
-### After Closing a Child Issue
-
-**ALWAYS check for remaining open children:**
-
-1. Call `github_issue_read method=get_sub_issues` on the parent issue
-2. If the result is NOT empty (children remain open) → STOP, do NOT close parent
-3. If the result IS empty (all children closed) → Close parent with summary comment
-
----
-
-## ⚠️ ENFORCED: Parent Closure Pre-Check (Agent Intelligence Required)
-
-**Before closing ANY parent issue, the agent MUST perform intelligent verification.**
-
-### Pre-Close Checklist
-
-**Before closing a parent `[SPEC]` issue, the agent MUST:**
-
-| Step | Action |
-|------|--------|
-| **1** | Query sub-issues: `github_issue_read(method="get_sub_issues", issue_number=<parent>)` |
-| **2** | Classify each sub-issue (closed/completed/superseded/incomplete) |
-| **3** | All children closed/completed/superseded → ✅ Close parent |
-| **4** | Any child open + incomplete → 🚫 POST warning, DO NOT close |
+**After closing child addressed by PR:** Verify remaining sub-issues. If empty, close parent. If not empty, STOP and report.
 
 ### Classification Rules
 
@@ -257,95 +117,46 @@ This parent issue cannot be closed because the following sub-issue(s) remain inc
 
 ---
 
-## ⚠️ ENFORCED: Closed-Issue Remediation (Pre-Authorization Audit)
+## ⚠️ ENFORCED: Closed-Issue Remediation
 
-**When a closed issue is targeted for implementation via `#N approved`, the agent MUST audit before proceeding.**
+> **See `git-workflow` skill → `cleanup` task for complete remediation workflow.**
 
-### Pre-Authorization Audit (MANDATORY)
+**When a closed issue is targeted for implementation, the agent MUST audit before proceeding.**
 
-**When `#N approved` targets a closed issue:**
-
-1. **Query sub-issues immediately**: `github_issue_read(method="get_sub_issues", issue_number=N)`
-2. **Detect violations**: Open sub-issues on closed parent = violation
-3. **If NO sub-issues or ALL sub-issues closed**: Proceed to implementation
-4. **If ANY sub-issue open**: Execute closed-issue remediation workflow (see below)
-
-### Direct Inspection Requirement (CRITICAL)
+### Direct Inspection Required (CRITICAL)
 
 **NEVER rely on comments, changelogs, or memory.**
 
-| Evidence Type | Inspection Method | What It Proves |
-|---------------|-------------------|----------------|
-| **Code changes** | Read actual files mentioned in spec | Implementation exists or doesn't |
-| **PR merge state** | `github_pull_request_read(method="get")` | PR was merged or wasn't |
-| **Branch state** | `git log`, `git branch` | Commits exist in history |
-| **Database state** | Query actual database/tables | Schema/data changes applied |
-
-**FORBIDDEN Evidence Sources:**
-- Issue comments (indirect, unverified)
-- Memory from previous sessions
-- Changelogs/README notes
-- Issue body claims (only spec requirements are factual)
-
-### Remediation Actions
-
-| Direct Inspection Result | Correct Action |
-|-------------------------|----------------|
-| Code exists in codebase as specified | Close sub-issue: `completed` |
-| PR exists and `merged_at` is set | Close sub-issue: `completed` |
-| No code, no PR, nothing implemented | **Reopen parent** (work not done) |
-| Parent closed, no merged PR | **Reopen parent** (premature closure) |
-| Superseding issue exists with completed work | Verify superseding issue is complete, then close: `not_planned` |
+| Evidence Type | Inspection Method |
+|---------------|-------------------|
+| Code changes | Read actual files mentioned in spec |
+| PR merge state | `github_pull_request_read(method="get")` |
+| Branch state | `git log`, `git branch` |
+| Database state | Query actual database/tables |
 
 ---
 
-## ⚠️ ENFORCED: Superseded Issue Closure (Without Implementation)
+## ⚠️ ENFORCED: Superseded Issue Closure
+
+> **See `git-workflow` skill → `cleanup` task for complete superseded workflow.**
 
 **Issues superseded by new issues MUST follow atomic closure workflow.**
 
 ### 🚫 PROHIBITED
 
-1. **NEVER claim future action in a closing comment**
-   - ❌ "A new spec will be created"
-   - ❌ "This will be replaced by a new issue"
-   - ❌ "Follow-up work to be done separately"
+| Prohibition | Why It's Wrong |
+|-------------|----------------|
+| Claim future action in closing comment | "New spec will be created" = never created |
+| Close without completing workflow | "Close and create new" = must do BOTH NOW |
+| Reference issue that doesn't exist | "Replaced by #TBD" = no tracking |
 
-2. **NEVER close an issue without completing the claimed workflow**
-   - If you say "close and create new", you MUST do BOTH NOW
-   - If you can't create the new issue immediately, don't claim you will
+### ✅ REQUIRED: Atomic Workflow
 
-3. **NEVER reference a replacement issue that doesn't exist yet**
-   - ❌ "Replaced by #TBD" (issue not yet created)
-   - ❌ "See new spec" (without issue number)
+1. Create replacement issue FIRST
+2. Note the new issue number
+3. Close old issue WITH replacement reference
 
-### ✅ REQUIRED ATOMIC WORKFLOW
-
-| Step | Action | Order |
-|------|--------|-------|
-| Create new issue | Create the replacement issue FIRST | Step 1 |
-| Get issue number | Note the new issue number | Step 2 |
-| Close old issue | Add closing comment WITH replacement reference | Step 3 |
-
-**Critical: New issue MUST exist BEFORE closing old issue.**
-
-### Closing Summary for Superseded Issues
-
-**When closing an issue without implementation (superseded/cancelled):**
-
-```
-🤖 ✅ **Issue Closing Summary**
-
-- **Reason**: Issue superseded by #<number> / cancelled / obsolete approach
-- **Replacement**: #<number> (if applicable)
-- **Rationale**: [Why the original issue won't be implemented]
-- **Work Done**: [Any partial work or investigation completed]
-- **Next Steps**: [Where to find the replacement work]
-
-**NOT IMPLEMENTED**: This issue was closed without implementation.
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
+**New issue MUST exist BEFORE closing old issue.**
 
 ---
 
@@ -359,19 +170,6 @@ Before closing any issue (SPEC or Task), the AI agent MUST provide a final summa
 - **Test Results**: Summary of verification steps (tests run, coverage, manual checks)
 - **Impacts**: Any impacts on other issues or project components
 - **Superseded/Not Implemented**: Explicitly state if any planned items were superseded, deferred, or intentionally skipped
-
-### Example Closing Comment
-
-```
-🤖 ✅ **Issue Closing Summary**
-- **Changes**: Implemented the new rate limiting middleware in `pubmed_client.py` and updated `110-http-workflow.md`.
-- **Test Results**: All 12 unit tests in `test_rate_limit.py` passed. Manual verification confirmed retry logic works.
-- **Impacts**: None on existing issues.
-- **Superseded/Not Implemented**: The "Phase 3: Circuit breaker" was deferred to a follow-up issue #165.
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
 
 ### When to Close
 


### PR DESCRIPTION
## Summary

Continue skills-first guideline pruning by removing procedural content and consolidating enforcement rules. Three guideline files pruned by 26-52%, moving procedural content to skills while keeping rules in guidelines.

## Changes

- **124-github-archive-workflow.md** (2127 → 1018 words, 52% reduction): Consolidated merge verification rules, moved procedural checklists to git-workflow skill
- **085-engineering-approach.md** (1604 → 1163 words, 27% reduction): Moved pre/post-implementation checklists to implementation-quality skill
- **070-environment.md** (1995 → 1424 words, 26% reduction): Removed isolated tool environment examples, consolidated Node.js prohibition rules

**Key Principle**: Guidelines now contain ONLY essential rules (prohibitions/requirements). All procedural content, examples, and step-by-step procedures remain in skills.

**Total Progress**: ~33,630 → 29,437 words (~12% reduction from initial, ~7% from PR #499)

Fixes #494