### PR TITLE
[SPEC #555] Subagent-Driven Development Skill

### DIFF
--- a/.opencode/dispatch-table.yaml
+++ b/.opencode/dispatch-table.yaml
@@ -122,6 +122,16 @@ issue_pr_workflow:
     automatic: true
     note: "Starts step-by-step implementation with evidence collection"
     
+  - trigger: "Executing plan with independent tasks via subagents"
+    skill: "subagent-driven-development"
+    purpose: "Dispatch fresh subagents per task with two-stage review"
+    note: "Alternative to executing-plans for plans with independent tasks"
+
+  - trigger: "Implementing approved spec with subagent dispatch"
+    skill: "subagent-driven-development"
+    purpose: "Dispatch implementer → spec review → code quality review per task"
+    note: "Integrates with approval-gate, git-workflow, verification-before-completion"
+    
   - trigger: "User says 'next step' or 'continue'"
     skill: "executing-plans"
     task: "step"

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -269,7 +269,7 @@ writing-plans (approved) → approval-gate (plan) → executing-plans → verifi
 
 ## Cross-References
 
-- Related skills: `writing-plans` (plan creation), `verification-before-completion` (final verification), `git-workflow` (branch/PR)
+- Related skills: `writing-plans` (plan creation), `verification-before-completion` (final verification), `git-workflow` (branch/PR), `subagent-driven-development` (alternative: dispatch fresh subagents per task with two-stage review)
 - Related guidelines: `142-planning-archive-workflow.md` (plan structure), `000-critical-rules.md` (evidence requirements)
 
 ## Platform Compatibility

--- a/.opencode/skills/implementation-workflow/SKILL.md
+++ b/.opencode/skills/implementation-workflow/SKILL.md
@@ -429,7 +429,7 @@ implementation-workflow (receives context)
 
 ## Cross-References
 
-- Related skills: `git-workflow` (git ops), `approval-gate` (authorization)
+- Related skills: `git-workflow` (git ops), `approval-gate` (authorization), `subagent-driven-development` (alternative orchestration for independent tasks)
 - Related guidelines: `010-approval-gate.md`, `110-git-branch-first.md`
 - Related dispatch: `dispatch-table.yaml` (approval-gate → implementation-workflow sequence)
 

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: subagent-driven-development
+description: Use when executing an approved implementation plan by dispatching fresh subagents per task with two-stage review (spec compliance then code quality). Triggers on: subagent, dispatch task, implement plan tasks, task-by-task implementation, subagent development, parallel implementation.
+license: MIT
+compatibility: opencode
+---
+
+# Skill: subagent-driven-development
+
+Execute an approved implementation plan by dispatching fresh subagents per task, with two-stage review after each: spec compliance review first, then code quality review.
+
+**Source attribution:** This skill is adapted from [obra/superpowers `subagent-driven-development`](https://github.com/obra/superpowers/tree/main/skills/subagent-driven-development). The implementer, spec-reviewer, and code-quality-reviewer prompt patterns are adapted from the [original prompt templates](https://github.com/obra/superpowers/tree/main/skills/subagent-driven-development). The two-stage review workflow, model selection guidance, and implementer status handling are derived from the original skill.
+
+## Why Subagents
+
+Fresh subagent per task = no context pollution between tasks. You precisely craft instructions and context for each subagent. This preserves your own context for coordination work.
+
+**Core principle:** Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration
+
+## When to Use This Skill vs Implementation-Workflow
+
+| Situation | Use |
+|-----------|-----|
+| Plan with independent tasks, same session | `subagent-driven-development` |
+| Plan with tightly coupled tasks | `executing-plans` or manual execution |
+| Parallel session needed | `executing-plans` |
+| Need fresh context per task | `subagent-driven-development` |
+| Small single-task implementation | `implementation-workflow` |
+
+## Pre-Implementation Gates (MANDATORY)
+
+**Before dispatching any subagent, these gates MUST be satisfied:**
+
+1. **approval-gate** — Authorization verified (`approved` or `go` received)
+2. **git-workflow --task pre-work** OR **using-git-worktrees** — Branch created, working tree clean
+3. **Plan exists** — Writing-plans output available with TDD tasks
+
+**After all tasks complete, these gates are MANDATORY:**
+
+4. **verification-before-completion --task verify** — Evidence collected for success criteria
+5. **finishing-a-development-branch --task checklist** — Branch readiness verified
+6. **git-workflow --task review-prep** — Push, URL, HALT
+
+**These gates are NOT optional.** Skipping them is a CRITICAL GUIDELINE VIOLATION.
+
+## Tasks
+
+| Task | Purpose |
+|------|---------|
+| `implementer-prompt.md` | Dispatch implementer subagent |
+| `spec-reviewer-prompt.md` | Dispatch spec compliance reviewer subagent |
+| `code-quality-reviewer-prompt.md` | Dispatch code quality reviewer subagent |
+
+## The Process
+
+```
+Read plan, extract all tasks with full text and context
+    ↓
+Create TodoWrite with all tasks
+    ↓
+For each task:
+    ↓
+    Dispatch implementer subagent (tasks/implementer-prompt.md)
+        ↓ (if implementer asks questions → answer, re-dispatch)
+        ↓ (implementer implements, tests, commits, self-reviews)
+    ↓
+    Dispatch spec reviewer subagent (tasks/spec-reviewer-prompt.md)
+        ↓ (if spec compliance fails → implementer fixes → re-review)
+    ↓
+    Dispatch code quality reviewer subagent (tasks/code-quality-reviewer-prompt.md)
+        ↓ (if quality fails → implementer fixes → re-review)
+    ↓
+    Mark task complete in TodoWrite
+    ↓
+After all tasks:
+    ↓
+    Dispatch final code reviewer for entire implementation
+    ↓
+    Invoke verification-before-completion --task verify (MANDATORY)
+    ↓
+    Invoke finishing-a-development-branch --task checklist (MANDATORY)
+    ↓
+    Invoke git-workflow --task review-prep (MANDATORY)
+    ↓
+    HALT (no PR without explicit "create a PR")
+```
+
+## Model Selection
+
+Use the least powerful model that can handle each role to conserve cost and increase speed.
+
+| Task Type | Model Level | Examples |
+|-----------|-------------|----------|
+| Mechanical implementation (1-2 files, clear spec) | Cheap/fast | Typo fixes, isolated functions |
+| Integration (multi-file, pattern matching) | Standard | API integration, refactoring |
+| Architecture, design, review | Most capable | System design, complex reviews |
+
+**Task complexity signals:**
+- Touches 1-2 files with a complete spec → cheap model
+- Touches multiple files with integration concerns → standard model
+- Requires design judgment or broad codebase understanding → most capable model
+
+## Handling Implementer Status
+
+Implementer subagents report one of four statuses:
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| **DONE** | Work complete | Proceed to spec compliance review |
+| **DONE_WITH_CONCERNS** | Work complete but flagged doubts | Read concerns. If about correctness/scope → address before review. If observations → note and proceed |
+| **NEEDS_CONTEXT** | Missing information | Provide context and re-dispatch same model |
+| **BLOCKED** | Cannot complete | Provide context and re-dispatch, or escalate model, or break task into smaller pieces |
+
+**Never** ignore an escalation or force the same model to retry without changes.
+
+## Branch Model
+
+This project uses the `feature→dev→main` three-branch workflow:
+
+- Feature branches (`spec/` or `feature/`) branch FROM `dev`
+- Feature branches merge INTO `dev` via PR
+- Releases merge from `dev` to `main` (human-triggered)
+- Use `using-git-worktrees` skill for subagent isolation
+
+## Integration with Repo Workflow Skills
+
+| Phase | Skill | Purpose |
+|-------|-------|---------|
+| Pre-implementation | `approval-gate` | Verify authorization |
+| Branch creation | `git-workflow --task pre-work` or `using-git-worktrees` | Create feature branch |
+| Per-task | Implementer → spec review → code quality review loop | Execute tasks |
+| Post-implementation | `verification-before-completion --task verify` | Evidence collection |
+| Completion | `finishing-a-development-branch --task checklist` | Branch readiness |
+| Review prep | `git-workflow --task review-prep` | Push, URL, HALT |
+
+**Plans come from `writing-plans` skill output (not standalone).**
+
+## Prompt Templates
+
+- `tasks/implementer-prompt.md` — Dispatch implementer subagent
+- `tasks/spec-reviewer-prompt.md` — Dispatch spec compliance reviewer subagent
+- `tasks/code-quality-reviewer-prompt.md` — Dispatch code quality reviewer subagent
+
+## Example Workflow
+
+```
+1. Read plan, extract 5 tasks with full text
+2. Create TodoWrite with all 5 tasks
+
+Task 1: Hook installation script
+   → Dispatch implementer (cheap model, 1-2 files)
+   → Implementer self-reviews, commits
+   → Dispatch spec reviewer: ✅ compliant
+   → Dispatch code quality reviewer: ✅ approved
+   → Mark Task 1 complete
+
+Task 2: Recovery modes (integration concerns)
+   → Dispatch implementer (standard model)
+   → Implementer: DONE_WITH_CONCERNS (noted file size)
+   → Read concerns — observation only, proceed
+   → Dispatch spec reviewer: ❌ missing progress reporting
+   → Implementer fixes: adds progress reporting
+   → Spec reviewer: ✅ compliant now
+   → Dispatch code quality reviewer: ⚠️ magic number
+   → Implementer fixes: extracts constant
+   → Code reviewer: ✅ approved
+   → Mark Task 2 complete
+
+... (Tasks 3-5 similar)
+
+After all tasks:
+   → Dispatch final code reviewer (most capable model)
+   → All requirements met, ready for merge
+   → verification-before-completion --task verify (MANDATORY)
+   → finishing-a-development-branch --task checklist (MANDATORY)
+   → git-workflow --task review-prep (MANDATORY)
+   → Report completion + HALT
+```
+
+## Red Flags
+
+**Never:**
+- Skip approval-gate before starting
+- Skip git-workflow pre-work or worktree setup
+- Skip reviews (spec compliance OR code quality)
+- Proceed with unfixed review issues
+- Start code quality review before spec compliance passes
+- Dispatch multiple implementation subagents in parallel (conflicts)
+- Make subagent read plan file (provide full text instead)
+- Skip scene-setting context
+- Ignore subagent questions
+- Accept "close enough" on spec compliance
+- Skip review loops
+- Let implementer self-review replace actual review (both needed)
+- Skip verification-before-completion after all tasks
+- Skip finishing-a-development-branch checklist
+- Skip review-prep before HALT
+- Create PR without explicit "create a PR" instruction
+
+**If reviewer finds issues:**
+- Implementer (same subagent) fixes them
+- Reviewer reviews again
+- Repeat until approved
+- Don't skip re-review
+
+**If subagent fails (BLOCKED or NEEDS_CONTEXT):**
+- Provide context and re-dispatch
+- Escalate to more capable model if needed
+- Break task into smaller pieces if too large
+- Don't try to fix manually (context pollution)
+
+## Dispatch Table Integration
+
+This skill integrates with the repo's mandatory workflow:
+
+```
+approval-gate (authorization)
+    ↓
+subagent-driven-development (this skill)
+    → pre-work: git-workflow or using-git-worktrees
+    → per-task: implementer → spec review → code quality review
+    → post-implementation: verification-before-completion
+    → completion: finishing-a-development-branch
+    → review-prep: git-workflow
+    ↓
+Wait for "create a PR" (explicit instruction)
+```
+
+## Coexistence with Implementation-Workflow
+
+- **`subagent-driven-development`**: For plans with independent tasks where fresh context per task is beneficial
+- **`implementation-workflow`**: For sequential orchestration with yield-back context passing
+- Both enforce the same mandatory post-implementation gates
+- Both use `git-workflow` for git operations
+- Choice depends on task independence and context isolation needs
+
+Co-authored with AI: OpenCode (ollama-cloud/glm-5)

--- a/.opencode/skills/subagent-driven-development/tasks/code-quality-reviewer-prompt.md
+++ b/.opencode/skills/subagent-driven-development/tasks/code-quality-reviewer-prompt.md
@@ -1,0 +1,90 @@
+# Code Quality Reviewer Prompt Template
+
+Use this template when dispatching a code quality reviewer subagent.
+
+**Purpose:** Verify implementation is well-built (clean, tested, maintainable)
+
+**Only dispatch after spec compliance review passes.**
+
+**Source attribution:** This prompt pattern is adapted from [obra/superpowers `subagent-driven-development`](https://github.com/obra/superpowers/tree/main/skills/subagent-driven-development).
+
+**Dispatch AFTER spec compliance review passes. Never dispatch code quality review before spec compliance is ✅.**
+
+```
+Task tool (general-purpose):
+  description: "Review code quality for Task N"
+  prompt: |
+    You are reviewing code quality for an implementation that has passed spec compliance review.
+
+    ## What Was Requested
+
+    [FULL TEXT of task requirements]
+
+    ## What Was Implemented
+
+    [From implementer's report]
+
+    ## Changes to Review
+
+    Base commit: [commit before task]
+    Head commit: [current commit]
+
+    Review the git diff between these commits.
+
+    ## Code Quality Assessment
+
+    ### Critical (Must Fix)
+    - Security vulnerabilities
+    - Data loss risks
+    - Race conditions
+    - Breaking changes to public APIs
+    - Missing error handling for expected failure modes
+
+    ### Important (Should Fix)
+    - Poor names that don't communicate intent
+    - Functions that are too long or do too much
+    - Missing or insufficient tests for critical paths
+    - Dead code or unused imports
+    - Magic numbers without named constants
+    - Inconsistent error handling patterns
+
+    ### Minor (Nice to Have)
+    - Style nitpicks
+    - Minor naming improvements
+    - Documentation improvements
+    - Minor test improvements
+
+    ## File Decomposition Review
+
+    In addition to standard code quality, check:
+    - Does each file have one clear responsibility with a well-defined interface?
+    - Are units decomposed so they can be understood and tested independently?
+    - Is the implementation following the file structure from the plan?
+    - Did this implementation create new files that are already large, or significantly
+      grow existing files? (Don't flag pre-existing file sizes — focus on what this
+      change contributed.)
+
+    ## Branch Model Context
+
+    This project uses the `feature→dev→main` three-branch workflow:
+    - Verify changes are on the correct feature branch (spec/ or feature/)
+    - Verify no accidental changes to main or dev branches
+    - Verify commit messages follow project conventions
+
+    ## Report Format
+
+    **Strengths:** [What's done well]
+
+    **Issues:**
+    - Critical: [Must fix before proceeding]
+    - Important: [Should fix, may proceed with justification]
+    - Minor: [Nice to have]
+
+    **Assessment:** APPROVED | NEEDS_CHANGES
+
+    If NEEDS_CHANGES, list specific items that must be fixed. The implementer will
+    fix these and re-dispatch this reviewer.
+
+    If all issues are Minor only, you MAY approve with suggestions noted.
+    If ANY Critical or Important issues exist, you MUST mark NEEDS_CHANGES.
+```

--- a/.opencode/skills/subagent-driven-development/tasks/implementer-prompt.md
+++ b/.opencode/skills/subagent-driven-development/tasks/implementer-prompt.md
@@ -1,0 +1,122 @@
+# Implementer Subagent Prompt Template
+
+Use this template when dispatching an implementer subagent.
+
+**Source attribution:** This prompt pattern is adapted from [obra/superpowers `subagent-driven-development`](https://github.com/obra/superpowers/tree/main/skills/subagent-driven-development).
+
+```
+Task tool (general-purpose):
+  description: "Implement Task N: [task name]"
+  prompt: |
+    You are implementing Task N: [task name]
+
+    ## Task Description
+
+    [FULL TEXT of task from plan - paste it here, don't make subagent read file]
+
+    ## Context
+
+    [Scene-setting: where this fits, dependencies, architectural context, branch name, related files]
+
+    ## Before You Begin
+
+    If you have questions about:
+    - The requirements or acceptance criteria
+    - The approach or implementation strategy
+    - Dependencies or assumptions
+    - Anything unclear in the task description
+
+    **Ask them now.** Raise any concerns before starting work.
+
+    ## Your Job
+
+    Once you're clear on requirements:
+    1. Implement exactly what the task specifies
+    2. Write tests (following TDD if task says to)
+    3. Verify implementation works
+    4. Commit your work
+    5. Self-review (see below)
+    6. Report back
+
+    Work from: [directory]
+
+    **While you work:** If you encounter something unexpected or unclear, **ask questions**.
+    It's always OK to pause and clarify. Don't guess or make assumptions.
+
+    ## Code Organization
+
+    You reason best about code you can hold in context at once, and your edits are more
+    reliable when files are focused. Keep this in mind:
+    - Follow the file structure defined in the plan
+    - Each file should have one clear responsibility with a well-defined interface
+    - If a file you're creating is growing beyond the plan's intent, stop and report
+      it as DONE_WITH_CONCERNS — don't split files on your own without plan guidance
+    - If an existing file you're modifying is already large or tangled, work carefully
+      and note it as a concern in your report
+    - In existing codebases, follow established patterns. Improve code you're touching
+      the way a good developer would, but don't restructure things outside your task.
+
+    ## When You're in Over Your Head
+
+    It is always OK to stop and say "this is too hard for me." Bad work is worse than
+    no work. You will not be penalized for escalating.
+
+    **STOP and escalate when:**
+    - The task requires architectural decisions with multiple valid approaches
+    - You need to understand code beyond what was provided and can't find clarity
+    - You feel uncertain about whether your approach is correct
+    - The task involves restructuring existing code in ways the plan didn't anticipate
+    - You've been reading file after file trying to understand the system without progress
+
+    **How to escalate:** Report back with status BLOCKED or NEEDS_CONTEXT. Describe
+    specifically what you're stuck on, what you've tried, and what kind of help you need.
+
+    ## Before Reporting Back: Self-Review
+
+    Review your work with fresh eyes. Ask yourself:
+
+    **Completeness:**
+    - Did I fully implement everything in the spec?
+    - Did I miss any requirements?
+    - Are there edge cases I didn't handle?
+
+    **Quality:**
+    - Is this my best work?
+    - Are names clear and accurate (match what things do, not how they work)?
+    - Is the code clean and maintainable?
+
+    **Discipline:**
+    - Did I avoid overbuilding (YAGNI)?
+    - Did I only build what was requested?
+    - Did I follow existing patterns in the codebase?
+
+    **Testing:**
+    - Do tests actually verify behavior (not just mock behavior)?
+    - Did I follow TDD if required?
+    - Are tests comprehensive?
+
+    If you find issues during self-review, fix them now before reporting.
+
+    ## Report Format
+
+    When done, report:
+    - **Status:** DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    - What you implemented (or what you attempted, if blocked)
+    - What you tested and test results
+    - Files changed
+    - Self-review findings (if any)
+    - Any issues or concerns
+
+    Use DONE_WITH_CONCERNS if you completed the work but have doubts about correctness.
+    Use BLOCKED if you cannot complete the task. Use NEEDS_CONTEXT if you need
+    information that wasn't provided. Never silently produce work you're unsure about.
+
+    ## Branch and Commit Rules
+
+    - You are working on branch: [branch-name]
+    - Feature branches target `dev`, not `main`
+    - Commit with descriptive messages
+    - Include co-author trailer: Co-authored-by: OpenCode (<model-id>)
+    - Run lint and typecheck before committing
+    - Run tests to verify your changes work
+```

--- a/.opencode/skills/subagent-driven-development/tasks/spec-reviewer-prompt.md
+++ b/.opencode/skills/subagent-driven-development/tasks/spec-reviewer-prompt.md
@@ -1,0 +1,77 @@
+# Spec Compliance Reviewer Prompt Template
+
+Use this template when dispatching a spec compliance reviewer subagent.
+
+**Purpose:** Verify implementer built what was requested (nothing more, nothing less)
+
+**Source attribution:** This prompt pattern is adapted from [obra/superpowers `subagent-driven-development`](https://github.com/obra/superpowers/tree/main/skills/subagent-driven-development).
+
+```
+Task tool (general-purpose):
+  description: "Review spec compliance for Task N"
+  prompt: |
+    You are reviewing whether an implementation matches its specification.
+
+    ## What Was Requested
+
+    [FULL TEXT of task requirements]
+
+    ## What Implementer Claims They Built
+
+    [From implementer's report]
+
+    ## CRITICAL: Do Not Trust the Report
+
+    The implementer finished suspiciously quickly. Their report may be incomplete,
+    inaccurate, or optimistic. You MUST verify everything independently.
+
+    **DO NOT:**
+    - Take their word for what they implemented
+    - Trust their claims about completeness
+    - Accept their interpretation of requirements
+
+    **DO:**
+    - Read the actual code they wrote
+    - Compare actual implementation to requirements line by line
+    - Check for missing pieces they claimed to implement
+    - Look for extra features they didn't mention
+
+    ## Your Job
+
+    Read the implementation code and verify:
+
+    **Missing requirements:**
+    - Did they implement everything that was requested?
+    - Are there requirements they skipped or missed?
+    - Did they claim something works but didn't actually implement it?
+
+    **Extra/unneeded work:**
+    - Did they build things that weren't requested?
+    - Did they over-engineer or add unnecessary features?
+    - Did they add "nice to haves" that weren't in spec?
+
+    **Misunderstandings:**
+    - Did they interpret requirements differently than intended?
+    - Did they solve the wrong problem?
+    - Did they implement the right feature but wrong way?
+
+    **Verify by reading code, not by trusting report.**
+
+    ## Branch Model Context
+
+    This project uses the `feature→dev→main` three-branch workflow:
+    - Feature branches target `dev`, not `main`
+    - Verify changes are on the correct feature branch
+    - Verify no changes to `main` or `dev` branches
+
+    ## Integration Checklist
+
+    Verify the implementation integrates correctly with repo workflow skills:
+    - Does it follow established patterns in the codebase?
+    - Does it conflict with any existing workflow gates?
+    - Are there any missing integration points with approval-gate, git-workflow, or verification skills?
+
+    Report:
+    - ✅ Spec compliant (if everything matches after code inspection)
+    - ❌ Issues found: [list specifically what's missing or extra, with file:line references]
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/subagent-driven-development
+
+- Add `subagent-driven-development` skill adapted from obra/superpowers
+- Create implementer, spec-reviewer, and code-quality-reviewer prompt templates
+- Implement two-stage review per task (spec compliance then code quality)
+- Document model selection guidance for cheap/standard/capable models
+- Add implementer status handling (DONE, DONE_WITH_CONCERNS, NEEDS_CONTEXT, BLOCKED)
+- Integrate with approval-gate, git-workflow, verification-before-completion, finishing-a-development-branch
+- Document when to use subagent-driven-development vs implementation-workflow
+- Add cross-references to implementation-workflow, executing-plans, and dispatch-table
+- Include source attribution to obra/superpowers in all adapted files
+
 ### spec/556-writing-plans-enhancement
 
 - Add TDD step granularity within phases (failing test → verify fail → implement → verify pass → commit)


### PR DESCRIPTION
## Summary

Add `subagent-driven-development` skill adapted from [obra/superpowers](https://github.com/obra/superpowers/tree/main/skills/subagent-driven-development) that dispatches fresh subagents per task with mandatory two-stage review (spec compliance then code quality), integrated with the repo's feature→dev→main workflow gates.

## Outcome

Agents can now execute implementation plans by dispatching isolated subagents per task, with automatic spec compliance and code quality review loops ensuring each task meets requirements before proceeding.

Fixes #555
Fixes #559
Fixes #560