### PR TITLE
[SPEC] Plan Fidelity Auditor: Clean-Room Plan Comparison

### DIFF
--- a/.opencode/dispatch-table.yaml
+++ b/.opencode/dispatch-table.yaml
@@ -42,6 +42,11 @@ code_quality:
     parameters: "--mode maintenance"
     
   - trigger: "After spec creation"
+    skill: "plan-fidelity-auditor"
+    purpose: "Validate plan fidelity with clean-room comparison"
+    parameters: "--issue N"
+    
+  - trigger: "After spec creation"
     skill: "concern-separation-auditor"
     purpose: "Validate phase structure, deployment independence"
     

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -802,14 +802,15 @@ This check is REQUIRED in these workflows:
 - "audit the issue"
 - Any request involving spec quality or structure
 
-**CRITICAL: If you run ONE auditor, you MUST run BOTH auditors in order.**
+**CRITICAL: If you run ONE auditor, you MUST run ALL auditors in order.**
 
 ### Complete Audit Chain
 
 | Order | Skill | Purpose |
 |-------|-------|---------|
-| **1st** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names |
-| **2nd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
+| **1st** | `plan-fidelity-auditor` | Clean-room plan comparison, substantive gap detection, scope alignment |
+| **2nd** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names |
+| **3rd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
 
 ### Guideline Auditor (`guideline-auditor`)
 
@@ -839,6 +840,20 @@ Invoked with: `/skill spec-auditor --issue N`
 
 **Output:** Posts findings to GitHub Issue, creates audit log in `./tmp/audit-spec-YYYYMMDD.md`
 
+### Plan Fidelity Auditor (`plan-fidelity-auditor`)
+
+Invoked with: `/skill plan-fidelity-auditor --issue N`
+
+**Purpose:** Audit GitHub Issue `[SPEC]` specs for plan fidelity — clean-room plan comparison, substantive gap detection, scope alignment. Runs FIRST in the mandatory audit chain.
+
+**When to invoke:**
+- FIRST in the audit chain (before concern-separation-auditor)
+- When "audit/review/revisit" keywords used
+- After spec creation (before concern-separation-auditor)
+- Before approving spec implementation
+
+**Output:** Posts findings to GitHub Issue, creates audit log in `./tmp/audit-fidelity-YYYYMMDD.md`
+
 ### Concern Separation Auditor (`concern-separation-auditor`)
 
 Invoked with: `/skill concern-separation-auditor --issue N`
@@ -857,9 +872,9 @@ Invoked with: `/skill concern-separation-auditor --issue N`
 
 | Trigger | Action |
 |---------|--------|
-| Spec created | REQUIRED: Run BOTH auditors in order (concern-separation FIRST, then spec-auditor) |
-| "Audit/review/revisit this spec" | REQUIRED: Run BOTH auditors in order |
-| Before implementation approval | REQUIRED: Verify both auditors passed |
+| Spec created | REQUIRED: Run ALL auditors in order (plan-fidelity-auditor FIRST, then concern-separation-auditor, then spec-auditor) |
+| "Audit/review/revisit this spec" | REQUIRED: Run ALL auditors in order |
+| Before implementation approval | REQUIRED: Verify all auditors passed |
 | Guideline change proposed | Optional: `/skill guideline-auditor` |
 | Post-implementation | Optional: Re-run auditors to verify no new issues |
 

--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -57,10 +57,11 @@ When phases mix concerns, roadmap priorities can inappropriately influence phase
 
 | Order | Skill | Purpose |
 |-------|-------|---------|
-| **1st** | `concern-separation-auditor` | Phase structure, BOILERPLATE-TITLE, concern analysis, smart splits |
-| **2nd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
+| **1st** | `plan-fidelity-auditor` | Clean-room plan comparison, substantive gap detection, scope alignment |
+| **2nd** | `concern-separation-auditor` | Phase structure, BOILERPLATE-TITLE, concern analysis, smart splits |
+| **3rd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
 
-**CRITICAL: If you run ONE auditor, you MUST run BOTH auditors in order.**
+**CRITICAL: If you run ONE auditor, you MUST run ALL auditors in order.**
 
 ## Mandatory Invocation for AI Agents
 
@@ -71,13 +72,14 @@ When phases mix concerns, roadmap priorities can inappropriately influence phase
 When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 
 1. Create the spec issue with phases and steps
-2. **Invoke `/skill concern-separation-auditor --issue N`** (auto-fix phase structure)
-3. **Invoke `/skill spec-auditor --issue N`** (check content quality)
-4. Fixes applied automatically by both auditors
-5. Add `needs-approval` label
-6. Post "ready for review" comment
+2. **Invoke `/skill plan-fidelity-auditor --issue N`** (clean-room plan comparison)
+3. **Invoke `/skill concern-separation-auditor --issue N`** (auto-fix phase structure)
+4. **Invoke `/skill spec-auditor --issue N`** (check content quality)
+5. Fixes applied automatically by all auditors
+6. Add `needs-approval` label
+7. Post "ready for review" comment
 
-**Skipping either auditor is a CRITICAL GUIDELINE VIOLATION.**
+**Skipping any auditor is a CRITICAL GUIDELINE VIOLATION.**
 
 ## Operating Modes
 
@@ -97,8 +99,9 @@ Present each finding to user for decision. Use when human review is needed.
 
 | Auditor | Scope | Runs When |
 |---------|-------|----------|
-| **concern-separation-auditor** | Phase structure, BOILERPLATE-TITLE, concern analysis, smart splits | **FIRST** - before content quality |
-| **spec-auditor** | Fresh-start context, completeness, content quality, LLM implementability | **SECOND** - after structure passes |
+| **plan-fidelity-auditor** | Clean-room plan comparison, substantive gap detection, scope alignment | **FIRST** - before structure and content |
+| **concern-separation-auditor** | Phase structure, BOILERPLATE-TITLE, concern analysis, smart splits | **SECOND** - after fidelity passes |
+| **spec-auditor** | Fresh-start context, completeness, content quality, LLM implementability | **THIRD** - after structure passes |
 
 ## What This Auditor Owns
 

--- a/.opencode/skills/github-issue-creation/tasks/post-creation.md
+++ b/.opencode/skills/github-issue-creation/tasks/post-creation.md
@@ -17,7 +17,7 @@ Invoke auditors and create sub-issues after issue creation, ensuring spec qualit
 
 ## Exit Criteria
 
-- Auditors invoked (concern-separation, spec-auditor)
+- Auditors invoked (plan-fidelity-auditor, concern-separation-auditor, and spec-auditor)
 - Sub-issues created (if multi-task)
 - Issue ready for approval workflow
 
