### PR TITLE
feat: import upstream opencode changes — ai_bin → .opencode/tools + bug-discovery guardrail

### DIFF
--- a/.opencode/dispatch-table.yaml
+++ b/.opencode/dispatch-table.yaml
@@ -283,7 +283,7 @@ optional_skills:
 development_maintenance:
   - trigger: "When tool selection matters"
     skill: "mcp-tool-usage"
-    purpose: "Five-tier tool hierarchy (opencode built-in primary, domain MCP primary, ai_bin primary, JetBrains MCP fallback, CLI last resort)"
+    purpose: "Five-tier tool hierarchy (opencode built-in primary, domain MCP primary, .opencode/tools primary, JetBrains MCP fallback, CLI last resort)"
     
   - trigger: "Working with Jupyter notebooks"
     skill: "notebook-operations"

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -474,9 +474,56 @@ PRs require the developer to say one of these EXACT phrases: "create a PR", "mak
 
 ______________________________________________________________________
 
-## Critical Violation: Analysis → Implementation Without Authorization
+## Critical Violation: Bug Discovery Does NOT Authorize Bug Fixing
 
-**⚠️ Finding a bug during analysis does NOT authorize fixing it.**
+**⚠️ Finding a bug during analysis or any other activity does NOT authorize fixing it. This is a systemic behavioral violation, not a one-off mistake.**
+
+### 🚫 FORBIDDEN
+
+- Editing source code after discovering a bug — even if the fix seems trivial
+- Creating branches for bug fixes without an approved spec
+- Treating bug discovery as implicit authorization to modify code
+- Implementing "quick fixes" or "obvious corrections" discovered during other work
+- Starting implementation after reporting a bug (reporting ≠ authorization)
+- Conflating bug reporting (always appropriate) with bug fixing (requires spec + auth)
+
+### ✅ REQUIRED — Bug Discovery Protocol
+
+1. **STOP all code changes immediately** upon discovering a bug during unrelated work
+2. **Report the bug** — create a GitHub/GitBucket issue documenting the bug
+3. **HALT** — wait for explicit `approved` or `go` before any code changes
+4. **If the bug blocks current work**: document the blocker, report it, and HALT — do not fix it
+5. **Self-correction**: If you catch yourself editing code without a spec, immediately `git checkout` the affected files and HALT
+
+### Bug Discovery Authorization Matrix
+
+| Action | Requires Spec? | Requires Auth? | Permitted Without Auth? |
+|--------|---------------|----------------|--------------------------|
+| Create bug report issue | NO | NO | ✅ YES — always permitted |
+| Analyze bug (read-only) | NO | NO | ✅ YES — read-only only |
+| Edit source code to fix bug | ✅ YES | ✅ YES | 🚫 NO — NEVER |
+| Create branch for bug fix | ✅ YES | ✅ YES | 🚫 NO — NEVER |
+| Commit bug fix code | ✅ YES | ✅ YES | 🚫 NO — NEVER |
+| Create PR for bug fix | ✅ YES | ✅ YES | 🚫 NO — NEVER |
+
+### Self-Correction Protocol
+
+When the agent catches itself about to edit code without an approved spec:
+
+1. **STOP** — do not proceed with the edit
+2. **REVERT** — `git checkout -- <affected-files>` to undo any unauthorized changes
+3. **REPORT** — document what happened as a factual observation
+4. **HALT** — wait for explicit authorization before proceeding
+
+### Why This Matters
+
+| Scenario | Consequence |
+|----------|-------------|
+| Fix bug without spec | Unauthorized code changes pollute branch |
+| "Quick fix" during other work | Scope creep, introduces new bugs |
+| Treat reporting as authorization | Wastes human time reverting changes |
+| Skip spec for "obvious" fixes | No documentation, no review, no traceability |
+| Continue after bug discovery | Branch contamination, lost work |
 
 **See `approval-gate` skill for the complete discovery protocol and authorization boundaries, including the analysis → implementation authorization decision table.**
 

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -98,6 +98,22 @@ Key rule: Explicit authorization (`approved`/`go`) OVERRIDES the `needs-approval
 
 Key rule: Bug reports requiring code changes → add `needs-approval` label → HALT → wait for explicit authorization.
 
+### Bug Discovery Protocol (CRITICAL)
+
+**⚠️ Finding a bug during analysis or any other activity does NOT authorize fixing it.**
+
+**See `000-critical-rules.md` → "Bug Discovery Does NOT Authorize Bug Fixing" for the complete authorization matrix, self-correction protocol, and enforcement details.**
+
+Key rules:
+- 🚫 NEVER edit source code after discovering a bug without an approved spec
+- 🚫 NEVER create a branch for a bug fix without authorization
+- ✅ ALWAYS create a bug report issue (permitted without authorization)
+- ✅ ALWAYS perform read-only analysis (permitted without authorization)
+- ✅ ALWAYS HALT and wait for explicit authorization before any code changes
+- ✅ If you catch yourself editing code without a spec, immediately `git checkout` and HALT
+
+**Bug discovery is a reporting action, NOT an implementation authorization.**
+
 ## Skill Enforcement (CRITICAL)
 
 **⚠️ CRITICAL: Skills MUST enforce authorization — guidelines alone are insufficient.**

--- a/.opencode/guidelines/016-srclight-preference.md
+++ b/.opencode/guidelines/016-srclight-preference.md
@@ -1,6 +1,6 @@
 # Srclight Preference Guideline for Python Code Analysis
 
-This guideline defines when to prefer srclight MCP tools vs opencode built-in tools vs `ai_bin/guidelines` for search/analysis tasks.
+This guideline defines when to prefer srclight MCP tools vs opencode built-in tools vs `.opencode/tools/guidelines` for search/analysis tasks.
 
 ## Critical: Srclight Limitations
 
@@ -32,7 +32,7 @@ Is the task about Python code?
 │              (or pycharm_* for unique capabilities like rename)
 │
 └─ NO (docs, configs, .md files) → Use opencode built-in tools
-                                       (or ai_bin/guidelines for .opencode/guidelines/)
+                                       (or .opencode/tools/guidelines for .opencode/guidelines/)
 ```
 
 ## Tier 1: Srclight MCP (Python Code Analysis ONLY)
@@ -82,15 +82,15 @@ Use JetBrains MCP only for operations with no opencode equivalent:
 | Get file problems | `pycharm_get_file_problems` |
 | Rename refactoring | `pycharm_rename_refactoring` |
 
-## Tier 4: ai_bin/guidelines (Guidelines ONLY)
+## Tier 4: .opencode/tools/guidelines (Guidelines ONLY)
 
-Use `ai_bin/guidelines` commands for searching developer guidelines:
+Use `.opencode/tools/guidelines` commands for searching developer guidelines:
 
 | Task | Command |
 |------|---------|
-| Search guidelines | `uv run python ai_bin/guidelines search <term>` |
-| Read guideline | `uv run python ai_bin/guidelines read <filename>` |
-| List guidelines | `uv run python ai_bin/guidelines read --list` |
+| Search guidelines | `uv run python .opencode/tools/guidelines search <term>` |
+| Read guideline | `uv run python .opencode/tools/guidelines read <filename>` |
+| List guidelines | `uv run python .opencode/tools/guidelines read --list` |
 
 ## Tool Selection Matrix
 
@@ -107,7 +107,7 @@ Use `ai_bin/guidelines` commands for searching developer guidelines:
 | Recent commits | `srclight_recent_changes` | `git log` |
 | Code hotspots | `srclight_git_hotspots` | Manual analysis |
 | Project overview | `srclight_codebase_map` | — |
-| **Search .md files/guidelines** | `grep` | `ai_bin/guidelines search` |
+| **Search .md files/guidelines** | `grep` | `.opencode/tools/guidelines search` |
 | Find files by glob | `glob` | — |
 | Read file content | `read` | — |
 | Edit file | `edit` | — |
@@ -172,8 +172,8 @@ pycharm_search_in_files_by_text(searchText="article parsing")
 # ✅ CORRECT: Use grep for .md files
 grep(pattern="MCP", glob="**/*.md")
 
-# ✅ ALSO CORRECT: Use ai_bin/guidelines for .opencode/guidelines/
-# Run: uv run python ai_bin/guidelines search MCP
+# ✅ ALSO CORRECT: Use .opencode/tools/guidelines for .opencode/guidelines/
+# Run: uv run python .opencode/tools/guidelines search MCP
 
 # ❌ WRONG: Srclight does not index .md files
 srclight_search_symbols(query="MCP")  # Returns no results for .md files
@@ -225,11 +225,11 @@ Srclight does not support filename search.
 
 ### Guidelines and .md Files
 
