### PR TITLE
[SPEC] Guidelines/Skill Separation: Remove Procedural Content from Guidelines

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -17,28 +17,9 @@ This file provides critical rules that must never be violated.
 - Editing files while on `main` or `dev` branch
 - Skipping stash when pending changes exist
 
-### ✅ MANDATORY PRE-CHECK SEQUENCE
+### ✅ MANDATORY
 
-**BEFORE any file operation, ANY verification, ANY work:**
-
-```bash
-# Step 1: Check git state (MANDATORY)
-git branch --show-current
-git status
-
-# Step 2: If ANY pending changes (modified, deleted, untracked)
-git stash push -u -m "WIP: before <branch-name>"
-
-# Step 3: Verify stash succeeded
-git stash list  # MUST show stash entry
-git status      # MUST show clean working tree
-
-# Step 4: Create feature branch (if on main or dev)
-git checkout dev && git pull origin dev
-git checkout -b spec/<short-name>
-
-# Step 5: NOW proceed with work
-```
+**See `git-workflow` skill `--task pre-work` for the mandatory pre-check sequence, stash verification, and branch creation steps.**
 
 ### Why This Matters
 
@@ -47,43 +28,9 @@ git checkout -b spec/<short-name>
 | Edit files on `main` | Cannot create branch, changes stuck on `main` |
 | Skip git status check | Untracked files lost when switching branches |
 | Forget `-u` flag | Untracked files NOT stashed, lost forever |
-| Skip stash verification | Modifictions silently lost |
-
-### Data Loss Prevention
-
-**The `-u` flag is MANDATORY when stashing.**
-
-| Command | What It Stashes |
-|---------|------------------|
-| `git stash push -m "..."` | Modified files ONLY |
-| `git stash push -u -m "..."` | Modified + untracked + deleted files |
-
-**ALWAYS use `-u` flag. Untracked files are just as important as tracked files.**
-
-### Verification Requirements
-
-**After stashing, these MUST pass before creating branch:**
-
-| Check | Command | Expected Result |
-|-------|---------|------------------|
-| Stash created | `git stash list \| grep "WIP:"` | Shows stash entry |
-| Working tree clean | `git status --porcelain` | Empty output (no characters) |
-
-**If EITHER check fails ⇒ STOP. Report failure. Let user resolve.**
+| Skip stash verification | Modifications silently lost |
 
 ______________________________________________________________________
-
-## Agent-Specific Notes
-
-### OpenCode Desktop (OPENCODE=1)
-
-- MCP tools auto-probe on startup
-- Use OpenCode-specific instructions from `opencode.json`
-- Read `.opencode/guidelines/` for detailed guidance
-
-### Amazon Q / CodeWhisperer
-
-- Treat as unknown agent — use manual MCP probe
 
 ## Critical Violation: Implementing Without Documentation Verification
 
@@ -127,32 +74,15 @@ This is the same class of failure as skipping `review-prep`: skills exist, dispa
 - Skipping verification because "the changes look correct"
 - Proceeding to `review-prep` before verification skills pass
 
-### ✅ REQUIRED SEQUENCE (MANDATORY, NO DECISION POINT)
+### ✅ REQUIRED
 
-After every implementation, the following skills MUST be invoked in this exact order:
-
-```
-Implementation completes
-    ↓
-1. verification-before-completion --task verify
-    ↓ (if verification FAILS → HALT and report)
-    ↓ (if verification PASSES → continue)
-2. finishing-a-development-branch --task checklist
-    ↓ (if checklist FAILS → HALT and report)
-    ↓ (if checklist PASSES → continue)
-3. git-workflow --task review-prep
-    ↓
-HALT with compare URL
-```
-
-**The order matters:**
-1. `verification-before-completion` checks SUCCESS CRITERIA (evidence required)
-2. `finishing-a-development-branch` checks BRANCH READINESS (committed, tested, pushed)
-3. `git-workflow --task review-prep` generates compare URL
+**See `verification-before-completion` skill `--task verify` for evidence requirements.**
+**See `finishing-a-development-branch` skill `--task checklist` for branch readiness enforcement.**
+**See `git-workflow` skill `--task review-prep` for the mandatory post-implementation workflow.**
 
 ### Why Manual Execution Is NOT Sufficient
 
-Manual execution of skill steps is PROHIBITED because:
+Manual execution of skill steps is PROHIBITED because skills contain enforcement checklists, CRITICAL VIOLATION warnings, and mandatory decision points that inline steps lack.
 
 | Manual Execution | Formal Skill Invocation |
 |-------------------|------------------------|
@@ -170,13 +100,6 @@ Manual execution of skill steps is PROHIBITED because:
 | Skip both | No evidence of completion, no quality gate |
 | Manual execution only | Agent bypasses enforcement, misses steps |
 
-### Implementation-Workflow Integration
-
-The `implementation-workflow` skill orchestrates this sequence in Step 3.5 (Verification Gate). See `implementation-workflow/SKILL.md` for the orchestration protocol.
-
-**See `verification-before-completion` skill for evidence requirements.**
-**See `finishing-a-development-branch` skill for branch readiness checklist.**
-
 ______________________________________________________________________
 
 ## Critical Violation: Skipping review-prep After Implementation
@@ -193,15 +116,7 @@ ______________________________________________________________________
 
 ### ✅ REQUIRED
 
-After EVERY implementation:
-
-1. Commit all changes with proper trailers
-1. Push feature branch to remote
-1. Invoke `review-prep` automatically
-1. Generate GitHub compare URL
-1. Report exec summary + URL in chat (URL LAST)
-1. Post completion comment to issue (NO URL)
-1. HALT and wait for "create a PR"
+**See `git-workflow` skill `--task review-prep` for the mandatory post-implementation workflow including commit, push, compare URL generation, and HALT protocol.**
 
 ### Why This Matters
 
@@ -213,45 +128,15 @@ After EVERY implementation:
 | No HALT | Premature PR creation or issue closure |
 | Wrong format | Developer lacks context before URL |
 
-**The `review-prep` task is invoked AUTOMATICALLY after implementation. There is NO decision point.**
-
-**See `git-workflow` skill for complete review-prep workflow.**
-
 ______________________________________________________________________
 
 ## Critical Violation: Wrong Chat Output Format
 
 **⚠️ Posting URL before executive summary in chat is a CRITICAL GUIDELINE VIOLATION.**
 
-### 🚫 FORBIDDEN
+The executive summary MUST appear BEFORE the URL in chat output. URL must be LAST.
 
-```
-Compare URL: https://github.com/owner/repo/compare/main...branch
-
-**Summary:** Changes to skill files...
-**Outcome:** Added enforcement rules
-```
-
-### ✅ REQUIRED
-
-```
-**Summary:**
-
-Updated git-workflow skill to enforce automatic invocation...
-
-**Outcome:** Developers will now see compare URL after every implementation.
-
-Compare URL: https://github.com/owner/repo/compare/main...branch
-```
-
-### Why This Matters
-
-- Developer needs context BEFORE clicking URL
-- Executive summary explains business impact
-- Outcome states what changed for stakeholders
-- URL appears LAST as actionable link
-
-**See `git-workflow` skill → "Chat Output Format (CRITICAL)" section.**
+**See `git-workflow` skill → "Chat Output Format (CRITICAL)" section for complete format requirements and examples.**
 
 ______________________________________________________________________
 
@@ -259,47 +144,9 @@ ______________________________________________________________________
 
 **⚠️ Writing implementation details instead of executive summary in PR bodies is a CRITICAL GUIDELINE VIOLATION.**
 
-### 🚫 FORBIDDEN
+PR bodies MUST use the executive summary format (Summary/Outcome/Fixes). Implementation details do NOT belong in PR bodies.
 
-```
-Add plan-fidelity-auditor skill as the first auditor in the mandatory audit chain. It generates independent clean-room plans from problem statements and compares them against existing spec plans to identify substantive gaps — missing phases, incorrect approaches, and scope misalignment — before structural and content auditors run.
-
-Fixes #505
-```
-
-**Why this is wrong:** This describes *what the code does* (implementation details, skill internals, methodology) rather than *why the change matters* (stakeholder impact, quality improvement). A non-technical stakeholder cannot understand the value.
-
-### ✅ REQUIRED
-
-The PR body MUST use the same executive summary format as chat output and issue comments:
-
-```
-**Summary:**
-
-Ensures specs are audited for plan fidelity before implementation, catching missing phases and scope misalignment early.
-
-**Outcome:** Developers will catch spec quality issues before code changes begin.
-
-Fixes #505
-```
-
-### Format Requirements
-
-| Section | Purpose | Content |
-|---------|---------|---------|
-| `**Summary:**` | Why this matters | 1-2 sentences describing stakeholder value and business impact |
-| `**Outcome:**` | What changed | What stakeholders will experience differently |
-| `Fixes #N` | Autoclose | Issue numbers for automatic closure on merge |
-
-### Why This Matters
-
-| Violation | Consequence |
-|-----------|-------------|
-| Implementation details in PR body | Non-technical stakeholders cannot understand value |
-| No stakeholder context | reviewers must parse code to understand purpose |
-| Inconsistent format | Different expectations for chat vs PR vs comments |
-
-**See `git-workflow` skill → `pr-creation` task → "PR Body Requirements" section.**
+**See `git-workflow` skill → `pr-creation` task → "PR Body Requirements" section for complete format specification and examples.**
 
 ______________________________________________________________________
 