@@ -64,12 +64,18 @@ github_sub_issue_write(
 **Run auditors in order:**
 
 ```
-1. concern-separation-auditor --issue <number>
+1. plan-fidelity-auditor --issue <number>
+   - Generates clean-room plan from problem statement
+   - Compares against existing plan
+   - Auto-fixes simple discrepancies, flags substantive ones
+   - Reports findings to issue
+
+2. concern-separation-auditor --issue <number>
    - Validates phase structure
    - Checks concern separation
    - Reports findings to issue
 
-2. spec-auditor --issue <number>
+3. spec-auditor --issue <number>
    - Validates spec completeness
    - Checks fresh-start context
    - Reports findings to issue
@@ -111,7 +117,7 @@ github_sub_issue_write(
 
 Before proceeding, verify ALL:
 
-- Auditors invoked (both concern-separation and spec-auditor)
+- Auditors invoked (plan-fidelity-auditor, concern-separation-auditor, and spec-auditor)
 - Sub-issues created (if multi-task)
 - Completion comment posted
 

--- a/.opencode/skills/plan-fidelity-auditor/SKILL.md
+++ b/.opencode/skills/plan-fidelity-auditor/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: plan-fidelity-auditor
+description: Generates a clean-room plan from scratch and compares it against the existing spec plan to identify discrepancies. Auto-updates the issue with corrections unless invoked with --check-only. Runs FIRST in the mandatory audit chain.
+license: MIT
+compatibility: opencode
+---
+
+# Skill: plan-fidelity-auditor
+
+## Overview
+
+Plan Fidelity Auditor generates a clean-room plan from scratch using only the problem statement from a spec issue, then compares it against the existing plan to identify discrepancies. Uses AI agent intelligence to differentiate simple auto-fixes from substantive changes requiring human review. Runs FIRST in the mandatory audit chain.
+
+**Source Attribution:** New skill for the snea-shoebox-editor audit chain.
+
+## Persona
+
+You are a Plan Fidelity Auditor. Your focus is validating that spec plans faithfully and completely address the stated problem by generating an independent clean-room plan and comparing it against the existing plan.
+
+## Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| `audit` | Full audit workflow (default) | ~800 |
+| `compare` | Compare clean-room plan against existing plan | ~600 |
+| `auto-fix` | Apply corrections to the issue | ~500 |
+
+## Invocation
+
+- `/skill plan-fidelity-auditor --issue N` — Full audit with auto-fix (default)
+- `/skill plan-fidelity-auditor --issue N --check-only` — Audit without auto-fix (report only)
+- `/skill plan-fidelity-auditor` — Overview only
+
+## ⚠️ MANDATORY AUDIT CHAIN (ALL SKILLS RUN)
+
+**When ANY request comes for spec/issue/task audit/review/revisit, ALL auditor skills must run in order. NO SKIPPING.**
+
+### Complete Audit Chain
+
+| Order | Skill | Purpose |
+|-------|-------|---------|
+| **1st** | `plan-fidelity-auditor` | Clean-room plan comparison, substantive gap detection |
+| **2nd** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation |
+| **3rd** | `spec-auditor` | Fresh-start context, completeness, content quality |
+
+**CRITICAL: If you run ONE auditor, you MUST run ALL auditors in order.**
+
+## What This Auditor Does
+
+### Audit Workflow
+
+1. **Read the spec issue** — Extract problem statement, context, constraints, success criteria
+2. **Assess problem statement clarity** — If vague, trigger brainstorming (one question at a time)
+3. **Generate clean-room plan** — Invoke `writing-plans --task clean-room` via subtask
+4. **Compare plans** — Compare clean-room plan against existing issue plan
+5. **Apply intelligence** — Differentiate simple fixes from substantive changes
+6. **Auto-update or report** — Fix simple discrepancies, flag substantive ones, post findings
+
+### Comparison Levels
+
+| Level | What's Compared | Example |
+|-------|----------------|---------|
+| **Phase-level** | Missing phases, extra phases, phase ordering | Clean-room has "Database Schema" phase not in original |
+| **Step-level** | Missing steps, extra steps, step ordering | Clean-room has "Add index" step not in original |
+| **Content-level** | Different approaches, missing edge cases, wrong assumptions | Clean-room covers pagination edge case not in original |
+
+### Semantic Matching
+
+The auditor attempts **semantic matching** before reporting differences:
+- "User Schema" vs "Database Tables" → **matching** (same concept, different naming)
+- "Authentication Setup" vs "OAuth2 Integration" → **matching** if OAuth2 is the auth method
+- "API Endpoints" vs "REST API" → **matching** (same concept)
+
+Only **substantive differences** after semantic matching are reported.
+
+### Auto-Fix Intelligence
+
+| Discrepancy Type | Action | Rationale |
+|-----------------|--------|-----------|
+| Missing file references | **Auto-fix** | Simple addition, no scope expansion |
+| Discovered repo changes | **Auto-fix** | Spec needs updating for current codebase |
+| Additional affected files | **Auto-fix** | Completeness improvement |
+| Missing phases | **Flag for human** | Substantive scope change |
+| Different approaches | **Flag for human** | Architectural decision needed |
+| Ordering differences | **Flag for human** | May be intentional dependency order |
+| Extra scope | **Flag for human** | Scope expansion requires approval |
+
+### Vague Problem Statement Handling
+
+If the problem statement extracted from the spec is vague:
+
+1. **Trigger brainstorming** — Invoke `/skill brainstorming` in one-question-at-a-time mode
+2. **Resolve vagueness** — Ask questions until the problem is clearly stated
+3. **Proceed** — Use the clarified problem statement for clean-room generation
+4. **Document** — Post the clarified problem statement as a comment on the issue
+
+### Operating Modes
+
+#### Mode 1: Auto-fix (default)
+
+Run without `--check-only`. Automatically:
+1. Generate clean-room plan
+2. Compare against existing plan
+3. Auto-fix simple discrepancies (additional files, discovered changes)
+4. Flag substantive discrepancies for human review
+5. Post GitHub comment with executive summary and link
+
+#### Mode 2: Check-only (`--check-only`)
+
+Run with `--check-only` flag. Generate comparison report only:
+1. Generate clean-room plan
+2. Compare against existing plan
+3. Post findings as GitHub comment (no issue updates)
+4. **Do NOT modify the issue**
+
+## Clean-Room Plan Generation
+
+### Process
+
+1. **Extract problem statement** from the spec issue (Objective, Problem Statement, Context, Constraints, Success Criteria sections only)
+2. **Write extracted content** to `./tmp/clean-room-input.md`
+3. **Invoke writing-plans subtask:**
+   ```
+   task(
+     subagent_type="general",
+     description="Generate clean-room plan for issue N",
+     prompt="Use the writing-plans skill --task clean-room to generate a plan from the problem statement in ./tmp/clean-room-input.md. The plan should address ONLY the problem stated, with no knowledge of the existing plan. Return the generated plan as structured markdown."
+   )
+   ```
+4. **Read the clean-room plan** from subtask output
+5. **Compare** against existing plan using the `compare` task
+
+### Clean-Room Input Isolation
+
+The clean-room plan MUST be generated from:
+- **ONLY** the problem statement, context, constraints, and success criteria from the issue
+- **NOT** the existing phases, steps, or implementation details
+- **NOT** any other issues, comments, or external context
+
+This ensures the clean-room plan is truly independent and can catch gaps the original author missed.
+
+### Subtask Context
+
+```yaml
+# Context received by writing-plans subtask
+problem_statement: "<extracted from issue>"
+context: "<extracted from issue>"
+constraints: "<extracted from issue>"
+success_criteria: "<extracted from issue>"
+existing_files: "<from codebase exploration>"
+clean_room: true  # Flag: skip approval gate, skip existing plan reference
+
+# Context yielded by the subtask
+status: "success|failure"
+plan: "<generated plan markdown>"  # If success
+error: "<error message>"  # If failure
+```
+
+## Division of Responsibility
+
+| Auditor | Scope | Runs When |
+|---------|-------|----------|
+| **plan-fidelity-auditor** | Substantive correctness, missing content, scope alignment | **FIRST** - before structure/content |
+| **concern-separation-auditor** | Phase structure, deployment independence, risk isolation | **SECOND** - after content fidelity |
+| **spec-auditor** | Fresh-start context, completeness, content quality | **THIRD** - after structure passes |
+
+## What This Auditor Owns
+
+| Check | Problem Class | Auto-Fix? | Description |
+|-------|---------------|-----------|-------------|
+| Missing phases | `MISSING_PHASE` | Flag for human | Clean-room identifies phase not in original |
+| Extra phases | `EXTRA_PHASE` | Flag for human | Original has phase not in clean-room (may be scope creep) |
+| Missing steps | `MISSING_STEP` | Auto-fix if simple | Clean-room identifies step not in original |
+| Extra steps | `EXTRA_STEP` | Flag for human | Original has step not in clean-room |
+| Different approaches | `APPROACH_DIFFERENCE` | Flag for human | Same goal, different implementation approach |
+| Missing edge cases | `MISSING_EDGE_CASE` | Flag for human | Clean-room covers edge case not in original |
+| Missing file references | `MISSING_FILE_REF` | Auto-fix | Clean-room identifies affected files not in original |
+| Ordering differences | `ORDERING_DIFFERENCE` | Flag for human | Steps in different order |
+| Scope expansion | `SCOPE_EXPANSION` | Flag for human | Clean-room is significantly larger than original |
+| Vague problem statement | `VAGUE_PROBLEM` | Trigger brainstorming | Problem statement is too vague for comparison |
+
+## GitHub Comment Format
+
+### Auto-fix Mode (Executive Summary)
+
+```
+## Plan Fidelity Audit
+
+**Summary:** <1-2 sentences describing findings and impact>
+
+**Outcome:** <What changed for stakeholders — link to revised spec or "no changes needed">
+
+### Auto-Fixed
+- <list of simple fixes applied>
+
+### Flagged for Review
+- <list of substantive changes requiring human decision>
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>): Plan Fidelity Auto-Audit
+```
+
+### Check-Only Mode
+
+```
+## Plan Fidelity Check (Report Only)
+
+**Summary:** <1-2 sentences describing findings>
+
+**Outcome:** No changes applied (--check-only mode)
+
+### Discrepancies Found
+- <list of all discrepancies>
+
+---
+🤖 📝 Updated by <AgentName> (<ModelID>): Plan Fidelity Check
+```
+
+## Integration with writing-plans
+
+The plan-fidelity-auditor invokes `writing-plans --task clean-room` as a subtask:
+
+```yaml
+# Subtask invocation
+skill: writing-plans
+task: clean-room
+input: ./tmp/clean-room-input.md  # Problem statement only
+output: structured plan markdown
+skip_approval: true  # Clean-room plans don't need approval
+skip_existing_plan: true  # Don't reference existing plan
+```
+
+The `clean-room` task in writing-plans MUST:
+- Read only the problem statement from the provided input
+- Not reference any existing plan or spec details
+- Generate an independent plan based solely on the stated problem
+- Return structured markdown that can be parsed for comparison
+
+## Edge Cases
+
+| Scenario | Action |
+|----------|--------|
+| Clean-room generation fails | Report failure, continue with remaining auditors (don't block chain) |
+| No existing plan (new spec) | Compare clean-room against spec's phase structure directly |
+| `--check-only` mode | Report findings as comment only, do NOT update issue |
+| Clean-room identical to existing | Report "no discrepancies found" and proceed |
+| Existing plan superior | Report as negative discrepancy (original has more coverage) |
+| Vague problem statement | Trigger brainstorming (one question at a time), then proceed |
+| Clean-room much larger | Report as "scope concern" in executive summary, don't auto-expand |
+
+## Mandatory Invocation (NO SKIPPING)
+
+**AI agents creating or auditing specs MUST invoke this auditor. NO EXCEPTIONS.**
+
+Updated workflow:
+
+```
+1. Create/audit spec issue
+2. Invoke /skill plan-fidelity-auditor --issue N (FIRST - plan fidelity)
+3. Invoke /skill concern-separation-auditor --issue N (SECOND - phase structure)
+4. Invoke /skill spec-auditor --issue N (THIRD - content quality)
+5. Apply fixes from all auditors
+6. Add needs-approval label
+7. Post "ready for review" comment
+```
+
+**Skipping this auditor is a CRITICAL GUIDELINE VIOLATION.**
+
+## Failure Recovery
+
+If the writing-plans subtask fails:
+
+1. **Log the failure** in the audit comment
+2. **Post a warning** that plan fidelity could not be verified
+3. **Continue** with remaining auditors (concern-separation, spec-auditor)
+4. **Do NOT block** the audit chain on clean-room generation failure
+
+## Scope Boundaries
+
+- Read-only analysis of GitHub Issue `[SPEC]` specs (unless auto-fix mode)
+- Edits limited to spec content via GitHub Issue updates
+- No changes to project source code
+- No new specs or expansions beyond what auto-fix requires
+- Must use GitHub MCP tools for all issue operations
+
+## Cross-References
+
+- Related skills: `writing-plans` (clean-room generation), `brainstorming` (vague input resolution), `concern-separation-auditor` (2nd in chain), `spec-auditor` (3rd in chain)
+- Related guidelines: `000-critical-rules.md` (auditor enforcement), `140-planning-spec-creation.md` (spec structure)

--- a/.opencode/skills/plan-fidelity-auditor/tasks/audit.md
+++ b/.opencode/skills/plan-fidelity-auditor/tasks/audit.md
@@ -1,0 +1,212 @@
+# Task: audit
+
+## Purpose
+
+Full audit workflow: extract problem statement, generate clean-room plan, compare against existing plan, auto-fix or flag discrepancies.
+
+## Operating Protocol
+
+1. **Mandatory invocation:** This task MUST run when plan-fidelity-auditor is invoked without `--check-only`.
+
+## Entry Criteria
+
+- Issue number provided via `--issue N`
+- Issue exists on GitHub and contains `[SPEC]` content
+- `writing-plans` skill is available for subtask invocation
+
+## Exit Criteria
+
+- Clean-room plan generated (or failure documented)
+- Comparison completed
+- Auto-fixes applied (unless `--check-only`)
+- Findings posted as GitHub comment
+- Remaining auditors can proceed
+
+## Procedure
+
+### Step 1: Read and Extract Problem Statement
+
+**Read the spec issue:**
+```
+github_issue_read(method="get", owner=OWNER, repo=REPO, issue_number=N)
+```
+
+**Extract ONLY the following sections:**
+- Objective
+- Problem Statement
+- Context
+- Constraints
+- Assumptions
+- Success Criteria
+- Edge Cases
+- Dependencies
+- Risk Assessment
+
+**Do NOT extract:**
+- Existing phases/steps (we want a clean-room perspective)
+- Implementation details
+- Code snippets from the spec body
+
+### Step 2: Assess Problem Statement Clarity
+
+**Evaluate the extracted problem statement:**
+
+| Clarity Level | Criteria | Action |
+|---------------|----------|--------|
+| **Clear** | Problem, context, constraints, and success criteria are all well-defined | Proceed to clean-room generation |
+| **Somewhat vague** | Missing some context or constraints, but core problem is understandable | Proceed with noted limitations |
+| **Too vague** | Problem statement is ambiguous, missing context, or too brief | Trigger brainstorming |
+
+**If too vague:**
+1. Invoke `/skill brainstorming` in one-question-at-a-time mode
+2. Post brainstorming questions to the issue as comments
+3. Wait for resolution (or use the brainstorming skill's exploration)
+4. Use clarified problem statement for generation
+5. Post clarified statement as comment on the issue
+
+### Step 3: Write Clean-Room Input
+
+**Write the extracted content to temp file:**
+```
+Write to: ./tmp/clean-room-input-N.md
+Content: Structured markdown with extracted sections only
+```
+
+**Format of clean-room input:**
+```markdown
+# Clean-Room Input for Issue #N
+
+## Objective
+<extracted objective>
+
+## Problem Statement
+<extracted problem statement>
+
+## Context
+<extracted context>
+
+## Constraints
+<extracted constraints>
+
+## Assumptions
+<extracted assumptions>
+
+## Success Criteria
+<extracted success criteria>
+
+## Edge Cases
+<extracted edge cases>
+
+## Dependencies
+<extracted dependencies>
+
+## Risk Assessment
+<extracted risk assessment>
+```
+
+### Step 4: Generate Clean-Room Plan
+
+**Invoke writing-plans subtask:**
+```
+task(
+  subagent_type="general",
+  description="Generate clean-room plan for issue N",
+  prompt="Use the writing-plans skill --task clean-room to generate an implementation plan from the problem statement in ./tmp/clean-room-input-N.md. The plan must address ONLY the problem stated, with NO knowledge of any existing plan. Generate phases with specific concern names, actionable steps, and verification methods. Return the complete plan as structured markdown."
+)
+```
+
+**If subtask fails:**
+1. Log the failure
+2. Post warning comment on issue: "Plan fidelity audit could not generate clean-room plan. Skipping fidelity check. Remaining auditors will continue."
+3. **Continue to next auditor** — do NOT block the chain
+
+### Step 5: Invoke Compare Task
+
+**Load the compare task:**
+```
+/skill plan-fidelity-auditor --task compare
+```
+
+Pass context:
+```yaml
+# Context received
+issue_number: N
+clean_room_plan: "<markdown from subtask>"
+existing_plan: "<extracted from issue>"
+mode: "auto-fix"  # or "check-only" if flag was set
+```
+
+### Step 6: Invoke Auto-Fix Task (if not check-only)
+
+**If auto-fix mode:**
+```
+/skill plan-fidelity-auditor --task auto-fix
+```
+
+Pass comparison results and discrepancy list.
+
+**If check-only mode:**
+- Skip this task
+- Post findings as comment only
+
+### Step 7: Post Audit Comment
+
+**Post executive summary comment on the issue.**
+
+**Auto-fix mode:**
+```markdown
+## Plan Fidelity Audit
+
+**Summary:** <1-2 sentences describing findings>
+
+**Outcome:** <Link to revised spec OR "no changes needed">
+
+### Auto-Fixed
+- <list of simple fixes applied>
+
+### Flagged for Review
+- <list of substantive changes requiring human decision>
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>): Plan Fidelity Auto-Audit
+```
+
+**Check-only mode:**
+```markdown
+## Plan Fidelity Check (Report Only)
+
+**Summary:** <1-2 sentences>
+
+**Outcome:** No changes applied (--check-only mode)
+
+### Discrepancies Found
+- <list of all discrepancies>
+
+---
+🤖 📝 Updated by <AgentName> (<ModelID>): Plan Fidelity Check
+```
+
+### Step 8: Clean Up Temp Files
+
+```bash
+rm ./tmp/clean-room-input-N.md
+```
+
+**Do NOT delete clean-room plan output** if it was written to a temp file — it may be needed for reference.
+
+## Context Yielded
+
+```yaml
+status: "success|failure|partial"
+discrepancies_found: N
+auto_fixes_applied: M
+flagged_for_review: K
+clean_room_generated: true|false
+brainstorming_triggered: true|false
+next_auditor: "concern-separation-auditor"
+```
+
+## Context Required
+
+- Related tasks: `compare` (comparison logic), `auto-fix` (fix application)
+- Related skills: `writing-plans` (clean-room generation), `brainstorming` (vague input resolution)

--- a/.opencode/skills/plan-fidelity-auditor/tasks/auto-fix.md
+++ b/.opencode/skills/plan-fidelity-auditor/tasks/auto-fix.md
@@ -1,0 +1,154 @@
+# Task: auto-fix
+
+## Purpose
+
+Apply auto-fix corrections to the spec issue and flag substantive discrepancies for human review. Uses AI agent intelligence to differentiate simple fixes from changes requiring human decision.
+
+## Operating Protocol
+
+1. **Invoked by:** audit task (Step 6) after comparison is complete
+2. **NOT invoked in `--check-only` mode**
+3. **Requires:** Discrepancy list from compare task
+
+## Entry Criteria
+
+- Comparison results available from `compare` task
+- Discrepancy list classified (auto-fix vs flag-for-review)
+- Issue number for updates
+
+## Exit Criteria
+
+- Auto-fixes applied to the GitHub Issue
+- Substantive discrepancies flagged in a comment
+- Executive summary posted
+
+## Procedure
+
+### Step 1: Classify Discrepancies
+
+**Review each discrepancy from the comparison results:**
+
+| Discrepancy Type | Classification | Action |
+|-----------------|----------------|--------|
+| `MISSING_PHASE` | Flag for human | New phases are substantive scope changes |
+| `EXTRA_PHASE` | Flag for human | May be intentional scope or scope creep |
+| `MISSING_STEP` (file refs) | Auto-fix | Adding file references is a simple completeness fix |
+| `MISSING_STEP` (verification) | Auto-fix | Adding verification steps is quality improvement |
+| `MISSING_STEP` (other) | Flag for human | Missing implementation steps need review |
+| `EXTRA_STEP` | Flag for human | May be scope creep or intentional addition |
+| `MISSING_FILE_REF` | Auto-fix | Adding affected files to existing steps |
+| `MISSING_EDGE_CASE` | Flag for human | Edge cases need architectural consideration |
+| `APPROACH_DIFFERENCE` | Flag for human | Different approaches need design decisions |
+| `ORDERING_DIFFERENCE` | Flag for human | May be intentional dependency order |
+| `SCOPE_EXPANSION` | Flag for human | Significant scope increase needs approval |
+| `POSSIBLE_SCOPE_CREEP` | Flag for human | Original may include unnecessary work |
+| `VAGUE_PROBLEM` | Already handled | Triggered brainstorming in audit task |
+
+### Step 2: Apply Auto-Fixes
+
+**For each auto-fix discrepancy:**
+
+2.1. **Read the current issue body**
+```
+github_issue_read(method="get", owner=OWNER, repo=REPO, issue_number=N)
+```
+
+2.2. **Determine the fix location in the issue body**
+- `MISSING_FILE_REF`: Add file to the Affected Files table
+- `MISSING_STEP` (verification): Add verification step to appropriate phase
+- `MISSING_STEP` (file refs): Add file reference to existing step
+
+2.3. **Apply the fix via issue update**
+```
+github_issue_write(method="update", owner=OWNER, repo=REPO, issue_number=N, body=updated_body)
+```
+
+**Fix application rules:**
+- Only modify the specific section that needs the fix
+- Preserve all existing content, markers, and formatting
+- Add a comment indicating what was auto-fixed: `<!-- Auto-fixed by plan-fidelity-auditor -->`
+- Do NOT add new phases — that's a substantive change
+- do NOT remove existing phases — that's a substantive change
+
+### Step 3: Flag Substantive Discrepancies
+
+**For each flag-for-review discrepancy:**
+
+3.1. **Do NOT modify the issue body**
+3.2. **Prepare a flag entry describing:**
+   - What the discrepancy is
+   - Why it needs human review
+   - What the clean-room suggests instead
+   - The specific section of the spec affected
+
+**Flag entry format:**
+```markdown
+- **[DISCREPANCY_TYPE]**: <description>
+  - Clean-room suggests: <suggestion>
+  - Affected section: <section reference>
+  - Recommendation: <brief recommendation>
+```
+
+### Step 4: Generate Executive Summary
+
+**Compose the executive summary:**
+
+```markdown
+## Plan Fidelity Audit
+
+**Summary:** <1-2 sentences: X discrepancies found, Y auto-fixed, Z flagged for review>
+
+**Outcome:** <Link to revised spec OR "X simple fixes applied. Z items flagged for human review. See details below.">
+
+### Auto-Fixed (<count>)
+<list of auto-fixes with brief descriptions>
+
+### Flagged for Review (<count>)
+<list of substantive discrepancies with recommendations>
+
+---
+🤖 ✅ Completed by <AgentName> (<ModelID>): Plan Fidelity Auto-Audit
+```
+
+### Step 5: Post Comment
+
+**Post the executive summary as a comment on the issue:**
+```
+github_add_issue_comment(owner=OWNER, repo=REPO, issue_number=N, body=executive_summary)
+```
+
+### Step 6: Clean Up
+
+**Remove temporary files:**
+```bash
+rm -f ./tmp/clean-room-input-N.md
+rm -f ./tmp/clean-room-plan-N.md
+rm -f ./tmp/comparison-results-N.json
+```
+
+## Edge Cases
+
+| Scenario | Action |
+|----------|--------|
+| No auto-fixes needed | Skip Step 2, report "no auto-fixes" in summary |
+| No discrepancies found | Report "no discrepancies found" with link to original spec |
+| Issue update fails | Document in comment, continue with reporting |
+| All discrepancies are substantive | No auto-fixes, all flagged for review |
+| Auto-fix introduces formatting error | Revert the fix, flag for manual application |
+
+## Context Yielded
+
+```yaml
+status: "auto-fix-complete"
+auto_fixes_applied: M
+flagged_for_review: K
+total_discrepancies: N
+issue_updated: true|false
+comment_posted: true|false
+next_auditor: "concern-separation-auditor"
+```
+
+## Context Required
+
+- Related tasks: `audit` (invokes this), `compare` (provides discrepancy list)
+- Related skills: `concern-separation-auditor` (next in audit chain)

--- a/.opencode/skills/plan-fidelity-auditor/tasks/compare.md
+++ b/.opencode/skills/plan-fidelity-auditor/tasks/compare.md
@@ -1,0 +1,205 @@
+# Task: compare
+
+## Purpose
+
+Compare clean-room plan against existing plan to identify discrepancies at phase-level, step-level, and content-level. Uses semantic matching to avoid false positives from naming differences.
+
+## Operating Protocol
+
+1. **Invoked by:** audit task (Step 5) or directly via `/skill plan-fidelity-auditor --task compare`
+2. **Requires:** Both plans available for comparison
+
+## Entry Criteria
+
+- Clean-room plan generated (markdown content)
+- Existing plan extracted from the spec issue
+- Issue number for context
+
+## Exit Criteria
+
+- Discrepancy list generated
+- Each discrepancy classified (auto-fix or flag-for-review)
+- Semantic matching applied to reduce false positives
+- Results ready for auto-fix task or reporting
+
+## Procedure
+
+### Step 1: Parse Both Plans
+
+**Clean-room plan structure:**
+Extract phases, steps, and key content from the subtask output.
+
+**Existing plan structure:**
+Extract phases and steps from the spec issue body. Look for `## Phase N:` headers and `☐`/`↻`/`☑`/`☒` step markers.
+
+**Parse into comparable format:**
+```python
+# Parsed structure
+{
+  "phases": [
+    {
+      "name": "Phase concern name",
+      "steps": ["Step description 1", "Step description 2"],
+      "verification": ["How to verify 1"],
+      "key_concepts": ["concept1", "concept2"]
+    }
+  ],
+  "edge_cases": ["Edge case 1"],
+  "success_criteria": ["Criterion 1"],
+  "affected_files": ["path/to/file.py"]
+}
+```
+
+### Step 2: Phase-Level Comparison
+
+**For each clean-room phase, attempt to match with existing phases:**
+
+1. **Exact match:** Same concern name → direct comparison
+2. **Semantic match:** Different name, same conceptual scope → compare content
+3. **No match:** Clean-room phase has no counterpart → `MISSING_PHASE`
+
+**For each existing phase with no clean-room counterpart:** `EXTRA_PHASE` (potential scope creep)
+
+**Semantic matching rules:**
+| Pattern | Match? | Examples |
+|---------|--------|----------|
+| Same concept, different wording | YES | "User Schema" ≈ "Database Tables", "Auth Setup" ≈ "OAuth2 Integration" |
+| Overlapping but not identical | CONTEXTUAL | "User Data Access" ≈ "Repository Layer" — compare steps |
+| Distinct concepts | NO | "API Endpoints" ≠ "UI Components" |
+
+**Comparison results format:**
+```yaml
+phase_comparison:
+  - clean_room_phase: "Database Schema Setup"
+    existing_phase: "Phase 1: User Schema"
+    match_type: "semantic"  # exact, semantic, none
+    discrepancy: null  # null if matched
+  - clean_room_phase: "Error Handling Layer"
+    existing_phase: null
+    match_type: "none"
+    discrepancy: "MISSING_PHASE"
+  - existing_phase: "UI Components"
+    clean_room_phase: null
+    match_type: "none"
+    discrepancy: "EXTRA_PHASE"
+```
+
+### Step 3: Step-Level Comparison
+
+**For each matched phase pair, compare steps:**
+
+1. **Extract steps** from both plans for the matched phase
+2. **Attempt semantic matching** between steps
+3. **Identify:**
+   - `MISSING_STEP`: Steps in clean-room not in existing
+   - `EXTRA_STEP`: Steps in existing not in clean-room
+   - `ORDERING_DIFFERENCE`: Same steps in different order
+
+**Simple fix classification:**
+| Step Type | Auto-Fix? | Rationale |
+|----------|-----------|-----------|
+| Missing file reference | YES | Simple addition, no scope change |
+| Discovered repo change | YES | Spec needs updating for current codebase |
+| Additional affected file | YES | Completeness improvement |
+| Missing verification step | YES | Quality improvement, no scope change |
+| Missing phase | NO | Substantive scope change |
+| Different approach | NO | Architectural decision needed |
+| Different ordering | NO | May be intentional dependency |
+
+### Step 4: Content-Level Comparison
+
+**Compare key content between matched phase/step pairs:**
+
+| Content Area | What to Compare | Discrepancy Class |
+|--------------|----------------|-------------------|
+| Approaches | Implementation strategy differences | `APPROACH_DIFFERENCE` |
+| Edge cases | Missing or different edge case coverage | `MISSING_EDGE_CASE` |
+| File references | Missing files that should be affected | `MISSING_FILE_REF` |
+| Assumptions | Different underlying assumptions | Flag for review |
+| Constraints | Different constraint handling | Flag for review |
+
+### Step 5: Scope Assessment
+
+**Compare overall plan sizes:**
+
+```python
+scope_ratio = clean_room_phase_count / existing_phase_count
+
+if scope_ratio > 1.5:
+    # Clean-room is significantly larger
+    discrepancy_class = "SCOPE_EXPANSION"
+    action = "Flag for human review — clean-room identifies more work than originally scoped"
+
+elif scope_ratio < 0.67:
+    # Existing is significantly larger
+    discrepancy_class = "POSSIBLE_SCOPE_CREEP"
+    action = "Flag for human review — original may include unnecessary work"
+
+else:
+    # Roughly the same scope
+    action = "Proceed with detailed comparison"
+```
+
+### Step 6: Generate Discrepancy Report
+
+**Compile all discrepancies into a structured report:**
+
+```yaml
+discrepancies:
+  # Phase-level
+  - type: "MISSING_PHASE"
+    clean_room: "Error Handling Layer"
+    existing: null
+    auto_fix: false
+    reason: "Clean-room identifies error handling as separate concern"
+
+  - type: "EXTRA_PHASE"
+    clean_room: null
+    existing: "UI Polish"
+    auto_fix: false
+    reason: "Existing includes UI polish — may be scope creep"
+
+  # Step-level
+  - type: "MISSING_STEP"
+    phase: "Database Schema Setup"
+    clean_room: "Add migration rollback support"
+    existing: null
+    auto_fix: true
+    reason: "Missing verification for schema changes"
+
+  # Content-level
+  - type: "MISSING_FILE_REF"
+    phase: "User Data Access"
+    clean_room: "src/repositories/user_repository.py"
+    existing: "Not mentioned"
+    auto_fix: true
+    reason: "Repository file should be referenced"
+
+  # Scope
+  - type: "SCOPE_EXPANSION"
+    ratio: "1.8"
+    auto_fix: false
+    reason: "Clean-room identifies more work than originally scoped"
+```
+
+### Step 7: Yield Comparison Results
+
+**Pass structured results to auto-fix task or reporting:**
+
+```yaml
+# Yield-back context
+status: "comparison_complete"
+total_discrepancies: N
+auto_fix_count: M
+flag_for_review_count: K
+discrepancies: "<structured list>"
+clean_room_plan: "<full markdown>"
+existing_plan: "<full markdown>"
+semantic_matches: "<list of matched phase pairs>"
+scope_assessment: "balanced|expansion|creep"
+```
+
+## Context Required
+
+- Related tasks: `audit` (invokes this), `auto-fix` (uses results)
+- Related skills: `writing-plans` (provides clean-room plan)

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -11,22 +11,24 @@ compatibility: opencode
 
 **This auditor checks whether an LLM agent with NO memory context can implement the spec correctly.**
 