-**Use `ai_bin/guidelines` or opencode `grep`:**
+**Use `.opencode/tools/guidelines` or opencode `grep`:**
 
 ```
 # For .opencode/guidelines/*.md files:
-# Run: uv run python ai_bin/guidelines search <term>
+# Run: uv run python .opencode/tools/guidelines search <term>
 
 # For other .md files:
 grep(pattern="<term>", glob="**/*.md")
@@ -250,7 +250,7 @@ glob(pattern="**/test_*.py")
 | Python semantic analysis | `srclight_*` (PREFERENTIALLY) |
 | Basic file operations | opencode `read`/`write`/`edit`/`glob`/`grep` (PRIMARY) |
 | Notebook operations | `the-notebook-mcp_*` (MANDATORY for .ipynb) |
-| Guidelines search | `ai_bin/guidelines` or `grep` |
+| Guidelines search | `.opencode/tools/guidelines` or `grep` |
 | Filename search | `glob` |
 | Semantic rename | `pycharm_rename_refactoring` (FALLBACK) |
 | Code reformat | `pycharm_reformat_file` (FALLBACK) |

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -6,7 +6,7 @@
 - **ABSOLUTE PROHIBITION: The agent must never write the word "GO" as a standalone token, line, or heading in any response.** This includes standalone lines (`GO`), Markdown headings (`## GO`), phase labels (`GO - Phase 2`), acknowledgements, transition markers, or narrative labels. Any use of "GO" in agent output (including `<UPDATE>` blocks, tool parameters, or chat text) is a protocol violation and does NOT constitute authorization. The only permitted use is inside a quoted/code-fenced example illustrating a prohibited pattern. To acknowledge authorization, use a full sentence (e.g., "Authorization received.") — never a bare "GO".
 - **No `echo` or `printf` commands — ever.** The agent is absolutely prohibited from running `echo`, `printf`, or any equivalent shell output command for any purpose. This includes:
   - **Output for Narration**: Signalling waiting states, confirming completion, or self-narration.
-  - **File Operations**: Bypassing `ai_bin` tools via `printf "..." > file.md` or `echo "..." >> file.md`.
+  - **File Operations**: Bypassing `.opencode/tools` tools via `printf "..." > file.md` or `echo "..." >> file.md`.
   - **Script Injection**: Writing logic into temp scripts via shell redirection.
 - **No "awaiting GO" or pending-state markers — anywhere, ever.** The agent is absolutely prohibited from using the phrase "awaiting GO", "waiting for GO", "pending GO", "awaiting explicit phase approval", "awaiting approval", "pending approval", or any equivalent pending-state marker.
 - **NEVER prompt or solicitation for authorization.** The agent is absolutely prohibited from asking, prompting, nudging, or inviting the user to issue "GO", "approved", or any other approval token in any form.

--- a/.opencode/guidelines/050-scope-autonomy.md
+++ b/.opencode/guidelines/050-scope-autonomy.md
@@ -37,6 +37,7 @@ Agent is strictly an execution tool. All architectural/design decisions are the 
   - Create PRs
   - Implement fixes
 - **NEVER treat analysis as authorization.** "Check X" = analyze and report, NOT "fix X".
+- **NEVER fix bugs discovered during other work without an approved spec.** This is a CRITICAL violation regardless of how trivial the fix seems. See `000-critical-rules.md` → "Bug Discovery Does NOT Authorize Bug Fixing".
 
 ### Analysis vs Implementation Table
 
@@ -48,11 +49,16 @@ Agent is strictly an execution tool. All architectural/design decisions are the 
 | "fix this" | Create spec, get approval, implement |
 | "can you check X" | Analyze X, report findings, HALT |
 
-**Discovery Protocol:**
-1. User requests analysis → Perform analysis ONLY
-2. Report findings (bugs, errors, issues) as factual observations
-3. HALT and wait for explicit authorization
-4. If user wants fix → Create spec issue, get approval, then implement
+### Bug Discovery Self-Correction
+
+If you catch yourself about to edit code to fix a bug discovered during other work:
+
+1. **STOP** — do not proceed with the edit
+2. **REVERT** — `git checkout -- <affected-files>` to undo any unauthorized changes
+3. **REPORT** — create a GitHub/GitBucket issue for the bug
+4. **HALT** — wait for explicit authorization before any code changes
+
+**This applies even when the fix seems trivial or obvious. No exceptions.**
 
 ## 4. Q&A and Feedback
 

--- a/.opencode/guidelines/060-tool-usage.md
+++ b/.opencode/guidelines/060-tool-usage.md
@@ -9,7 +9,7 @@
 ```
 TIER 1 — PRIMARY: opencode built-in tools (read/write/edit/glob/grep)
 TIER 2 — PRIMARY: Domain MCP (srclight, the-notebook-mcp, GitHub MCP)
-TIER 3 — PRIMARY: ai_bin/ (guidelines, md, memory, py ls/mkpkg)
+TIER 3 — PRIMARY: .opencode/tools/ (guidelines, md, memory, py ls/mkpkg)
 TIER 4 — FALLBACK: JetBrains MCP (pycharm_*) — only for unique capabilities
 TIER 5 — LAST RESORT: Direct CLI (bash)
 
@@ -24,10 +24,10 @@ ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance,
 ## 1. Guidelines Lookup
 
 ### ✅ ALWAYS DO
-- **Reading or searching guideline files MUST use `uv run python ai_bin/guidelines`** — never raw `open`, `cat`, or `grep` on `.opencode/guidelines/` files.
-- `uv run python ai_bin/guidelines read <filename>` — print a single guideline file.
-- `uv run python ai_bin/guidelines search <term>` — search all guideline files for a term.
-- `uv run python ai_bin/guidelines search <term> --file <filename>` — search within one file.
+- **Reading or searching guideline files MUST use `uv run python .opencode/tools/guidelines`** — never raw `open`, `cat`, or `grep` on `.opencode/guidelines/` files.
+- `uv run python .opencode/tools/guidelines read <filename>` — print a single guideline file.
+- `uv run python .opencode/tools/guidelines search <term>` — search all guideline files for a term.
+- `uv run python .opencode/tools/guidelines search <term> --file <filename>` — search within one file.
 
 ### ⚠️ ASK FIRST
 - Significant edits to core guideline files.
@@ -47,7 +47,7 @@ ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance,
 ### ✅ ALWAYS DO
 - All temporary scripts and output files MUST be written ONLY to `./tmp/` (project root). NO OTHER FOLDERS OR PATHS ARE PERMITTED.
 - Create the directory if needed: `mkdir -p ./tmp`.
-- **Mandatory pre-submit root cleanliness check:** Before calling `submit`, run `uv run python ai_bin/file-exists .output.txt` and confirm it is MISSING. If it exists, move it to `./tmp/.output.txt` immediately.
+- **Mandatory pre-submit root cleanliness check:** Before calling `submit`, run `uv run python .opencode/tools/file-exists .output.txt` and confirm it is MISSING. If it exists, move it to `./tmp/.output.txt` immediately.
 - **ALWAYS clean up temp files after modification tasks are complete.**
 ### 🚫 NEVER DO
 - **ZERO TOLERANCE — NEVER use or access any other folder (e.g., `/tmp/`, `.tmp/`, etc.) for any reason.** Only `./tmp/` is permitted.

--- a/.opencode/guidelines/070-environment.md
+++ b/.opencode/guidelines/070-environment.md
@@ -6,7 +6,7 @@
   `uv run python`. Package ops: add dependencies by editing `pyproject.toml` then running `uv sync` — never `uv add`. `pip` prohibited. No `sys.path` hacks or manual
   path additions.
 - **Never use `python3` or `python` directly** — always `uv run python`. Never prefix commands with absolute paths or `cd /absolute/path &&`. See `060-tool-usage.md § Python Interpreter` and `§ Path Rules` for the full zero-tolerance rules.
-- Reusable agent scripts live in `ai_bin/` (project root). Invoke with `uv run python ai_bin/<script>`.
+- Reusable agent scripts live in `.opencode/tools/` (project root). Invoke with `uv run python .opencode/tools/<script>`.
 - When `pyproject.toml` changes, purge `.venv` and run `uv sync` as a standalone command (never embedded in git hooks,
   commit scripts, or automated pipelines).
 - **Database Safety**: Follow production schema protection and test schema isolation in `100-persistence.md`.
@@ -159,7 +159,7 @@ This rule applies universally to:
 - Verification of script correctness must use static analysis (lint, grep, code review) or a dedicated test fixture
   with an isolated `./tmp/` path — never the live production instance.
 - **NEVER use production spec files (GitHub Issues) as smoke-test or verification targets.** Spec issues are authoritative tracking artifacts — they are never modified for testing purposes.
-- **This applies to `ai_bin/` tool verification too.** When fixing or verifying any tool that mutates plan files,
+- **This applies to `.opencode/tools/` tool verification too.** When fixing or verifying any tool that mutates plan files,
   always create a throwaway plan copy in `./tmp/` and run the tool against that copy. Never invoke a mutating tool
   against a live plan file as a "test" or "verification" step.
   To create a throwaway copy: `cp plans/SPEC-some-plan.md ./tmp/spec_test.md`, then pass
@@ -182,12 +182,12 @@ This rule applies universally to:
 
 - All temp scripts/data/artifacts in `./tmp/` ONLY. NO OTHER FOLDERS PERMITTED. **Never use `/tmp/` (system temp) or any other folder.** This includes any diagnostic or exploratory Python scripts — files named `temp_*.py`, `test_*.py` (outside `test/`), or similar one-off scripts must be placed in `./tmp/`, never at the project root.
 - **NO BOGUS PATHS**: Using relative paths that exit the current directory (e.g., `../tmp/`) in scripts or notebooks is **absolutely forbidden**. This creates brittle, non-portable code. All file system operations MUST use paths derived from `project_root` or `base_dir` (e.g., `project_root / 'tmp' / 'index.html'`) as provided by the project's standard utilities (e.g., `notebook_utils.py`).
-- **Mandatory for CLI text updates:** Use `./tmp/` to store input files for `ai_bin` text update tools to avoid shell escaping and newline issues.
+- **Mandatory for CLI text updates:** Use `./tmp/` to store input files for `.opencode/tools` text update tools to avoid shell escaping and newline issues.
 - Project root must stay clean — no root-level temp files.
 - **`.output.txt` files must be placed in `./tmp/` (e.g., `./tmp/.output.txt`), never at the project root (`.output.txt` is a violation).**
 - **Mandatory pre-submit root cleanliness check:** Before calling `submit`, confirm the project root is clean:
   (1) Never create `.output.txt`, `temp_*.py`, or any other temp/diagnostic file at the project root — always use `./tmp/` at time of creation.
-  (2) Run `uv run python ai_bin/file-exists .output.txt` — if it exists, move it to `./tmp/.output.txt` immediately (`mv .output.txt ./tmp/.output.txt`).
+  (2) Run `uv run python .opencode/tools/file-exists .output.txt` — if it exists, move it to `./tmp/.output.txt` immediately (`mv .output.txt ./tmp/.output.txt`).
   (3) Check for any `temp_*.py` files at the project root (`ls temp_*.py 2>/dev/null`) — if any exist, move them to `./tmp/` before submitting.
 
 ### ⚠️ MANDATORY: Temp Files Cleanup After Task Completion

--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -46,7 +46,7 @@ These standards apply to **ALL code artifacts**: Python modules, Jupyter noteboo
     any imports or `__all__` entries.
 - **Top-Level Documentation**: Every Python source file must include a brief top-level comment identifying the
   package's or class's purpose. Use a module docstring (preferred) or a leading `#` comment. Keep it to one or two