@@ -316,31 +163,9 @@ ______________________________________________________________________
 
 ### ✅ REQUIRED
 
-**Before marking any task complete:**
-
-```bash
-git status              # Verify changes are staged
-git add -A              # Stage all changes
-git commit -m "message" --trailer "Co-authored-by: ..." --trailer "Co-authored-by: ..."
-git push -u origin <branch>  # Push to remote
-git branch -vv          # Verify upstream is set
-```
-
-### Verification Checklist
-
-| Check | Command | Expected |
-|-------|---------|----------|
-| Changes staged | `git status --porcelain` | Empty (all committed) |
-| Branch pushed | `git branch -vv` | Shows `[origin/branch]` |
-| Commits exist | `git log origin/main..HEAD --oneline` | Shows commits |
-
-**If ANY check fails → STOP. Fix and retry.**
-
-**See `git-workflow` skill → "Enforcement Checklist" sections.**
+**See `finishing-a-development-branch` skill `--task checklist` for the complete commit/push verification procedure and enforcement checklist.**
 
 ______________________________________________________________________
-
-**Search guidelines:** Use `srclight_search_symbols` or `pycharm_search_in_files_by_text` to find relevant guidelines.
 
 ## Critical Violation: Fabricating URLs — ZERO TOLERANCE
 
@@ -363,29 +188,6 @@ All URLs must be constructed exclusively from values provided by the session-ini
 1. Extract `GITBUCKET_HTML_URL` (preferred) or `GITBUCKET_URL` (legacy) from session init output
 1. Construct ALL URLs using that base URL + `GIT_OWNER` + `GIT_REPO`
 1. If session init does not provide a required URL component → HALT and report
-
-### URL Construction Rules
-
-| URL Type | Construction |
-|----------|-------------|
-| Issue/PR | `{GITBUCKET_HTML_URL}{GIT_OWNER}/{GIT_REPO}/issues/{number}` |
-| Compare | `{GITBUCKET_HTML_URL}{GIT_OWNER}/{GIT_REPO}/compare/{base}...{head}` |
-| Pull request | `{GITBUCKET_HTML_URL}{GIT_OWNER}/{GIT_REPO}/pull/{number}` |
-
-Where `{GITBUCKET_HTML_URL}` is from session init output only.
-
-### Specific Anti-Pattern: SSH Hostname ≠ Web URL
-
-**The git remote SSH hostname is NEVER the same as the web UI hostname.**
-
-```
-GIT_REMOTE_URL=ssh://git@tomcat-0002.newsrx.com:29418/org/repo.git
-GITBUCKET_HTML_URL=https://gitbucket.newsrx.com/gitbucket/
-```
-
-| Wrong (fabricated from remote) | Right (from GITBUCKET_HTML_URL) |
-|-------------------------------|-------------------------------|
-| `https://tomcat-0002.newsrx.com/gitbucket/...` | `https://gitbucket.newsrx.com/gitbucket/...` |
 
 ### Why This Matters
 
@@ -418,16 +220,10 @@ ______________________________________________________________________
 - Using cached/stale owner values from previous sessions
 - Making ANY GitHub MCP call without session init values being available
 
-### ✅ REQUIRED SEQUENCE
+### ✅ REQUIRED
 
 1. Values are automatically injected by the session-init plugin (`.opencode/scripts/session_init.py`)
-1. Store ALL output values for session duration:
-   - `DEV_NAME` (human name for commit trailers)
-   - `DEV_EMAIL` (human email for commit trailers)
-   - `GIT_OWNER` (repository owner for GitHub API calls)
-   - `GIT_REPO` (repository name for GitHub API calls)
-   - `GIT_HOOKS_PATH` (git hooks path)
-   - `GIT_REMOTE_URL` (full remote URL)
+1. Store ALL output values (`DEV_NAME`, `DEV_EMAIL`, `GIT_OWNER`, `GIT_REPO`, `GIT_HOOKS_PATH`, `GIT_REMOTE_URL`) for session duration
 1. Use `GIT_OWNER` and `GIT_REPO` for EVERY GitHub MCP call
 1. NEVER assume or hardcode owner/repo values
 
@@ -464,92 +260,24 @@ AI co-authorship applies to **original content authored by AI**, NOT copy-pasted
 
 ### Attribution Format
 
-```
-Co-authored with AI: <AI-Name> (<model-id>)
-```
+`Co-authored with AI: <AI-Name> (<model-id>)`
 
-**Example:** `Co-authored with AI: OpenCode (ollama-cloud/glm-5)`
+Example: `Co-authored with AI: OpenCode (ollama-cloud/glm-5)`
 
-### Repository Creation
-
-When creating a new repository, the README MUST include:
-
-```markdown
-## Co-Authored With AI
-
-This repository was created with assistance from AI:
-
-- **AI Agent**: OpenCode
-- **Model**: ollama-cloud/glm-5
-- **Date**: YYYY-MM-DD
-```
-
-**Note:** The LICENSE file uses standard MIT license without modification. AI attribution goes in README, not LICENSE.
-
-**See `.opencode/guidelines/080-code-standards.md` for complete attribution requirements.**
+**See `.opencode/guidelines/080-code-standards.md` for complete attribution requirements (file types, formats, exceptions).**
 
 ## Critical Violation: Missing Progress Comments
 
 **⚠️ Failing to post progress comments to the associated issue is a CRITICAL GUIDELINE VIOLATION.**
 
-Every implementation task MUST be documented with progress comments on the GitHub issue:
+Every implementation task MUST be documented with progress comments on the GitHub issue.
 