-**Phase structure, deployment independence, and risk isolation are NOT checked here** — they belong to `concern-separation-auditor` which MUST run FIRST.
+**Phase structure, deployment independence, and risk isolation are NOT checked here** — they belong to `concern-separation-auditor` which runs SECOND (after `plan-fidelity-auditor`).
 
 ### Division of Responsibility
 
 | Auditor | Scope | Role |
 |---------|-------|------|
-| **concern-separation-auditor** | Phase structure, deployment independence, risk isolation, blast radius, phase names | Runs FIRST - structural safety |
-| **spec-auditor** | Fresh-start context, completeness, content quality, LLM implementability | Runs SECOND - content quality |
+| **plan-fidelity-auditor** | Clean-room plan comparison, substantive gap detection, scope alignment | Runs FIRST - plan fidelity |
+| **concern-separation-auditor** | Phase structure, deployment independence, risk isolation, blast radius, phase names | Runs SECOND - structural safety |
+| **spec-auditor** | Fresh-start context, completeness, content quality, LLM implementability | Runs THIRD - content quality |
 
-**CRITICAL: Both auditors are MANDATORY. No skipping.**
+**CRITICAL: All auditors are MANDATORY. No skipping.**
 
 **Workflow:**
 ```
 Create spec issue #N →
-Invoke concern-separation-auditor --issue N (FIRST - phase structure, auto-fix) →
-Invoke spec-auditor --issue N (SECOND - content quality) →
+Invoke plan-fidelity-auditor --issue N (FIRST - plan fidelity, clean-room comparison) →
+Invoke concern-separation-auditor --issue N (SECOND - phase structure, auto-fix) →
+Invoke spec-auditor --issue N (THIRD - content quality) →
 Add needs-approval label →
 Post "ready for review" comment
 ```
