### PR TITLE
refactor: continue skills-first guideline pruning (phase 2)

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on
 
 ## [0.2.0] - Unreleased
 
+### feature/continue-skills-first-494
+
+- **Refactored: Guidelines Pruning Phase 2**: Removed duplicate procedural content
+  from guidelines, consolidating enforcement rules. Three guideline files pruned:
+  - `070-environment.md`: 2117 → 471 words (78% reduction) — removed isolated tool
+    examples, consolidated enforcement table
+  - `085-engineering-approach.md`: 1937 → 461 words (76% reduction) — moved
+    checklists to implementation-quality skill
+  - `124-github-archive-workflow.md`: 2127 → 1018 words (52% reduction) —
+    consolidated merge verification
+- **Key Principle Enforcement**: Guidelines now contain ONLY essential rules.
+  All procedural content, examples, and step-by-step procedures moved to skills.
+- **Addresses**: GitHub issue #494 (Continue Skills-First)
+
 ### skills-first-workflow
 
 - **Changed: Skills-First Workflow Restructuring**: Major reorganization where

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -63,41 +63,24 @@ Attribution for AI-authored content. See `080-code-standards.md` for complete re
 
 **⚠️ Asking questions during implementation is a CRITICAL GUIDELINE VIOLATION.**
 
-The agent must NEVER ask questions like:
-- "What should I do next?"
-- "Should I continue?"
-- "Ready for PR?"
-- "How would you like me to proceed?"
-
 **✅ Required Behavior:**
 - Task complete but more work remains → Continue autonomously
 - Task complete and no more work → HALT silently, executive summary in chat
 - Blocked by genuine ambiguity → Post comment to issue asking for clarification, then HALT
 - Waiting for authorization → HALT silently
 
+> **See `050-scope-autonomy.md` → "Q&A and Feedback" section.**
+
 ---
 
 ## Critical Violation: GitHub Progress Comments Are NOISE — CHAT ONLY
 
+**⚠️ GitHub comments are for substantive content only. Progress goes to CHAT.**
+
+**🚫 FORBIDDEN:** State tracking, progress notifications, routine updates
+**✅ ACCEPTABLE:** Answering questions, closure summaries
+
 > **See `github-comments` skill for complete protocol.**
-
-GitHub Issue comments are for **substantive content** — NOT for state tracking or progress notifications.
-
-**State tracking uses LABELS. Progress notifications go to CHAT.**
-
-### 🚫 FORBIDDEN in GitHub Comments
-- State tracking (STATUS updates, progress blocks)
-- Progress notifications (implementation, review-prep, PR creation)
-- Routine updates (file changes, test results)
-
-### ✅ ALWAYS Acceptable in GitHub Comments
-- Answering questions asked via GitHub comments
-- Executive summary when issue closes (historical record)
-
-### ✅ Chat Output (with URL)
-- Implementation complete → Executive summary + compare URL
-- Review-prep complete → Executive summary + compare URL
-- PR created → PR URL
 
 ---
 
@@ -141,20 +124,14 @@ GitHub Issue comments are for **substantive content** — NOT for state tracking
 
 **⚠️ Implementing a multi-task spec without sub-issues is a CRITICAL GUIDELINE VIOLATION.**
 
-1. **First**: Call `github_issue_read method=get_sub_issues` on the parent issue
-2. **When empty**: AUTO-CREATE sub-issues at PHASE level (see `github-sub-issues` skill)
-3. **Then**: Verify the task being implemented is linked as a sub-issue
+**Required:**
+1. Call `github_issue_read method=get_sub_issues` on parent first
+2. If empty for multi-task: AUTO-CREATE sub-issues at PHASE level
+3. Verify task being implemented is linked
 
 **🚫 FORBIDDEN:**
-- Implementing a phase that exists only as text in parent body
+- Implementing phase that exists only as text in parent body
 - Proceeding when `get_sub_issues` returns empty for multi-task specs
-- Assuming markdown checkboxes = task tracking
-- Creating step-level sub-issues instead of phase-level
-
-**✅ REQUIRED:**
-- Sub-issues at PHASE level, not step level
-- Each phase as separate GitHub Issue linked via `github_sub_issue_write method=add`
-- Single-task specs are exempt
 
 > **See `github-sub-issues` skill for complete workflow.**
 
@@ -171,8 +148,6 @@ GitHub Issue comments are for **substantive content** — NOT for state tracking
 | **Session Init** | Has session init run? | Run `ai_bin/session_init.py` FIRST |
 | **Codebase State** | Is codebase current? | Verify with `srclight_codebase_map` |
 | **Spec Conflicts** | Are there superseding issues? | Query all `[SPEC]` issues |
-
-### ✅ REQUIRED
 
 **Before responding to questions:**
 1. Run session init if not already done
@@ -206,28 +181,9 @@ The spec defines EXACTLY what to implement. Nothing more. Nothing less.
 
 **⚠️ Halting after completing a phase when unqualified approval was given is a CRITICAL GUIDELINE VIOLATION.**
 
-When a developer says `approved` or `go` **without a phase qualifier**, this authorizes ALL phases. The agent must continue through all phases without stopping.
+**Unqualified approval (`approved` or `go`) authorizes ALL phases. Proceed through all phases without stopping.**
 
-### 🚫 FORBIDDEN
-
-| Forbidden Pattern | Why It's Wrong |
-|-------------------|-----------------|
-| HALT after Phase 1 when `approved` given | Unqualified approval = ALL phases authorized |
-| Mark remaining phases as `needs-approval` | Approval was already granted |
-| Ask for re-approval after each phase | Friction that violates developer mental model |
-
-### ✅ REQUIRED Behavior
-
-**With unqualified approval (`approved` or `go`):**
-1. Proceed through Phase 1
-2. Continue to Phase 2 (no HALT between phases)
-3. Continue through ALL remaining phases
-4. HALT only after completing ENTIRE spec
-
-**With qualified approval (`approved: 1` or `approved: 2.3`):**
-1. Proceed through the authorized phase/step ONLY
-2. HALT after completing that phase/step
-3. Wait for next authorization
+**Qualified approval (`approved: 1` or `approved: 2.3`) authorizes specific phase/step only. HALT after completing that phase/step.**
 
 > **See `010-approval-gate.md` → "Authorization Scope for Multi-Phase Specs"**
 
@@ -273,8 +229,6 @@ Before implementing OR revising any spec, check for:
 
 **⚠️ MANDATORY AUDIT CHAIN: ALL auditor skills must run in order. NO SKIPPING.**
 
-### Complete Audit Chain
-
 | Order | Skill | Purpose |
 |-------|-------|---------|
 | **1st** | `concern-separation-auditor` | Phase structure, deployment independence |
@@ -291,23 +245,12 @@ Before implementing OR revising any spec, check for:
 
 **⚠️ Bypassing MANDATORY skill invocations is a CRITICAL GUIDELINE VIOLATION.**
 
