### PR TITLE
[SPEC] Fix session_init.py output format for consistent key-value pairs

### DIFF
--- a/.opencode/scripts/session_init.py
+++ b/.opencode/scripts/session_init.py
@@ -105,7 +105,7 @@ def is_gitbucket_remote(url: str) -> bool:
 
 
 def parse_gitbucket_url(
-        url: str,
+    url: str,
 ) -> tuple[str | None, str, str] | tuple[None, None, None]:
     """Parse owner and repo from GitBucket remote URL. Base URL comes from .env ONLY.
 
@@ -244,10 +244,10 @@ def main() -> int:
 
     # Output in the specified format
     print("# Session Init - Git Context")
-    print(f"Human Developer: {user_name}")
-    print(f"Human Email: {user_email}")
+    print(f"DEV_NAME={user_name}")
+    print(f"DEV_EMAIL={user_email}")
     print(f"GIT_HOOKS_PATH={hooks_path}")
-    print(f"Git Remote Url: {remote_url}")
+    print(f"GIT_REMOTE_URL={remote_url}")
 
     # Check if GitHub remote
     if is_github_remote(remote_url):
@@ -258,12 +258,14 @@ def main() -> int:
             print(f"Remote URL: {remote_url}", file=sys.stderr)
             return 1
 
-        print(f"Repository Owner: {owner}")
-        print(f"Repository: {repo}")
+        print(f"GIT_OWNER={owner}")
+        print(f"GIT_REPO={repo}")
         print("GIT_PLATFORM=github")
         print("GITHUB_HTML_URL=https://github.com/")
         print("")
-        print("# GitHub Repository Detected")
+        print("# ============================")
+        print("# GITHUB REPOSITORY DETECTED")
+        print("# ============================")
         print("# 📋 Invoke: /skill github-issue-creation before creating issues")
         print("# 📋 See: .opencode/skills/github-issue-creation/SKILL.md")
         check_srclight()
@@ -280,7 +282,9 @@ def main() -> int:
             print("GITBUCKET_URL=")
             print("GITBUCKET_HAS_CREDENTIALS=false")
             print("")
-            print("# GitBucket Repository Detected (URL Parse Failed)")
+            print("# ==============================")
+            print("# GITBUCKET REPOSITORY DETECTED")
+            print("# ==============================")
             print("# 📋 Invoke: /skill gitbucket-api before using GitBucket Python API")
             print("# 📋 See: .opencode/skills/gitbucket-api/SKILL.md")
             return 0
@@ -303,13 +307,13 @@ def main() -> int:
                 with open(env_path) as f:
                     content = f.read()
                     has_credentials = "GITBUCKET_TOKEN=" in content and (
-                            "GITBUCKET_HTML_URL=" in content or "GITBUCKET_URL=" in content
+                        "GITBUCKET_HTML_URL=" in content or "GITBUCKET_URL=" in content
                     )
         except OSError:
             pass
 
-        print(f"Repository Owner: {owner}")
-        print(f"Repository: {repo}")
+        print(f"GIT_OWNER={owner}")
+        print(f"GIT_REPO={repo}")
         print("GIT_PLATFORM=gitbucket")
         print(f"GITBUCKET_HTML_URL={base_url or ''}")
         ssh_url = extract_ssh_url(remote_url)
@@ -317,7 +321,9 @@ def main() -> int:
             print(f"GITBUCKET_SSH_URL={ssh_url}")
         print(f"GITBUCKET_HAS_CREDENTIALS={'true' if has_credentials else 'false'}")
         print("")
-        print("# GitBucket Repository Detected")
+        print("# ============================")
+        print("# GITBUCKET REPOSITORY DETECTED")
+        print("# ============================")
         print("# 📋 Invoke: /skill gitbucket-api before using GitBucket Python API")
         print("# 📋 GitBucket API has specific authentication patterns and limitations")
         print("# 📋 See: .opencode/skills/gitbucket-api/SKILL.md")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Session initialization is handled automatically by the `session-init` OpenCode p
 2. Injects the output into the LLM system context via `experimental.chat.system.transform`
 3. Sets key-value pairs as shell environment variables via `shell.env`
 
-**No manual step is required.** The following values are available automatically:
+**No manual step is required.** The script outputs all values as `KEY=value` pairs — extract them directly, no mapping or interpretation needed. Use `GIT_OWNER` and `GIT_REPO` for EVERY API call.
 
 - `DEV_NAME`: Human collaborator name (for commit trailers)
 - `DEV_EMAIL`: Human collaborator email (for commit trailers)
@@ -29,8 +29,11 @@ Session initialization is handled automatically by the `session-init` OpenCode p
 - `GIT_HOOKS_PATH`: Git hooks path (to verify hooks installed)
 - `GIT_REMOTE_URL`: Full remote URL (for reference)
 - `GIT_PLATFORM`: Platform type (`github` or `gitbucket`)
+- `GITHUB_HTML_URL`: GitHub web UI base URL (if GitHub)
 - `GITBUCKET_HTML_URL`: GitBucket web UI base URL (if GitBucket, non-secret)
 - `GITBUCKET_HAS_CREDENTIALS`: `true` if credentials configured in `.env`
+
+The output includes a prominent platform banner (`# GITHUB REPOSITORY DETECTED` or `# GITBUCKET REPOSITORY DETECTED`) that makes the platform type unambiguous.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/fix-session-init-output-format
+
+- Convert session_init.py output from inconsistent `Label: value` / `KEY=value` mix to consistent `KEY=value` format
+- Change `Human Developer:` → `DEV_NAME=`, `Human Email:` → `DEV_EMAIL=`, `Git Remote Url:` → `GIT_REMOTE_URL=`, `Repository Owner:` → `GIT_OWNER=`, `Repository:` → `GIT_REPO=`
+- Add prominent platform banners with horizontal rules (`# GITHUB REPOSITORY DETECTED` / `# GITBUCKET REPOSITORY DETECTED`)
+- Update AGENTS.md to document KEY=value format and add missing `GITHUB_HTML_URL` variable
+
 ### spec/adjust-tool-priorities
 
 - Remove 36 superseded ai_bin scripts (nb, plans, py-find, py-structure, start, multi-find)


### PR DESCRIPTION
## Summary

Fix session init script output to use consistent `KEY=value` format instead of mixed `Label: value` / `KEY=value`, and add prominent platform banners so GitHub vs GitBucket is unmissable.

## Outcome

Agents can now extract `GIT_OWNER`, `GIT_REPO`, `DEV_NAME`, `DEV_EMAIL`, and `GIT_REMOTE_URL` directly from output — no label-to-variable mapping needed. Platform type is visually obvious via banner.

## Changes

- `.opencode/scripts/session_init.py`: Convert 7 output lines from `Label: value` to `KEY=value` format; add prominent `# GITHUB REPOSITORY DETECTED` / `# GITBUCKET REPOSITORY DETECTED` banners with horizontal rules
- `AGENTS.md`: Document KEY=value format, add `GITHUB_HTML_URL` to variable list, add platform banner note
- `CHANGELOG.md`: Add entry for this change

Fixes #548