@@ -41,8 +43,9 @@ Post "ready for review" comment
 
 | Order | Skill | Purpose |
 |-------|-------|---------|
-| **1st** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names |
-| **2nd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
+| **1st** | `plan-fidelity-auditor` | Clean-room plan comparison, substantive gap detection, scope alignment |
+| **2nd** | `concern-separation-auditor` | Phase structure, deployment independence, risk isolation, blast radius, phase names |
+| **3rd** | `spec-auditor` | Fresh-start context, completeness, content quality, LLM implementability |
 
 **Trigger words that require ALL skills:**
 - "audit this spec"
@@ -53,7 +56,7 @@ Post "ready for review" comment
 - "audit the issue"
 - Any request involving spec quality or structure
 
-**CRITICAL: If you run ONE auditor, you MUST run BOTH auditors in order.**
+**CRITICAL: If you run ONE auditor, you MUST run ALL auditors in order.**
 
 ---
 
@@ -169,16 +172,20 @@ Per `085-engineering-approach.md`:
 | Conflicts | `CONFLICTING` | Parts contradict each other? |
 | Superseded closure | `SUPERSEDED-CLOSURE-VIOLATION` | Closing comment claims future action? |
 
-### What This Auditor Does NOT Check (Belongs to concern-separation-auditor)
+### What This Auditor Does NOT Check (Belongs to Other Auditors)
 
 | Check | Belongs To |
 |-------|------------|
