### PR TITLE
Add enforcement gate for post-implementation verification skills

### DIFF
--- a/.opencode/dispatch-table.yaml
+++ b/.opencode/dispatch-table.yaml
@@ -128,32 +128,41 @@ issue_pr_workflow:
     task: "verify"
     purpose: "Verify all success criteria have evidence"
     automatic: true
-    note: "Prevents premature completion claims without evidence"
+    note: "MANDATORY - prevents premature completion claims without evidence"
+    enforcement: "CRITICAL VIOLATION to skip - see 000-critical-rules.md"
     
   - trigger: "Agent marks step as ☑ in plan"
     skill: "verification-before-completion"
     task: "verify"
     purpose: "Verify step completion has evidence"
     automatic: true
+    enforcement: "CRITICAL VIOLATION to skip - see 000-critical-rules.md"
     
   - trigger: "Agent attempts to close issue or create PR"
     skill: "verification-before-completion"
     task: "verify"
     purpose: "Final verification before closure"
     automatic: true
+    enforcement: "CRITICAL VIOLATION to skip - see 000-critical-rules.md"
 
   - trigger: "Missing evidence detected"
     skill: "verification-before-completion"
     task: "collect"
     purpose: "Collect missing evidence for incomplete criteria"
 
-  # THIRD CHECK - Implementation workflow orchestration
-  - trigger: "After approval-gate confirms authorization"
-    skill: "implementation-workflow"
-    task: "orchestrate"
-    purpose: "Orchestrate implementation workflow with yield-back context passing"
+  # BRANCH COMPLETION GATE - Before review-prep (after verification)
+  - trigger: "Implementation completes on feature branch"
+    skill: "finishing-a-development-branch"
+    task: "checklist"
+    purpose: "Verify branch is ready for PR creation (committed, tested, pushed)"
     automatic: true
-    note: "Sequences pre-work → implementation subagent → review-prep with context"
+    note: "MANDATORY - must pass AFTER verification-before-completion, BEFORE review-prep"
+    enforcement: "CRITICAL VIOLATION to skip - see 000-critical-rules.md"
+    
+  - trigger: "User says 'done' or 'finished' or 'ready for PR'"
+    skill: "finishing-a-development-branch"
+    task: "checklist"
+    purpose: "Run completion checklist before PR"
     
   # Git workflow tasks (called by implementation-workflow orchestration)
   - trigger: "Implementation-workflow calls pre-work"
@@ -226,8 +235,9 @@ quality_gates:
 
   - trigger: "Implementation completes on feature branch"
     skill: "finishing-a-development-branch"
-    task: "prepare"
-    purpose: "Verify branch is ready for PR creation"
+    task: "checklist"
+    purpose: "Verify branch is ready for PR creation (MUST come before review-prep)"
+    enforcement: "CRITICAL VIOLATION to skip - see 000-critical-rules.md"
 
   - trigger: "User says 'done' or 'finished' or 'ready for PR'"
     skill: "finishing-a-development-branch"
@@ -320,16 +330,23 @@ automatic_invocation:
     task: "start"
     note: "Automatic execution start after plan approval"
   
-  # VERIFICATION GATE - Before completion claims
+  # VERIFICATION GATE - Before completion claims (MANDATORY, no decision point)
   - skill: "verification-before-completion"
     trigger: "Agent claims 'task complete' or 'step complete'"
     task: "verify"
-    note: "Mandatory evidence verification before completion claims"
+    note: "MANDATORY evidence verification before completion claims. CRITICAL VIOLATION to skip."
+
+  # BRANCH COMPLETION GATE - After verification, before review-prep (MANDATORY, no decision point)
+  - skill: "finishing-a-development-branch"
+    trigger: "Verification-before-completion passes"
+    task: "checklist"
+    note: "MANDATORY branch readiness check. CRITICAL VIOLATION to skip. Must come BEFORE review-prep."
   
+  # REVIEW-PREP - After verification and branch completion gates pass
   - skill: "git-workflow"
     trigger: "Implementation completes"
     task: "review-prep"