-  concise sentences — enough for `ai_bin/py ls` to display alongside the filename.
+  concise sentences — enough for `.opencode/tools/py ls` to display alongside the filename.
 - **Docstring/Comment Determinism**: Pydoc/docstrings and code comments must use deterministic wording. Avoid ambiguous hedge/alternative phrasing such as `maybe`, `if ... or ...`, `and/or`, or `A + B or C` when describing required behavior, validation paths, or implementation intent.
 - **Labels Over Index Numbers**: When editing structured artifacts (notebooks, migration lists, cell arrays, ordered
   configs), add and use stable labels/names so that inserts, deletes, and moves which change index numbers do not cause

--- a/.opencode/guidelines/100-persistence.md
+++ b/.opencode/guidelines/100-persistence.md
@@ -50,7 +50,7 @@ Applies to `pubmed_data_3` and all new persistence code.
 - Migration versions: date-based `yyyymmddhhmmss` format in UTC. Simple increments prohibited.
 - **Migration location**: ALL schema migrations are defined inline in `src/commons/persistence/pg/schema.py` as
   `_Migration` entries in the `_MIGRATIONS` list. There is no external migrations directory. Do not search elsewhere.
-  To add a migration, generate a version timestamp with `uv run python ai_bin/schema-version` — **immediately before
+  To add a migration, generate a version timestamp with `uv run python .opencode/tools/schema-version` — **immediately before
   adding a migration, not earlier. NEVER run `schema-version` speculatively (analysis, exploration, curiosity, or as
   a side-effect of any other task that does not need a timestamp).** Then append a
   `_Migration(version=..., description=..., statements=[...])` entry to

--- a/.opencode/guidelines/143-planning-spec-templates.md
+++ b/.opencode/guidelines/143-planning-spec-templates.md
@@ -406,7 +406,7 @@ CREATED: YYYY-MM-DD
 ## Success Criteria
 
 1. ✅ Guideline documentation updated
-2. ✅ Changes load correctly in `ai_bin/guidelines`
+2. ✅ Changes load correctly in `.opencode/tools/guidelines`
 3. ✅ All files pass linting
 
 ---
@@ -416,7 +416,7 @@ CREATED: YYYY-MM-DD
 ### Steps
 
 1. ☐ [Update guideline file]
-2. ☐ [Verify with ai_bin tools]
+2. ☐ [Verify with .opencode/tools tools]
 
 ---
 

--- a/.opencode/guidelines/210-scripting.md
+++ b/.opencode/guidelines/210-scripting.md
@@ -35,7 +35,7 @@ Every script/notebook MUST include root resolution:
 - `nbformat` direct access
 - Jupyter Server REST API
 - Any file tool (`read`/`edit`/`write`) on `.ipynb` files
-- `ai_bin/nb` (removed — use `the-notebook-mcp` exclusively)
+- `.opencode/tools/nb` (removed — use `the-notebook-mcp` exclusively)
 
 ### Notebook Cell Edit Workflow
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -211,15 +211,24 @@ To create PR: Say 'create a PR' explicitly.
 
 **Finding a bug during analysis does NOT authorize fixing it.**
 
-| Request Type | Authorized Actions |
-|-------------|---------------------|
-| "check logs" | Read logs, report findings, HALT |
-| "analyze error" | Analyze, report root cause, HALT |
-| "why is this failing" | Investigate, report findings, HALT |
-| "check X" | Analyze X, report findings, HALT |
-| "fix this" | Create spec issue, get approval, implement |
+**This is a CRITICAL behavioral violation, not a one-off mistake. See `000-critical-rules.md` → "Bug Discovery Does NOT Authorize Bug Fixing" for the complete rule, authorization matrix, and self-correction protocol.**
 
-**See `approval-gate` guideline `010-approval-gate.md` → "Analysis → Implementation Without Authorization" for the zero-tolerance rule.**
+### Bug Discovery ≠ Bug Fixing Authorization
+
+| Discovery Action | Authorized? | Action Required |
+|-----------------|-------------|-----------------|
+| Found a bug during analysis | ✅ YES | Create bug report issue |
+| Read-only analysis of bug | ✅ YES | Report findings |
+| Edit code to fix the bug | 🚫 NO | STOP, create spec, wait for authorization |
+| Create branch for fix | 🚫 NO | STOP, wait for authorization |
+| Commit fix code | 🚫 NO | STOP, wait for authorization |
+
+### Self-Correction When Catching Unauthorized Edits
+
+1. **STOP** — do not proceed
+2. **REVERT** — `git checkout -- <affected-files>`
+3. **REPORT** — document as factual observation
+4. **HALT** — wait for explicit authorization
 
 ## Revision Revokes Approval
 

--- a/.opencode/skills/git-workflow/tasks/commit-prep.md
+++ b/.opencode/skills/git-workflow/tasks/commit-prep.md
@@ -140,7 +140,7 @@ Commits occur during the PR creation workflow, not as a separate step:
 ### ✅ ALWAYS DO
 
 - To inspect a file at a historical commit: `git show <ref>:<path> > ./tmp/historical_file.ext`
-- Process the saved file with appropriate `ai_bin/` or IDE tool
+- Process the saved file with appropriate `.opencode/tools/` or IDE tool
 
 ### 🚫 NEVER DO
 

--- a/.opencode/skills/implementation-workflow/SKILL.md
+++ b/.opencode/skills/implementation-workflow/SKILL.md
@@ -112,6 +112,16 @@ ready_for: "implementation"
 
 ### Step 3: Invoke Implementation Subagent
 