+| Clean-room plan comparison, substantive gaps | `plan-fidelity-auditor` |
 | Phase names describe concerns | `concern-separation-auditor` |
 | Concern mixing (`PHASE-CONCERN-MERGE` → `CONCERN_MIXING`) | `concern-separation-auditor` |
 | Deployment independence | `concern-separation-auditor` |
 | Risk profile separation | `concern-separation-auditor` |
 | Blast radius minimization | `concern-separation-auditor` |
 | Dependency direction | `concern-separation-auditor` |
+| BOILERPLATE-TITLE for phases/titles | `concern-separation-auditor` |
+| Missing phases, steps, or content from clean-room analysis | `plan-fidelity-auditor` |
+| Scope alignment with problem statement | `plan-fidelity-auditor` |
 | BOILERPLATE-TITLE for phases/titles | `concern-separation-auditor` |
 
 ## Problem Class Definitions
@@ -388,8 +395,9 @@ GitHub Comment: <URL to comment>
 
 When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 1. Create the spec issue with all required content
-2. Invoke `/skill concern-separation-auditor --issue N` (FIRST - phase structure, auto-fix by default)
-3. Invoke `/skill spec-auditor --issue N` (SECOND - content quality)
+2. Invoke `/skill plan-fidelity-auditor --issue N` (FIRST - plan fidelity, clean-room comparison)
+3. Invoke `/skill concern-separation-auditor --issue N` (SECOND - phase structure, auto-fix by default)
+4. Invoke `/skill spec-auditor --issue N` (THIRD - content quality)
 4. Apply any fixes identified by auditors
 5. Add `needs-approval` label
 6. Post "ready for review" comment
@@ -406,30 +414,32 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 
 ## Coordination Points
 
-### Integration with concern-separation-auditor
+### Integration with Other Auditors
 
-**BOTH auditors are required. They check different things.**
+**ALL three auditors are required. They check different things.**
 
 | Auditor | Runs When | Checks |
 |---------|----------|--------|
-| `concern-separation-auditor` | FIRST | Phase structure, deployment independence, risk isolation, blast radius, phase names, BOILERPLATE-TITLE |
-| `spec-auditor` | SECOND | Fresh-start context, completeness, content quality, LLM implementability |
+| `plan-fidelity-auditor` | FIRST | Clean-room plan comparison, substantive gap detection, scope alignment |
+| `concern-separation-auditor` | SECOND | Phase structure, deployment independence, risk isolation, blast radius, phase names, BOILERPLATE-TITLE |
+| `spec-auditor` | THIRD | Fresh-start context, completeness, content quality, LLM implementability |
 
-**Order matters:** concern-separation-auditor fixes structural issues first, then spec-auditor checks content quality.
+**Order matters:** plan-fidelity-auditor validates content fidelity first, then concern-separation-auditor fixes structural issues, then spec-auditor checks content quality.
 
 ### Integration with Approval Gate
 
-- **Approval Gate (`010-approval-gate.md`)**: Before approving implementation, both auditors must have been run.
+- **Approval Gate (`010-approval-gate.md`)**: Before approving implementation, all auditors must have been run.
 - **Critical Rules (`000-critical-rules.md`)**: References auditor skills for enforcement.
 - **Planning Guidelines (`140-planning-spec-creation.md`)**: Defines the structure requirements enforced by these auditors.
 
 ### Enforcement Flow
 
 1. User creates a [SPEC] issue.
-2. concern-separation-auditor runs (phase structure fixes).
-3. spec-auditor runs (content quality fixes).
-4. After both auditors pass → Add `needs-approval` label.
-5. After approval → Implementation begins.
+2. plan-fidelity-auditor runs (plan fidelity check).
+3. concern-separation-auditor runs (phase structure fixes).
+4. spec-auditor runs (content quality fixes).
+5. After all auditors pass → Add `needs-approval` label.
+6. After approval → Implementation begins.
 
 ## Example Session
 

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -24,6 +24,7 @@ You are an Implementation Planner. Your focus is transforming approved design sp
 | `create` | Create plan from approved spec | ~1000 |
 | `validate` | Check for placeholders and completeness | ~600 |
 | `retroactive` | Create plan for existing spec | ~800 |
+| `clean-room` | Generate independent plan from problem statement only (for comparison) | ~500 |
 
 ## Invocation
 
@@ -31,6 +32,7 @@ You are an Implementation Planner. Your focus is transforming approved design sp
 - `/skill writing-plans --task create` - Create plan from current spec
 - `/skill writing-plans --task validate` - Validate existing plan
 - `/skill writing-plans --task retroactive` - Create plan for existing spec
+- `/skill writing-plans --task clean-room` - Generate clean-room plan from problem statement only (for plan-fidelity-auditor comparison)
 
 ## Operating Protocol
 

--- a/.opencode/skills/writing-plans/tasks/clean-room.md
+++ b/.opencode/skills/writing-plans/tasks/clean-room.md
@@ -1,0 +1,168 @@
+# Task: clean-room
+
+## Purpose
+
+Generate a clean-room implementation plan from a problem statement only, with no knowledge of any existing plan. Used by the plan-fidelity-auditor to create an independent plan for comparison against the existing spec.
+
+## Operating Protocol
+
+1. **Invoked by:** `plan-fidelity-auditor` via subtask invocation (not by users directly)
+2. **Bypasses:** Approval gate (clean-room plans don't need approval — they're comparison artifacts, not implementation plans)
+3. **Does NOT reference:** Any existing plan, spec phases, or spec steps
+
+## Entry Criteria
+
+- Problem statement input file exists at `./tmp/clean-room-input-N.md`
+- Problem statement contains: Objective, Problem Statement, Context, Constraints, Success Criteria
+- The writing-plans skill is available
+
+## Exit Criteria
+
+- Clean-room plan generated as structured markdown
+- Plan returned to the invoking subtask context
+- No issue created (clean-room plans are comparison artifacts, not tracked in GitHub)
+
+## Key Differences from Standard Plan Creation
+
+| Aspect | Standard Plan (`--task create`) | Clean-Room Plan (`--task clean-room`) |
+|--------|-------------------------------|--------------------------------------|
+| Input source | Approved spec issue | Problem statement only (from temp file) |
+| References existing plan | May reference spec phases | **NEVER references existing plan** |
+| Creates GitHub issue | Yes | **No** — returned as markdown only |
+| Requires approval | Yes (`needs-approval` label) | **No** — comparison artifact |
+| Skip approval gate | No | **Yes** — not an implementation plan |
+| Persists after comparison | Yes (tracked) | **No** — deleted after comparison |
+
+## Procedure
+
+### Step 1: Read Problem Statement
+
+**Read the clean-room input file:**
+```
+Read: ./tmp/clean-room-input-N.md
+```
+
+**Extract sections:**
+- Objective
+- Problem Statement
+- Context
+- Constraints
+- Assumptions
+- Success Criteria
+- Edge Cases
+- Dependencies
+- Risk Assessment
+
+### Step 2: Explore Codebase (If Applicable)
+
+**For files and patterns mentioned in the problem statement:**
+- Use `srclight_search_symbols` or `pycharm_search_in_files_by_text` to find relevant code
+- Identify affected files, modules, and patterns
+- Note existing patterns that should be followed
+
+**Important:** This exploration uses ONLY the problem statement, not the existing spec's phases or steps.
+
+### Step 3: Generate Independent Plan
+
+**Generate a plan based solely on the problem statement and codebase exploration.**
+
+**Plan template:**
+```markdown
+# Clean-Room Plan: [Feature Name]
+
+GENERATED: YYYY-MM-DD
+SOURCE: Problem statement only (no reference to existing plan)
+
+---
+
+## Phase 1: [Specific Concern Name]
+
+### Steps
+1. ☐ [Specific actionable step]
+2. ☐ [Specific actionable step]
+3. ☐ Verification: [How to verify]
+
+---
+
+## Phase 2: [Specific Concern Name]
+
+### Steps
+1. ☐ [Specific actionable step]
+2. ☐ [Specific actionable step]
+3. ☐ Verification: [How to verify]
+
+---
+
+## Affected Files
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `path/to/file` | [New/Modified/Deleted] | [What changes] |
+
+---
+
+## Edge Cases Addressed
+
+1. [Edge case from problem statement]
+2. [Edge case discovered during analysis]
+
+---
+
+## Success Criteria (from problem statement)
+
+1. ✅ [Criterion from problem statement]
+2. ✅ [Criterion from problem statement]
+```
+
+**Quality requirements:**
+- Phase names describe **specific concerns**, NOT generic activities
+- Each step is **actionable** (not abstract goals)
+- Verification methods included for each phase
+- Affected files listed based on codebase exploration
+- Edge cases from problem statement are addressed
+- **No TBD, TODO, or placeholder content**
+
+### Step 4: Validate Plan
+
+**Check for prohibited patterns:**
+- No `TBD`, `TODO`, `[to be determined]`, `[placeholder]`
+- All phases have specific concern names (not "Implementation", "Testing")
+- All steps are actionable
+- Success criteria are testable
+
+**If validation fails:**
+- Re-generate the missing sections
+- Do NOT leave placeholders
+
+### Step 5: Yield Results
+
+**Return the plan as structured markdown to the invoking subtask:**
+
+```yaml
+# Yield-back context
+status: "success|failure"
+plan: "<complete plan markdown>"  # If success
+error: "<error message>"  # If failure
+phases_count: N
+steps_count: M
+affected_files_count: K
+```
+
+**If failure:**
+- Return error message
+- Do NOT create a partial plan
+- Do NOT create a GitHub Issue
+
+## Scope Boundaries
+
+- **NO** GitHub Issue creation — plan is returned as markdown only
+- **NO** approval gate — clean-room plans are comparison artifacts
+- **NO** reference to existing plan — independent generation only
+- **YES** codebase exploration — to identify affected files and patterns
+- **YES** structured markdown output — for comparison by `compare` task
+
+## Cross-References
+
+- Invoked by: `plan-fidelity-auditor` (audit task)
+- Related tasks: `create` (standard plan creation), `validate` (plan validation)
+- Related skills: `plan-fidelity-auditor` (invoker)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,90 +1,173 @@
 # AGENTS.md — Repository Guidelines for Coding Agents
 