-    note: "Automatic, no decision point"
+    note: "Automatic, no decision point. Must ONLY run after verification and finishing gates pass."
     
   - skill: "git-workflow"
     trigger: "User requests PR creation ('create a PR', 'make a PR', 'push and create PR')"

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -113,6 +113,72 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
+## Critical Violation: Skipping Post-Implementation Verification Skills
+
+**⚠️ Failing to invoke `verification-before-completion` and `finishing-a-development-branch` after implementation is a CRITICAL GUIDELINE VIOLATION.**
+
+This is the same class of failure as skipping `review-prep`: skills exist, dispatch triggers are documented, but the agent skips them because there is no enforcement mechanism blocking progression.
+
+### 🚫 FORBIDDEN
+
+- Claiming "task complete" without invoking `verification-before-completion --task verify`
+- Claiming "implementation complete" without invoking `finishing-a-development-branch --task checklist`
+- Manually executing skill steps instead of formally invoking the skill
+- Skipping verification because "the changes look correct"
+- Proceeding to `review-prep` before verification skills pass
+
+### ✅ REQUIRED SEQUENCE (MANDATORY, NO DECISION POINT)
+
+After every implementation, the following skills MUST be invoked in this exact order:
+
+```
+Implementation completes
+    ↓
+1. verification-before-completion --task verify
+    ↓ (if verification FAILS → HALT and report)
+    ↓ (if verification PASSES → continue)
+2. finishing-a-development-branch --task checklist
+    ↓ (if checklist FAILS → HALT and report)
+    ↓ (if checklist PASSES → continue)
+3. git-workflow --task review-prep
+    ↓
+HALT with compare URL
+```
+
+**The order matters:**
+1. `verification-before-completion` checks SUCCESS CRITERIA (evidence required)
+2. `finishing-a-development-branch` checks BRANCH READINESS (committed, tested, pushed)
+3. `git-workflow --task review-prep` generates compare URL
+
+### Why Manual Execution Is NOT Sufficient
+
+Manual execution of skill steps is PROHIBITED because:
+
+| Manual Execution | Formal Skill Invocation |
+|-------------------|------------------------|
+| Skips enforcement checklists | Loads and follows enforcement checklist |
+| Agent may skip "obvious" steps | Every step is explicit and mandatory |
+| No CRITICAL VIOLATION warnings in context | Skill content includes enforcement warnings |
+| Error-prone, agent decides what to skip | No decision points — all steps required |
+
+### Why This Matters
+
+| Violation | Consequence |
+|-----------|-------------|
+| Skip verification | Success criteria not checked, bugs shipped |
+| Skip finishing checklist | Uncommitted changes, failing tests, broken PRs |
+| Skip both | No evidence of completion, no quality gate |
+| Manual execution only | Agent bypasses enforcement, misses steps |
+
+### Implementation-Workflow Integration
+
+The `implementation-workflow` skill orchestrates this sequence in Step 3.5 (Verification Gate). See `implementation-workflow/SKILL.md` for the orchestration protocol.
+
+**See `verification-before-completion` skill for evidence requirements.**
+**See `finishing-a-development-branch` skill for branch readiness checklist.**
+
+______________________________________________________________________
+
 ## Critical Violation: Skipping review-prep After Implementation
 
 **⚠️ Failing to invoke `review-prep` after implementation is a CRITICAL GUIDELINE VIOLATION.**
@@ -1343,6 +1409,72 @@ Every specification MUST include:
 - API changes between library versions cause silent failures
 - Incorrect parameter names waste debugging time
 - Outdated patterns accumulate technical debt