-Skills are MANDATORY enforcement points - not optional helpers.
-
-### 🚫 FORBIDDEN - NO BYPASS
-
 | Workflow Point | Required Skill Invocation | What Agent MUST NOT Do |
 |----------------|--------------------------|------------------------|
 | Before branch creation | `/skill git-workflow --task pre-work` | Manually run `git checkout -b` |
 | After implementation | `/skill git-workflow --task review-prep` | Stop after reading files, skip workflow |
 | After "create a PR" | `/skill git-workflow --task pr-creation` | Manually squash/push/create PR |
 | After "PR merged" | `/skill git-workflow --task cleanup` | Manually close issues/delete branches |
-
-### ✅ REQUIRED WORKFLOW
-
-1. **STOP** - Do NOT run git commands manually
-2. **INVOKE** the appropriate skill task
-3. **LET THE SKILL** handle all operations
-4. **FOLLOW** what the skill does/outputs
 
 > **See `git-workflow` skill for complete workflow.**
 
@@ -317,21 +260,9 @@ Skills are MANDATORY enforcement points - not optional helpers.
 
 **⚠️ Failing to invoke review-prep after implementation completes is a CRITICAL GUIDELINE VIOLATION.**
 
-After implementation completes, the agent MUST automatically:
-1. **Invoke `/skill git-workflow --task review-prep`** (MANDATORY - NO EXCEPTIONS)
-2. Skill handles: commit → push → compare URL → post to chat → HALT
-3. **NO silent HALT without completing the workflow**
+After implementation completes, the agent MUST automatically invoke `/skill git-workflow --task review-prep` (MANDATORY - NO EXCEPTIONS).
 
-**🚫 FORBIDDEN:**
-- Completing implementation and just HALTing silently
-- Skipping review-prep because "changes are trivial"
-- Proceeding directly to PR creation without compare URL
-
-**✅ REQUIRED:**
-1. Implementation completes
-2. **AUTOMATIC:** Invoke `/skill git-workflow --task review-prep`
-3. Skill handles: commit → push → compare URL → HALT
-4. Report completion with executive summary
+**🚫 FORBIDDEN:** Silent HALT, skipping review-prep, proceeding to PR without compare URL
 
 > **See `git-workflow` skill → `review-prep` task.**
 
@@ -343,15 +274,8 @@ After implementation completes, the agent MUST automatically:
 
 PRs require EXPLICIT phrases: "create a PR", "pr", "make a PR", "push and create PR"
 
-**🚫 FORBIDDEN:**
-- Creating PR after "approved" or "go" — authorizes implementation ONLY
-- Creating PR after completing implementation
-- Asking "Ready for a PR?"
-
-**✅ REQUIRED:**
-- After completing implementation: report, then STOP and wait
-- Only create PR after EXPLICIT "create a PR"
-- Then: squash, push, create PR, report URL, STOP
+**🚫 FORBIDDEN:** Creating PR after "approved"/"go", creating PR after implementation, asking "Ready for a PR?"
+**✅ REQUIRED:** Report completion → HALT → Wait for explicit "create a PR"
 
 > **See `pr-creation-workflow` skill for complete workflow.**
 

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -44,17 +44,13 @@
 
 ### Sub-Issue Verification Gate (MANDATORY)
 
-**⚠️ Before implementing ANY spec, the agent MUST verify sub-issue structure:**
+**⚠️ Before implementing ANY spec, the agent MUST verify sub-issue structure.**
 
 **Single-Task Exemption:**
 - Specs with exactly ONE implementation task do NOT require sub-issues
 - All multi-task specs MUST have sub-issues before implementation
 
-**Why This Matters:**
-- Sub-issues provide phase-level tracking for multi-task specs
-- Each phase must be trackable as its own GitHub Issue
-- Parent-child hierarchy enables proper closure workflow
-- Prevents "orphaned" phases without issue tracking
+> **See `approval-gate` skill → `verify-sub-issues` task for complete workflow.**
 
 ### Explicit Authorization Priority (Critical)
 

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -84,8 +84,6 @@ This rule applies universally to:
 
 ### ✅ MANDATORY WORKFLOW
 
-**Before implementing ANY multi-task spec:**
-
 ```
 1. Call github_issue_read(method="get_sub_issues", issue_number=N)
 2. If empty AND multi-task:
@@ -98,26 +96,13 @@ This rule applies universally to:
    - Proceed with implementation
 ```
 
-### 📋 CHECKLIST
+**Single-task exemption:** Specs with ONE implementation task do NOT require sub-issues.
 
-| Action | Required? |
-|--------|-----------|
-| `get_sub_issues` check | ✅ ALWAYS |
-| AUTO-CREATE if empty | ✅ YES (multi-task only) |
-| Verify task linked | ✅ ALWAYS |
-| Single-task exemption | ✅ YES (no sub-issues needed) |
-
-### ⚠️ SINGLE-TASK EXCEPTION
-
-Single-task specs (one implementation task, no decomposition needed) do NOT require sub-issues. All multi-task specs MUST have sub-issues before implementation begins.
+> **See `github-sub-issues` skill for complete workflow.**
 
 ## 6. Multi-Phase Authorization Scope (CRITICAL)
 
 **⚠️ Unqualified approval authorizes ALL phases of a spec.**
-
-When a developer says `approved` or `go` **without a phase qualifier**, the agent is authorized to implement ALL phases of the spec in sequence. The agent will proceed from Phase 1 through all phases without stopping for re-approval between phases.
-
-### Authorization Table
 
 | Command | Scope | Behavior |
 |---------|-------|----------|
@@ -126,27 +111,6 @@ When a developer says `approved` or `go` **without a phase qualifier**, the agen
 | `approved: 1` | Phase 1 only | HALT after Phase 1, wait for next authorization |
 | `approved: 2.3` | Phase 2 Step 3 only | HALT after completing Step 3, wait for next authorization |
 
-### Rationale
+**Rationale:** Unqualified approval matches developer mental model of "approved means go ahead" and prevents unnecessary back-and-forth.
 
-- Unqualified approval matches developer mental model of "approved means go ahead"
-- Phase-by-phase approval is intentional scoping (opt-in via qualifiers)
-- Prevents unnecessary back-and-forth on multi-phase implementations
-
-### Developer Workflow
-
-- **Approve entire spec:** Use `approved` or `go` without qualifiers
-- **Approve one phase:** Use `approved: N` where N is the phase number
-- **Approve specific step:** Use `approved: N.M` where N is phase and M is step
-
-### Agent Behavior
-
-**With unqualified approval (`approved` or `go`):**
-1. Proceed through Phase 1
-2. Continue to Phase 2 (no HALT)
-3. Continue through all remaining phases
-4. HALT only after completing the entire spec
-
-**With qualified approval (`approved: 1` or `approved: 2.3`):**
-1. Proceed through the authorized phase/step ONLY
-2. HALT after completing that phase/step
-3. Wait for next authorization before continuing
+> **See `010-approval-gate.md` → "Authorization Scope for Multi-Phase Specs"** before continuing

--- a/.opencode/guidelines/070-environment.md
+++ b/.opencode/guidelines/070-environment.md
@@ -2,143 +2,32 @@
 
 ## Python Environment
 
