### PR TITLE
feat: replace dispatch table with skill self-discovery via YAML frontmatter (#553 Phase 2)

### DIFF
--- a/.opencode/dispatch-table.yaml
+++ b/.opencode/dispatch-table.yaml
@@ -1,5 +1,19 @@
-# Skill Dispatch Table - Externalized from AGENTS.md
-# Loaded dynamically by AI agents on session start
+# DEPRECATED: Skill Dispatch Table
+#
+# This file is DEPRECATED and kept for historical reference only.
+# Skill invocation is now driven by self-discovery via YAML frontmatter
+# in each SKILL.md file. The session-enforcement plugin reads skill
+# descriptions from frontmatter at startup and injects them into the
+# first user message.
+#
+# See AGENTS.md "Skill Self-Discovery" section for details.
+# Source attribution: Self-discovery pattern adapted from obra/superpowers
+# https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md
+#
+# ============================================================
+# HISTORICAL CONTENT BELOW — DO NOT USE FOR ACTIVATION
+# ============================================================
+# Original: Skill Dispatch Table - Externalized from AGENTS.md
 # Version: 2.0
 # Last Updated: 2026-04-07
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: approval-gate
-description: Authorization gatekeeper ensuring all code changes follow spec + authorization workflow. Verifies specs exist, authorization is explicit, sub-issues structure is correct.
+description: Use when user says "approved", "go", or any implementation instruction. Verifies specs exist, authorization is explicit, sub-issues structure is correct. Prevents unauthorized code changes. Triggers on: approval, authorized, implement, start work, go ahead, needs-approval label.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorming
-description: Mandatory pre-spec brainstorming workflow with agent-driven exploration instead of rigid templates. Dimensions are chosen by judgment, not mandated.
+description: Use when creating a spec, planning a feature, or exploring requirements before implementation. Mandatory before any spec creation. Triggers on: spec, plan, feature, brainstorm, explore, requirements, ideate, think through, what should.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/changelog-generator/SKILL.md
+++ b/.opencode/skills/changelog-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-generator
-description: Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes. Turns hours of manual changelog writing into minutes of automated generation.
+description: Use when creating release notes, documenting changes between versions, or preparing a changelog. Triggers on: changelog, release notes, what changed, version history, commit summary, release.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/code-size-enforcement/SKILL.md
+++ b/.opencode/skills/code-size-enforcement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-size-enforcement
-description: Enforce size limits on functions, notebook cells, and files. Defines detection methods, prohibited patterns, grandfather policy, and violation recovery.
+description: Use when writing or modifying code to check function length, file size, or notebook cell size limits. Triggers on: long function, big file, too many lines, size limit, code size, function length, cell size.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/coherence-auditor/SKILL.md
+++ b/.opencode/skills/coherence-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coherence-auditor
-description: Audit coherence between guidelines, skills, and AI agent behavior to ensure they work together effectively. Can be used for extraction (identifying skill candidates) and maintenance (detecting drift).
+description: Use when guidelines or skills are updated, to check consistency between rules and behavior. Triggers on: coherence, consistency, audit guidelines, skill extraction, drift detection, guideline update, skill update.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: concern-separation-auditor
-description: Analyzes spec phase structure for concern separation quality. Reports findings to the agent — does NOT auto-fix. Invoked via spec-auditor orchestrator, not directly.
+description: Use when auditing a spec for phase structure quality and concern separation. Invoked via spec-auditor, not directly. Triggers on: concern separation, phase structure, spec audit, mixed concerns.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/engineering-approach/SKILL.md
+++ b/.opencode/skills/engineering-approach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: engineering-approach
-description: Engineering principles and checklists for proper development methodology. Invoked when implementing specs to ensure understanding, design, verification, and scope discipline.
+description: Use when implementing a spec to ensure understanding, design, verification, and scope discipline are followed. Triggers on: implement, build, develop, engineering checklist, design before code, verify before complete.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: executing-plans
-description: Plan execution workflow that implements approved plans step-by-step with verification evidence collection and quality gates.
+description: Use when executing an approved plan step-by-step, collecting verification evidence at each gate. Triggers on: execute plan, next step, continue implementation, plan approved, start implementation.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-development-branch
-description: Branch completion workflow ensuring all changes are committed, verified, pushed, and ready for PR creation.
+description: Use when implementation is complete and branch needs final checks before PR. Triggers on: done, finished, ready for PR, implementation complete, branch ready, push changes, final check.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/fragment-manager/SKILL.md
+++ b/.opencode/skills/fragment-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fragment-manager
-description: Manages duplicate content blocks (fragments) within the repository. Provides CRUD operations for fragment masters and synchronization from masters to destination copies in skills.
+description: Use when managing duplicate content blocks (fragments) across guidelines or skills. Triggers on: fragment, duplicate content, sync content, content block, shared content, master copy, synchronize.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Handles pre-work git branch, git stash, work, git commit, and PR creation as dictated by the guidelines. Automatically invoked when user approves implementation or requests PR creation. Enforces three-branch workflow (feature → dev → main).
+description: Use when creating a branch, committing changes, pushing work, or creating a PR. Automatically invoked when user approves implementation or says "create a PR". Triggers on: branch, commit, push, PR, pull request, pre-work, review-prep, feature branch, dev branch, squash.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/gitbucket-api/SKILL.md
+++ b/.opencode/skills/gitbucket-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitbucket-api
-description: GitBucket API patterns and capabilities using OpenAPI specification and Python client. Documents actual API responses, authentication patterns, and error recovery.
+description: Use when working with a GitBucket repository for API operations, issue management, or label handling. Triggers on: GitBucket, gitbucket, API call, issue creation, label, token authentication, error recovery, non-GitHub platform.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-comments
-description: GitHub comment format and protocol for AI agents. Defines AI identity attribution, lifecycle status indicators, comment types, progress comments, closure summaries, and when to comment vs edit issue bodies.
+description: Use when posting comments to GitHub Issues or PRs. Defines format, byline, progress format, closure summaries. Triggers on: comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/github-issue-creation/SKILL.md
+++ b/.opencode/skills/github-issue-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-issue-creation
-description: Issue Creation Enforcer ensuring all GitHub Issues follow spec-first workflow with validation, labels, and auditor integration. Invoked automatically before any issue is created.
+description: Use when creating a GitHub Issue or before any issue creation attempt. Validates spec, labels, auditor integration. Triggers on: create issue, new issue, spec creation, submit issue, GitHub issue, file issue, bug report.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/github-sub-issues/SKILL.md
+++ b/.opencode/skills/github-sub-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-sub-issues
-description: Multi-task spec sub-issue creation and management workflow. Defines single-task exemption, auto-create workflow, database ID requirement, and phase-level structure for GitHub Issue sub-issues.
+description: Use when a multi-task spec needs phase-level sub-issues created or linked. Triggers on: sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/guideline-auditor/SKILL.md
+++ b/.opencode/skills/guideline-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: guideline-auditor
-description: Analyzes guideline files for ambiguity, conflicts, and LLM compliance issues
+description: Use when checking guideline files for ambiguity, conflicts, or LLM compliance issues. Triggers on: audit guidelines, guideline quality, guideline conflict, ambiguous rule, LLM compliance.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/implementation-workflow/SKILL.md
+++ b/.opencode/skills/implementation-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-workflow
-description: Orchestration layer that sequences subtasks with yield-back context passing. Calls git-workflow tasks for git ops, runs implementation agents for actual work, and yields structured results between stages.
+description: Use when orchestrating implementation of an approved spec or plan. Sequences git-workflow tasks and implementation agents. Triggers on: implement, build, execute plan, start work, orchestrate, yield-back context.
 license: MIT
 compatibility: opencode
 ---
@@ -79,7 +79,7 @@ implementation-workflow/orchestrate (receives auth context)
 issue: 77
 authorized: true
 context:
-  title: "[SPEC] Integrate Superpowers workflow"
+  title: "[SPEC] Integrate skill enforcement plugin"
   phases: [Core Skills, Dispatch Table, Quality Gates, ...]
   current_phase: 1
   authorization_comment: "approved"
@@ -239,7 +239,7 @@ compare_url: "https://github.com/owner/repo/compare/main...branch"
 exec_summary: |
   **Summary:**
   
-  Integrated workflow skills from Superpowers repository.
+  Integrated workflow skills into the enforcement plugin.
   
   **Outcome:**
   

--- a/.opencode/skills/mcp-tool-usage/SKILL.md
+++ b/.opencode/skills/mcp-tool-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-tool-usage
-description: Defines tool priority hierarchy for all operations. Five-tier system with opencode built-in primary, domain MCP primary, .opencode/tools primary, JetBrains MCP fallback, and CLI last resort.
+description: Use when selecting tools for file operations, code search, or any task that could use multiple tool options. Triggers on: which tool, tool priority, MCP, PyCharm, JetBrains, read file, write file, search code, tool selection.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/notebook-operations/SKILL.md
+++ b/.opencode/skills/notebook-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notebook-operations
-description: Jupyter notebook operations with zero-tolerance corruption rules. Defines permitted MCP tools, forbidden operations, execution restrictions, and cell labeling requirements.
+description: Use when working with .ipynb Jupyter notebook files for reading, writing, or executing cells. Triggers on: notebook, ipynb, Jupyter, cell, execute cell, kernel, zero tolerance, forbidden operations.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/plan-fidelity-auditor/SKILL.md
+++ b/.opencode/skills/plan-fidelity-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-fidelity-auditor
-description: Generates a clean-room plan and compares it against the existing spec plan to identify discrepancies. Reports findings — does NOT auto-fix. Invoked via spec-auditor orchestrator, not directly.
+description: Use when auditing a plan for fidelity against a spec, checking that implementation matches spec requirements. Invoked via spec-auditor. Triggers on: plan fidelity, plan audit, spec vs plan, discrepancy, clean-room plan.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creation-workflow
-description: Handles PR creation timing requirements. Defines when PRs can be created, what authorizes PR creation, and the mandatory HALT after PR creation.
+description: Use when asking about when to create a PR or whether PR creation is authorized. Defines PR timing rules and mandatory HALT. Triggers on: create PR, make PR, pull request, PR timing, when to PR, PR authorized.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/receiving-code-review/SKILL.md
+++ b/.opencode/skills/receiving-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: Workflow for responding to code review feedback systematically, addressing all comments without scope creep.
+description: Use when receiving code review feedback on a PR to address all comments without scope creep. Triggers on: code review, PR feedback, review comment, address feedback, fix review, respond to review.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/requesting-code-review/SKILL.md
+++ b/.opencode/skills/requesting-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requesting-code-review
-description: Workflow for preparing and requesting code reviews with proper context and documentation.
+description: Use when preparing a PR for code review with proper context and documentation. Triggers on: request review, code review, review request, ready for review, review preparation.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends AI capabilities with specialized knowledge, workflows, or tool integrations.
+description: Use when creating a new skill or updating an existing skill that extends AI capabilities with specialized knowledge, workflows, or tool integrations. Triggers on: new skill, update skill, create skill, skill template, skill structure, SKILL.md.
 license: Apache-2.0
 compatibility: opencode
 ---

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-auditor
-description: Audit orchestrator that determines which subtasks to run and reports all findings. The single entry point for spec quality auditing.
+description: Use when auditing a spec for quality, structure, and completeness. The single entry point for spec auditing. Triggers on: audit spec, review spec, spec quality, validate spec, check spec, audit issue, revisit spec.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/sync-guidelines/SKILL.md
+++ b/.opencode/skills/sync-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-guidelines
-description: Intelligently synchronize guidelines, skills, and tools between repositories through GitHub issues. Classifies files by semantic analysis and creates sync issues for human review.
+description: Use when synchronizing guidelines, skills, or tools between repositories. Triggers on: sync guidelines, cross-repo sync, guideline update, skill update, multi-repo, consistency between repos.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/systematic-debugging/SKILL.md
+++ b/.opencode/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systematic-debugging
-description: Systematic bug diagnosis and fix process that ensures root cause analysis before any code changes.
+description: Use when encountering a bug, error, or unexpected behavior to ensure root cause analysis before any code changes. Triggers on: bug, error, fix, debug, diagnose, crash, failure, unexpected behavior, vibe debugging.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/test-driven-development/SKILL.md
+++ b/.opencode/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Test-driven development workflow writing tests before implementation to ensure correctness and prevent regression.
+description: Use when writing tests before implementation following TDD red-green-refactor workflow. Triggers on: TDD, test first, red green refactor, write test, test-driven, unit test, regression.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/verification-before-completion/SKILL.md
+++ b/.opencode/skills/verification-before-completion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verification-before-completion
-description: Evidence-based verification workflow that prevents premature completion claims by ensuring success criteria have actual evidence.
+description: Use when claiming a task is complete, marking a step done, or closing an issue. Prevents premature completion by requiring evidence. Triggers on: task complete, done, finished, step complete, mark done, verify completion, success criteria.
 license: MIT
 compatibility: opencode
 ---

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: Plan creation workflow producing prose plans structured by agent judgment, not templates. Plans must have zero placeholders before implementation.
+description: Use when creating an implementation plan from an approved spec. Produces prose plans with zero placeholders. Triggers on: write plan, create plan, implementation plan, plan spec, approved plan, plan creation.
 license: MIT
 compatibility: opencode
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ Session initialization and skill enforcement are handled automatically by the `s
 1. Runs `.opencode/scripts/session_init.py` once per session (cached for 5 minutes)
 2. Injects session context into the LLM system prompt via `experimental.chat.system.transform`
 3. Sets key-value pairs as shell environment variables via `shell.env`
-4. Injects skill enforcement content into the first user message via `experimental.chat.messages.transform`, ensuring agents invoke mandatory workflow skills
+4. Loads skill descriptions from YAML frontmatter in each SKILL.md file at startup (via `loadSkillDescriptions()`)
+5. Injects skill enforcement content (1% rule, red-flags table, skill list with "Use when..." descriptions) into the first user message via `experimental.chat.messages.transform`, ensuring agents invoke mandatory workflow skills
 
 **No manual step is required.** The script outputs all values as `KEY=value` pairs — extract them directly, no mapping or interpretation needed. Use `GIT_OWNER` and `GIT_REPO` for EVERY API call.
 
@@ -77,23 +78,20 @@ For GitBucket repositories, invoke `gitbucket-api` skill BEFORE using GitBucket 
 
 ---
 
-## Dispatch Table Loading (MANDATORY)
+## Skill Self-Discovery (Automatic)
 
-**On EVERY session, load the dispatch table dynamically:**
+Skills are discovered automatically via YAML frontmatter in each `SKILL.md` file. The `session-enforcement` plugin reads each skill's `description` field at startup and injects them into the first user message.
 
-```yaml
-# File: .opencode/dispatch-table.yaml
-# This file tells the AI agent when to invoke which skills
-```
+**Each skill description uses "Use when..." format** with triggering conditions and keyword coverage, NOT workflow summaries. This ensures the agent can self-discover which skill to invoke based on the current task context.
 
-**The dispatch table defines:**
-- When to invoke platform skills (`gitbucket-api`, `github-issue-creation`)
-- When to invoke code quality skills (`code-size-enforcement`, `spec-auditor`)
-- When to invoke workflow skills (`git-workflow`, `approval-gate`, `pr-creation-workflow`)
-- Automatic invocation rules
-- Sub-task invocation patterns
+**The plugin handles:**
+- Loading skill descriptions from YAML frontmatter at session start
+- Sorting process skills before implementation skills
+- Injecting enforcement content (1% rule, red-flags table, skill list) into the first user message
 
-**DO NOT embed the dispatch table in AGENTS.md. LOAD IT DYNAMICALLY.**
+**The dispatch table is deprecated** — see `.opencode/dispatch-table.yaml` for historical reference only. Skill invocation is now driven by self-discovery via frontmatter descriptions.
+
+**DO NOT embed skill invocation rules in AGENTS.md. They are discovered dynamically from SKILL.md frontmatter.**
 
 ---
 
@@ -108,7 +106,7 @@ OpenCode skills are available in `.opencode/skills/`. Each skill has a `SKILL.md
 /skill <skill-name> --task <task-name>
 ```
 
-**For dispatch rules**, see `.opencode/dispatch-table.yaml` which defines when each skill is invoked.
+**Skill invocation is driven by self-discovery** — see "Skill Self-Discovery" section above. Each SKILL.md frontmatter `description` field uses "Use when..." format with triggering conditions for automatic discovery.
 
 ### Sub-Task Architecture
 
@@ -142,7 +140,7 @@ Skills with `tasks/` subdirectory support `--task` parameter for loading specifi
 
 ### Workflow Skills
 
-The dispatch table (`dispatch-table.yaml`) orchestrates workflow skills in sequence:
+Skill invocation is driven by self-discovery from SKILL.md frontmatter (see "Skill Self-Discovery" section). Key workflow skills:
 
 | Skill | Purpose | Dispatch Trigger |
 |-------|---------|------------------|
@@ -265,7 +263,7 @@ When parent issue has sub-issues, authorization cascades to ALL sub-issues:
 
 ## Q/A Mode
 
-After session init and dispatch table load, switch to Q/A mode:
+After session init and skill discovery, switch to Q/A mode:
 
 1. **Report identity**: `<AgentName> (<ModelID>)`
 2. **Report init results**: Platform, MCP availability
@@ -280,7 +278,7 @@ After session init and dispatch table load, switch to Q/A mode:
 
 | File | Purpose |
 |------|---------|
-| `.opencode/dispatch-table.yaml` | Skill invocation rules (LOAD DYNAMICALLY) |
+| `.opencode/dispatch-table.yaml` | Skill invocation rules (DEPRECATED — kept for reference only) |
 | `.opencode/.guidelines/registry.yaml` | Registry of migrated content blocks |
 | `000-critical-rules.md` | Zero-tolerance violations |
 | `010-approval-gate.md` | Authorization workflow |


### PR DESCRIPTION
## Summary

Replace the centralized dispatch-table.yaml with skill self-discovery via YAML frontmatter descriptions, following CSO (Content Search Optimization) principles. All 30 SKILL.md files now use "Use when..." format with triggering conditions and keyword coverage, enabling the session-enforcement plugin to dynamically surface relevant skills at session start.

## Outcome

Agents now discover skills through self-describing YAML frontmatter rather than a static dispatch table, improving maintainability and ensuring each skill declares its own invocation triggers.

Fixes #553