+
+______________________________________________________________________
+
+## Critical Violation: Skipping Post-Implementation Verification Skills
+
+**⚠️ Failing to invoke `verification-before-completion` and `finishing-a-development-branch` after implementation is a CRITICAL GUIDELINE VIOLATION.**
+
+This is the same class of failure as skipping `review-prep`: skills exist, dispatch triggers are documented, but the agent skips them because there is no enforcement mechanism blocking progression.
+
+### 🚫 FORBIDDEN
+
+- Claiming "task complete" without invoking `verification-before-completion --task verify`
+- Claiming "implementation complete" without invoking `finishing-a-development-branch --task checklist`
+- Manually executing skill steps instead of formally invoking the skill
+- Skipping verification because "the changes look correct"
+- Proceeding to `review-prep` before verification skills pass
+
+### ✅ REQUIRED SEQUENCE (MANDATORY, NO DECISION POINT)
+
+After every implementation, the following skills MUST be invoked in this exact order:
+
+```
+Implementation completes
+    ↓
+1. verification-before-completion --task verify
+    ↓ (if verification FAILS → HALT and report)
+    ↓ (if verification PASSES → continue)
+2. finishing-a-development-branch --task checklist
+    ↓ (if checklist FAILS → HALT and report)
+    ↓ (if checklist PASSES → continue)
+3. git-workflow --task review-prep
+    ↓
+HALT with compare URL
+```
+
+**The order matters:**
+1. `verification-before-completion` checks SUCCESS CRITERIA (evidence required)
+2. `finishing-a-development-branch` checks BRANCH READINESS (committed, tested, pushed)
+3. `git-workflow --task review-prep` generates compare URL
+
+### Why Manual Execution Is NOT Sufficient
+
+Manual execution of skill steps is PROHIBITED because:
+
+| Manual Execution | Formal Skill Invocation |
+|-------------------|------------------------|
+| Skips enforcement checklists | Loads and follows enforcement checklist |
+| Agent may skip "obvious" steps | Every step is explicit and mandatory |
+| No CRITICAL VIOLATION warnings in context | Skill content includes enforcement warnings |
+| Error-prone, agent decides what to skip | No decision points — all steps required |
+
+### Why This Matters
+
+| Violation | Consequence |
+|-----------|-------------|
+| Skip verification | Success criteria not checked, bugs shipped |
+| Skip finishing checklist | Uncommitted changes, failing tests, broken PRs |
+| Skip both | No evidence of completion, no quality gate |
+| Manual execution only | Agent bypasses enforcement, misses steps |
+
+### Implementation-Workflow Integration
+
+The `implementation-workflow` skill orchestrates this sequence in Step 3.5 (Verification Gate). See `implementation-workflow/SKILL.md` for the orchestration protocol.
+
+**See `verification-before-completion` skill for evidence requirements.**
+**See `finishing-a-development-branch` skill for branch readiness checklist.**
 
 ______________________________________________________________________
 

--- a/.opencode/skills/implementation-workflow/SKILL.md
+++ b/.opencode/skills/implementation-workflow/SKILL.md
@@ -56,6 +56,14 @@ implementation-workflow/orchestrate (receives auth context)
     [invokes implementation subagent]
     YIELDS: {files_changed: [...], commit_status: {...}}
     ↓
+    [invokes verification-before-completion --task verify]  ← MANDATORY GATE
+    YIELDS: {verification: "pass" | "fail"}
+    ↓ (if FAIL → HALT and report)
+    ↓ (if PASS → continue)
+    [invokes finishing-a-development-branch --task checklist]  ← MANDATORY GATE
+    YIELDS: {checklist: "pass" | "fail"}
+    ↓ (if FAIL → HALT and report)
+    ↓ (if PASS → continue)
     [calls git-workflow --task review-prep]
     YIELDS: {compare_url: "...", exec_summary: "..."}
     ↓
@@ -134,6 +142,76 @@ ready_for: "review"
 ```
 
 **Intelligence note:** Format provides what review-prep needs (files changed, commit summary).
+
+### Step 3.5: Verification Gate (MANDATORY, NO DECISION POINT)
+
+**⚠️ CRITICAL: This step is MANDATORY and has NO decision point. Skipping it is a CRITICAL GUIDELINE VIOLATION.**
+
+After implementation completes, BEFORE proceeding to review-prep, invoke verification skills in strict sequence:
+
+**Step 3.5a: Invoke verification-before-completion**
+```
+/skill verification-before-completion --task verify
+```
+
+**Context:**
+```yaml
+issue: 77
+phase: "Phase 1 implementation"
+success_criteria: [from spec issue]
+files_changed: [...]
+```
+
+**Expected yield:**
+```yaml
+status: pass | fail
+verified_criteria:
+  - criterion: "..."
+    evidence: "..."
+    verified: true
+unverified_criteria: []  # Must be empty to pass
+missing_evidence: []      # Must be empty to pass
+```
+
+**If verification FAILS → HALT and report.** Do NOT proceed to Step 4.
+
+**Step 3.5b: Invoke finishing-a-development-branch**
+```
+/skill finishing-a-development-branch --task checklist
+```
+
+**Context:**
+```yaml
+branch: "spec/workflow-skills-integration"
+implementation_complete: true
+verification_passed: true
+```
+
+**Expected yield:**
+```yaml
+status: pass | fail
+checklist_results:
+  - item: "All changes committed"
+    passed: true
+  - item: "Lint checks pass"
+    passed: true
+  - item: "Tests pass"
+    passed: true
+  - item: "Branch pushed"
+    passed: true
+failed_items: []  # Must be empty to pass
+```
+
+**If checklist FAILS → HALT and report.** Do NOT proceed to Step 4.
+
+**Why This Gate Exists:**
+
+| Without Gate | With Gate |
+|-------------|-----------|
+| Agent skips verification | Success criteria checked with evidence |
+| Agent skips branch checklist | Uncommitted changes, failing tests caught |
+| Agent manually executes steps | Full skill context loaded with enforcement |
+| "Changes look correct" justification | Required evidence for each criterion |
 
 ### Step 4: Call Review-Prep (Git Ops Only)
 
@@ -218,6 +296,23 @@ commit_summary: string
 implementation_status: success | failure
 ```
 