-- Post comment IMMEDIATELY after completing each task
-- Post comment when creating PR
-- Never proceed to next task without commenting first
-
-### Required Format: Executive Summary
-
-**Intermediate task (multi-task spec):**
-
-```
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-**Final task or single-task spec:**
-
-```
-**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value.>
-
-**Outcome:** <What changed for stakeholders>
-
-All tasks complete from this specification.
-
----
-🤖 ✅ Completed by <AgentName> (<ModelID>)
-```
-
-**⚠️ CRITICAL: Emoji must be PLAIN TEXT (not inside italic/bold formatting).**
-
-**Status Emoji Guide:**
-| Status | Emoji | Byline Format |
-|--------|-------|---------------|
-| Task Complete | ✅ | `🤖 ✅ Completed by <AgentName> (<ModelID>)` |
-| In Progress | ↻ | `🤖 ↻ Working by <AgentName> (<ModelID>)` |
-| Created | ✨ | `🤖 ✨ Created by <AgentName> (<ModelID>)[: Issue #N]` |
-| Updated | 📝 | `🤖 📝 Updated by <AgentName> (<ModelID>)[: description]` |
-| Completed | ✅ | `🤖 ✅ Completed by <AgentName> (<ModelID>)` |
-| Rejected | ❌ | `🤖 ❌ Rejected by <AgentName> (<ModelID>): <reason>` |
-
-**When to include context in byline:**
-
-- **Progress comments**: No context (content already describes the work)
-- **Issue creation**: Optional — add issue number if useful
-- **Rejection/Superseded**: Always include reason or replacement reference
+**See `github-comments` skill for complete progress comment format, emoji guide, and byline requirements.**
 
 ### 🚫 FORBIDDEN in Progress Comments
 
 - **File lists** — Redundant (visible in git commits)
-- **"Next" field** — Dialog prompt (violates `AGENTS.md` § 125)
+- **"Next" field** — Dialog prompt (violates AGENTS.md)
 - **Punch-list format** — Use executive summary paragraphs
 - **"Awaiting authorization"** — Use HALT protocol, not comments
 - **Technical changelog** — Focus on impact, not file-by-file changes
@@ -567,22 +295,9 @@ Audit findings from `spec-auditor` are internal agent guidance — equivalent to
 | Agent makes non-substantive spec changes (STATUS, typos, cross-refs) after audit | ❌ NO |
 | Agent posts audit findings report | 🚫 FORBIDDEN — act on findings, don't post the report |
 
-**Correct workflow:** Audit → Act on findings (revise spec) → Post comment ONLY for substantive revisions (changes to requirements, phases, success criteria, scope).
-
 ### ⚠️ Chat Output Rule (CRITICAL)
 
 **Progress executive summaries go to BOTH GitHub comments AND chat.**
-
-| Location | Content |
-|----------|---------|
-| **GitHub Issue Comment** | Full executive summary (summary, outcome) |
-| **Chat Output** | Same executive summary (summary, outcome) |
-
-**Why:** Both GitHub history AND chat transcript should show progress. GitHub preserves long-term history; chat maintains session context.
-
-**✅ DO:** Post executive summary to GitHub, then provide SAME summary in chat
-**🚫 NEVER:** Skip either location
-**🚫 NEVER:** Put full summary in chat but skip GitHub comment
 
 **See `github-comments` skill for complete requirements.**
 
@@ -592,32 +307,15 @@ ______________________________________________________________________
 
 **⚠️ Failing to respond to user comments on GitHub Issues is a CRITICAL GUIDELINE VIOLATION.**
 
-Users communicating via GitHub Issues:
+Users communicating via GitHub Issues cannot see your internal analysis, are not mind readers, and expect responses where they asked the question.
 
-- Cannot see your internal analysis
-- Are not mind readers
-- Expect responses where they asked the question
-
-**MANDATORY RESPONSE PROTOCOL:**
-
-1. Read issue comments via `github_issue_read method=get_comments`
-1. Respond PUBLICLY via `github_add_issue_comment`
-1. Include analysis, findings, and next steps in your response
-1. Ask for authorization if needed
-
-**See `github-comments` skill → "Responding to User Comments (MANDATORY)" section for complete requirements.**
+**MANDATORY: Read issue comments and respond publicly. See `github-comments` skill → "Responding to User Comments (MANDATORY)" section for complete protocol.**
 
 ______________________________________________________________________
 
 ## Critical Violation: Sub-issue Structure Bypass — Multi-task Specs
 
 **⚠️ Implementing a multi-task spec without sub-issues is a CRITICAL GUIDELINE VIOLATION.**
-
-When implementing a multi-task spec (one with multiple phases/tasks):
-
-1. **First**: Call `github_issue_read method=get_sub_issues` on the parent issue
-1. **When empty**: AUTO-CREATE sub-issues at PHASE level (see `github-sub-issues` skill)
-1. **Then**: Verify the task being implemented is linked as a sub-issue
 
 **🚫 FORBIDDEN:**
 
@@ -632,12 +330,7 @@ When implementing a multi-task spec (one with multiple phases/tasks):
 - Each phase as separate GitHub Issue linked via `github_sub_issue_write method=add`
 - Single-task specs are exempt from sub-issue requirement
 
-**See `github-sub-issues` skill for complete workflow including:**
-
-- Single-task vs multi-task exemption
-- Auto-create workflow
-- Database ID requirement
-- Phase-level structure
+**See `github-sub-issues` skill for complete workflow including single-task vs multi-task exemption, auto-create workflow, database ID requirement, and phase-level structure.**
 
 ______________________________________________________________________
 
@@ -654,76 +347,11 @@ When a parent issue has sub-issues, authorization cascades to ALL sub-issues. Th
 - Asking for "approved" between phases of multi-task spec
 - Reporting completion after each phase instead of after ALL phases
 
-### ✅ CORRECT BEHAVIOR
+**See `approval-gate` skill → "Multi-Task Spec Authorization" for the complete authorization cascade workflow and enforcement matrix.**
 
-**Multi-task authorization flow:**
+Authorization cascades to ALL sub-issues. Complete ALL phases, then report ONCE and HALT ONCE.
 
-```
-User: "#34 approved" (parent issue with sub-issues)
-    ↓
-Agent verifies: parent has sub-issues? YES
-    ↓
-ALL sub-issues authorized (cascade)
-    ↓
-Complete Phase 2 (#39)
-Continue to Phase 3 (#40)
-Continue to Phase 4 (#41)
-Continue to Phase 5 (#42)
-Continue to Phase 6 (#43)
-    ↓
-ALL phases done
-    ↓
-Report once at end
-    ↓
-HALT once at end
-```
-
-**Exception: User explicitly restricts authorization**
-
-```
-User: "approved: Phase 2 only"
-    ↓
-Agent completes Phase 2 only
-    ↓
-HALT
-```
-
-### Enforcement Matrix
-
-| Authorization | Scope | Behavior |
-|---------------|-------|----------|
-| `#34 approved` (parent with sub-issues) | ALL sub-issues | Complete ALL phases, HALT once at end |
-| `#39 approved` (single sub-issue) | That sub-issue only | Complete that phase, HALT |
-| `approved: 1.2` (specific phase) | That phase only | Complete that phase, HALT |
-
-### Why This Matters
-
-| Wrong Behavior | Impact |
-|----------------|--------|
-| HALT after Phase 2 | Wasted developer time re-authorizing |
-| Per-phase authorization | Broken workflow expectations |
-| Multiple HALTs | Loss of trust in AI reliability |
-
-### Checklist for Multi-Task Specs
-
-- \[ \] User authorized parent issue
-- \[ \] Verify parent has sub-issues
-- \[ \] Authorization cascades to ALL sub-issues
-- \[ \] Complete Phase 2
-- \[ \] Continue to Phase 3 (NO HALT)
-- \[ \] Continue to Phase 4 (NO HALT)
-- \[ \] Continue to Phase 5 (NO HALT)
-- \[ \] Continue to Phase 6 (NO HALT)
-- \[ \] ALL phases complete → Report → HALT
-
-**STOP conditions (require dev intervention):**
-
-- Exception raised during implementation
-- Conflict detected requiring resolution
-- Missing dependency blocking progress
-- User explicitly says "stop" or "wait"
-
-**See `010-approval-gate.md` → "Multi-Task Spec Authorization"**
+**Exception:** User explicitly restricts authorization (e.g., "approved: Phase 2 only") → complete that phase ONLY, then HALT.
 
 ## Critical Violation: Sub-issue Closure Timing — ZERO TOLERANCE
 
@@ -736,76 +364,7 @@ HALT
 - **Manually closing sub-issues that have "Fixes #N" in PR description**
 - **Closing sub-issues without verifying PR merge via GitHub API**
 
-### ✅ CORRECT WORKFLOW
-
-**The platform (GitBucket/GitHub) closes issues automatically via "Fixes #N" annotations.**
-
-1. **Implement sub-issue** → Create PR with `Fixes #N` in description (NO manual sub-issue closure)
-1. **PR created** → Report URL, HALT
-1. **Human merges PR** → Platform automatically closes sub-issue
-1. **User confirms "pr merged"** → Agent verifies merge via GitHub API
-1. **Agent verifies sub-issues are closed** → API check (`state: "closed"`)
-1. **If sub-issue still open (edge case)** → Agent closes it manually
-1. **All sub-issues closed?** → Close parent issue
-
-### Why This Matters
-
-| Wrong Behavior | Correct Behavior |
-|----------------|------------------|
-| Agent closes sub-issue after implementation | Platform closes via "Fixes #N" |
-| Sub-issue shows "completed" before PR merge | Sub-issue closes WHEN PR merges |
-| Tracks completion without code review | Tracks completion AFTER code review |
-| May hide problems if PR never merges | PR merge is the verification step |
-
-### "Fixes #N" Annotation (MANDATORY)
-
-**PR descriptions MUST include sub-issue numbers to enable automatic closure:**
-
-```markdown
-Fixes #86, #87, #88
-
-[PR body...]
-```
-
-**This allows GitBucket/GitHub to automatically close sub-issues when the PR merges.**
-
-### Final Verification Step (AFTER PR Merge)
-
-After user confirms "pr merged":
-
-```python
-# Step 1: Verify PR merge via GitHub API
-pr = github_pull_request_read(method="get", owner=..., repo=..., pullNumber=...)
-if pr.get("merged_at") is None:
-    halt("PR not merged yet")
-
-# Step 2: Check all sub-issues are closed
-children = github_issue_read(method="get_sub_issues", issue_number=parent)
-open_children = [c for c in children if c["state"] == "open"]
-
-if open_children:
-    # Edge case: Platform failed to auto-close
-    for child in open_children:
-        github_issue_write(method="update", issue_number=child["number"], 
-                          state="closed", state_reason="completed")
-
-# Step 3: Close parent only after all children closed
-if not open_children:
-    github_issue_write(method="update", issue_number=parent,
-                       state="closed", state_reason="completed")
-```
-
-### Edge Case Handling
-
-| Scenario | Action |
-|----------|--------|
-| Platform fails to auto-close sub-issue | Agent closes manually after PR merge verification |
-| PR closed without merge | Sub-issues remain open (correct behavior) |
-| Draft PR | Sub-issues remain open until PR is merged (correct behavior) |
-| Multiple sub-issues in one PR | Include all in "Fixes #N, #M, #P" annotation |
-
-**See `124-github-archive-workflow.md` for complete closure timing workflow.**
-**See `git-workflow` skill → "cleanup" task for post-merge verification.**
+**See `git-workflow` skill `--task cleanup` for the complete post-merge verification workflow, sub-issue closure, and parent issue closure.**
 
 ## Critical Violation: Scope Creep — NEVER Do Things Outside the Spec
 
@@ -837,8 +396,6 @@ ______________________________________________________________________
 
 **⚠️ Creating a spec without completed investigation is a CRITICAL GUIDELINE VIOLATION.**
 
-Investigation MUST be completed BEFORE finalizing a spec for review.
-
 **🚫 FORBIDDEN:**
 
 - Creating specs from vague requirements without exploration
@@ -847,37 +404,7 @@ Investigation MUST be completed BEFORE finalizing a spec for review.
 - Proceeding without success criteria defined
 - Running test code against production systems during investigation
 
-**✅ REQUIRED:**
-
-- Investigate codebase for existing patterns and reusable components
-- Create test scripts in `./tmp/` to validate hypotheses (isolated from production)
-- Document alternatives considered with tradeoffs
-- Identify risks and mitigation strategies
-- Define testable, measurable success criteria
-
-**✅ ALLOWED During Investigation:**
-
-- Read production code (exploration)
-- Read production data (analysis)
-- Create and run test scripts in `./tmp/` (isolated fixtures)
-- Create isolated test fixtures (dedicated test DB/schemas)
-- Run static analysis (lint, typecheck)
-- Document findings for the spec
-
-**Investigation Completion Criteria:**
-
-Before creating a spec, the agent MUST verify:
-
-| Requirement | Evidence |
-|-------------|----------|
-| Problem understood | Clearly stated problem, context, stakeholders |
-| Codebase explored | Existing patterns, reusable components identified |
-| Hypotheses tested | Test scripts run, results documented |
-| Alternatives considered | At least 2 approaches documented with tradeoffs |
-| Risks identified | Risk assessment with mitigation strategies |
-| Success criteria defined | Testable, measurable completion criteria |
-
-See `142-planning-archive-workflow.md` → "Investigation Completion Criteria" for complete requirements.
+**See `brainstorming` skill for investigation requirements and completion criteria.**
 
 ______________________________________________________________________
 
@@ -885,37 +412,15 @@ ______________________________________________________________________
 
 **⚠️ Implementing a stale or superseded spec without revision is a CRITICAL GUIDELINE VIOLATION.**
 
-Before implementing OR revising any spec, the agent MUST check for:
+**See `github-issue-creation` skill `--task pre-creation` for the complete superseded/stale spec check procedure.**
 
-### Superseding Issues
+### If Superseding Issue Exists
 
-**When to check:** Before any implementation or revision of a spec.
+- SILENTLY HALT and report the conflict to the issue
+- Do NOT proceed with the superseded spec
+- Wait for user direction
 
-**What to check:**
-
-- Query all open `[SPEC]`, `[SPEC-FIX]`, and `[SPEC-ENHANCEMENT]` issues
-- Identify conflicting/overlapping objectives
-- Look for later issues that may render the active spec obsolete
-
-**If superseding issue exists:**
-
-1. SILENTLY HALT
-1. Report the conflict to the issue
-1. Do NOT proceed with the superseded spec
-1. Wait for user direction
-
-### Staleness from Implemented Specs
-
-**When to check:** Before any implementation or revision of a spec.
-
-**What to check:**
-
-- Check for merged PRs that implemented related functionality
-- Check if referenced code locations have been modified since spec creation
-- Check if referenced dependencies/libraries have changed
-- Check if the problem statement still applies (may have been fixed by another implementation)
-
-**If staleness detected:**
+### If Staleness Detected
 
 **🚫 FORBIDDEN:**
 
@@ -925,121 +430,26 @@ Before implementing OR revising any spec, the agent MUST check for:
 
 **✅ REQUIRED:**
 
-1. REVISE the spec to reflect current reality:
-   - Update problem statement if context changed
-   - Update affected files/lines if code locations changed
-   - Update success criteria if requirements shifted
-   - Update dependencies if integration points changed
-1. Report the revision via comment on the issue
-1. HALT — wait for user approval before proceeding
-1. Never implement a stale spec without revision
-
-### Where to Check
-
-This check is REQUIRED in these workflows:
-
-| Workflow | Guideline |
-|----------|-----------|
-| Before implementing any spec | `010-approval-gate.md` |
-| When listing available specs | `140-planning-spec-creation.md` |
-| Before revising a spec | `130-authority-source.md` |
+- REVISE the spec to reflect current reality
+- Report the revision via comment on the issue
+- HALT — wait for user approval before proceeding
+- Never implement a stale spec without revision
 
 ______________________________________________________________________
 
 ## Auditor Skills Enforcement
 
-**⚠️ MANDATORY AUDIT: Run spec-auditor orchestrator when auditing specs. NO SKIPPING.**
+**⚠️ MANDATORY AUDIT: Run `spec-auditor` orchestrator when auditing specs. NO SKIPPING.**
 
-### When to Run Auditor Skills
+**Trigger words that require the auditor:** "audit this spec", "review this issue", "revisit this task", "check this [SPEC]", "validate the spec", "audit the issue", or any request involving spec quality or structure.
 
-**Trigger words that require the auditor:**
-
-- "audit this spec"
-- "review this issue"
-- "revisit this task"
-- "check this \[SPEC\]"
-- "validate the spec"
-- "audit the issue"
-- Any request involving spec quality or structure
-
-### Orchestration Model (CURRENT)
-
-**spec-auditor is the orchestrator.** It decides which subtasks to run based on scope:
-
-```
-spec-auditor --issue N
-    ├── Baseline (always run):
-    │   ├── fresh-start      — Self-contained context, fresh-start requirements
-    │   ├── structure        — Phase structure, concern separation, naming quality
-    │   ├── content-quality  — Completeness, clarity, LLM implementability
-    │   └── traceability     — Cross-references, anchors, no stale line numbers
-    └── Conditional (based on scope):
-        ├── operational      — Operational requirements, success criteria
-        ├── fidelity         — Plan fidelity, clean-room comparison (replaces old plan-fidelity-auditor)
-        └── concerns         — Concern separation, deployment independence (replaces old concern-separation-auditor)
-```
-
-**Why orchestration over fixed chains:**
-- Not every spec needs fidelity or concern audits
-- Spec-auditor determines scope and selects relevant subtasks
-- Eliminates rigid "run ALL three in order" requirement
-- Agent judgment replaces rote checklist execution
-
-### Guideline Auditor (`guideline-auditor`)
-
-Invoked with: `/skill guideline-auditor`
-
-**Purpose:** Audit `.opencode/guidelines/` for gaps, conflicts, and LLM compliance.
-
-**When to invoke:**
-
-- Before approving guideline changes
-- Periodic maintenance to check for guideline drift
-- Post-implementation verification for guideline changes
-
-**Output:** Creates audit log in `./tmp/audit-YYYYMMDD.md`
-
-### Spec Auditor (`spec-auditor`) — Orchestrator
-
-Invoked with: `/skill spec-auditor --issue N`
-
-**Purpose:** Orchestrate spec quality audit by selecting and running relevant subtasks.
-
-**When to invoke:**
-
-- When "audit/review/revisit" keywords used
-- After spec creation
-- Before approving spec implementation
-- Periodic audit to check for spec drift
-
-**Subtask invocation:**
-
-```
-/skill spec-auditor --task fresh-start     # Fresh-start context audit
-/skill spec-auditor --task structure       # Phase structure audit
-/skill spec-auditor --task content-quality # Content completeness audit
-/skill spec-auditor --task traceability    # Cross-reference audit
-/skill spec-auditor --task operational     # Operational requirements audit
-/skill spec-auditor --task fidelity        # Plan fidelity audit (replaces old plan-fidelity-auditor)
-/skill spec-auditor --task concerns        # Concern separation audit (replaces old concern-separation-auditor)
-```
-
-**Output:** Posts findings to GitHub Issue, creates audit log in `./tmp/audit-spec-YYYYMMDD.md`
-
-### Legacy Auditors (Subtasks, Not Separate Chain Entries)
-
-**plan-fidelity-auditor** and **concern-separation-auditor** still exist as standalone skills but are invoked as subtasks by spec-auditor, not as separate chain entries:
-
-- `/skill plan-fidelity-auditor` — Runs fidelity subtask internally (report-only, no auto-fix)
-- `/skill concern-separation-auditor` — Runs concerns subtask internally (report-only, no auto-fix)
-
-**These can also be invoked directly for standalone audits when only fidelity or concern checks are needed.**
+**See `spec-auditor` skill for the complete orchestration model, baseline subtasks, conditional subtasks, and invocation commands.**
 
 ### Enforcement Flow
 
 | Trigger | Action |
 |---------|--------|
-| Spec created | REQUIRED: Invoke `spec-auditor --issue N` (orchestrator selects subtasks) |
+| Spec created | REQUIRED: Invoke `spec-auditor --issue N` |
 | "Audit/review/revisit this spec" | REQUIRED: Invoke `spec-auditor --issue N` |
 | Before implementation approval | REQUIRED: Verify spec-auditor found no critical issues |
 | Guideline change proposed | Optional: `/skill guideline-auditor` |
@@ -1051,12 +461,7 @@ ______________________________________________________________________
 
 **⚠️ Creating a PR without EXPLICIT developer instruction is a CRITICAL GUIDELINE VIOLATION.**
 
-PRs require the developer to say one of these EXACT phrases:
-
-- "create a PR"
-- "make a PR"
-- "push and create PR"
-- "let's get a PR up"
+PRs require the developer to say one of these EXACT phrases: "create a PR", "make a PR", "push and create PR", "let's get a PR up".
 
 **🚫 FORBIDDEN:**
 
@@ -1065,17 +470,7 @@ PRs require the developer to say one of these EXACT phrases:
 - Asking "Ready for a PR?" or "Should I create a PR?" — just STOP and report completion
 - **Pushing branch to remote without "create a PR" instruction** — pushing is part of PR creation, NOT implementation
 
-**✅ REQUIRED:**
-
-- After completing implementation: report completion concisely, then STOP
-- Wait for EXPLICIT "create a PR" instruction
-- Only then: squash, push, create PR, report URL, STOP
-
-**See `pr-creation-workflow` skill for the full PR timing workflow including:**
-
-- Authorization boundary (what authorizes implementation vs PR)
-- Developer must test before PR
-- HALT after PR creation
+**See `pr-creation-workflow` skill for the full PR timing workflow including authorization boundary, developer testing, and HALT after PR creation.**
 
 ______________________________________________________________________
 
@@ -1083,93 +478,7 @@ ______________________________________________________________________
 
 **⚠️ Finding a bug during analysis does NOT authorize fixing it.**
 
-### 🚫 FORBIDDEN
-
-- Implementing fixes discovered during analysis tasks
-- Creating branches/specs/PRs after finding bugs in analysis mode
-- Treating analysis requests as implementation authorization
-- "Vibe coding" — seeing a bug and immediately implementing a fix without spec
-
-### ✅ REQUIRED SEQUENCE
-
-| Request Type | Authorized Actions |
-|-------------|---------------------|
-| "check logs" | Read logs, report findings, HALT |
-| "analyze error" | Analyze, report root cause, HALT |
-| "why is this failing" | Investigate, report findings, HALT |
-| "check X" | Analyze X, report findings, HALT |
-| "fix this" | Create spec issue, get approval, implement |
-
-1. User requests analysis → Perform analysis ONLY
-1. Report findings (bugs, errors, issues) as factual observations
-1. HALT and wait for explicit authorization
-1. If user wants fix → Create spec issue, get approval, then implement
-
-### Why This Matters
-
-| Violation | Consequence |
-|-----------|-------------|
-| Implement during analysis | No spec to track changes |
-| No spec issue | No approval workflow |
-| Direct to implementation | Bypasses review process |
-| Vibe coding | Untracked, undocumented changes |
-
-**Discovery Protocol:**
-
-1. Bug discovered during analysis → Record as factual observation
-1. Create GitHub Issue for the discovery (if not exists)
-1. Report existence in chat
-1. HALT
-1. Wait for explicit "fix this" or "create spec"
-1. If authorized → Create spec, get approval, implement
-
-______________________________________________________________________
-
-## Critical Violation: Creating PRs Without Explicit Instruction
-
-**⚠️ Creating a PR without EXPLICIT developer instruction is a CRITICAL GUIDELINE VIOLATION.**
-
-PRs require the developer to say one of these EXACT phrases:
-
-- "create a PR"
-- "make a PR"
-- "push and create PR"
-- "let's get a PR up"
-
-**🚫 FORBIDDEN:**
-
-- Creating a PR after "approved" or "go" — these authorize implementation ONLY
-- Creating a PR after completing implementation — completion does NOT authorize PR creation
-- Asking "Ready for a PR?" or "Should I create a PR?" — just STOP and report completion
-- **Pushing branch to remote without "create a PR" instruction** — pushing is part of PR creation, NOT implementation
-
-**✅ REQUIRED:**
-
-- After completing implementation: report completion concisely, then STOP
-- Wait for EXPLICIT "create a PR" instruction
-- Only then: squash, push, create PR, report URL, STOP
-
-**The PR Timing Boundary:**
-
-| Authorization | What It Authorizes |
-|---------------|---------------------|
-| "approved" / "go" | Implementation ONLY |
-| Completion of implementation | Report + STOP |
-| "create a PR" | PR creation workflow |
-| Branch push | Part of PR creation, NOT implementation |
-
-**Correct Sequence:**
-
-1. "approved" → Implement → Report completion → STOP
-1. Wait for "create a PR" → Push branch → Report URL in chat → STOP
-1. Wait for "create a PR" → Squash → Create PR → Report URL in chat → STOP
-1. Wait for human to merge → Close issues
-
-**See `pr-creation-workflow` skill for the full PR timing workflow including:**
-
-- Authorization boundary (what authorizes implementation vs PR)
-- Developer must test before PR
-- HALT after PR creation
+**See `approval-gate` skill for the complete discovery protocol and authorization boundaries, including the analysis → implementation authorization decision table.**
 
 ______________________________________________________________________
 
@@ -1185,23 +494,7 @@ ______________________________________________________________________
 - Closing issues without explicit "merge confirmed" from human
 - Closing issues based on `git pull` fast-forward alone (MUST use GitHub API)
 
-**✅ REQUIRED SEQUENCE:**
-
-1. Complete implementation → Create PR → Report URL in chat → **HALT**
-1. Wait for human to review and merge PR
-1. User confirms "pr merged" → **Call `github_pull_request_read method=get` to verify**
-1. Verify `merged_at` timestamp or `state: "closed"` with merge
-1. ONLY after API confirms merge → Close issues
-1. Post closing summary comment
-
-**Why `git pull` is insufficient:**
-
-- Local fast-forward shows `git pull` succeeded
-- Does NOT verify the PR merge state in GitHub
-- Agent could close issue before human actually merged
-
-**See `124-github-archive-workflow.md` for complete issue closure timing.**
-**See `git-workflow` skill → "Phase 4" section for post-merge workflow including issue closure.**
+**See `git-workflow` skill `--task cleanup` for complete post-merge verification.**
 
 ______________________________________________________________________
 
@@ -1223,8 +516,6 @@ ______________________________________________________________________
 - review-prep is MANDATORY before any issue closure
 - PR merge verification is required before closing ANY issue
 
-**File Types That Require Full PR Workflow:**
-
 | File Type | PR Required? | Reason |
 |-----------|--------------|--------|
 | Code (`.py`, `.java`, etc.) | ✅ YES | Code changes |
@@ -1233,17 +524,13 @@ ______________________________________________________________________
 | Config (`*.toml`, `*.yaml`) | ✅ YES | Config changes |
 | **NO files modified** | ❌ NO | Already implemented |
 
-**The only exception is when ZERO files were modified** — all proposed changes were already present in the codebase. In that case, close with a verification comment without PR workflow.
-
-**See `git-workflow` skill → "Edge Case: Already Implemented" for the complete workflow.**
+**The only exception is when ZERO files were modified.**
 
 ______________________________________________________________________
 
 ## Critical Violation: Parent/Child Issue Closure
 
 **⚠️ Closing a parent issue while child issues remain open is a CRITICAL GUIDELINE VIOLATION.**
-
-When working with parent/child issue hierarchies (specs with sub-issues):
 
 **🚫 FORBIDDEN:**
 
@@ -1258,60 +545,7 @@ When working with parent/child issue hierarchies (specs with sub-issues):
 - After closing a child: check if other children remain open
 - If all children are closed, then (and only then) close the parent
 
-### Correct Workflow
-
-| Step | Action | Issues Affected |
-|------|--------|-----------------|
-| PR merged for child task | Close corresponding child issue | Child issue only |
-| Check remaining children | Verify all children closed | No action yet |
-| All children closed? | Close parent with summary | Parent issue |
-
-### Example
-
-```
-SPEC #100 (parent)
-├── Task #101: Phase 1 - Database schema
-├── Task #102: Phase 2 - API endpoints
-└── Task #103: Phase 3 - UI components
-
-PR merges for Phase 1 → Close #101 ONLY
-#100 remains open (children #102, #103 pending)
-
-Later, PR merges for Phase 2 → Close #102 ONLY
-#100 remains open (child #103 pending)
-
-Later, PR merges for Phase 3 → Close #103 AND #100 (all children done)
-```
-
-### Exception: All Children Completed
-
-**When ALL child issues are completed by a single PR merge:**
-
-1. Close the child issue corresponding to the PR
-1. **ALSO close the parent issue** (all children are now complete)
-1. Add summary comment to the parent explaining all work is complete
-
-**Example:** If PR #150 fixes both #102 and #103 (the last remaining children), close BOTH child issues AND the parent #100 after merge.
-
-### Why This Matters
-
-- Parent issues track overall progress across all phases
-- Premature parent closure loses visibility into remaining work
-- Stakeholders need to see open issues for incomplete work
-- GitHub sub-issue view shows which children remain
-
-### Sub-Issue Double-Check (MANDATORY)
-
-**After closing child issues addressed by PR, ALWAYS verify remaining sub-issues before closing parent.**
-
-**The Problem:**
-
-- Single PR may address multiple sub-issues
-- Agent may close sub-issues prematurely (before PR merge)
-- Agent may forget to close sub-issues after PR merge
-- Parent gets closed while children remain open
-
-**See `git-workflow` skill → "Sub-Issue Double-Check" section and `124-github-archive-workflow.md` → "Sub-Issue Double-Check" section for complete workflow.**
+**See `git-workflow` skill `--task cleanup` for the complete parent/child closure workflow and sub-issue double-check procedure.**
 
 ______________________________________________________________________
 
@@ -1334,9 +568,6 @@ ______________________________________________________________________
 - **MERGED branches**: Delete IMMEDIATELY after merge confirmation — no asking, no waiting
 - **UNMERGED branches with work**: Preserve until explicitly asked to delete
 - **Stashes**: Preserve until explicitly asked to delete
-- After PR creation: report URL, wait for merge confirmation, then DELETE the branch
-
-### Quick Reference
 
 | Branch Status | Action |
 |---------------|--------|
@@ -1356,19 +587,9 @@ See `.opencode/guidelines/085-engineering-approach.md` for complete requirements
 ### Core Engineering Principles
 
 1. **Understand Before Solving** — Read all relevant code before proposing changes
-1. **Design Before Implementing** — Document approach and obtain approval before coding
-1. **Verify Before Declaring Complete** — Run tests, check edge cases, validate success criteria
-1. **Communicate Changes** — Post comments when changes occur (NOT when creating issues)
-
-### Requirements Analysis Mandatory
-
-Every specification MUST include:
-
-- Problem definition with context and stakeholders
-- Constraints, assumptions, and success criteria
-- Edge cases identified
-- Dependencies and integrations affected
-- Risk assessment
+2. **Design Before Implementing** — Document approach and obtain approval before coding
+3. **Verify Before Declaring Complete** — Run tests, check edge cases, validate success criteria
+4. **Communicate Changes** — Post comments when changes occur (NOT when creating issues)
 
 ### No Feature Creep
 
@@ -1383,259 +604,6 @@ Every specification MUST include:
 - "Should I do X?" is a question, not authorization
 - Wait for clear "approved" or "go" before starting
 - If unclear, ask — do not assume
-
-## Critical Violation: Implementing Without Documentation Verification
-
-**⚠️ Implementing code without verifying against live documentation is a CRITICAL GUIDELINE VIOLATION.**
-
-### 🚫 FORBIDDEN
-
-- Implementing API calls without verifying parameter names from official docs
-- Using environment variables without confirming correct names from config files
-- Guessing function signatures from memory or similar libraries
-- Using outdated blog posts/tutorials instead of official documentation
-
-### ✅ REQUIRED
-
-- **ALWAYS verify API signatures before implementing**
-- Check official documentation for current API usage
-- Use `srclight_get_signature` or `pycharm_get_symbol_info` for function signatures
-- Read source code and type hints when docs unavailable
-- Confirm environment variable names from `.env.example` or config
-
-### Why This Matters
-
-- Assumption-based implementations lead to broken functionality
-- API changes between library versions cause silent failures
-- Incorrect parameter names waste debugging time
-- Outdated patterns accumulate technical debt
-
-______________________________________________________________________
-
-## Critical Violation: Skipping Post-Implementation Verification Skills
-
-**⚠️ Failing to invoke `verification-before-completion` and `finishing-a-development-branch` after implementation is a CRITICAL GUIDELINE VIOLATION.**
-
-This is the same class of failure as skipping `review-prep`: skills exist, dispatch triggers are documented, but the agent skips them because there is no enforcement mechanism blocking progression.
-
-### 🚫 FORBIDDEN
-
-- Claiming "task complete" without invoking `verification-before-completion --task verify`
-- Claiming "implementation complete" without invoking `finishing-a-development-branch --task checklist`
-- Manually executing skill steps instead of formally invoking the skill
-- Skipping verification because "the changes look correct"
-- Proceeding to `review-prep` before verification skills pass
-
-### ✅ REQUIRED SEQUENCE (MANDATORY, NO DECISION POINT)
-
-After every implementation, the following skills MUST be invoked in this exact order:
-
-```
-Implementation completes
-    ↓
-1. verification-before-completion --task verify
-    ↓ (if verification FAILS → HALT and report)
-    ↓ (if verification PASSES → continue)
-2. finishing-a-development-branch --task checklist
-    ↓ (if checklist FAILS → HALT and report)
-    ↓ (if checklist PASSES → continue)
-3. git-workflow --task review-prep
-    ↓
-HALT with compare URL
-```
-
-**The order matters:**
-1. `verification-before-completion` checks SUCCESS CRITERIA (evidence required)
-2. `finishing-a-development-branch` checks BRANCH READINESS (committed, tested, pushed)
-3. `git-workflow --task review-prep` generates compare URL
-
-### Why Manual Execution Is NOT Sufficient
-
-Manual execution of skill steps is PROHIBITED because:
-
-| Manual Execution | Formal Skill Invocation |
-|-------------------|------------------------|
-| Skips enforcement checklists | Loads and follows enforcement checklist |
-| Agent may skip "obvious" steps | Every step is explicit and mandatory |
-| No CRITICAL VIOLATION warnings in context | Skill content includes enforcement warnings |
-| Error-prone, agent decides what to skip | No decision points — all steps required |
-
-### Why This Matters
-
-| Violation | Consequence |
-|-----------|-------------|
-| Skip verification | Success criteria not checked, bugs shipped |
-| Skip finishing checklist | Uncommitted changes, failing tests, broken PRs |
-| Skip both | No evidence of completion, no quality gate |
-| Manual execution only | Agent bypasses enforcement, misses steps |
-
-### Implementation-Workflow Integration
-
-The `implementation-workflow` skill orchestrates this sequence in Step 3.5 (Verification Gate). See `implementation-workflow/SKILL.md` for the orchestration protocol.
-
-**See `verification-before-completion` skill for evidence requirements.**
-**See `finishing-a-development-branch` skill for branch readiness checklist.**
-
-______________________________________________________________________
-
-## Critical Violation: Skipping review-prep After Implementation
-
-**⚠️ Failing to invoke `review-prep` after implementation is a CRITICAL GUIDELINE VIOLATION.**
-
-### 🚫 FORBIDDEN
-
-- Marking implementation complete WITHOUT committing, pushing, and generating URL
-- Skipping `review-prep` because "no changes were made"
-- Skipping `review-prep` because "already pushed"
-- Skipping `review-prep` for documentation/guideline changes
-- Proceeding to next phase without URL in chat
-
-### ✅ REQUIRED
-
-After EVERY implementation:
-
-1. Commit all changes with proper trailers
-1. Push feature branch to remote
-1. Invoke `review-prep` automatically
-1. Generate GitHub compare URL
-1. Report exec summary + URL in chat (URL LAST)
-1. Post completion comment to issue (NO URL)
-1. HALT and wait for "create a PR"
-
-### Why This Matters
-
-| Violation | Consequence |
-|-----------|-------------|
-| No commit | Changes lost, no tracking |
-| No push | Remote has no branch, compare URL fails |
-| No URL | Developer cannot review changes |
-| No HALT | Premature PR creation or issue closure |
-| Wrong format | Developer lacks context before URL |
-
-**The `review-prep` task is invoked AUTOMATICALLY after implementation. There is NO decision point.**
-
-**See `git-workflow` skill for complete review-prep workflow.**
-
-______________________________________________________________________
-
-## Critical Violation: Wrong Chat Output Format
-
-**⚠️ Posting URL before executive summary in chat is a CRITICAL GUIDELINE VIOLATION.**
-
-### 🚫 FORBIDDEN
-
-```
-Compare URL: https://github.com/owner/repo/compare/main...branch
-
-**Summary:** Changes to skill files...
-**Outcome:** Added enforcement rules
-```
-
-### ✅ REQUIRED
-
-```
-**Summary:**
-
-Updated git-workflow skill to enforce automatic invocation...
-
-**Outcome:** Developers will now see compare URL after every implementation.
-
-Compare URL: https://github.com/owner/repo/compare/main...branch
-```
-
-### Why This Matters
-
-- Developer needs context BEFORE clicking URL
-- Executive summary explains business impact
-- Outcome states what changed for stakeholders
-- URL appears LAST as actionable link
-
-**See `git-workflow` skill → "Chat Output Format (CRITICAL)" section.**
-
-______________________________________________________________________
-
-## Critical Violation: Wrong PR Body Format
-
-**⚠️ Writing implementation details instead of executive summary in PR bodies is a CRITICAL GUIDELINE VIOLATION.**
-
-### 🚫 FORBIDDEN
-
-```
-Add plan-fidelity-auditor skill as the first auditor in the mandatory audit chain. It generates independent clean-room plans from problem statements and compares them against existing spec plans to identify substantive gaps — missing phases, incorrect approaches, and scope misalignment — before structural and content auditors run.
-
-Fixes #505
-```
-
-**Why this is wrong:** This describes *what the code does* (implementation details, skill internals, methodology) rather than *why the change matters* (stakeholder impact, quality improvement). A non-technical stakeholder cannot understand the value.
-
-### ✅ REQUIRED
-
-The PR body MUST use the same executive summary format as chat output and issue comments:
-
-```
-**Summary:**
-
-Ensures specs are audited for plan fidelity before implementation, catching missing phases and scope misalignment early.
-
-**Outcome:** Developers will catch spec quality issues before code changes begin.
-
-Fixes #505
-```
-
-### Format Requirements
-
-| Section | Purpose | Content |
-|---------|---------|---------|
-| `**Summary:**` | Why this matters | 1-2 sentences describing stakeholder value and business impact |
-| `**Outcome:**` | What changed | What stakeholders will experience differently |
-| `Fixes #N` | Autoclose | Issue numbers for automatic closure on merge |
-
-### Why This Matters
-
-| Violation | Consequence |
-|-----------|-------------|
-| Implementation details in PR body | Non-technical stakeholders cannot understand value |
-| No stakeholder context | reviewers must parse code to understand purpose |
-| Inconsistent format | Different expectations for chat vs PR vs comments |
-
-**See `git-workflow` skill → `pr-creation` task → "PR Body Requirements" section.**
-
-______________________________________________________________________
-
-## Critical Violation: Uncommitted/Unpushed Changes After Implementation
-
-**⚠️ Marking implementation complete WITHOUT committing and pushing is a CRITICAL GUIDELINE VIOLATION.**
-
-### 🚫 FORBIDDEN
-
-- Marking task complete when `git status` shows uncommitted changes
-- Skipping `git commit` because "changes are small"
-- Skipping `git push` because "branch exists"
-- Proceeding to review-prep without push verification
-
-### ✅ REQUIRED
-
-**Before marking any task complete:**
-
-```bash
-git status              # Verify changes are staged
-git add -A              # Stage all changes
-git commit -m "message" --trailer "Co-authored-by: ..." --trailer "Co-authored-by: ..."
-git push -u origin <branch>  # Push to remote
-git branch -vv          # Verify upstream is set
-```
-
-### Verification Checklist
-
-| Check | Command | Expected |
-|-------|---------|----------|
-| Changes staged | `git status --porcelain` | Empty (all committed) |
-| Branch pushed | `git branch -vv` | Shows `[origin/branch]` |
-| Commits exist | `git log origin/main..HEAD --oneline` | Shows commits |
-
-**If ANY check fails → STOP. Fix and retry.**
-
-**See `git-workflow` skill → "Enforcement Checklist" sections.**
 
 ______________________________________________________________________
 

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -61,54 +61,25 @@ The `needs-approval` label is a **tracking tool**, not a permanent gate. Its pur
 
 **When parent issue has sub-issues:** authorization cascades to ALL sub-issues.
 
-| Authorization | Scope | Behavior |
-|---------------|-------|----------|
-| `#34 approved` (parent with sub-issues) | ALL sub-issues authorized | Complete ALL phases in sequence, HALT once at end |
-| `#39 approved` (single sub-issue) | That sub-issue only | Complete that phase, HALT after completion |
-| `approved: 1.2` (specific phase) | That phase only | Complete that phase, HALT after completion |
+**See `approval-gate` skill → "Multi-Task Spec Authorization" for the complete authorization cascade workflow and enforcement matrix.**
 
-**⚠️ PROHIBITED (Common Misinterpretation):**
+Key rules:
 - 🚫 DO NOT halt after each phase of multi-task spec
 - 🚫 DO NOT ask for re-authorization between phases
 - 🚫 DO NOT treat sub-issues as separate authorization units
+- ✅ Complete ALL phases, then report ONCE and HALT ONCE
 
-**✅ REQUIRED Behavior:**
-1. User authorizes parent issue
-2. Verify: parent has sub-issues? → ALL sub-issues authorized (cascade)
-3. Complete Phase 2 (or resume from current phase)
-4. Continue to Phase 3, Phase 4, Phase 5, Phase 6
-5. Report ONCE at the end
-6. HALT ONCE after ALL phases complete
-
-**Exception: User explicitly names a phase**
-- If user says "Phase 2 only" or "approved: 1.2" → complete that phase ONLY, then HALT
-- The explicit phase restriction OVERRIDES the cascade
-
-**Rationale:**
-- Sub-issues exist for **tracking visibility**, not authorization gates
-- GitHub sub-issue view shows progress across all phases
-- Developer already approved the entire spec—redundant per-phase HALTs waste time
-- Sub-issue database IDs link phases to parent for GitHub's hierarchy view
+**Exception:** User explicitly names a phase (e.g., "approved: 1.2" or "Phase 2 only") → complete that phase ONLY, then HALT.
 
 ### Revision Revokes Approval (MANDATORY)
 
 **Any modification to a spec or task document MUST immediately revoke approval.**
 
-When a spec is modified:
-1. **Status transitions to pending**: `STATUS: X.Y` → `STATUS: X.Y (REVISED - NEEDS APPROVAL)`
-2. **Label applied**: Add `needs-approval` label to the issue
-3. **Agent MUST HALT**: Do NOT proceed with implementation
-4. **Fresh authorization required**: New explicit approval needed before implementation
+**See `approval-gate` skill for revision status transition rules, mandatory actions, and exemption categories.**
 
-**Note**: When using `revise` command, the agent MAY post comments explaining changes but MUST NOT proceed with implementation. `revise` commands allow only documentation updates, never code changes.
+Key rule: Revision = `STATUS: X.Y (REVISED - NEEDS APPROVAL)` + `needs-approval` label + HALT.
 
-**This applies to:**
-- Any modification to the spec body (requirements, steps, criteria)
-- Any modification to task steps or acceptance criteria
-- Typo fixes in spec content (use GitHub comments for clarifications instead)
-- Minor clarifications that affect interpretation
-
-**Exempt from approval revocation:**
+Exempt from approval revocation:
 - STATUS marker updates (`☐ → ☑`, `1.1 → 1.2`)
 - Progress comments added to issue
 - Bug report additions (separate from spec content changes)
@@ -117,87 +88,25 @@ When a spec is modified:
 
 **The `needs-approval` label is informational when explicit authorization is present.**
 
-| Situation | Action |
-|-----------|--------|
-| User authorizes AND label present | Proceed with implementation. Label is informational, not blocking. |
-| User authorizes AND no label | Proceed with implementation. |
-| No authorization AND label present | HALT and wait for explicit authorization. |
-| No authorization AND no label | Check for other blockers; proceed if clear. |
+**See `approval-gate` skill for the complete label handling enforcement matrix.**
 
-**Workflow:**
-1. **Explicit authorization received** → Proceed (label status is informational)
-2. **No explicit authorization** → Check for `needs-approval` label
-3. **Label present without authorization** → HALT and wait for user to authorize
+Key rule: Explicit authorization (`approved`/`go`) OVERRIDES the `needs-approval` label.
 
 ### Bug Report Response
 
-When bug report requires code changes:
+**See `approval-gate` skill for the complete bug report response protocol.**
 
-1. Add `needs-approval` label
-2. Post additional spec comment
-3. HALT immediately
-4. Wait for explicit `go` or `approved`
+Key rule: Bug reports requiring code changes → add `needs-approval` label → HALT → wait for explicit authorization.
 
 ## Skill Enforcement (CRITICAL)
 
 **⚠️ CRITICAL: Skills MUST enforce authorization — guidelines alone are insufficient.**
 
-### Why Skills Must Enforce
-
-- **Guidelines document** what agents should do
-- **Skills contain code** that actually executes
-- Agents have proven to bypass documented guidelines
-- Enforcement in code prevents bypass
-
-**This is not theoretical. This actually happened:**
-- User said "Continue IF you have next steps"
-- Agent interpreted this as authorization
-- Agent committed, pushed, created PR
-- Both implementation and PR timing authorizations were bypassed
-
-### Which Skills MUST Enforce
-
-| Skill | Authorization Check Required |
-|-------|------------------------------|
-| `git-workflow` `--task pre-work` | ✅ YES - Check explicit "approved"/"go" before branch creation |
-| `git-workflow` `--task pr-creation` | ✅ YES - Check explicit "create a PR" before PR creation |
-| `git-workflow` `--task review-prep` | ❌ NO - Automatic after implementation |
-| `git-workflow` `--task cleanup` | ❌ NO - Automatic after PR merge confirmed |
-| All other skills | ❌ NO - Not git operation related |
-
-### Enforcement Matrix
-
-| Scenario | Action |
-|----------|--------|
-| Explicit "approved"/"go" | PROCEED - explicit auth wins |
-| Label + no auth | HALT - wait for authorization |
-| No label + no auth | HALT - wait for authorization |
-| Conditional phrase | HALT - not explicit authorization |
-| Implementation complete | HALT - wait for "create a PR" |
-
-### What Skills MUST Check
-
-**For `pre-work` task:**
-1. Get issue context from invocation
-2. Query GitHub Issue for labels (`needs-approval`)
-3. Query GitHub Issue for comments (look for "approved", "go", #"N approved")
-4. Check for conditionals ("if", "when", "continue if")
-5. Apply enforcement matrix
-
-**For `pr-creation` task:**
-1. Check conversation for "create a PR" instruction
-2. Distinguish implementation auth ("approved") from PR auth ("create a PR")
-3. Apply enforcement matrix
-
-### Conditional Phrases Are NOT Authorization
-
-| Phrase | Why NOT Authorization |
-|--------|----------------------|
-| "continue if you have next steps" | CONDITIONAL - agent must have next steps OR ask |
-| "proceed when ready" | CONDITIONAL - agent must report ready |
-| "if you have a plan, continue" | CONDITIONAL - agent must present plan |
-| "should I do X?" | QUESTION - seeking permission |
-| Implementation complete | NOT an instruction |
+**See `approval-gate` skill for the complete enforcement specification including:**
+- Which skills MUST check authorization
+- What each skill MUST check (pre-work, pr-creation)
+- Enforcement matrix (explicit auth, label + no auth, conditionals)
+- Conditional phrases that are NOT authorization
 
 ## What This Guideline Does NOT Cover
 

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -87,31 +87,11 @@ This rule applies universally to:
 - **NEVER proceed when `get_sub_issues` returns empty array for multi-task specs**
 - **NEVER assume markdown checkboxes = task tracking**
 
-### ✅ MANDATORY WORKFLOW
+### ✅ MANDATORY
 
-**Before implementing ANY multi-task spec:**
+**See `github-sub-issues` skill for the complete auto-create workflow, single-task exemption, database ID requirement, and phase-level structure.**
 
-```
-1. Call github_issue_read(method="get_sub_issues", issue_number=N)
-2. If empty AND multi-task:
-   a. AUTO-CREATE sub-issues at PHASE level
-   b. Link each via github_sub_issue_write(method="add")
-   c. Post comment: "Created X sub-issues for phase tracking"
-   d. THEN proceed to implementation
-3. If sub-issues exist:
-   - Verify phase being implemented is among them
-   - Proceed with implementation
-```
-
-### 📋 CHECKLIST
-
-| Action | Required? |
-|--------|-----------|
-| `get_sub_issues` check | ✅ ALWAYS |
-| AUTO-CREATE if empty | ✅ YES (multi-task only) |
-| Verify task linked | ✅ ALWAYS |
-| Single-task exemption | ✅ YES (no sub-issues needed) |
-
-### ⚠️ SINGLE-TASK EXCEPTION
-
-Single-task specs (one implementation task, no decomposition needed) do NOT require sub-issues. All multi-task specs MUST have sub-issues before implementation begins.
+Key points:
+- Sub-issues at PHASE level, not step level
+- Single-task specs are exempt from sub-issue requirement
+- All multi-task specs MUST have sub-issues before implementation begins

--- a/.opencode/guidelines/144-planning-spec-examples.md
+++ b/.opencode/guidelines/144-planning-spec-examples.md
@@ -322,39 +322,9 @@ When a spec has ONE task, no sub-issues are required.
 - ✅ Single unit of work
 - ✅ Can be implemented directly
 
-### ✅ GOOD Auto-create Workflow
+### Sub-issue Auto-create
 
-When a multi-task spec has NO sub-issues, the agent AUTO-CREATES them.
-
-**Scenario:**
-- Agent starts implementing spec #100
-- Calls `github_issue_read method=get_sub_issues` on #100
-- Result: Empty array `[]`
-- Spec has 3 phases → multi-task
-
-**Agent Actions:**
-```
-1. For each PHASE in spec:
-   - Create issue: github_issue_write method=create with title "[Task: #100] <phase-description>"
-   - Get database ID from response
-   - Link: github_sub_issue_write method=add
-
-2. Post comment: "Created 3 sub-issues for phase tracking"
-
-3. Proceed to implement first phase
-```
-
-**Result:**
-- Sub-issues created: #101, #102, #103
-- Parent issue #100 now shows sub-issues
-- Progress tracking established
-- Agent can proceed with implementation
-
-**Why AUTO-CREATE instead of BLOCK:**
-- Maintains workflow momentum
-- Developer doesn't have to manually create sub-issues
-- Reduces friction in implementation
-- Sub-issues still created for proper tracking
+**See `github-sub-issues` skill for the complete auto-create workflow, single-task exemption, database ID requirement, and phase-level structure.**
 
 ---
 
@@ -377,25 +347,7 @@ This is BAD because:
 
 When GitHub MCP tools are available, GitHub Issues are the ONLY authoritative source.
 
-**Workflow:**
-1. Create GitHub Issue with `[SPEC]` prefix
-2. Link sub-issues via `github_sub_issue_write method=add`
-3. Track STATUS in issue body
-4. Post progress comments to issue
-5. Close issue after PR merge
-
-**Why this works:**
-- Single source of truth in GitHub
-- All agents can access
-- History preserved automatically
-- Progress visible to stakeholders
-- No sync required
-
-**When GitHub MCP Unavailable:**
-- STOP immediately
-- Report: "GitHub MCP tools unavailable. Cannot create or track specs without GitHub Issues."
-- Wait for GitHub MCP to be restored
-- NO fallback to local plan files
+**See `github-issue-creation` skill for the complete issue creation workflow, `github-sub-issues` skill for sub-issue creation, and the GitHub MCP Required — No Fallback policy.**
 
 ---
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -207,6 +207,47 @@ User said 'approved' which authorizes implementation ONLY, not PR creation.
 To create PR: Say 'create a PR' explicitly.
 ```
 
+## Analysis → Implementation Authorization Boundary
+
+**Finding a bug during analysis does NOT authorize fixing it.**
+
+| Request Type | Authorized Actions |
+|-------------|---------------------|
+| "check logs" | Read logs, report findings, HALT |
+| "analyze error" | Analyze, report root cause, HALT |
+| "why is this failing" | Investigate, report findings, HALT |
+| "check X" | Analyze X, report findings, HALT |
+| "fix this" | Create spec issue, get approval, implement |
+
+**See `approval-gate` guideline `010-approval-gate.md` → "Analysis → Implementation Without Authorization" for the zero-tolerance rule.**
+
+## Revision Revokes Approval
+
+**Any modification to a spec or task document MUST immediately revoke approval.**
+
+### Status Transition
+
+When a spec is modified:
+1. **Status transitions to pending**: `STATUS: X.Y` → `STATUS: X.Y (REVISED - NEEDS APPROVAL)`
+2. **Label applied**: Add `needs-approval` label to the issue
+3. **Agent MUST HALT**: Do NOT proceed with implementation
+4. **Fresh authorization required**: New explicit approval needed before implementation
+
+### Exempt from Approval Revocation
+
+- STATUS marker updates (`☐ → ☑`, `1.1 → 1.2`)
+- Progress comments added to issue
+- Bug report additions (separate from spec content changes)
+
+## Bug Report Response Protocol
+
+When a bug report requires code changes:
+
+1. Add `needs-approval` label to the issue
+2. Post additional spec comment documenting the bug
+3. HALT immediately — do NOT implement
+4. Wait for explicit `go` or `approved`
+
 ## Cross-References
 
 - Related skills: `git-workflow` (branch operations, cleanup with parent closure check), `pr-creation-workflow` (PR timing)

--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -169,6 +169,46 @@ brainstorming (mandatory) → spec creation → approval-gate → git-workflow
 - Approval gate checks for spec existence AFTER exploration
 - Exploration does NOT require approval (exploration phase)
 
+## Investigation Completion Criteria
+
+**Before creating a spec, investigation MUST be complete.** This is a hard gate, not optional.
+
+### Completion Requirements
+
+| Requirement | Evidence |
+|-------------|----------|
+| Problem understood | Clearly stated problem, context, stakeholders |
+| Codebase explored | Existing patterns, reusable components identified |
+| Hypotheses tested | Test scripts run, results documented |
+| Alternatives considered | At least 2 approaches documented with tradeoffs |
+| Risks identified | Risk assessment with mitigation strategies |
+| Success criteria defined | Testable, measurable completion criteria |
+
+### Permissible Investigation Activities
+
+| Activity | Allowed? | Notes |
+|----------|----------|-------|
+| Read production code | YES | Read-only exploration |
+| Read production data | YES | Read-only analysis |
+| Create test scripts in `./tmp/` | YES | Isolated from production |
+| Run test scripts in `./tmp/` | YES | No production impact |
+| Create isolated test fixtures | YES | Dedicated test databases/schemas |
+| Run static analysis | YES | Code verification |
+| Modify production code | NO | Requires approved spec |
+| Modify production data | NO | Requires approved spec |
+| Run code against production DB | NO | Requires explicit user authorization |
+
+### CRITICAL VIOLATION: Spec Without Investigation
+
+Creating a spec without completed investigation is a CRITICAL GUIDELINE VIOLATION:
+- PROHIBITED: Creating specs from vague requirements without exploration
+- PROHIBITED: Skipping codebase analysis before planning
+- PROHIBITED: Finalizing specs before investigating edge cases
+- PROHIBITED: Proceeding without success criteria defined
+- PROHIBITED: Running test code against production systems
+
+**See `142-planning-archive-workflow.md` → "Investigation Completion Criteria" and `000-critical-rules.md` → "Spec Without Investigation" for the zero-tolerance rules.**
+
 ## Cross-References
 
 - Related skills: `approval-gate` (authorization), `writing-plans` (plan creation)

--- a/.opencode/skills/github-issue-creation/SKILL.md
+++ b/.opencode/skills/github-issue-creation/SKILL.md
@@ -137,6 +137,25 @@ When creating a new issue:
 4. Invoke `/skill github-issue-creation --task creation`
 5. Invoke `/skill github-issue-creation --task post-creation`
 
+## GitHub MCP Required — No Fallback
+
+**When GitHub MCP tools are NOT available, the agent MUST refuse planning work entirely.**
+
+### NO FALLBACK TO LOCAL FILES
+
+- **PROHIBITED**: Using `plans/SPEC-*.md` files as fallback when GitHub MCP is unavailable
+- **PROHIBITED**: Creating local plan files when GitHub MCP is unavailable
+- **PROHIBITED**: Proceeding with implementation without GitHub Issue tracking
+
+### REQUIRED ACTION
+
+If GitHub MCP is unavailable:
+1. STOP immediately
+2. Report: "GitHub MCP tools unavailable. Cannot create or track specs without GitHub Issues."
+3. Wait for GitHub MCP to be restored before proceeding
+
+**See `140-planning-spec-creation.md` → "GitHub MCP Required — No Fallback" for the complete rule.**
+
 ## Cross-References
 
 - Related skills: `spec-auditor`, `approval-gate`, `github-comments`, `github-sub-issues`


### PR DESCRIPTION
## Summary

Refactored guidelines to contain only rules and constraints (WHAT/WHY), removing procedural content (HOW/WHEN) and replacing it with cross-references to the corresponding skills where the procedures now live.

## Outcome

Guidelines are now cleanly separated: rules stay in guidelines, procedures stay in skills. Agents following skill references reach the same procedures with no behavioral change.

| File | Change |
|------|--------|
| `000-critical-rules.md` | Removed step sequences, command blocks, enforcement details. Added skill cross-references. (738→609 lines) |
| `010-approval-gate.md` | Removed revision procedure, label matrix, bug protocol, conditional phrases. Added skill references. (187→132 lines) |
| `144-planning-spec-examples.md` | Removed GitHub MCP fallback procedure. Added combined skill reference. (353→349 lines) |
| `approval-gate/SKILL.md` | Added auth boundary table, revision revokes section, bug report protocol |
| `brainstorming/SKILL.md` | Added investigation completion criteria, permissible activities, critical violation rules |
| `github-issue-creation/SKILL.md` | Added GitHub MCP Required — No Fallback policy |

Fixes #525
Fixes #529
Fixes #530
Fixes #531
Fixes #532