-## 🚨 MANDATORY STARTUP SEQUENCE (Try/Catch/Finally)
+## Identity Detection (MANDATORY FIRST)
 
-**⚠️ ZERO TOLERANCE: Complete ALL steps before ANY tool calls.**
+The AI agent must determine its identity from the system prompt on EVERY session:
 
-### TRY BLOCK: Session Init (MUST COMPLETE FIRST)
+1. **Detect AI agent and model** from your system context
+2. **Report identity** in byline format: `<AgentName> (<ModelID>)`
+3. **Examples**: `OpenCode (ollama-cloud/glm-5)`, `OpenCode Desktop (ollama-cloud/glm-5)`, `Claude (claude-3-5-sonnet)`
+
+**WHY**: Different agents/loaders provide different context. System prompt tells you what you are.
+
+---
+
+## Session Init (MANDATORY)
+
+**Run BEFORE any other operations:**
 
 ```bash
 uv run python ai_bin/session_init.py
 ```
 
-**Store outputs for session duration:**
-- `DEV_NAME`, `DEV_EMAIL` → Commit trailers
-- `GIT_OWNER`, `GIT_REPO` → GitHub MCP calls
-- `GIT_HOOKS_PATH` → Hook verification
-- `GIT_REMOTE_URL` → Reference
+**Script outputs:**
+- `DEV_NAME`: Human collaborator name (for commit trailers)
+- `DEV_EMAIL`: Human collaborator email (for commit trailers)
+- `GIT_OWNER`: Repository owner (for API calls)
+- `GIT_REPO`: Repository name (for API calls)
+- `GIT_HOOKS_PATH`: Git hooks path (to verify hooks installed)
+- `GIT_REMOTE_URL`: Full remote URL (for reference)
+- `GIT_PLATFORM`: Platform type (`github` or `gitbucket`)
+- `GITBUCKET_HTML_URL`: GitBucket web UI base URL (if GitBucket, non-secret)
+- `GITBUCKET_HAS_CREDENTIALS`: `true` if credentials configured in `.env`
 
-**Exit codes:**
-- `0`: Success → Proceed to Finally block
-- `1`: No remote configured → Report error, HALT (developer must configure)
-- `2`: Non-GitHub remote → GitHub MCP unavailable
-
-### CATCH BLOCK: Error Handling
-
-| Exit Code | Problem | Action |
-|-----------|---------|--------|
-| 1 | No remote configured | Report error → HALT (developer must configure remote) |
-| 2 | Non-GitHub remote | GitHub MCP unavailable → Use `gh` CLI fallback |
-| Script not found | Report error | HALT — cannot proceed |
-
-### FINALLY BLOCK: MCP Probe (ALWAYS RUNS AFTER TRY)
-
-**Probe MCP availability:**
-1. PyCharm MCP: `pycharm_get_project_modules`
-2. GitHub MCP: `github_get_me`
-3. Record availability for tool selection
-
-### CIRCUIT BREAKER: Enforcement Gate
-
-🚫 **NO tool calls** before Try block completes successfully
-🚫 **NO MCP calls** before Finally block completes
-🚫 **NO implementation** before authorization verified
+**Store these values for session duration.**
 
 ---
 
-## Skills-First Workflow
+## Platform Detection and API Access
 
-**ALL procedural workflows are in skills. Guidelines contain ONLY essential rules.**
+The session init script detects git platform from remote URL:
 
-### Master Trigger Table
+| Platform | Detection | API Access |
+|----------|-----------|-----------| 
+| GitHub | `github.com` in URL | GitHub MCP tools or `gh` CLI |
+| GitBucket | Any other SSH/HTTPS remote | Direct API via `.env` credentials |
 
-| Workflow Trigger | Invocation |
-|------------------|------------|
-| Before ANY file edit | `/skill approval-gate --task verify-authorization` |
-| Before implementation | `/skill approval-gate --task verify-sub-issues` |
-| After authorization | `/skill git-workflow --task pre-work` |
-| After implementation | `/skill git-workflow --task review-prep` (AUTOMATIC) |
-| "create a PR" | `/skill git-workflow --task pr-creation` |
-| "PR merged" | `/skill git-workflow --task cleanup` |
-| Before creating file | `/skill implementation-quality --task file-locations` |
-| At implementation start | `/skill implementation-quality --task code-structure` |
-| Before running commands | `/skill implementation-quality --task environment` |
-| Before handling data | `/skill implementation-quality --task data-integrity` |
-| Writing code | `/skill code-size-enforcement` |
-| After ANY code/guideline/skill/task change | `/skill code-review` (MANDATORY) |
-| Before spec approval | `/skill concern-separation-auditor --issue N` (FIRST) |
-| After concern auditor | `/skill spec-auditor --issue N` (SECOND) |
-| After spec auditor | `/skill dev-architect --task review-spec` (THIRD) |
+### GitBucket API Access
 
-**See `.opencode/skills/` for complete skill documentation.**
+For GitBucket repositories, invoke `gitbucket-api` skill BEFORE using GitBucket Python API.
+
+**GitBucket-specific patterns:**
+- Token authentication only (no basic auth)
+- Auto-create labels when adding to issues
+- GitHub-compatible API v3
 
 ---
 
-## Essential Rules (Zero Tolerance)
+## MCP Enforcement Gate
 
-| Rule | Description |
-|------|-------------|
-| Spec before code | NO code changes WITHOUT approved spec |
-| Authorization required | NO implementation WITHOUT `"approved"` or `"go"` |
-| Branch first | Create feature branch BEFORE any file modification |
-| Human-only merge | Agents MUST NEVER merge PRs |
-| Silent halt | HALT after completion — no prompts |
-| PR timing | PRs require explicit `"create a PR"` instruction |
-| MCP tools | Use PyCharm/GitHub MCP for file operations when available |
-| `/tmp/` prohibited | Use `./tmp/` only |
-| Notebook operations | Use `the-notebook-mcp` ONLY — never edit `.ipynb` directly |
+**After session init, probe MCP availability:**
+
+1. **PyCharm MCP**: Call `pycharm_get_project_modules`
+2. **GitHub MCP**: Call `github_get_me` (if GitHub platform)
+3. **Record results**: Note which toolsets are available
+
+| Scenario | Spec Tracking | File Operations | API Operations |
+|----------|---------------|-----------------|----------------|
+| PyCharm + GitHub MCP + GitHub repo | GitHub Issues | PyCharm MCP ONLY | GitHub MCP ONLY |
+| PyCharm + GitHub MCP + GitBucket repo | GitBucket API via `.env` | PyCharm MCP ONLY | Direct API calls |
+| PyCharm only | GitBucket API via `.env` | PyCharm MCP ONLY | N/A |
+| Neither available | Issues via API | Direct tools + `# FALLBACK` | Direct API calls |
+
+🚫 **PROHIBITED**: Using `read`/`write`/`edit`/`glob`/`grep` on ANY files when PyCharm MCP is available.
+
+---
+
+## Dispatch Table Loading (MANDATORY)
+
+**On EVERY session, load the dispatch table dynamically:**
+
+```yaml
+# File: .opencode/dispatch-table.yaml
+# This file tells the AI agent when to invoke which skills
+```
+
+**The dispatch table defines:**
+- When to invoke platform skills (`gitbucket-api`, `github-issue-creation`)
+- When to invoke code quality skills (`code-size-enforcement`, `spec-auditor`)
+- When to invoke workflow skills (`git-workflow`, `approval-gate`, `pr-creation-workflow`)
+- Automatic invocation rules
+- Sub-task invocation patterns
+
+**DO NOT embed the dispatch table in AGENTS.md. LOAD IT DYNAMICALLY.**
+
+---
+
+## Skills
+
+OpenCode skills are available in `.opencode/skills/`. Each skill has a `SKILL.md` file.
+
+**To use a skill**, invoke it when relevant to the current task:
+
+```
+/skill <skill-name>
+/skill <skill-name> --task <task-name>
+```
+
+**For dispatch rules**, see `.opencode/dispatch-table.yaml` which defines when each skill is invoked.
+
+### Sub-Task Architecture
+
+Skills with `tasks/` subdirectory support `--task` parameter for loading specific workflow phases:
+
+```
+.opencode/skills/git-workflow/
+├── SKILL.md              (~100 lines - overview + task table)
+└── tasks/
+    ├── pre-work.md       (~80 lines - Phase 0)
+    ├── implementation.md (~80 lines - Phase 1)
+    ├── review-prep.md    (~70 lines - Phase 2)
+    ├── commit-prep.md    (~90 lines - Phase 3)
+    ├── pr-creation.md    (~80 lines - Phase 4)
+    └── cleanup.md        (~120 lines - Phase 5)
+```
+
+**Context Savings:** 75%+ reduction (load ~100 lines instead of ~500 lines)
+
+**Usage:**
+- `/skill git-workflow --task pre-work` - Load only pre-work task
+- `/skill git-workflow --task pr-creation` - Load only PR creation task
+- `/skill git-workflow` (no --task) - Skill overview only
+
+### Integration with Approval Gates
+
+- `approval-gate` skill: spec + authorization workflow
+- `010-approval-gate.md`: critical rules (zero tolerance violations)
+- `000-critical-rules.md`: auditor skill references
+- Both auditors create audit logs in `./tmp/` for tracking
+
+### Workflow Skills
+
+The dispatch table (`dispatch-table.yaml`) orchestrates workflow skills in sequence:
+
+| Skill | Purpose | Dispatch Trigger |
+|-------|---------|------------------|
+| `brainstorming` | Pre-spec requirements exploration | Before any spec creation |
+| `writing-plans` | Transform approved specs into action plans | After spec approval |
+| `executing-plans` | Step-by-step plan execution | After plan approval |
+| `verification-before-completion` | Evidence gates before completion claims | Before marking tasks complete |
+| `implementation-workflow` | Orchestration layer with yield-back context | After approval-gate confirms auth |
+| `systematic-debugging` | Root cause analysis before bug fixes | Bug or error encountered |
+| `finishing-a-development-branch` | Branch completion checklist | Implementation completes |
+| `test-driven-development` | TDD red-green-refactor workflow | User requests TDD approach |
+| `receiving-code-review` | Address review feedback precisely | PR receives review comments |
+| `requesting-code-review` | Prepare and submit review requests | User says "request review" |
+
+**Implementation-workflow** coordinates git-workflow tasks (pre-work, review-prep, pr-creation) and yields structured context between stages. Authorization is checked once by `approval-gate`, then passed through the orchestration chain — no redundant re-checks.
+
+---
+
+## Guidelines Structure
+
+Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
+
+| Series | Category | Files |
+|--------|----------|-------|
+| 000-099 | Core Rules | critical-rules, session-init, approval-gate, go-prohibitions, scope-autonomy, tool-usage, environment |
+| 200-209 | Error Handling | exception-handling, missing-data, logging-vs-raising |
+
+**Registry of migrated content**: `.opencode/.guidelines/registry.yaml` tracks content moved from guidelines to skills.
 
 ---
 