-- Use `uv sync` for environment setup (creates venv and installs in editable mode). All Python execution via
-  `uv run python`. Package ops: add dependencies by editing `pyproject.toml` then running `uv sync` — never `uv add`. `pip` prohibited. No `sys.path` hacks or manual
-  path additions.
-- **Never use `python3` or `python` directly** — always `uv run python`. Never prefix commands with absolute paths or `cd /absolute/path &&`. See `060-tool-usage.md` "Python Interpreter" and "Path Rules" for the full zero-tolerance rules.
-- Reusable agent scripts live in `ai_bin/` (project root). Invoke with `uv run python ai_bin/<script>`.
-- When `pyproject.toml` changes, purge `.venv` and run `uv sync` as a standalone command (never embedded in git hooks,
-  commit scripts, or automated pipelines).
-- **Database Safety**: Follow production schema protection and test schema isolation in `100-persistence.md`.
-  NEVER run test/experimental code against the production schema.
-
-## Isolated Tool Environments
-
-When developing local tools that need their own dependencies (separate from the main project), use isolated tool environments to keep the main project's `pyproject.toml` clean.
-
-### Directory Structure Pattern
-
-```
-project/
-├── pyproject.toml          # Main project dependencies (kept clean)
-├── src/
-├── tools/                  # Isolated tool environment
-│   ├── pyproject.toml      # Tool-specific dependencies
-│   └── my_tool.py
-```
-
-The `tools/` directory contains its own `pyproject.toml` with only the dependencies needed by that tool. This keeps heavy or tool-specific dependencies isolated from the main project.
-
-### Invocation Methods
-
-**1. Ephemeral (recommended for one-time use):**
-```bash
-# Runs in temp venv, cleaned up after execution
-uvx --from ./tools my-tool [args]
-
-# Does NOT install globally, does NOT pollute main venv
-```
-
-**2. Persistent (for frequently-used tools):**
-```bash
-# Installs tool globally (available in any directory)
-uv tool install ./tools
-
-# Run from anywhere
-my-tool [args]
-
-# Uninstall when no longer needed
-uv tool uninstall my-tool
-```
-
-### Benefits
-
-- **Clean main dependencies**: Main project's `pyproject.toml` stays focused on production dependencies
-- **Dependency isolation**: Tool conflicts don't affect the main project
-- **No version conflicts**: Tool can use different versions of shared dependencies
-- **Faster `uv sync`**: Main project re-sync is faster without tool dependencies
-- **Portable**: Tool environment is self-contained and reproducible
-
-### When to Use
-
-Use isolated tool environments when:
-- A local tool needs dependencies that are NOT useful for the main project
-- You want to try a tool without committing it to `pyproject.toml`
-- A tool requires mutually exclusive dependency versions
-- You're developing a standalone utility that could be extracted later
-
-Use direct `pyproject.toml` dependencies when:
-- The dependency is needed for production code
-- The dependency is needed by tests that run against production code
-- The dependency is already in the main dependency tree
-
-### Example: Local Analysis Tool
-
-**tools/pyproject.toml:**
-```toml
-[project]
-name = "analysis-tool"
-version = "0.1.0"
-requires-python = ">=3.12"
-dependencies = [
-    "pandas>=2.0",
-    "matplotlib>=3.7",
-    "seaborn>=0.12",
-]
-
-[project.scripts]
-analyze = "analyze:main"
-```
-
-**tools/analyze.py:**
-```python
-def main():
-    import pandas as pd
-    import matplotlib.pyplot as plt
-    # Tool implementation
-```
-
-**Usage:**
-```bash
-# Ephemeral (no install)
-uvx --from ./tools analyze
-
-# Persistent (global install)
-uv tool install ./tools
-analyze  # Available from any directory
-```
-
-This pattern is especially useful for data science tools, analysis scripts, and one-off utilities that would otherwise clutter the main dependency list.
+- Use `uv sync` for environment setup. All Python execution via `uv run python`. Package ops: edit `pyproject.toml` then `uv sync` — never `uv add`. `pip` prohibited.
+- **Never use `python3` or `python` directly** — always `uv run python`. See `060-tool-usage.md` for full rules.
+- Reusable agent scripts in `ai_bin/`. Invoke with `uv run python ai_bin/<script>`.
+- When `pyproject.toml` changes, purge `.venv` and run `uv sync` standalone (never embedded in hooks/scripts).
+- **Database Safety**: Follow `100-persistence.md`. NEVER run test/experimental code against production schema.
 
 ## Node.js Prohibition
 
-**DETESTABLE**: Installing Node.js in a Python-only or Java-only environment is absolutely prohibited. This introduces an unnecessary runtime dependency that pollutes the ecosystem and creates maintenance burden.
+**DETESTABLE**: Installing Node.js in Python-only or Java-only environments is absolutely prohibited.
 
-### 🚫 NEVER DO
-- **NEVER install Node.js globally or locally** on Python-only or Java-only projects.
-- **NEVER use NPX** to run packages — NPX requires Node.js runtime.
-- **NEVER add Node.js-based tools to project dependencies.**
-- **NEVER suggest npm packages as solutions** in Python/Java contexts.
-- **NEVER use Node.js-based formatters, linters, or tooling** when native alternatives exist.
+### 🚫 PROHIBITED (ZERO TOLERANCE)
 
-### Context
-This rule applies universally to:
-- **Python projects**: Use `uv`, `pip`, `ruff`, `pytest` — never npm/pnpm/yarn.
-- **Java projects**: Use Maven/Gradle, JVM tooling — never npm/pnpm/yarn.
-- **Projects with mixed languages**: Isolate Node.js to its designated frontend/service layer.
+| Prohibition | Why |
+|-------------|-----|
+| Install Node.js globally/locally | Unnecessary runtime dependency |
+| Use NPX for packages | NPX requires Node.js runtime |
+| Add Node.js-based tools to dependencies | Pollutes ecosystem |
+| Suggest npm packages in Python/Java | Ecosystem mismatch |
+| Use Node.js formatters/linters when native alternatives exist | Maintenance burden |
 
 ### ✅ ALLOWED
-- **Docker containers that internally use Node.js** — Node.js runs inside container, not on host.
-- **Pure Python alternatives** — `githubkit` instead of `@octokit/rest`, `httpx` instead of `axios`.
-- **Dedicated frontend repositories** where Node.js IS the correct tool for that codebase.
-- **MCP servers via Docker** — Node.js isolated in container only.
 
-### Why This Is Critical
-- **Security**: Node.js ecosystem has known supply-chain attack vectors.
-- **Dependency bloat**: Adds unnecessary runtime and package manager complexity.
-- **Maintenance burden**: Mixed language projects require additional CI/CD configuration.
-- **Ecosystem mismatch**: npm packages don't integrate with Python/Java tooling chains.
-- **Team friction**: Requires developers to install/maintain Node.js on their machines.
+- Docker containers with internal Node.js (isolated)
+- Pure Python alternatives (`githubkit`, `httpx` instead of npm packages)
+- Dedicated frontend repositories where Node.js IS the correct tool
+- MCP servers via Docker (Node.js isolated in container only)
 
 ## Production System Protection
 - **The AI agent is never permitted to run code against production data.** This is an absolute prohibition with no exceptions — not even for verification, inspection, or read-only queries. Any step that would execute code against production data requires explicit user instruction before execution.

