### PR TITLE
[SPEC] Prevent Redundant Audit Comments

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -488,6 +488,21 @@ All tasks complete from this specification.
 - **"Awaiting authorization"** — Use HALT protocol, not comments
 - **Technical changelog** — Focus on impact, not file-by-file changes
 
+### Audit Findings Are NOT Progress Comments
+
+**⚠️ Posting spec-audit findings as GitHub comments is FORBIDDEN.**
+
+Audit findings from `spec-auditor` are internal agent guidance — equivalent to linter output. They inform the agent what to fix, not what to announce to stakeholders.
+
+| Action | Post Comment? |
+|--------|---------------|
+| Agent completes implementation task | ✅ YES — progress comment with executive summary |
+| Agent revises spec substantively after audit | ✅ YES — one revision comment per `github-comments` skill |
+| Agent makes non-substantive spec changes (STATUS, typos, cross-refs) after audit | ❌ NO |
+| Agent posts audit findings report | 🚫 FORBIDDEN — act on findings, don't post the report |
+
+**Correct workflow:** Audit → Act on findings (revise spec) → Post comment ONLY for substantive revisions (changes to requirements, phases, success criteria, scope).
+
 ### ⚠️ Chat Output Rule (CRITICAL)
 
 **Progress executive summaries go to BOTH GitHub comments AND chat.**

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -411,6 +411,7 @@ When closing as superseded:
 - "Ready for approval?"
 - Cross-reference link additions (origin/back-reference links)
 - Housekeeping edits (typo fixes, formatting)
+- **Audit findings reports** — spec-auditor findings are internal agent guidance, not stakeholder communication. Act on findings by revising the spec; don't post the audit report as a comment.
 
 ### ✅ REQUIRED Comments
 
@@ -420,6 +421,23 @@ When closing as superseded:
 - Creating PR
 - Altering spec structure
 - Blocking/unblocking decision
+
+### Audit Findings Are NOT Comments
+
+Audit findings from `spec-auditor` are internal agent guidance — equivalent to linter output. They inform the agent what to fix, not what to announce.
+
+**Workflow:**
+1. Audit → collect findings
+2. Act → revise the spec to address findings
+3. Comment → ONLY if the revision is substantive (changes to requirements, phases, success criteria, scope)
+
+| Action | Post Comment? |
+|--------|---------------|
+| Audit finds issues, agent revises spec substantively | ✅ YES — one revision comment |
+| Audit finds issues, agent makes only non-substantive changes (STATUS, typos, cross-refs) | ❌ NO |
+| Audit finds zero issues | ❌ NO |
+| Agent posts audit findings report as a comment | 🚫 FORBIDDEN |
+| Stakeholder explicitly asks for audit results | ✅ YES — direct request override |
 
 ---
 
@@ -484,7 +502,7 @@ GOOD: "The keys look correct. Ready when you are."
 | Skill | Integration Point |
 |-------|-------------------|
 | `git-workflow` | Post comment when PR created |
-| `spec-auditor` | Comment audit findings on issue |
+| `spec-auditor` | Findings are internal guidance — act on them, don't post; comment only for substantive revisions |
 
 ## Example Workflows
 

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -127,15 +127,25 @@ Existing classes remain, plus two new ones:
 | **MISSING-TRACEABILITY** | Requirements/features without trace links (NEW) |
 | **OPERATIONAL-REQUIREMENTS-INCOMPLETE** | Missing logging/metrics/deployment (NEW) |
 
-## Audit Log Requirement
+## Audit Findings Handling
 
-After the audit session completes, create an audit log:
+After the audit session completes, findings are **internal agent guidance** — they inform action, not communication.
 
-**Location:** `./tmp/audit-spec-YYYYMMDD.md`
+**Findings are NOT posted as GitHub comments.** Audit findings are analogous to linter output: they tell the agent what to fix, not what to announce. The correct workflow is:
 
-**Post findings to the spec issue as a GitHub comment, then delete the temp file.**
+1. **Audit** → run subtasks, collect findings
+2. **Act** → revise the spec to address findings (if any)
+3. **Comment ONLY for substantive revisions** → if the spec revision changes requirements, phases, success criteria, or scope, post one revision comment following `github-comments` skill format. Non-substantive changes (STATUS markers, checklist updates, cross-reference additions, typo fixes) get NO comment.
 
-**Fresh-start context preservation:** Audit logs in `./tmp/` are NOT preserved between sessions. Always attach to the spec issue, then delete temp.
+**When NO comment is posted:**
+- Audit finds zero issues (all PASS) — move on, no comment
+- Agent only makes non-substantive changes (STATUS updates, typos, cross-refs) — no comment
+- Agent revises the spec but all changes are non-substantive — no comment
+
+**When a comment IS posted:**
+- Agent makes substantive spec changes (adding/removing phases, changing requirements, altering approach) — post one revision comment per `github-comments` skill
+
+**Session scratch space:** Findings may be written to `./tmp/audit-spec-YYYYMMDD.md` for session-level reference. This file is NOT posted anywhere and is deleted after the session ends.
 
 ## Mandatory Invocation
 
@@ -144,9 +154,9 @@ After the audit session completes, create an audit log:
 When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 1. Create the spec issue with all required content
 2. Invoke `/skill spec-auditor --issue N` (orchestrator determines subtasks)
-3. Apply any findings the agent decides to act on
+3. Apply any findings the agent decides to act on (revise the spec if substantive changes needed)
 4. Add `needs-approval` label
-5. Post "ready for review" comment
+5. Post "ready for review" comment ONLY if substantive spec changes were made during step 3
 
 **Skipping the orchestrator is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/prevent-redundant-audit-comments-521
+
+- Remove spec-auditor mandate to post audit findings as GitHub issue comments
+- Add audit findings prohibition to github-comments skill decision table
+- Clarify in critical-rules that audit findings are internal agent guidance, not progress comments
+- Establish workflow: audit → act on findings → comment only for substantive spec revisions
+
 ### feature/overwrite-skills-503
 
 - Restructure guidelines to rules-only: delete 15 procedural guideline files, move content to skills


### PR DESCRIPTION
**Summary:**

Eliminates the mandate for posting spec-audit findings as GitHub issue comments, classifying audit findings as internal agent guidance that should drive action (revising specs), not generate comment noise.

**Outcome:** Agents will no longer post redundant audit reports as GitHub comments. Only substantive spec revisions warrant comment posts.

Fixes #521