### PR TITLE
Reduce system prompt context by pruning opencode.jsonc instructions

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -2,7 +2,10 @@
   "$schema": "https://opencode.ai/config.json",
   "instructions": [
     "AGENTS.md",
-    ".opencode/guidelines/*.md"
+    ".opencode/guidelines/000-critical-rules.md",
+    ".opencode/guidelines/010-approval-gate.md",
+    ".opencode/guidelines/020-go-prohibitions.md",
+    ".opencode/guidelines/060-tool-usage.md"
   ],
   "mcp": {
     "the-notebook-mcp": {


### PR DESCRIPTION
## Summary

Reduces AI agent system prompt size by ~70% by replacing the wildcard `.opencode/guidelines/*.md` glob in `opencode.jsonc` with an explicit list of 4 zero-tolerance guideline files. All 26 guideline files remain on disk and accessible via `ai_bin/guidelines`.

## Outcome

- Changed: `opencode.jsonc` instructions field — wildcard glob replaced with explicit list of 4 essential files
- Kept: `000-critical-rules.md`, `010-approval-gate.md`, `020-go-prohibitions.md`, `060-tool-usage.md`
- Preserved: All 22 dropped guidelines remain on disk, loadable on-demand via `ai_bin/guidelines`
- Impact: System prompt reduced from ~185KB to ~54KB; critical rule compliance should improve

Fixes #541