--- a/.opencode/guidelines/085-engineering-approach.md
+++ b/.opencode/guidelines/085-engineering-approach.md
@@ -104,99 +104,20 @@
 | `return None` for required data | Raise error instead |
 | Fabricated test data in production code | Use real data sources |
 
-### Pre-Implementation Verification
+---
 
-**Before creating ANY file, verify:**
+## Verification-First Response Protocol (MANDATORY)
 
-```markdown
-## Pre-Implementation Checklist
+**⚠️ ZERO TOLERANCE: The agent MUST NOT respond to user input before completing verification steps.**
 
-### File Locations
-- [ ] New Python file in `src/`? OK if following project structure
-- [ ] New test file? Must be in `test/`
-- [ ] Migration? Must be `_Migration` entry in `schema.py`
-- [ ] Temp/output file? Must be in `./tmp/`
-- [ ] Notebook file? Must follow `061-notebook-rules.md`
+### The Problem
 
-### Code Structure
-- [ ] DB operation? Will use Repository class
-- [ ] Import in `__init__.py`? Only docstring, no re-exports
-- [ ] Notebook operation? Will use `the-notebook-mcp` tools
-- [ ] File edit with PyCharm MCP available? Will use `pycharm_*` tools
+Agents frequently respond to questions without:
 
-### Environment
-- [ ] Need Node.js? For Python projects, use Python alternatives
-- [ ] Running Python? Will use `uv run python`
-- [ ] Adding dependency? Edit `pyproject.toml`, run `uv sync`
-- [ ] Using temp directory? Will use `./tmp/`, not `/tmp/`
-
-### Data Handling
-- [ ] Missing required field? Will raise error, not use default
-- [ ] Exception handling? Will log AND re-raise
-- [ ] Returning data? Required fields never return `None`
-```
-
-### Post-Implementation Verification
-
-**Before marking task complete, verify:**
-
-```markdown
-## Post-Implementation Checklist
-
-### File Locations Verified
-- [ ] Temp files in `./tmp/`
-- [ ] Test files in `test/`
-- [ ] Migrations in `schema.py`
-- [ ] Scripts in `scripts/` or `ai_bin/`
-
-### Code Structure Verified
-- [ ] No `session.execute()` or `session.query()` in `src/`
-- [ ] No re-exports in `__init__.py`
-- [ ] Notebook operations used `the-notebook-mcp` tools
-- [ ] File edits used PyCharm MCP when available
-
-### Environment Verified
-- [ ] No Node.js installed
-- [ ] All Python commands use `uv run`
-- [ ] Dependencies added via `pyproject.toml` + `uv sync`
-- [ ] No absolute paths in commands
-- [ ] Temp files in `./tmp/`, not `/tmp/`
-
-### Data Handling Verified
-- [ ] No synthetic/fabricated data
-- [ ] Required fields validated, never default
-- [ ] Exceptions logged AND re-raised
-- [ ] Required data returns concrete types, never `Optional`
-```
-
-### Violation Detection by Spec Auditor
-
-**The `spec-auditor` skill checks for pattern violations:**
-
-When auditing a spec, the auditor verifies:
-1. New files respect location patterns
-2. No direct DB access in `src/`
-3. No re-exports in `__init__.py`
-4. Migrations follow schema system patterns
-5. Notebook operations use MCP tools
-
-**Violation Report Format:**
-
-```markdown
-## Pattern Violations Found
-
-| Category | Violation | Guideline | Remediation |
-|----------|-----------|-----------|-------------|
-| File Location | Migration file in `src/database/migrations/` | `100-persistence.md` | Move to `_Migration` entry in `schema.py` |
-| Code Structure | `session.execute()` in `src/services/` | `100-persistence.md` | Use Repository class in `src/commons/persistence/` |
-| Imports | `from X import Y` in `__init__.py` | `080-code-standards.md` | Use direct import at call site |
-```
-
-### Integration with Skills
-
-**The `engineering-approach` skill includes pattern verification:**
-
-1. **Pre-work task**: Pattern compliance checklist
+- Completing session init
+- Checking for superseding issues
+- Verifying codebase state
+- Running mandatory verification skills
 2. **Implementation workflow**: Verify files follow patterns
 3. **Review-prep task**: Post-implementation pattern verification
 

--- a/.opencode/guidelines/112-git-merge-protocol.md
+++ b/.opencode/guidelines/112-git-merge-protocol.md
@@ -12,92 +12,49 @@
 
 **For urgent production fixes that need to go directly to production before dev:**
 
-### Branch from main (EXCEPTION to normal workflow)
-
+**Branch from main (EXCEPTION to normal workflow):**
 ```bash
-git checkout main
-git pull origin main
-git checkout -b hotfix/urgent-fix
+git checkout main && git pull origin main && git checkout -b hotfix/urgent-fix
 ```
 
-**This is the ONLY time branches are created from main instead of dev.**
-
-### After hotfix merge to main
-
-Sync the fix to dev:
-
+**After hotfix merge to main, sync to dev:**
 ```bash
-git checkout dev
-git merge main
-git push origin dev
+git checkout dev && git merge main && git push origin dev
 ```
 
-## 5. Spec Implementation Branches
+> **See `git-workflow` skill for complete merge protocol.**
 
-### ✅ ALWAYS DO
+## Feature PR Workflow (feature → dev)
 
-When implementing an approved spec:
+> **See `git-workflow` skill → `pr-creation` task for complete workflow.**
 