@@ -94,116 +177,110 @@ uv run python ai_bin/session_init.py
 |------|---------|------------|
 | Sync dependencies | `uv sync` | - |
 | Run all tests | `uv run pytest test/` | - |
+| Run one test file | `uv run pytest test/test_filename.py` | - |
+| Run one test | `uv run pytest test/test_filename.py::test_function_name` | - |
 | Lint + auto-fix | `uvx ruff check --fix src/ test/` | Python ONLY |
 | Format | `uvx ruff format src/ test/` | Python ONLY |
 | Type check | `uvx pyright src/` | Python ONLY |
+| Coverage | `uv run coverage run -m pytest test/ && uv run coverage report` | - |
+| Dead code scan | `uvx vulture src/` | Python ONLY |
 | Markdown lint | `uvx pymarkdownlnt scan -r .opencode/guidelines/ docs/` | Markdown ONLY |
-| Markdown format | `uvx mdformat --number --wrap keep --end-of-line lf .opencode/guidelines/ docs/` | Markdown ONLY |
+| Markdown format | `uvx mdformat .opencode/guidelines/ docs/` | Markdown ONLY |
 
-**NEVER**: `python`, `python3`, `pip`, `uv add`, `ruff` on markdown
-
----
-
-## Authorization Recognition
-
-| Pattern | Example | Action |
-|---------|---------|--------|
-| Direct command | "implement #227" | ✅ Continue |
-| Compound command | "implement #227 and include in branch" | ✅ Continue |
-| Question | "should I implement #227?" | 🚫 HALT |
-| Conditional | "if you think #227 is needed..." | 🚫 HALT |
-
-**Multi-phase authorization:**
-- `approved` or `go` → ALL phases authorized
-- `approved: 1` → Phase 1 only
-- `approved: 2.3` → Phase 2, Step 3 only
-
-**Revision revokes approval:** Any spec change requires fresh authorization.
+**Never** use bare `python`, `python3`, or `pip`. Always prefix with `uv run` for project commands.
 
 ---
 
-## Guideline Files (Rules Only)
+## Project Structure
 
-| Guideline | Purpose |
-|-----------|---------|
-| `000-critical-rules.md` | Zero tolerance violations |
-| `000-session-init.md` | Startup sequence |
+- `src/`: Application source code
+- `test/`: Unit and integration tests
+- `docs/`: Documentation and specifications
+- `ai_bin/`: Agent utility scripts
+- `.opencode/`: Skills and guidelines
+  - `skills/`: Self-contained skills (no guideline dependencies)
+  - `guidelines/`: Core zero-tolerance rules only
+  - `.guidelines/registry.yaml`: Registry of migrated content
+
+---
+
+## Code Style
+
+See `.opencode/guidelines/080-code-standards.md` for details.
+
+---
+
+## Git Workflow
+
+See `git-workflow` skill for complete workflow including:
+- **Three-branch architecture:**
+  - Feature branches (`spec/*` or `feature/*`) → Dev branch (`dev`)
+  - Dev branch (`dev`) → Main branch (`main` or `master`)
+  - AI commits blocked on `main`/`master`/`dev` by git hooks
+- Branch before edit (MANDATORY)
+- Branch from `dev` for features (sync first)
+- Stash before branch creation
+- Squash before PR (target `dev`, not `main`)
+- Human-only merge
+- Cleanup after merge
+
+**Branch naming:** `spec/<short-name>` or `feature/<description>`
+
+---
+
+## Boundaries (Critical)
+
+**✅ ALWAYS:**
+- Run session init script at session start
+- Create feature branch BEFORE any filesystem change
+- Wait for explicit authorization ("approved" or "go") before implementing
+- SILENTLY HALT after completing a task
+- Use PyCharm MCP tools for all file operations when available
+
+**✅ Multi-Task Spec Workflow (CRITICAL):**
+When parent issue has sub-issues, authorization cascades to ALL sub-issues:
+
+- [ ] User authorizes parent issue
+- [ ] Verify parent has sub-issues
+- [ ] Authorization cascades to ALL sub-issues
+- [ ] Complete ALL phases in sequence (NO HALT between phases)
+- [ ] Report ONCE after ALL phases complete
+- [ ] HALT ONCE at the end
+
+**Exception:** User explicitly names a phase (e.g., "approved: Phase 2 only") → complete that phase ONLY, then HALT
+
+**🚫 NEVER:**
+- Write code/notebooks/configs/tests without approved spec
+- Interpret questions as authorization
+- Proceed to next task after completing a task — HALT
+- Create PRs without explicit "create a PR" instruction
+- Use `/tmp/` — only use `./tmp/`
+- Assume cached values from previous sessions
+- HALT after each phase of multi-task spec (see Multi-Task Spec Workflow above)
+
+---
+
+## Q/A Mode
+
+After session init and dispatch table load, switch to Q/A mode:
+
+1. **Report identity**: `<AgentName> (<ModelID>)`
+2. **Report init results**: Platform, MCP availability
+3. **Switch to Q/A**: "Ready. What would you like me to do?"
+4. **Wait for user input**
+
+**DO NOT proactively suggest tasks or ask leading questions.**
+
+---
+
+## Reference Files
+
+| File | Purpose |
+|------|---------|
+| `.opencode/dispatch-table.yaml` | Skill invocation rules (LOAD DYNAMICALLY) |
+| `.opencode/.guidelines/registry.yaml` | Registry of migrated content blocks |
+| `000-critical-rules.md` | Zero-tolerance violations |
 | `010-approval-gate.md` | Authorization workflow |
-| `015-mcp-preference.md` | Tool selection |
-| `020-go-prohibitions.md` | GO command limits |
-| `050-scope-autonomy.md` | Scope restrictions |
-| `060-tool-usage.md` | Tool usage rules |
-| `061-notebook-rules.md` | Notebook operations |
-| `070-environment.md` | Environment setup |
-| `075-docs-verification.md` | Documentation verification |
-| `080-code-standards.md` | Code quality standards |
-| `085-engineering-approach.md` | Engineering principles |
-| `086-http-requests.md` | HTTP request standards |
-| `087-no-backward-compat.md` | Refactoring rules |
-| `090-data-integrity.md` | Data handling rules |
-| `100-persistence.md` | PostgreSQL/SQLAlchemy standards |
-| `110-git-branch-first.md` | Branch workflow |
-| `111-git-commit-workflow.md` | Commit standards |
-| `112-git-merge-protocol.md` | Merge protocol |
-| `113-git-pr-workflow.md` | PR workflow |
-| `114-git-branch-cleanup.md` | Branch cleanup |
-| `115-git-hotfix-workflow.md` | Hotfix workflow |
-| `120-github-issue-first.md` | Issue workflow |
-| `121-github-pr-workflow.md` | PR creation |
-| `122-github-mcp-operations.md` | GitHub MCP |
-| `123-github-ai-identity.md` | AI identity in comments |
-| `124-github-archive-workflow.md` | Issue closure |
-| `125-github-issue-comments.md` | Comment protocol |
-| `130-authority-source.md` | Code as authority |
-| `140-planning-spec-creation.md` | Spec creation |
-
-**Procedural content moved to skills.** Guidelines now contain ONLY rules.
-
----
-
-## Identity Detection (CRITICAL)
-
-**🚫 FORBIDDEN: Copy hardcoded identity examples from guidelines.**
-
-**✅ REQUIRED: Extract identity from system prompt at runtime:**
-- `<AgentName>` → Your actual name (e.g., "OpenCode Desktop")
-- `<ModelID>` → Backing model (e.g., "ollama-cloud/qwen3.5:397b")
-- `<ai-email>` → Agent's noreply email
-
-**Example values in guidelines are ILLUSTRATIVE ONLY — substitute your actual identity.**
-
----
-
-## Session Communication
-
-| Output Type | Destination |
-|-------------|-------------|
-| Session summaries, progress updates | CHAT ONLY |
-| Interactive questions, chit-chat | CHAT ONLY |
-| Audit logs | Internal (`./tmp/`) — NOT posted anywhere |
-| Investigation artifacts | GitHub Issues (only when substantive) |
-| Closure summaries | GitHub Issues (historical record) |
-
-**CRITICAL:** ALL chat session communication goes to CHAT ONLY, NEVER to GitHub Issues. Audit logs are internal artifacts — do NOT post to chat or GitHub unless explicitly requested.
-
----
-
-## Guideline Violations
-
-**If agent violates guideline:**
-
-1. STOP task
-2. Update this file "NEVER" list
-3. Update relevant `.opencode/guidelines/` file
-4. Document fix in issue comment (FACTUAL ONLY)
-5. Wait for confirmation before resuming
-
----
-
-**Run session init FIRST:**
-```bash
-uv run python ai_bin/session_init.py
-```
-
----
-🤖 ✨ Created by OpenCode Desktop (ollama-cloud/qwen3.5:397b)
+| `020-go-prohibitions.md` | GO command restrictions |
+| `git-workflow` skill | Complete git workflow |
+| `approval-gate` skill | Authorization verification |