+### What Verification Gate Needs FROM Implementation
+
+```yaml
+issue_number: int
+phase: string
+success_criteria: list
+files_changed: list
+```
+
+### What Finishing Checklist Needs FROM Verification
+
+```yaml
+branch: string
+verification_passed: true
+implementation_complete: true
+```
+
 ### What Chat Needs FROM Review-Prep
 
 ```yaml
@@ -261,6 +356,20 @@ exec_summary: string (markdown, human-readable)
 ```
 
 ## Enforcement Mechanisms
+
+### ⚠️ CRITICAL: Verification Gate (Step 3.5)
+
+**This gate is MANDATORY and has NO decision point.** It cannot be skipped, bypassed, or manually executed.
+
+| Step | Skill | Required? | Decision Point? |
+|------|-------|-----------|-----------------|
+| 3.5a | verification-before-completion --task verify | YES | NO |
+| 3.5b | finishing-a-development-branch --task checklist | YES | NO |
+| 4 | git-workflow --task review-prep | YES | NO |
+
+**Skipping any step in this sequence is a CRITICAL GUIDELINE VIOLATION.**
+
+See `000-critical-rules.md` → "Skipping Post-Implementation Verification Skills" for the enforcement rule.
 
 ### ⚠️ CRITICAL: No Implementation Logic in Git-Workflow
 
@@ -321,6 +430,8 @@ implementation-workflow (receives context)
 | Authorization context lost | approval-gate passes context to implementation-workflow |
 | Pre-work asks for auth again | Pre-work receives context from orchestrator, no re-check |
 | Implementation doesn't commit | Implementation calls git-workflow commit-prep directly |
+| Verification fails | HALT and report missing evidence; do NOT proceed to review-prep |
+| Finishing checklist fails | HALT and report issues (lint, tests, uncommitted); do NOT proceed to review-prep |
 | Review-prep HALTs prematurely | Correct behavior - wait for "create a PR" |
 
 ## Migration from Old Architecture
@@ -355,6 +466,12 @@ implementation-workflow/orchestrate:
         → Subagent edits files
         → Subagent calls commit-prep directly
         → Subagent yields: "4 files changed, 2 commits"
+    → Invokes verification-before-completion --task verify
+        → All success criteria verified with evidence
+        → Verification PASSES
+    → Invokes finishing-a-development-branch --task checklist
+        → All changes committed, tests pass, branch pushed
+        → Checklist PASSES
     → Calls review-prep: "URL: https://..., summary: ..."
     → HALT with URL in chat
 ```
@@ -371,7 +488,37 @@ implementation-workflow/orchestrate:
     → Wait for user instruction
 ```
 
-### Example 3: Working Tree Dirty
+### Example 3: Verification Fails
+
+```
+implementation-workflow/orchestrate:
+    → Calls pre-work: "Branch: spec/X, ready"
+    → Invokes implementation subagent
+        → Subagent yields: {status: "success", files_changed: [...]}
+    → Invokes verification-before-completion --task verify
+        → Success criterion missing evidence
+        → Verification FAILS
+    → HALT: "Verification failed. Missing evidence for: [criterion]"
+    → Wait for user to provide evidence or fix
+```
+
+### Example 4: Branch Checklist Fails
+
+```
+implementation-workflow/orchestrate:
+    → Calls pre-work: "Branch: spec/X, ready"
+    → Invokes implementation subagent
+        → Subagent yields: {status: "success"}
+    → Invokes verification-before-completion --task verify
+        → Verification PASSES
+    → Invokes finishing-a-development-branch --task checklist
+        → Lint errors found, uncommitted changes
+        → Checklist FAILS
+    → HALT: "Branch not ready. Fix: [lint errors, commit changes]"
+    → Wait for user to fix issues
+```
+
+### Example 5: Working Tree Dirty
 
 ```
 implementation-workflow/orchestrate:


### PR DESCRIPTION
**Summary:**

Ensures agents can never skip `verification-before-completion` and `finishing-a-development-branch` after implementation by adding a mandatory enforcement gate to the implementation workflow.

**Outcome:** Agents will encounter a mandatory 3-step sequence (verify → checklist → review-prep) that blocks progression if any verification step fails, preventing premature completion claims without evidence.

Fixes #523