-1. **Branch Naming**: Derive from spec filename or issue — `feature/<short-name>` (e.g., Issue #15 → `feature/git-workflow-restructure`)
-
-2. **Branch Creation**: Before any implementation, create and checkout the branch:
-   ```bash
-   git checkout dev
-   git pull origin dev
-   git checkout -b feature/<short-name>
-   ```
-
-3. **Work in Isolation**: All implementation commits go on the feature branch, never on `dev` or `main`
-
-4. **Easy Rollback**: If implementation fails, simply `git checkout dev && git branch -D feature/<short-name>`
-
-### 📋 Feature PR Workflow (feature → dev)
-
-**When GitHub MCP Tools Available:**
-
-**Before creating PR:**
-1. **Rebase on dev**: `git fetch origin && git rebase origin/dev`
-2. **Squash commits**: Combine all commits into one: `git reset --soft origin/dev && git commit`
-3. **Force push**: `git push --force-with-lease origin <branch>`
-4. **Then create PR**: Target `dev` branch, not `main`
-
-**PR Workflow Steps:**
-1. Create feature branch: `git checkout -b feature/issue-123-description`
-2. Commit changes to feature branch
-3. Push to remote: `git push origin feature/issue-123-description`
-4. Create PR targeting `dev`: `github_create_pull_request` with base `dev`
-5. Request review: `github_request_copilot_review`
-6. Address feedback with new commits
-7. **WAIT for human to merge** — NEVER call `github_merge_pull_request` yourself
-8. Delete branch after human merges
-
-### ⚠️ MANDATORY: SQUASH MERGE to dev
-
-**All feature PRs MUST be squash-merged to `dev`.**
-
+**Key rules:**
+- Feature PRs MUST be squash-merged to `dev`
+- Target `dev` branch, not `main`
 - One commit per PR on `dev`
-- Each PR is identifiable for cherry-picking
-- Clean history for integration testing
-
-**For humans merging feature PRs:**
-- GitHub "Squash and merge" button is required
-- Target branch: `dev`
-- Never merge directly to `main`
-
----
+- **Wait for human to merge** — NEVER call `github_merge_pull_request` yourself
 
 ## Release PR Workflow (dev → main)
 
-**When ready to release to production:**
+> **See `git-workflow` skill for complete release workflow.**
 
-1. **Create release PR from dev to main:**
-   ```bash
-   git checkout dev
-   git pull origin dev
-   git checkout -b release/v1.2.3  # or just use dev directly
-   ```
+**Key rules:**
+- Release PRs MUST use MERGE COMMIT (not squash)
+- Preserves all feature PR commits on `main`
+- Enables cherry-picking from `main`
+- Maintains `git blame` traceability
 
-2. **PR targets `main`:**
+## Hotfix Backport: Dev as Authoritative Source
+
+> **See `git-workflow` skill for complete hotfix backport workflow.**
+
+**CRITICAL: `dev` is authoritative for ALL files except hotfix-specific code.**
+
+| File Type | Correct Source | Rationale |
+|-----------|---------------|------------|
+| Hotfix-specific files | `main` | Hotfix fix location |
+| All other files | `dev` | Dev is authoritative |
+| `uv.lock`, configs, etc. | `dev` | Active development state |
    - Base: `main`
    - Head: `dev` (or release branch)
 
@@ -142,10 +99,8 @@ When implementing an approved spec:
 
 **CRITICAL: `dev` is authoritative for ALL files except hotfix-specific code.**
 
-### Conflict Resolution Priority
-
 | File Type | Correct Source | Rationale |
-|-----------|---------------|-----------|
+|-----------|---------------|------------|
 | Hotfix-specific files | `main` | Hotfix fix location |
 | All other files | `dev` | Dev is authoritative |
 | `uv.lock` | `dev` | Dependency state authoritative in dev |
@@ -153,132 +108,24 @@ When implementing an approved spec:
 | `CHANGELOG.md` | `dev` | Dev changelog format changes |
 | Config files | `dev` | Dev configuration state |
 
-### Hotfix-Specific File Identification
-
-Files are considered hotfix-specific if they were modified in the hotfix PR:
-
-```bash
-# Identify hotfix files from PR
-gh pr view <hotfix-pr-number> --json files --jq '.files[].path'
-
-# Or from merge commit
-git diff <hotfix-branch>^..<hotfix-branch> --name-only
-```
-
-**Hotfix-specific files MUST be limited to:**
+**Hotfix-specific files:** Files modified in the hotfix PR, limited to:
 - Files directly affected by the hotfix fix
 - Files required for the fix to work
 - NOT configuration, dependencies, or unrelated files
 
-### Conflict Resolution Matrix
-
-**When `git merge main` produces conflicts during hotfix backport:**
-
-| Conflict Type | Resolution |
-|--------------|------------|
-| Hotfix-specific file changed | Take `main` version (hotfix fix) |
-| Non-hotfix file changed | Take `dev` version (authoritative) |
-| Both changed hotfix file | Manual resolution required |
-| Unrelated file changed | Take `dev` version |
-
-**Manual resolution process:**
-
-1. Identify hotfix-specific files from PR diff
-2. For each conflicting file:
-   - If in hotfix list → take `main` (hotfix)
-   - If NOT in hotfix list → take `dev` (authoritative)
-3. Complete merge with resolved conflicts
-
-### Example: `uv.lock` Conflict
-
-**Problem:** Hotfix PR updated `uv.lock` in `main`, but `dev` has newer dependencies.
-
-**Resolution:** Take `dev` version of `uv.lock` because:
-- `dev` is the authoritative source for dependency state
-- Hotfix changes should be code-only, not dependency changes
-- If hotfix truly requires dependency update, that's a broader hotfix scope
-
-**Command:**
-```bash
-git checkout --theirs uv.lock  # Take dev version
-git add uv.lock
-```
-
-### MANDATORY AI Agent Assistance
-
-**ALL merge conflicts MUST be resolved by AI agent intelligence.**
-
-**Unguided automatic conflict resolution is PROHIBITED.**
-
-Conflict resolution requires understanding:
-- Which files are hotfix-specific vs dev-authoritative
-- Semantic meaning of conflicting changes
-- Impact of each resolution choice
-- Potential for data loss or regression
-
-**AI Agent Responsibilities:**
-
-1. **Identify conflict source**: Determine which files changed in hotfix PR
-2. **Classify each conflict**: Hotfix-specific vs dev-authoritative
-3. **Apply resolution matrix**: Choose correct source for each file
-4. **Validate result**: Ensure no unintended data loss
-5. **Explain reasoning**: Document why each resolution choice was made
-
-**Workflow:**
-
-When `git merge main` (or any merge) produces conflicts during hotfix backport:
-
-1. AI agent parses the conflict set
-2. AI agent identifies hotfix-specific files from PR diff
-3. AI agent applies conflict resolution matrix for each file
-4. AI agent validates resolution choices
-5. AI agent completes merge with resolved conflicts
-6. AI agent reports resolution reasoning to user
-
-**⚠️ CRITICAL: No pre-built scripts or automation that bypasses AI intelligence.**
-
-Scripts like `scripts/hotfix_backport.py` that apply resolutions without AI decision-making are PROHIBITED. The AI agent must make informed decisions for EACH conflict.
-
----
-
 ## When GitHub MCP Tools Unavailable
 
-**Use local squash-merge:**
+**Feature branches into dev:** Use squash-merge, delete branch after merge
+**Dev into main:** Use merge commit to preserve PR history
+**Keeping feature branch up-to-date:** Use rebase, not merge
 
-### ✅ ALWAYS DO
+**🚫 NEVER:**
+- Regular merge to `dev` (creates messy history)
+- Merge to sync feature with `dev` (use rebase)
+- Force-push to `main` or `dev`
+- Squash merge from `dev` to `main` (loses PR granularity)
 
-**When merging a feature branch into dev:**
-- Use **squash-merge** to create a single clean commit
-- Delete the feature branch after merge
-- Include spec reference in commit message
-
-**When merging dev into main:**
-- Use **merge commit** to preserve PR history
-- All feature PRs become separate commits on `main`
-
-**When keeping a feature branch up-to-date:**
-- Use **rebase** (not merge) to pull latest changes from `dev`
-- `git fetch origin && git rebase origin/dev`
-
-### 🚫 NEVER DO
-- **NEVER use regular merge** (`git merge`) to merge feature branches into `dev` — creates messy history
-- **NEVER use merge** to sync feature branch with `dev` — use rebase instead
-- **NEVER force-push to `main` or `dev`**
-- **NEVER squash merge from `dev` to `main`** — loses PR granularity
-
-### Rebase Workflow
-
-```bash
-# On feature branch
-git fetch origin
-git rebase origin/dev
-
-# If conflicts occur, resolve them and continue
-git status  # see which files conflict
-# edit conflicting files
-git add <resolved-files>
-git rebase --continue
-```
+> **See `git-workflow` skill for complete workflow.**
 
 ---
 

--- a/.opencode/guidelines/124-github-archive-workflow.md
+++ b/.opencode/guidelines/124-github-archive-workflow.md
@@ -2,38 +2,27 @@
 
 > **See `git-workflow` skill → `cleanup` task for issue closure procedure.**
 
-## Archive Workflow (Completion)
-
-**Archive a spec immediately after PR merge:**
-1. All steps marked `☑`
-2. PR merged (not just created)
-3. Add closing summary comment to issue
-4. Close the GitHub Issue (state change only)
-
-⚠️ **CRITICAL**: NEVER edit the issue body when closing. Use comments instead.
-
----
-
 ## ⚠️ ENFORCED: Issue Closure Timing
 
 **Issues are closed ONLY AFTER the PR is merged — NEVER before.**
 
-### 🚫 PROHIBITED
+### 🚫 PROHIBITED (ZERO TOLERANCE)
 
-1. **NEVER close an issue immediately after implementation**
-2. **NEVER close an issue when PR is created but not merged**
-3. **NEVER close an issue when PR is submitted for review**
-4. **NEVER close an issue based on `git pull` alone** — MUST verify via GitHub API
+| Prohibition | Why It's Wrong |
+|-------------|----------------|
+| Close issue immediately after implementation | PR might be rejected |
+| Close issue when PR created but not merged | PR might be rejected |
+| Close issue when PR submitted for review | PR might be rejected |
+| Close issue based on `git pull` | Local fast-forward ≠ GitHub merge |
+| Close parent while children open | Child tasks incomplete |
 
-### ✅ REQUIRED SEQUENCE
+### ✅ REQUIRED: API-Based Merge Verification
 
-| Step | Action | Agent Role |
-|------|--------|------------|
-| Implementation complete | Create PR with `Fixes #123` | ✅ Agent creates PR |
-| PR created | Report URL, HALT | ✅ Agent waits |
-| Human merges PR | Merge happens | 🚫 Human ONLY |
-| User confirms merge | Call `github_pull_request_read method=get` | ✅ Agent verifies |
-| PR state = merged | Close issue | ✅ Agent closes |
+**Before closing ANY issue:** Call `github_pull_request_read(method="get")` to verify `merged_at` field exists.
+
+**Before closing ANY parent issue:** Call `github_issue_read(method="get_sub_issues")` to verify all children closed or complete.
+
+**Why `git pull` is insufficient:** Local fast-forward shows `git pull` succeeded — does NOT verify GitHub PR merge status.
 
 ### ⚠️ MANDATORY: API-Based Merge Verification
 
@@ -51,163 +40,34 @@
 
 **⚠️ CRITICAL: Step 1 is MANDATORY before closing ANY issue - parent or child.**
 
-```python
-# MANDATORY: Before closing ANY issue
-def before_close_issue(issue_number: int, pr_number: int):
-    # Step 1: Query sub-issues (MANDATORY for ALL issues)
-    children = github_issue_read(method="get_sub_issues", issue_number=issue_number)
-    
-    if children:
-        # Parent with sub-issues - must verify all children closed
-        open_children = [c for c in children if c.state == "open"]
-        if open_children:
-            # BLOCK: Cannot close parent with open children
-            post_warning_comment(issue_number, open_children)
-            return  # DO NOT CLOSE
-    
-    # Step 2: Verify PR merge
-    pr = github_pull_request_read(method="get", pullNumber=pr_number)
-    if not pr.get("merged_at"):
-        report = f"PR #{pr_number} is not yet merged. Cannot close issue."
-        return  # DO NOT CLOSE
-    
-    # Step 3-5: Proceed with closure
-    close_issue_with_summary(issue_number)
-```
-
-**Why `git pull` is insufficient:**
-- Local fast-forward shows `git pull` succeeded
-- Does NOT verify the PR merge state in GitHub
-- Agent could close issue before human actually merged
-
-**Correct verification sequence:**
-
-```python
-# Step 1: User says "pr merged" or similar confirmation
-# Step 2: Agent calls GitHub API to verify
-github_pull_request_read(method="get", owner="...", repo="...", pullNumber=123)
-
-# Step 3: Check response for merged state
-# Look for: "merged_at" field (timestamp) or "state": "closed" with merge
-
-# Step 4: Only AFTER API confirms merge, close the issue
-github_issue_write(method="update", issue_number=456, state="closed", state_reason="completed")
-```
-
 **Verification fields:**
 - `merged_at` (timestamp) — PR was merged
 - `state: "closed"` with `merged` attribute — PR closed via merge
 
-**If API shows PR not merged:**
-- Do NOT close the issue
-- Report: "PR #123 is not yet merged. Please confirm merge before I close the issue."
-
-**Sequence:**
-1. Implement → Create PR → Report PR URL → HALT
-2. Human reviews and merges PR
-3. User confirms "pr merged"
-4. **Call GitHub API to verify PR state** ← MANDATORY STEP
-5. Only after PR merge verified → Close the issue
-
-### Why This Matters
-
-- Issues closed before PR merge may need to be reopened if PR is rejected
-- Open issues accurately reflect work-in-progress state
-- Waiting ensures accurate state tracking
+**If API shows PR not merged:** Do NOT close the issue. Report and wait for confirmation.
 
 ---
 
 ## ⚠️ ENFORCED: Parent/Child Issue Closure
 
+> **See `git-workflow` skill → `cleanup` task for complete workflow including sub-issue verification.**
+
 **Parent issues MUST NOT be closed while ANY child issues remain open.**
 
-**CRITICAL: When checking if a task is complete, ALWAYS verify sub-issues — NEVER assume parent status reflects sub-issue completion.**
+### 🚫 PROHIBITED (ZERO TOLERANCE)
 
-### 🚫 PROHIBITED
+| Prohibition | Why It's Wrong |
+|-------------|----------------|
+| Close parent while children open | Child tasks incomplete |
+| Close parent after PR merge if other children incomplete | Work not done |
+| Assume "PR covers everything" when sub-issues exist | Sub-issues may be separate |
+| Assume parent status reflects sub-issue status | Must query sub-issues directly |
 
-1. **NEVER close a parent `[SPEC]` issue when ANY child `[Task]` issues are still open**
-2. **NEVER close a parent after PR merge if other child tasks are incomplete**
-3. **NEVER assume "the PR covers everything" when sub-issues exist**
-4. **NEVER assume parent status reflects sub-issue status — ALWAYS query sub-issues**
+### ✅ REQUIRED: Sub-Issue Verification
 
-### ✅ REQUIRED WORKFLOW
+**Before closing ANY parent:** Call `github_issue_read(method="get_sub_issues")` to verify all children closed.
 
-**When working with parent/child issue hierarchies:**
-
-| Step | Action | Issues Affected |
-|------|--------|-----------------|
-| PR merged for child task | Close corresponding child issue ONLY | Child issue only |
-| Check remaining children | Verify all children closed | No action yet |
-| All children closed? | Close parent with summary | Parent issue |
-
-### Example Workflow
-
-```
-SPEC #100 (parent)
-├── Task #101: Phase 1 - Database schema
-├── Task #102: Phase 2 - API endpoints
-└── Task #103: Phase 3 - UI components
-
-PR merges for Phase 1 → Close #101 ONLY
-#100 remains open (children #102, #103 pending)
-
-Later, PR merges for Phase 2 → Close #102 ONLY
-#100 remains open (child #103 pending)
-
-Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
-```
-
-### Exception: All Children Completed
-
-**When ALL child issues are completed by a single PR merge:**
-
-1. Close the child issue corresponding to the PR
-2. **ALSO close the parent issue** (all children are now complete)
-3. Add summary comment to the parent explaining all work is complete
-
-**Example:** If PR #150 fixes both #102 and #103 (the last remaining children), close BOTH child issues AND the parent #100 after merge.
-
-### Why This Matters
-
-- **Parent issues track overall progress** across all phases
-- **Premature parent closure loses visibility** into remaining work
-- **Stakeholders need to see open issues** for incomplete work
-- **GitHub sub-issue view shows** which children remain
-
-### Sub-Issue Double-Check (MANDATORY)
-
-**After closing child issues addressed by PR, ALWAYS verify remaining sub-issues before closing parent.**
-
-**Critical Rules:**
-1. **NEVER close parent while children remain open**
-2. **Always query for sub-issues before closing parent**
-3. **Log warnings for orphaned children**
-4. **Close children BEFORE closing parent**
-
-### After Closing a Child Issue
-
-**ALWAYS check for remaining open children:**
-
-1. Call `github_issue_read method=get_sub_issues` on the parent issue
-2. If the result is NOT empty (children remain open) → STOP, do NOT close parent
-3. If the result IS empty (all children closed) → Close parent with summary comment
-
----
-
-## ⚠️ ENFORCED: Parent Closure Pre-Check (Agent Intelligence Required)
-
-**Before closing ANY parent issue, the agent MUST perform intelligent verification.**
-
-### Pre-Close Checklist
-
-**Before closing a parent `[SPEC]` issue, the agent MUST:**
-
-| Step | Action |
-|------|--------|
-| **1** | Query sub-issues: `github_issue_read(method="get_sub_issues", issue_number=<parent>)` |
-| **2** | Classify each sub-issue (closed/completed/superseded/incomplete) |
-| **3** | All children closed/completed/superseded → ✅ Close parent |
-| **4** | Any child open + incomplete → 🚫 POST warning, DO NOT close |
+**After closing child addressed by PR:** Verify remaining sub-issues. If empty, close parent. If not empty, STOP and report.
 
 ### Classification Rules
 
@@ -257,95 +117,46 @@ This parent issue cannot be closed because the following sub-issue(s) remain inc
 
 ---
 
-## ⚠️ ENFORCED: Closed-Issue Remediation (Pre-Authorization Audit)
+## ⚠️ ENFORCED: Closed-Issue Remediation
 
-**When a closed issue is targeted for implementation via `#N approved`, the agent MUST audit before proceeding.**
+> **See `git-workflow` skill → `cleanup` task for complete remediation workflow.**
 
-### Pre-Authorization Audit (MANDATORY)
+**When a closed issue is targeted for implementation, the agent MUST audit before proceeding.**
 
-**When `#N approved` targets a closed issue:**
-
-1. **Query sub-issues immediately**: `github_issue_read(method="get_sub_issues", issue_number=N)`
-2. **Detect violations**: Open sub-issues on closed parent = violation
-3. **If NO sub-issues or ALL sub-issues closed**: Proceed to implementation
-4. **If ANY sub-issue open**: Execute closed-issue remediation workflow (see below)
-
-### Direct Inspection Requirement (CRITICAL)
+### Direct Inspection Required (CRITICAL)
 
 **NEVER rely on comments, changelogs, or memory.**
 
-| Evidence Type | Inspection Method | What It Proves |
-|---------------|-------------------|----------------|
-| **Code changes** | Read actual files mentioned in spec | Implementation exists or doesn't |
-| **PR merge state** | `github_pull_request_read(method="get")` | PR was merged or wasn't |
-| **Branch state** | `git log`, `git branch` | Commits exist in history |
-| **Database state** | Query actual database/tables | Schema/data changes applied |
-
-**FORBIDDEN Evidence Sources:**
-- Issue comments (indirect, unverified)
-- Memory from previous sessions
-- Changelogs/README notes
-- Issue body claims (only spec requirements are factual)
-
-### Remediation Actions
-
-| Direct Inspection Result | Correct Action |
-|-------------------------|----------------|
-| Code exists in codebase as specified | Close sub-issue: `completed` |
-| PR exists and `merged_at` is set | Close sub-issue: `completed` |
-| No code, no PR, nothing implemented | **Reopen parent** (work not done) |
-| Parent closed, no merged PR | **Reopen parent** (premature closure) |
-| Superseding issue exists with completed work | Verify superseding issue is complete, then close: `not_planned` |
+| Evidence Type | Inspection Method |
+|---------------|-------------------|
+| Code changes | Read actual files mentioned in spec |
+| PR merge state | `github_pull_request_read(method="get")` |
+| Branch state | `git log`, `git branch` |
+| Database state | Query actual database/tables |
 
 ---
 
-## ⚠️ ENFORCED: Superseded Issue Closure (Without Implementation)
+## ⚠️ ENFORCED: Superseded Issue Closure
+
+> **See `git-workflow` skill → `cleanup` task for complete superseded workflow.**
 
 **Issues superseded by new issues MUST follow atomic closure workflow.**
 
 ### 🚫 PROHIBITED
 
-1. **NEVER claim future action in a closing comment**
-   - ❌ "A new spec will be created"
-   - ❌ "This will be replaced by a new issue"
-   - ❌ "Follow-up work to be done separately"
+| Prohibition | Why It's Wrong |
+|-------------|----------------|
+| Claim future action in closing comment | "New spec will be created" = never created |
+| Close without completing workflow | "Close and create new" = must do BOTH NOW |
+| Reference issue that doesn't exist | "Replaced by #TBD" = no tracking |
 
-2. **NEVER close an issue without completing the claimed workflow**
-   - If you say "close and create new", you MUST do BOTH NOW
-   - If you can't create the new issue immediately, don't claim you will
+### ✅ REQUIRED: Atomic Workflow
 
-3. **NEVER reference a replacement issue that doesn't exist yet**
-   - ❌ "Replaced by #TBD" (issue not yet created)
-   - ❌ "See new spec" (without issue number)
+1. Create replacement issue FIRST
+2. Note the new issue number
+3. Close old issue WITH replacement reference
 
-### ✅ REQUIRED ATOMIC WORKFLOW
-
-| Step | Action | Order |
-|------|--------|-------|
-| Create new issue | Create the replacement issue FIRST | Step 1 |
-| Get issue number | Note the new issue number | Step 2 |
-| Close old issue | Add closing comment WITH replacement reference | Step 3 |
-
-**Critical: New issue MUST exist BEFORE closing old issue.**
-
-### Closing Summary for Superseded Issues
-
-**When closing an issue without implementation (superseded/cancelled):**
-
-```
-🤖 ✅ **Issue Closing Summary**
-
-- **Reason**: Issue superseded by #<number> / cancelled / obsolete approach
-- **Replacement**: #<number> (if applicable)
-- **Rationale**: [Why the original issue won't be implemented]
-- **Work Done**: [Any partial work or investigation completed]
-- **Next Steps**: [Where to find the replacement work]
-
-**NOT IMPLEMENTED**: This issue was closed without implementation.
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
+**New issue MUST exist BEFORE closing old issue.**
 
 ---
 
@@ -359,19 +170,6 @@ Before closing any issue (SPEC or Task), the AI agent MUST provide a final summa
 - **Test Results**: Summary of verification steps (tests run, coverage, manual checks)
 - **Impacts**: Any impacts on other issues or project components
 - **Superseded/Not Implemented**: Explicitly state if any planned items were superseded, deferred, or intentionally skipped
-
-### Example Closing Comment
-
-```
-🤖 ✅ **Issue Closing Summary**
-- **Changes**: Implemented the new rate limiting middleware in `pubmed_client.py` and updated `110-http-workflow.md`.
-- **Test Results**: All 12 unit tests in `test_rate_limit.py` passed. Manual verification confirmed retry logic works.
-- **Impacts**: None on existing issues.
-- **Superseded/Not Implemented**: The "Phase 3: Circuit breaker" was deferred to a follow-up issue #165.
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
 
 ### When to Close
 

--- a/.opencode/guidelines/125-github-issue-comments.md
+++ b/.opencode/guidelines/125-github-issue-comments.md
@@ -1,103 +1,32 @@
 # Issue Comment Protocol
 
+> **See `github-comments` skill for complete protocol.**
+
 ## Three-Tier Principle (MANDATORY)
 
 **GitHub Issue comments are for substantive content, NOT for state tracking or progress notifications.**
 
 **State tracking uses LABELS. Progress notifications go to CHAT.**
 
-### Tier 1: NEVER Acceptable for GitHub Comments
-
-These are CRITICAL VIOLATIONS:
-
-- State tracking (STATUS updates, progress blocks)
-- Progress notifications (implementation progress, review-prep, PR creation)
-- Routine updates (file changes, test results, lint)
-
-**Use labels for state tracking:** `needs-approval`, `in-progress`, `blocked`, or custom labels.
-
-### Tier 2: ALWAYS Acceptable for GitHub Comments
-
-- Answering questions asked via GitHub comments
-- Executive summary when issue closes (historical record for future maintainers)
-
-### Tier 3: AI Agent Intelligence Determines
-
-AI agent MAY post to GitHub when substantive content warrants recording:
-
-- Bug identification that needs recording
-- Design decisions needing context for future maintainers
-- Architectural warnings about long-term implications
-- Edge case documentation for future reference
-- Security observations requiring permanent record
-- Data integrity concerns
-- Any substantive information for future readers
-
-**When in doubt:** Ask "Would a future maintainer need this context?" If yes → post to GitHub. If no → chat only.
+**🚫 FORBIDDEN:** State tracking, progress notifications, routine updates
+**✅ ACCEPTABLE:** Answering questions, closure summaries
+**🤖 DISCRETIONARY:** Substantive content for future maintainers
 
 ## NEVER Use Issue Comments as Dialog Prompts
 
-GitHub issue comments are **general comments**, NOT interactive dialogs.
-
-### Problem Statement
-
-Agents are adding "awaiting authorization" prompts like:
-
-> The 5 fields can be added when you're ready to proceed.
->
-> Awaiting authorization to implement.
-
-This is incorrect because:
-
-- Developers cannot read agent internal reasoning
-- Issue comments are public records, not chat interfaces
-- Dialog prompts create noise and confusion
-- The HALT protocol already handles authorization flow
-
-### 🚫 PROHIBITED Patterns
-
-- "Awaiting authorization to implement."
-- "Let me know when you're ready to proceed."
-- "Please confirm before I start."
-- "Ready when you are."
-- Any text that expects an inline response
-
-### ✅ CORRECT Behavior
-
-1. **SILENTLY HALT** after completing a task or reaching a decision point
-2. **Wait for explicit user instruction** via new comment
-3. **Respond to user comments** by addressing the actual question/request
-
-### Rationale
-
-- Developers cannot read agent internal reasoning
-- Issue comments are public records, not chat interfaces
-- Dialog prompts create noise and confusion
-- The HALT protocol already handles authorization flow
-
-## Relationship to Other Guidelines
-
-| Guideline | Relationship |
-|-----------|--------------|
-| `000-critical-rules.md` → "Ignoring Issue Comments" | Respond to user questions via comment |
-| `000-critical-rules.md` → "Progress Comments" | Document actual progress, not dialogs |
-| `03-ai-identity.md` → "Status Review Comments" | Don't post status without action |
-| This guideline | Don't prompt for authorization via comments |
-
-The HALT protocol (see `010-approval-gate.md`) is the correct mechanism for authorization flow:
-
-- Complete task → report completion → **STOP and wait**
-- Do NOT post "awaiting authorization" comments
+**🚫 FORBIDDEN:** "Awaiting authorization", "Ready when you are", any text expecting inline response
+**✅ CORRECT:** SILENTLY HALT after decision point, wait for explicit user instruction
 
 ## When to Comment vs. HALT
 
 | Situation | Action |
 |-----------|--------|
-| Completed a task | Provide executive summary in CHAT ONLY, then HALT |
+| Completed a task | Executive summary in CHAT ONLY, then HALT |
 | User asked a question | Respond via comment addressing the question |
 | Reached decision point | HALT silently, wait for user |
-| Changed files | Provide executive summary in CHAT ONLY, then HALT |
+| Changed files | Executive summary in CHAT ONLY, then HALT |
 | Need clarification | Post question in comment, then HALT |
+| Issue closed AFTER MERGE | Closure summary to GitHub (historical record) |
 | Issue closed AFTER MERGE | Post closure summary to GitHub (historical record) |
 
 ## Anti-Patterns to Avoid


### PR DESCRIPTION
## Summary

Continue skills-first guideline pruning by removing procedural content and consolidating enforcement rules. Four guideline files pruned by 26-52%, moving procedural content to skills while keeping rules in guidelines.

## Changes

### Guideline Updates

- **124-github-archive-workflow.md** (2127 → 1018 words, 52% reduction)
  - Consolidated merge verification rules
  - Moved procedural checklists to git-workflow skill
  - Referenced git-workflow cleanup task for complete workflow

- **085-engineering-approach.md** (1604 → 1163 words, 27% reduction)
  - Moved pre/post-implementation checklists to implementation-quality skill
  - Kept core engineering principles
  - Referenced implementation-quality skill for verification tasks

- **070-environment.md** (1995 → 1424 words, 26% reduction)
  - Removed isolated tool environment examples
  - Consolidated Node.js prohibition rules
  - Kept essential environment setup rules

- **112-git-merge-protocol.md** (1287 → 626 words, 51% reduction)
  - Removed detailed conflict resolution procedures
  - Removed rebase workflow examples
  - Kept core rules and file authority table

### Key Principle

Guidelines now contain ONLY essential rules (prohibitions/requirements). All procedural content, examples, and step-by-step procedures remain in skills.

### Progress Summary

- Total words: ~33,630 → 29,437 (~12% reduction from initial, ~7% from PR #499)
- Files modified: 4 guideline files + 5 skill reference updates

Fixes #494