--- a/AGENTS.md.legacy
+++ b/AGENTS.md.legacy
@@ -1,0 +1,209 @@
+# AGENTS.md — Repository Guidelines for Coding Agents
+
+## 🚨 MANDATORY STARTUP SEQUENCE (Try/Catch/Finally)
+
+**⚠️ ZERO TOLERANCE: Complete ALL steps before ANY tool calls.**
+
+### TRY BLOCK: Session Init (MUST COMPLETE FIRST)
+
+```bash
+uv run python ai_bin/session_init.py
+```
+
+**Store outputs for session duration:**
+- `DEV_NAME`, `DEV_EMAIL` → Commit trailers
+- `GIT_OWNER`, `GIT_REPO` → GitHub MCP calls
+- `GIT_HOOKS_PATH` → Hook verification
+- `GIT_REMOTE_URL` → Reference
+
+**Exit codes:**
+- `0`: Success → Proceed to Finally block
+- `1`: No remote configured → Report error, HALT (developer must configure)
+- `2`: Non-GitHub remote → GitHub MCP unavailable
+
+### CATCH BLOCK: Error Handling
+
+| Exit Code | Problem | Action |
+|-----------|---------|--------|
+| 1 | No remote configured | Report error → HALT (developer must configure remote) |
+| 2 | Non-GitHub remote | GitHub MCP unavailable → Use `gh` CLI fallback |
+| Script not found | Report error | HALT — cannot proceed |
+
+### FINALLY BLOCK: MCP Probe (ALWAYS RUNS AFTER TRY)
+
+**Probe MCP availability:**
+1. PyCharm MCP: `pycharm_get_project_modules`
+2. GitHub MCP: `github_get_me`
+3. Record availability for tool selection
+
+### CIRCUIT BREAKER: Enforcement Gate
+
+🚫 **NO tool calls** before Try block completes successfully
+🚫 **NO MCP calls** before Finally block completes
+🚫 **NO implementation** before authorization verified
+
+---
+
+## Skills-First Workflow
+
+**ALL procedural workflows are in skills. Guidelines contain ONLY essential rules.**
+
+### Master Trigger Table
+
+| Workflow Trigger | Invocation |
+|------------------|------------|
+| Before ANY file edit | `/skill approval-gate --task verify-authorization` |
+| Before implementation | `/skill approval-gate --task verify-sub-issues` |
+| After authorization | `/skill git-workflow --task pre-work` |
+| After implementation | `/skill git-workflow --task review-prep` (AUTOMATIC) |
+| "create a PR" | `/skill git-workflow --task pr-creation` |
+| "PR merged" | `/skill git-workflow --task cleanup` |
+| Before creating file | `/skill implementation-quality --task file-locations` |
+| At implementation start | `/skill implementation-quality --task code-structure` |
+| Before running commands | `/skill implementation-quality --task environment` |
+| Before handling data | `/skill implementation-quality --task data-integrity` |
+| Writing code | `/skill code-size-enforcement` |
+| After ANY code/guideline/skill/task change | `/skill code-review` (MANDATORY) |
+| Before spec approval | `/skill concern-separation-auditor --issue N` (FIRST) |
+| After concern auditor | `/skill spec-auditor --issue N` (SECOND) |
+| After spec auditor | `/skill dev-architect --task review-spec` (THIRD) |
+
+**See `.opencode/skills/` for complete skill documentation.**
+
+---
+
+## Essential Rules (Zero Tolerance)
+
+| Rule | Description |
+|------|-------------|
+| Spec before code | NO code changes WITHOUT approved spec |
+| Authorization required | NO implementation WITHOUT `"approved"` or `"go"` |
+| Branch first | Create feature branch BEFORE any file modification |
+| Human-only merge | Agents MUST NEVER merge PRs |
+| Silent halt | HALT after completion — no prompts |
+| PR timing | PRs require explicit `"create a PR"` instruction |
+| MCP tools | Use PyCharm/GitHub MCP for file operations when available |
+| `/tmp/` prohibited | Use `./tmp/` only |
+| Notebook operations | Use `the-notebook-mcp` ONLY — never edit `.ipynb` directly |
+
+---
+
+## Build / Lint / Test Commands
+
+| Task | Command | File Types |
+|------|---------|------------|
+| Sync dependencies | `uv sync` | - |
+| Run all tests | `uv run pytest test/` | - |
+| Lint + auto-fix | `uvx ruff check --fix src/ test/` | Python ONLY |
+| Format | `uvx ruff format src/ test/` | Python ONLY |
+| Type check | `uvx pyright src/` | Python ONLY |
+| Markdown lint | `uvx pymarkdownlnt scan -r .opencode/guidelines/ docs/` | Markdown ONLY |
+| Markdown format | `uvx mdformat --number --wrap keep --end-of-line lf .opencode/guidelines/ docs/` | Markdown ONLY |
+
+**NEVER**: `python`, `python3`, `pip`, `uv add`, `ruff` on markdown
+
+---
+
+## Authorization Recognition
+
+| Pattern | Example | Action |
+|---------|---------|--------|
+| Direct command | "implement #227" | ✅ Continue |
+| Compound command | "implement #227 and include in branch" | ✅ Continue |
+| Question | "should I implement #227?" | 🚫 HALT |
+| Conditional | "if you think #227 is needed..." | 🚫 HALT |
+
+**Multi-phase authorization:**
+- `approved` or `go` → ALL phases authorized
+- `approved: 1` → Phase 1 only
+- `approved: 2.3` → Phase 2, Step 3 only
+
+**Revision revokes approval:** Any spec change requires fresh authorization.
+
+---
+
+## Guideline Files (Rules Only)
+
+| Guideline | Purpose |
+|-----------|---------|
+| `000-critical-rules.md` | Zero tolerance violations |
+| `000-session-init.md` | Startup sequence |
+| `010-approval-gate.md` | Authorization workflow |
+| `015-mcp-preference.md` | Tool selection |
+| `020-go-prohibitions.md` | GO command limits |
+| `050-scope-autonomy.md` | Scope restrictions |
+| `060-tool-usage.md` | Tool usage rules |
+| `061-notebook-rules.md` | Notebook operations |
+| `070-environment.md` | Environment setup |
+| `075-docs-verification.md` | Documentation verification |
+| `080-code-standards.md` | Code quality standards |
+| `085-engineering-approach.md` | Engineering principles |
+| `086-http-requests.md` | HTTP request standards |
+| `087-no-backward-compat.md` | Refactoring rules |
+| `090-data-integrity.md` | Data handling rules |
+| `100-persistence.md` | PostgreSQL/SQLAlchemy standards |
+| `110-git-branch-first.md` | Branch workflow |
+| `111-git-commit-workflow.md` | Commit standards |
+| `112-git-merge-protocol.md` | Merge protocol |
+| `113-git-pr-workflow.md` | PR workflow |
+| `114-git-branch-cleanup.md` | Branch cleanup |
+| `115-git-hotfix-workflow.md` | Hotfix workflow |
+| `120-github-issue-first.md` | Issue workflow |
+| `121-github-pr-workflow.md` | PR creation |
+| `122-github-mcp-operations.md` | GitHub MCP |
+| `123-github-ai-identity.md` | AI identity in comments |
+| `124-github-archive-workflow.md` | Issue closure |
+| `125-github-issue-comments.md` | Comment protocol |
+| `130-authority-source.md` | Code as authority |
+| `140-planning-spec-creation.md` | Spec creation |
+
+**Procedural content moved to skills.** Guidelines now contain ONLY rules.
+
+---
+
+## Identity Detection (CRITICAL)
+
+**🚫 FORBIDDEN: Copy hardcoded identity examples from guidelines.**
+
+**✅ REQUIRED: Extract identity from system prompt at runtime:**
+- `<AgentName>` → Your actual name (e.g., "OpenCode Desktop")
+- `<ModelID>` → Backing model (e.g., "ollama-cloud/qwen3.5:397b")
+- `<ai-email>` → Agent's noreply email
+
+**Example values in guidelines are ILLUSTRATIVE ONLY — substitute your actual identity.**
+
+---
+
+## Session Communication
+
+| Output Type | Destination |
+|-------------|-------------|
+| Session summaries, progress updates | CHAT ONLY |
+| Interactive questions, chit-chat | CHAT ONLY |
+| Audit logs | Internal (`./tmp/`) — NOT posted anywhere |
+| Investigation artifacts | GitHub Issues (only when substantive) |
+| Closure summaries | GitHub Issues (historical record) |
+
+**CRITICAL:** ALL chat session communication goes to CHAT ONLY, NEVER to GitHub Issues. Audit logs are internal artifacts — do NOT post to chat or GitHub unless explicitly requested.
+
+---
+
+## Guideline Violations
+
+**If agent violates guideline:**
+
+1. STOP task
+2. Update this file "NEVER" list
+3. Update relevant `.opencode/guidelines/` file
+4. Document fix in issue comment (FACTUAL ONLY)
+5. Wait for confirmation before resuming
+
+---
+
+**Run session init FIRST:**
+```bash
+uv run python ai_bin/session_init.py
+```
+
+---
+🤖 ✨ Created by OpenCode Desktop (ollama-cloud/qwen3.5:397b)


### PR DESCRIPTION
## Summary

Add `plan-fidelity-auditor` skill as the first auditor in the mandatory audit chain. It generates independent clean-room plans from problem statements and compares them against existing spec plans to identify substantive gaps — missing phases, incorrect approaches, and scope misalignment — before structural and content auditors run.

## Outcome

The audit chain now runs: plan-fidelity-auditor (1st) → concern-separation-auditor (2nd) → spec-auditor (3rd). New `writing-plans --task clean-room` mode enables comparison-only plan generation without approval gate or GitHub Issue creation. Fixed 5 inconsistencies where "both auditors" references needed updating to "all auditors" across guidelines and skills.

### New Files
- `.opencode/skills/plan-fidelity-auditor/SKILL.md` — skill definition, invocation, audit chain, auto-fix intelligence
- `.opencode/skills/plan-fidelity-auditor/tasks/audit.md` — core audit workflow (8 steps)
- `.opencode/skills/plan-fidelity-auditor/tasks/compare.md` — plan comparison with semantic matching (7 steps)
- `.opencode/skills/plan-fidelity-auditor/tasks/auto-fix.md` — auto-fix application (6 steps)
- `.opencode/skills/writing-plans/tasks/clean-room.md` — clean-room plan generation (5 steps)

### Modified Files
- `.opencode/dispatch-table.yaml` — added plan-fidelity-auditor trigger in quality_gates
- `.opencode/guidelines/000-critical-rules.md` — added plan-fidelity-auditor as 1st in audit chain
- `.opencode/skills/concern-separation-auditor/SKILL.md` — updated chain order (now 2nd)
- `.opencode/skills/spec-auditor/SKILL.md` — updated chain order (now 3rd)
- `.opencode/skills/writing-plans/SKILL.md` — added clean-room task and invocation
- `.opencode/skills/github-issue-creation/tasks/post-creation.md` — invoke plan-fidelity-auditor first

Fixes #505
Fixes #506
Fixes #507
Fixes #508