+**⚠️ PRE-IMPLEMENTATION CHECK (CRITICAL):**
+
+Before invoking the implementation subagent, verify:
+
+1. **Bug-discovery guardrail**: Is this implementation for a bug discovered during other work? If yes, HALT — bug discovery does NOT authorize implementation. Create an issue and wait for explicit authorization.
+2. **Spec exists**: Verify the issue has a spec that was explicitly approved.
+3. **Authorization confirmed**: Verify the user said "approved" or "go" for this specific issue.
+
+If ANY check fails → HALT and report. Do NOT invoke the implementation subagent.
+
 **Context passed to subagent:**
 ```yaml
 branch: "spec/workflow-skills-integration"

--- a/.opencode/skills/mcp-tool-usage/SKILL.md
+++ b/.opencode/skills/mcp-tool-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-tool-usage
-description: Defines tool priority hierarchy for all operations. Five-tier system with opencode built-in primary, domain MCP primary, ai_bin primary, JetBrains MCP fallback, and CLI last resort.
+description: Defines tool priority hierarchy for all operations. Five-tier system with opencode built-in primary, domain MCP primary, .opencode/tools primary, JetBrains MCP fallback, and CLI last resort.
 license: MIT
 compatibility: opencode
 ---
@@ -52,7 +52,7 @@ Session init values are automatically injected by the session-init plugin (`.ope
 ```
 TIER 1 — PRIMARY: opencode built-in tools (read/write/edit/glob/grep)
 TIER 2 — PRIMARY: Domain MCP (srclight, the-notebook-mcp, GitHub MCP)
-TIER 3 — PRIMARY: ai_bin/ (guidelines, md, memory, py ls/mkpkg)
+TIER 3 — PRIMARY: .opencode/tools/ (guidelines, md, memory, py ls/mkpkg)
 TIER 4 — FALLBACK: JetBrains MCP (pycharm_*) — only for unique capabilities
 TIER 5 — LAST RESORT: Direct CLI (bash)
 
@@ -115,15 +115,15 @@ All notebook operations use `the-notebook-mcp_notebook_*` tools exclusively. Rea
 | Get file contents | `github_get_file_contents` |
 | Push files | `github_push_files` |
 
-### TIER 3: ai_bin/ Scripts (PRIMARY for their domains)
+### TIER 3: .opencode/tools/ Scripts (PRIMARY for their domains)
 
 | Tool | Domain | Why PRIMARY |
 |------|--------|-------------|
-| `ai_bin/guidelines` | Guideline search/read | Only tool that parses `.opencode/guidelines/` correctly |
-| `ai_bin/md` | Markdown section operations | Semantic section awareness that opencode tools lack |
-| `ai_bin/py ls` | Python package listing | Project-aware package structure listing |
-| `ai_bin/py mkpkg` | Python package creation | Creates `__init__.py`, `py.typed`, etc. correctly |
-| `ai_bin/memory` | Session memory management | Purpose-built for context persistence |
+| `.opencode/tools/guidelines` | Guideline search/read | Only tool that parses `.opencode/guidelines/` correctly |
+| `.opencode/tools/md` | Markdown section operations | Semantic section awareness that opencode tools lack |
+| `.opencode/tools/py ls` | Python package listing | Project-aware package structure listing |
+| `.opencode/tools/py mkpkg` | Python package creation | Creates `__init__.py`, `py.typed`, etc. correctly |
+| `.opencode/tools/memory` | Session memory management | Purpose-built for context persistence |
 
 ### TIER 4: JetBrains MCP (FALLBACK — unique capabilities only)
 
@@ -192,12 +192,12 @@ Operation: READ FILE
 ├─ Python semantic → srclight_get_symbol (TIER 2)
 ├─ Any text file → opencode `read` (TIER 1)
 ├─ Notebook → the-notebook-mcp_notebook_read (TIER 2 MANDATORY)
-└─ Guidelines → ai_bin/guidelines read (TIER 3)
+└─ Guidelines → .opencode/tools/guidelines read (TIER 3)
 
 Operation: SEARCH CODE
 ├─ Python semantic → srclight_search_symbols / srclight_hybrid_search (TIER 2)
 ├─ Text search → opencode `grep` (TIER 1)
-└─ Guideline search → ai_bin/guidelines search (TIER 3)
+└─ Guideline search → .opencode/tools/guidelines search (TIER 3)
 
 Operation: EDIT FILE
 ├─ Any text file → opencode `edit` (TIER 1)
@@ -265,7 +265,7 @@ uvx srclight index --embed qwen3-embedding
 
 | Guideline | Section |
 |-----------|---------|
-| `016-srclight-preference.md` | Srclight vs ai_bin hierarchy |
+| `016-srclight-preference.md` | Srclight vs .opencode/tools hierarchy |
 | `060-tool-usage.md` | Tool usage and terminal rules |
 | Session init plugin | `.opencode/plugins/session-init.ts` | MCP probe at startup |
 

--- a/.opencode/skills/systematic-debugging/SKILL.md
+++ b/.opencode/skills/systematic-debugging/SKILL.md
@@ -122,6 +122,44 @@ After diagnosis confirms the root cause:
 - Run existing tests → confirm no regression
 - Check edge cases → confirm they're handled
 
+## Bug Discovery Guardrail (CRITICAL)
+
+**⚠️ Finding a bug during diagnosis does NOT authorize fixing it.**
+
+This skill handles diagnosis (read-only). Fixing requires separate authorization.
+
+### Authorization Check Before Fix
+
+Before applying ANY fix (`--task fix`):
+
+1. **Check authorization**: Was this bug explicitly authorized for fixing?
+   - Does an approved spec issue exist for this fix?
+   - Did the user explicitly say "approved" or "go" for this fix?
+2. **If NO authorization**: HALT immediately after diagnosis
+   - Report findings to the bug issue
+   - Do NOT apply any code changes
+   - Wait for explicit authorization
+
+### Bug Discovery During Other Work
+
+When the `diagnose` task is triggered as a side-effect of other work (not an explicit "debug this" request):
+
+1. **STOP all code changes** — diagnosis is read-only
+2. **Complete diagnosis** — identify root cause
+3. **Create bug report** — file a GitHub/GitBucket issue
+4. **HALT** — do NOT proceed to `--task fix` without explicit authorization
+
+### Self-Correction Protocol
+
+If the agent catches itself about to edit code without an approved spec:
+
+1. **STOP** — do not proceed with the edit
+2. **REVERT** — `git checkout -- <affected-files>` to undo unauthorized changes
+3. **REPORT** — document what happened as a factual observation
+4. **HALT** — wait for explicit authorization
+
+**See `000-critical-rules.md` → "Bug Discovery Does NOT Authorize Bug Fixing" for the complete authorization matrix.**
+
 ## Enforcement Mechanism
 
 **⚠️ CRITICAL: Debugging MUST be systematic — no random code changes.**

--- a/.opencode/tools/file-exists
+++ b/.opencode/tools/file-exists
@@ -2,14 +2,14 @@
 """
 DESCRIPTION: Check whether one or more file/directory paths exist and report EXISTS or MISSING.
 
-Usage: uv run python ai_bin/file-exists <path> [<path> ...]
+Usage: uv run python .opencode/tools/file-exists <path> [<path> ...]
 """
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 def main() -> None:
@@ -19,7 +19,7 @@ def main() -> None:
 
     paths = [a for a in sys.argv[1:] if not a.startswith("-")]
     if not paths:
-        print("Usage: uv run python ai_bin/file-exists <path> [<path> ...]")
+        print("Usage: uv run python .opencode/tools/file-exists <path> [<path> ...]")
         sys.exit(1)
 
     all_exist = True

--- a/.opencode/tools/guidelines
+++ b/.opencode/tools/guidelines
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S uv run python
 """
-DESCRIPTION: Guidelines tools dispatcher. Usage: uv run python ai_bin/guidelines <action> [args...]
+DESCRIPTION: Guidelines tools dispatcher. Usage: uv run python .opencode/tools/guidelines <action> [args...]
 Actions: read, load, list, show, search, edit
-Example: uv run python ai_bin/guidelines search <term>
+Example: uv run python .opencode/tools/guidelines search <term>
 """
 from __future__ import annotations
 import os
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 ACTIONS = {
     "read": "guidelines-read",
@@ -31,7 +31,7 @@ def _suggest_search_for_unknown_action(action: str, rest: list[str]) -> str | No
     query = " ".join(query_parts).strip()
     if not query:
         return None
-    return f'Hint: did you mean `uv run python ai_bin/guidelines search "{query}"`?'
+    return f'Hint: did you mean `uv run python .opencode/tools/guidelines search "{query}"`?'
 
 
 def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
@@ -39,7 +39,7 @@ def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
         [sys.executable, str(script)] + forwarded_args,
         capture_output=True,
         text=True,
-        env={**os.environ, "AIBIN_DISPATCHER": "1"},
+        env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
     )
     if result.stdout:
         sys.stdout.write(result.stdout)
@@ -66,8 +66,8 @@ def main() -> None:
         print(__doc__)
         print("Available actions:")
         for action, script in ACTIONS.items():
-            desc = _get_description(BASE_DIR / "impl" / script)
-            print(f"  {action:<20} — {desc}" if desc else f"  {action:<20} → ai_bin/{script}")
+            desc = _get_description(BASE_DIR / ".opencode" / "tools" / "impl" / script)
+            print(f"  {action:<20} — {desc}" if desc else f"  {action:<20} → .opencode/tools/{script}")
         print(f"CWD: {os.getcwd()}")
         sys.exit(0)
     action = args[0]
@@ -77,8 +77,8 @@ def main() -> None:
         if suggestion:
             print(suggestion, file=sys.stderr)
         sys.exit(1)
-    script = BASE_DIR / "impl" / ACTIONS[action]
-    sys.exit(_run_action(script, args[1:], f"OK: ai_bin/guidelines {action} completed."))
+    script = BASE_DIR / ".opencode" / "tools" / "impl" / ACTIONS[action]
+    sys.exit(_run_action(script, args[1:], f"OK: .opencode/tools/guidelines {action} completed."))
 
 
 if __name__ == "__main__":

--- a/.opencode/tools/help
+++ b/.opencode/tools/help
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S uv run python
 """
-DESCRIPTION: List all agent tools in ai_bin/ with their descriptions.
+DESCRIPTION: List all agent tools in .opencode/tools/ with their descriptions.
 
-Usage: uv run python ai_bin/help
+Usage: uv run python .opencode/tools/help
 """
 from __future__ import annotations
 
@@ -11,7 +11,8 @@ import os
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+TOOLS_DIR = Path(__file__).resolve().parent
 
 
 def get_description(script: Path) -> str:
@@ -35,15 +36,15 @@ def main() -> None:
         return
 
     scripts = sorted(
-        p for p in BASE_DIR.iterdir()
+        p for p in TOOLS_DIR.iterdir()
         if p.is_file() and not p.name.startswith(".")
     )
 
     if not scripts:
-        print("No tools found in ai_bin/.")
+        print("No tools found in .opencode/tools/.")
         return
 
-    print(f"Agent tools in ai_bin/  (run with: uv run python ai_bin/<tool>)\n")
+    print(f"Agent tools in .opencode/tools/  (run with: uv run python .opencode/tools/<tool>)\n")
     for script in scripts:
         desc = get_description(script)
         print(f"  {script.name:<24} — {desc}")

--- a/.opencode/tools/impl/guidelines-edit
+++ b/.opencode/tools/impl/guidelines-edit
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Edit a guideline file by replacing a section or appending content.
-Usage: uv run python ai_bin/guidelines edit <filename> --find-file <path> --replace-file <path>
-       uv run python ai_bin/guidelines edit <filename> --append-file <path>
-       uv run python ai_bin/guidelines edit <filename> --find-regex-file <path> --replace-file <path>
+Usage: uv run python .opencode/tools/guidelines edit <filename> --find-file <path> --replace-file <path>
+       uv run python .opencode/tools/guidelines edit <filename> --append-file <path>
+       uv run python .opencode/tools/guidelines edit <filename> --find-regex-file <path> --replace-file <path>
 WARNING: Use file-based options (--find-file, --replace-file, --append-file, --find-regex-file) exclusively.
          Direct text on CLI (--find, --replace, --append, --find-regex) is FORBIDDEN.
 Options:
@@ -20,9 +20,9 @@ Line endings are normalized (LF/CRLF) during matching to improve robustness.
 from __future__ import annotations
 import os as _os
 
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print(
-        "ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/guidelines ...). "
+        "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/guidelines ...). "
         "Direct invocation is not permitted.",
         file=__import__("sys").stderr,
     )
@@ -31,7 +31,7 @@ import re
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 GUIDELINES_DIR = BASE_DIR / ".opencode" / "guidelines"
 
 

--- a/.opencode/tools/impl/guidelines-read
+++ b/.opencode/tools/impl/guidelines-read
@@ -1,17 +1,17 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Print the contents of a guideline file from .opencode/guidelines/.
-Usage: uv run python ai_bin/guidelines read <filename>
-Example: uv run python ai_bin/guidelines read 041
+Usage: uv run python .opencode/tools/guidelines read <filename>
+Example: uv run python .opencode/tools/guidelines read 041
 Note: Prefer 3-digit shorthand when available (for example `041` instead of full filename).
 """
 
 from __future__ import annotations
 import os as _os
 
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print(
-        "ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+        "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
         "Direct invocation is not permitted.",
         file=__import__("sys").stderr,
     )
@@ -19,7 +19,7 @@ if _os.environ.get("AIBIN_DISPATCHER") != "1":
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 GUIDELINES_DIR = BASE_DIR / ".opencode" / "guidelines"
 SKILLS_DIR = BASE_DIR / ".opencode" / "skills"
 

--- a/.opencode/tools/impl/guidelines-search
+++ b/.opencode/tools/impl/guidelines-search
@@ -1,29 +1,29 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Search guideline files using BM25 ranking with optional section blocks and context lines.
-Usage: uv run python ai_bin/guidelines search <query> [--file <filename>] [--top N] [--section-names] [--section-blocks] [--context-lines N] [--minimal] [--surrounding N]
-       uv run python ai_bin/guidelines search <filename.md> <query>
+Usage: uv run python .opencode/tools/guidelines search <query> [--file <filename>] [--top N] [--section-names] [--section-blocks] [--context-lines N] [--minimal] [--surrounding N]
+       uv run python .opencode/tools/guidelines search <filename.md> <query>
 Note: Prefer 3-digit guideline filename shorthand when available (for example `041`).
       Searches recursively in subdirectories (git/, planning/, errors/, github/).
 Flags:
   --minimal          Output match line only (no context)
   --surrounding N    Alias for --context-lines N
   --context-lines N  Set context lines (default: 1)
-Examples: uv run python ai_bin/guidelines search "pyclbr"
-          uv run python ai_bin/guidelines search "grep" --file 041
-          uv run python ai_bin/guidelines search 041 "grep"
-          uv run python ai_bin/guidelines search "notebook editing" --top 10
-          uv run python ai_bin/guidelines search "pre-plan" --section-blocks
-          uv run python ai_bin/guidelines search "branch" --minimal
-          uv run python ai_bin/guidelines search "error" --surrounding 3
+Examples: uv run python .opencode/tools/guidelines search "pyclbr"
+          uv run python .opencode/tools/guidelines search "grep" --file 041
+          uv run python .opencode/tools/guidelines search 041 "grep"
+          uv run python .opencode/tools/guidelines search "notebook editing" --top 10
+          uv run python .opencode/tools/guidelines search "pre-plan" --section-blocks
+          uv run python .opencode/tools/guidelines search "branch" --minimal
+          uv run python .opencode/tools/guidelines search "error" --surrounding 3
 """
 
 from __future__ import annotations
 import os as _os
 
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print(
-        "ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+        "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
         "Direct invocation is not permitted.",
         file=__import__("sys").stderr,
     )
@@ -33,7 +33,7 @@ import re
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 GUIDELINES_DIR = BASE_DIR / ".opencode" / "guidelines"
 
 DEFAULT_TOP = 15

--- a/.opencode/tools/impl/guidelines-show
+++ b/.opencode/tools/impl/guidelines-show
@@ -1,17 +1,17 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Show guideline files with their brief summary header.
-Usage: uv run python ai_bin/guidelines show [<file> ...]
-Example: uv run python ai_bin/guidelines show 010 040
+Usage: uv run python .opencode/tools/guidelines show [<file> ...]
+Example: uv run python .opencode/tools/guidelines show 010 040
 Note: Prefer 3-digit shorthand for guideline files when available (for example `041`).
 """
 
 from __future__ import annotations
 import os as _os
 
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print(
-        "ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+        "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
         "Direct invocation is not permitted.",
         file=__import__("sys").stderr,
     )
@@ -19,7 +19,7 @@ if _os.environ.get("AIBIN_DISPATCHER") != "1":
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 OPENCODE_DIR = BASE_DIR / ".opencode"
 GUIDELINES_DIR = OPENCODE_DIR / "guidelines"
 

--- a/.opencode/tools/impl/jupyter-start
+++ b/.opencode/tools/impl/jupyter-start
@@ -2,15 +2,15 @@
 """
 DESCRIPTION: Start Jupyter server on port 18888 (XSRF disabled, no token) for notebook editing.
 
-Usage: uv run python ai_bin/jupyter start [--help]
+Usage: uv run python .opencode/tools/jupyter start [--help]
 
 Checks if port 18888 is already listening. If not, starts the server in the
 background and logs to tmp/jupyter.log. Prints the server URL on success.
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 
@@ -19,7 +19,7 @@ import sys
 import time
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent  # project root
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent  # project root
 PORT = 18888
 LOG_FILE = BASE_DIR / "tmp" / "jupyter.log"
 

--- a/.opencode/tools/impl/jupyter-stop
+++ b/.opencode/tools/impl/jupyter-stop
@@ -2,15 +2,15 @@
 """
 DESCRIPTION: Stop the Jupyter server running on port 18888.
 
-Usage: uv run python ai_bin/jupyter stop [--help]
+Usage: uv run python .opencode/tools/jupyter stop [--help]
 
 Sends SIGTERM to any process listening on port 18888. Waits up to 5 seconds
 to confirm the port is released, then reports success or failure.
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 
@@ -19,7 +19,7 @@ import sys
 import time
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent  # project root
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent  # project root
 PORT = 18888
 
 

--- a/.opencode/tools/impl/md-add
+++ b/.opencode/tools/impl/md-add
@@ -1,13 +1,13 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Insert a new section (header + body) into a markdown file.
-Usage: uv run python ai_bin/md add <file.md> --header "New Header" --level N (--content <text> | --content-file <path>) [--after "Header" | --before "Header" | --append] [--help]
+Usage: uv run python .opencode/tools/md add <file.md> --header "New Header" --level N (--content <text> | --content-file <path>) [--after "Header" | --before "Header" | --append] [--help]
 Default position: --append (add at end of file).
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import re

--- a/.opencode/tools/impl/md-delete
+++ b/.opencode/tools/impl/md-delete
@@ -1,14 +1,12 @@
 #!/usr/bin/env -S uv run python
 """
-DESCRIPTION: Replace the body of a section in a markdown file, preserving the header line.
-Usage: uv run python ai_bin/md write <file.md> --header "Header Text" (--content <text> | --content-file <path>) [--level N] [--help]
-WARNING: Use --content-file <path> for any content containing newlines or special characters
-         to avoid shell escaping and literal \n issues.
+DESCRIPTION: Delete a section (header line + body) from a markdown file by header.
+Usage: uv run python .opencode/tools/md delete <file.md> --header "Header Text" [--level N] [--help]
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import re
@@ -25,7 +23,7 @@ def _header_text(line: str) -> str:
     return re.sub(r'^#{1,6}\s+', '', line).rstrip()
 
 
-def write_section(lines: list[str], header: str, level: int | None, new_body: str) -> list[str]:
+def delete_section(lines: list[str], header: str, level: int | None) -> list[str]:
     start = None
     target_level = None
     for i, line in enumerate(lines):
@@ -47,9 +45,7 @@ def write_section(lines: list[str], header: str, level: int | None, new_body: st
             end = i
             break
 
-    body_lines = [(l if l.endswith("\n") else l + "\n") for l in new_body.splitlines()] if new_body else []
-
-    return lines[:start + 1] + body_lines + lines[end:]
+    return lines[:start] + lines[end:]
 
 
 def main() -> None:
@@ -65,7 +61,6 @@ def main() -> None:
 
     header: str | None = None
     level: int | None = None
-    content: str | None = None
 
     i = 1
     while i < len(args):
@@ -75,12 +70,6 @@ def main() -> None:
         elif args[i] == "--level" and i + 1 < len(args):
             level = int(args[i + 1])
             i += 2
-        elif args[i] == "--content" and i + 1 < len(args):
-            content = args[i + 1]
-            i += 2
-        elif args[i] == "--content-file" and i + 1 < len(args):
-            content = Path(args[i + 1]).read_text(encoding="utf-8")
-            i += 2
         else:
             print(f"ERROR: Unknown argument: {args[i]}", file=sys.stderr)
             sys.exit(1)
@@ -88,14 +77,11 @@ def main() -> None:
     if not header:
         print("ERROR: --header is required", file=sys.stderr)
         sys.exit(1)
-    if content is None:
-        print("ERROR: --content or --content-file is required", file=sys.stderr)
-        sys.exit(1)
 
     lines = file_path.read_text(encoding="utf-8").splitlines(keepends=True)
-    updated = write_section(lines, header, level, content)
+    updated = delete_section(lines, header, level)
     file_path.write_text("".join(updated), encoding="utf-8")
-    print(f"Updated section: {header!r} in {file_path}")
+    print(f"Deleted section: {header!r} from {file_path}")
 
 
 if __name__ == "__main__":

--- a/.opencode/tools/impl/md-new
+++ b/.opencode/tools/impl/md-new
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Create a new markdown file with an optional H1 title. Fails if file already exists.
-Usage: uv run python ai_bin/md new <file.md> [--title "Title Text"] [--help]
+Usage: uv run python .opencode/tools/md new <file.md> [--title "Title Text"] [--help]
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys

--- a/.opencode/tools/impl/md-read
+++ b/.opencode/tools/impl/md-read
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Read a section from a markdown file by header, or list all headers.
-Usage: uv run python ai_bin/md read <file.md> (--header "Header Text" [--level N] | --list) [--help]
+Usage: uv run python .opencode/tools/md read <file.md> (--header "Header Text" [--level N] | --list) [--help]
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import re

--- a/.opencode/tools/impl/md-write
+++ b/.opencode/tools/impl/md-write
@@ -1,12 +1,14 @@
 #!/usr/bin/env -S uv run python
 """
-DESCRIPTION: Delete a section (header line + body) from a markdown file by header.
-Usage: uv run python ai_bin/md delete <file.md> --header "Header Text" [--level N] [--help]
+DESCRIPTION: Replace the body of a section in a markdown file, preserving the header line.
+Usage: uv run python .opencode/tools/md write <file.md> --header "Header Text" (--content <text> | --content-file <path>) [--level N] [--help]
+WARNING: Use --content-file <path> for any content containing newlines or special characters
+         to avoid shell escaping and literal \n issues.
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import re
@@ -23,7 +25,7 @@ def _header_text(line: str) -> str:
     return re.sub(r'^#{1,6}\s+', '', line).rstrip()
 
 
-def delete_section(lines: list[str], header: str, level: int | None) -> list[str]:
+def write_section(lines: list[str], header: str, level: int | None, new_body: str) -> list[str]:
     start = None
     target_level = None
     for i, line in enumerate(lines):
@@ -45,7 +47,9 @@ def delete_section(lines: list[str], header: str, level: int | None) -> list[str
             end = i
             break
 
-    return lines[:start] + lines[end:]
+    body_lines = [(l if l.endswith("\n") else l + "\n") for l in new_body.splitlines()] if new_body else []
+
+    return lines[:start + 1] + body_lines + lines[end:]
 
 
 def main() -> None:
@@ -61,6 +65,7 @@ def main() -> None:
 
     header: str | None = None
     level: int | None = None
+    content: str | None = None
 
     i = 1
     while i < len(args):
@@ -70,6 +75,12 @@ def main() -> None:
         elif args[i] == "--level" and i + 1 < len(args):
             level = int(args[i + 1])
             i += 2
+        elif args[i] == "--content" and i + 1 < len(args):
+            content = args[i + 1]
+            i += 2
+        elif args[i] == "--content-file" and i + 1 < len(args):
+            content = Path(args[i + 1]).read_text(encoding="utf-8")
+            i += 2
         else:
             print(f"ERROR: Unknown argument: {args[i]}", file=sys.stderr)
             sys.exit(1)
@@ -77,11 +88,14 @@ def main() -> None:
     if not header:
         print("ERROR: --header is required", file=sys.stderr)
         sys.exit(1)
+    if content is None:
+        print("ERROR: --content or --content-file is required", file=sys.stderr)
+        sys.exit(1)
 
     lines = file_path.read_text(encoding="utf-8").splitlines(keepends=True)
-    updated = delete_section(lines, header, level)
+    updated = write_section(lines, header, level, content)
     file_path.write_text("".join(updated), encoding="utf-8")
-    print(f"Deleted section: {header!r} from {file_path}")
+    print(f"Updated section: {header!r} in {file_path}")
 
 
 if __name__ == "__main__":

--- a/.opencode/tools/impl/memory-clear
+++ b/.opencode/tools/impl/memory-clear
@@ -1,18 +1,18 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Clear the Session State section of .opencode/memory.md.
-Usage: uv run python ai_bin/memory clear
+Usage: uv run python .opencode/tools/memory clear
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 
 SESSION_HEADER = "## Session State"

--- a/.opencode/tools/impl/memory-read
+++ b/.opencode/tools/impl/memory-read
@@ -1,18 +1,18 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Print the full contents of .opencode/memory.md.
-Usage: uv run python ai_bin/memory read
+Usage: uv run python .opencode/tools/memory read
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 
 

--- a/.opencode/tools/impl/memory-update
+++ b/.opencode/tools/impl/memory-update
@@ -2,21 +2,21 @@
 """
 DESCRIPTION: Update a single key: value line in .opencode/memory.md.
 If the key exists, its line is replaced. If not, it is appended to the matching section.
-Usage: uv run python ai_bin/memory update <section> <key> (<value> | --value-file <path>)
+Usage: uv run python .opencode/tools/memory update <section> <key> (<value> | --value-file <path>)
 WARNING: Use --value-file <path> for complex text to avoid shell escaping issues.
 Sections: project_context, key_symbols, persistent_notes, session_state
-Example: uv run python ai_bin/memory update session_state task "refine topic seeds"
+Example: uv run python .opencode/tools/memory update session_state task "refine topic seeds"
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 
 SECTION_HEADERS = {

--- a/.opencode/tools/impl/memory-write
+++ b/.opencode/tools/impl/memory-write
@@ -1,19 +1,19 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Overwrite .opencode/memory.md with content from stdin or a file argument.
-Usage: uv run python ai_bin/memory write [file]
-       echo "content" | uv run python ai_bin/memory write
+Usage: uv run python .opencode/tools/memory write [file]
+       echo "content" | uv run python .opencode/tools/memory write
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 MEMORY_FILE = PROJECT_ROOT / ".opencode" / "memory.md"
 
 

--- a/.opencode/tools/impl/py-ls
+++ b/.opencode/tools/impl/py-ls
@@ -1,23 +1,23 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: List packages and modules under a path (replaces `ls` for Python source trees).
-Usage: uv run python ai_bin/py ls [<path>] [--all]
-Example: uv run python ai_bin/py ls src/commons
-         uv run python ai_bin/py ls src/commons/persistence
-         uv run python ai_bin/py ls  (lists top-level packages in src/)
+Usage: uv run python .opencode/tools/py ls [<path>] [--all]
+Example: uv run python .opencode/tools/py ls src/commons
+         uv run python .opencode/tools/py ls src/commons/persistence
+         uv run python .opencode/tools/py ls  (lists top-level packages in src/)
 Options:
   --all   Include non-package directories and non-.py files too
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 
 
 def is_package(p: Path) -> bool:

--- a/.opencode/tools/impl/py-mkpkg
+++ b/.opencode/tools/impl/py-mkpkg
@@ -1,20 +1,20 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Create a Python package (directory + __init__.py). Creates all intermediate packages too.
-Usage: uv run python ai_bin/py mkpkg <path> [<path2> ...]
-Example: uv run python ai_bin/py mkpkg src/commons/query
-         uv run python ai_bin/py mkpkg src/commons/query test/commons/query
+Usage: uv run python .opencode/tools/py mkpkg <path> [<path2> ...]
+Example: uv run python .opencode/tools/py mkpkg src/commons/query
+         uv run python .opencode/tools/py mkpkg src/commons/query test/commons/query
 """
 from __future__ import annotations
 import os as _os
-if _os.environ.get("AIBIN_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python ai_bin/nb ...). "
+if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
+    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 
 
 def make_package(rel_path: str) -> None:

--- a/.opencode/tools/jupyter
+++ b/.opencode/tools/jupyter
@@ -1,9 +1,8 @@
 #!/usr/bin/env -S uv run python
 """
-DESCRIPTION: Python source tools dispatcher. Usage: uv run python ai_bin/py <action> [args...]
-Actions: ls, mkpkg
-Example: uv run python ai_bin/py ls src/commons
-         uv run python ai_bin/py mkpkg src/commons/query
+DESCRIPTION: Jupyter server tools dispatcher. Usage: uv run python .opencode/tools/jupyter <action> [args...]
+Actions: start, stop
+Example: uv run python .opencode/tools/jupyter start
 """
 from __future__ import annotations
 import os
@@ -11,11 +10,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 ACTIONS = {
-    "ls": "py-ls",
-    "mkpkg": "py-mkpkg",
+    "start": "jupyter-start",
+    "stop": "jupyter-stop",
 }
 
 
@@ -24,7 +23,7 @@ def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
         [sys.executable, str(script)] + forwarded_args,
         capture_output=True,
         text=True,
-        env={**os.environ, "AIBIN_DISPATCHER": "1"},
+        env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
     )
     if result.stdout:
         sys.stdout.write(result.stdout)
@@ -51,16 +50,16 @@ def main() -> None:
         print(__doc__)
         print("Available actions:")
         for action, script in ACTIONS.items():
-            desc = _get_description(BASE_DIR / "impl" / script)
-            print(f"  {action:<20} — {desc}" if desc else f"  {action:<20} → ai_bin/{script}")
+            desc = _get_description(BASE_DIR / ".opencode" / "tools" / "impl" / script)
+            print(f"  {action:<20} — {desc}" if desc else f"  {action:<20} → .opencode/tools/{script}")
         print(f"CWD: {os.getcwd()}")
         sys.exit(0)
     action = args[0]
     if action not in ACTIONS:
         print(f"Error: unknown action {action!r}. Available: {', '.join(ACTIONS)}", file=sys.stderr)
         sys.exit(1)
-    script = BASE_DIR / "impl" / ACTIONS[action]
-    sys.exit(_run_action(script, args[1:], f"OK: ai_bin/py {action} completed."))
+    script = BASE_DIR / ".opencode" / "tools" / "impl" / ACTIONS[action]
+    sys.exit(_run_action(script, args[1:], f"OK: .opencode/tools/jupyter {action} completed."))
 
 
 if __name__ == "__main__":

--- a/.opencode/tools/jupyter-start
+++ b/.opencode/tools/jupyter-start
@@ -2,7 +2,7 @@
 """
 DESCRIPTION: Start Jupyter server on port 18888 (XSRF disabled, no token) for notebook editing.
 
-Usage: uv run python ai_bin/jupyter-start [--help]
+Usage: uv run python .opencode/tools/jupyter-start [--help]
 
 Checks if port 18888 is already listening. If not, starts the server in the
 background and logs to tmp/jupyter.log. Prints the server URL on success.
@@ -14,7 +14,7 @@ import sys
 import time
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent  # project root
+BASE_DIR = Path(__file__).resolve().parent.parent.parent  # project root
 PORT = 18888
 LOG_FILE = BASE_DIR / "tmp" / "jupyter.log"
 

--- a/.opencode/tools/jupyter-stop
+++ b/.opencode/tools/jupyter-stop
@@ -2,7 +2,7 @@
 """
 DESCRIPTION: Stop the Jupyter server running on port 18888.
 
-Usage: uv run python ai_bin/jupyter-stop [--help]
+Usage: uv run python .opencode/tools/jupyter-stop [--help]
 
 Sends SIGTERM to any process listening on port 18888. Waits up to 5 seconds
 to confirm the port is released, then reports success or failure.
@@ -14,7 +14,7 @@ import sys
 import time
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent  # project root
+BASE_DIR = Path(__file__).resolve().parent.parent.parent  # project root
 PORT = 18888
 
 

--- a/.opencode/tools/md
+++ b/.opencode/tools/md
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S uv run python
 """
-DESCRIPTION: Jupyter server tools dispatcher. Usage: uv run python ai_bin/jupyter <action> [args...]
-Actions: start, stop
-Example: uv run python ai_bin/jupyter start
+DESCRIPTION: Markdown tools dispatcher. Usage: uv run python .opencode/tools/md <action> [args...]
+Actions: read, write, add, delete, new
+Example: uv run python .opencode/tools/md read <file.md> [--section <header>]
 """
 from __future__ import annotations
 import os
@@ -10,11 +10,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 ACTIONS = {
-    "start": "jupyter-start",
-    "stop": "jupyter-stop",
+    "read": "md-read",
+    "write": "md-write",
+    "add": "md-add",
+    "delete": "md-delete",
+    "new": "md-new",
 }
 
 
@@ -23,7 +26,7 @@ def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
         [sys.executable, str(script)] + forwarded_args,
         capture_output=True,
         text=True,
-        env={**os.environ, "AIBIN_DISPATCHER": "1"},
+        env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
     )
     if result.stdout:
         sys.stdout.write(result.stdout)
@@ -38,8 +41,14 @@ def _get_description(script_path: Path) -> str:
     import re
     try:
         text = script_path.read_text()
-        m = re.search(r'DESCRIPTION:\s*(.+)', text)
-        return m.group(1).strip() if m else ""
+        # Find all lines between the first and last triple quotes
+        m = re.search(r'"""(.*?)"""', text, re.DOTALL)
+        if m:
+            docstring = m.group(1).strip()
+            # Extract only the DESCRIPTION line
+            dm = re.search(r'DESCRIPTION:\s*(.+)', docstring)
+            return dm.group(1).strip() if dm else ""
+        return ""
     except Exception:
         return ""
 
@@ -50,16 +59,16 @@ def main() -> None:
         print(__doc__)
         print("Available actions:")
         for action, script in ACTIONS.items():
-            desc = _get_description(BASE_DIR / "impl" / script)
-            print(f"  {action:<20} — {desc}" if desc else f"  {action:<20} → ai_bin/{script}")
+            desc = _get_description(BASE_DIR / ".opencode" / "tools" / "impl" / script)
+            print(f"  {action:<20} — {desc}" if desc else f"  {action:<20} → .opencode/tools/{script}")
         print(f"CWD: {os.getcwd()}")
         sys.exit(0)
     action = args[0]
     if action not in ACTIONS:
         print(f"Error: unknown action {action!r}. Available: {', '.join(ACTIONS)}", file=sys.stderr)
         sys.exit(1)
-    script = BASE_DIR / "impl" / ACTIONS[action]
-    sys.exit(_run_action(script, args[1:], f"OK: ai_bin/jupyter {action} completed."))
+    script = BASE_DIR / ".opencode" / "tools" / "impl" / ACTIONS[action]
+    sys.exit(_run_action(script, args[1:], f"OK: .opencode/tools/md {action} completed."))
 
 
 if __name__ == "__main__":

--- a/.opencode/tools/memory
+++ b/.opencode/tools/memory
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S uv run python
 """
-DESCRIPTION: Memory tools dispatcher. Usage: uv run python ai_bin/memory <action> [args...]
+DESCRIPTION: Memory tools dispatcher. Usage: uv run python .opencode/tools/memory <action> [args...]
 Actions: read, write, update (alias: set), clear
-Example: uv run python ai_bin/memory read
+Example: uv run python .opencode/tools/memory read
 """
 from __future__ import annotations
 import os
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 ACTIONS = {
     "read": "memory-read",
@@ -26,7 +26,7 @@ def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
         [sys.executable, str(script)] + forwarded_args,
         capture_output=True,
         text=True,
-        env={**os.environ, "AIBIN_DISPATCHER": "1"},
+        env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
     )
     if result.stdout:
         sys.stdout.write(result.stdout)
@@ -44,15 +44,15 @@ def main() -> None:
         print("Available actions:")
         seen_scripts: set[str] = set()
         for action, script in ACTIONS.items():
-            script_path = BASE_DIR / "impl" / script
-            print(f"  {action:<20} → ai_bin/impl/{script}")
+            script_path = BASE_DIR / ".opencode" / "tools" / "impl" / script
+            print(f"  {action:<20} → .opencode/tools/impl/{script}")
             if script not in seen_scripts:
                 seen_scripts.add(script)
                 try:
                     result = subprocess.run(
                         [sys.executable, str(script_path), "--help"],
                         capture_output=True, text=True,
-                        env={**os.environ, "AIBIN_DISPATCHER": "1"},
+                        env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
                     )
                     for line in (result.stdout or result.stderr).splitlines():
                         stripped = line.strip()
@@ -89,8 +89,8 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-    script = BASE_DIR / "impl" / ACTIONS[action]
-    sys.exit(_run_action(script, args[1:], f"OK: ai_bin/memory {action} completed."))
+    script = BASE_DIR / ".opencode" / "tools" / "impl" / ACTIONS[action]
+    sys.exit(_run_action(script, args[1:], f"OK: .opencode/tools/memory {action} completed."))
 
 
 if __name__ == "__main__":

--- a/.opencode/tools/py
+++ b/.opencode/tools/py
@@ -1,8 +1,9 @@
 #!/usr/bin/env -S uv run python
 """
-DESCRIPTION: Markdown tools dispatcher. Usage: uv run python ai_bin/md <action> [args...]
-Actions: read, write, add, delete, new
-Example: uv run python ai_bin/md read <file.md> [--section <header>]
+DESCRIPTION: Python source tools dispatcher. Usage: uv run python .opencode/tools/py <action> [args...]
+Actions: ls, mkpkg
+Example: uv run python .opencode/tools/py ls src/commons
+         uv run python .opencode/tools/py mkpkg src/commons/query
 """
 from __future__ import annotations
 import os
@@ -10,14 +11,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 ACTIONS = {
-    "read": "md-read",
-    "write": "md-write",
-    "add": "md-add",
-    "delete": "md-delete",
-    "new": "md-new",
+    "ls": "py-ls",
+    "mkpkg": "py-mkpkg",
 }
 
 
@@ -26,7 +24,7 @@ def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
         [sys.executable, str(script)] + forwarded_args,
         capture_output=True,
         text=True,
-        env={**os.environ, "AIBIN_DISPATCHER": "1"},
+        env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
     )
     if result.stdout:
         sys.stdout.write(result.stdout)
@@ -41,14 +39,8 @@ def _get_description(script_path: Path) -> str:
     import re
     try:
         text = script_path.read_text()
-        # Find all lines between the first and last triple quotes
-        m = re.search(r'"""(.*?)"""', text, re.DOTALL)
-        if m:
-            docstring = m.group(1).strip()
-            # Extract only the DESCRIPTION line
-            dm = re.search(r'DESCRIPTION:\s*(.+)', docstring)
-            return dm.group(1).strip() if dm else ""
-        return ""
+        m = re.search(r'DESCRIPTION:\s*(.+)', text)
+        return m.group(1).strip() if m else ""
     except Exception:
         return ""
 
@@ -59,16 +51,16 @@ def main() -> None:
         print(__doc__)
         print("Available actions:")
         for action, script in ACTIONS.items():
-            desc = _get_description(BASE_DIR / "impl" / script)
-            print(f"  {action:<20} — {desc}" if desc else f"  {action:<20} → ai_bin/{script}")
+            desc = _get_description(BASE_DIR / ".opencode" / "tools" / "impl" / script)
+            print(f"  {action:<20} — {desc}" if desc else f"  {action:<20} → .opencode/tools/{script}")
         print(f"CWD: {os.getcwd()}")
         sys.exit(0)
     action = args[0]
     if action not in ACTIONS:
         print(f"Error: unknown action {action!r}. Available: {', '.join(ACTIONS)}", file=sys.stderr)
         sys.exit(1)
-    script = BASE_DIR / "impl" / ACTIONS[action]
-    sys.exit(_run_action(script, args[1:], f"OK: ai_bin/md {action} completed."))
+    script = BASE_DIR / ".opencode" / "tools" / "impl" / ACTIONS[action]
+    sys.exit(_run_action(script, args[1:], f"OK: .opencode/tools/py {action} completed."))
 
 
 if __name__ == "__main__":

--- a/.opencode/tools/schema-version
+++ b/.opencode/tools/schema-version
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run python
 """
 DESCRIPTION: Print current UTC datetime as YYYYMMDDHHMMSS. ONLY run when explicitly instructed to create a migration. NEVER run speculatively.
-Usage: uv run python ai_bin/schema-version
+Usage: uv run python .opencode/tools/schema-version
 
 Use this value as the VERSION constant when writing a new migration script.
 Never copy a version number from memory or a previous migration — always run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,8 +195,8 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 - `src/`: Application source code
 - `test/`: Unit and integration tests
 - `docs/`: Documentation and specifications
-- `ai_bin/`: Agent utility scripts
-- `.opencode/`: Skills and guidelines
+- `.opencode/`: Skills, guidelines, and agent tools
+  - `tools/`: Agent utility scripts (guidelines, md, memory, py, jupyter, etc.)
   - `skills/`: Self-contained skills (no guideline dependencies)
   - `guidelines/`: Core zero-tolerance rules only
   - `.guidelines/registry.yaml`: Registry of migrated content


### PR DESCRIPTION
## Summary

Migrated agent utility scripts from `ai_bin/` (project root) to `.opencode/tools/` (alongside skills and guidelines) and added the bug-discovery guardrail, both imported from upstream opencode configuration.

## Outcome

Agent tools are now colocated with skills and guidelines under `.opencode/`, eliminating the separate `ai_bin/` directory. A new critical-violation rule prevents agents from fixing bugs discovered during other work without explicit authorization.

## Changes

- **`ai_bin/` → `.opencode/tools/`**: All 26 scripts moved, `AIBIN_DISPATCHER` → `OPENCODE_TOOLS_DISPATCHER`, path references updated across 12 guidelines and 4 skills
- **Bug-discovery guardrail**: New "Bug Discovery Does NOT Authorize Bug Fixing" section in `000-critical-rules.md` with authorization matrix, self-correction protocol, and enforcement across `010-approval-gate.md`, `050-scope-autonomy.md`, `approval-gate/SKILL.md`, `implementation-workflow/SKILL.md`, `systematic-debugging/SKILL.md`
- **AGENTS.md**: Updated project structure to reflect new tool location

Fixes #545