### PR TITLE
[SPEC] Approval Cascade Gap — Sub-issue creation as pre-implementation setup step

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -346,7 +346,7 @@ ______________________________________________________________________
 **🚫 FORBIDDEN:**
 
 - Implementing a phase that exists only as text in the parent issue body
-- Proceeding when `get_sub_issues` returns empty array for multi-task specs
+- Proceeding **to implementation** when `get_sub_issues` returns empty array for multi-task specs **without creating sub-issues first**
 - Assuming markdown checkboxes = task tracking
 - Creating step-level sub-issues instead of phase-level
 
@@ -355,8 +355,13 @@ ______________________________________________________________________
 - Sub-issues at PHASE level, not step level
 - Each phase as separate GitHub Issue linked via `github_sub_issue_write method=add`
 - Single-task specs are exempt from sub-issue requirement
+- Auto-create sub-issues as a pre-implementation setup step when `get_sub_issues` returns empty for an approved multi-task spec
+
+**The prohibition is against implementing phases without sub-issue structure, NOT against auto-creating sub-issues as a setup step.** Sub-issue creation is a tracking/setup action covered by the parent spec's authorization — no separate authorization is required.
 
 **See `github-sub-issues` skill for complete workflow including single-task vs multi-task exemption, auto-create workflow, database ID requirement, and phase-level structure.**
+
+**Note:** Sub-issue auto-creation is NOT a violation of this prohibition. Auto-creating sub-issues and then proceeding to implementation is the CORRECT workflow. The prohibition is against implementing phases while sub-issues are still missing, NOT against the auto-creation step itself.
 
 ______________________________________________________________________
 

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -84,7 +84,7 @@ This rule applies universally to:
 
 ### 🚫 ABSOLUTE PROHIBITION
 - **NEVER implement a multi-task spec without verified sub-issue structure**
-- **NEVER proceed when `get_sub_issues` returns empty array for multi-task specs**
+- **NEVER proceed **to implementation** when `get_sub_issues` returns empty array for multi-task specs **without auto-creating sub-issues first****
 - **NEVER assume markdown checkboxes = task tracking**
 
 ### ✅ MANDATORY
@@ -95,3 +95,5 @@ Key points:
 - Sub-issues at PHASE level, not step level
 - Single-task specs are exempt from sub-issue requirement
 - All multi-task specs MUST have sub-issues before implementation begins
+- Auto-creating sub-issues for an approved multi-task spec is a pre-implementation setup step covered by the parent's authorization. No separate authorization is required.
+- After auto-creating sub-issues, the agent proceeds with implementation immediately (no re-authorization needed).

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -118,6 +118,35 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 - Developer already approved the entire spec—redundant per-phase HALTs waste time
 - Sub-issue database IDs link phases to parent for GitHub's hierarchy view
 
+## Sub-Issue Creation Authorization
+
+**When a multi-task spec is approved and has no sub-issues yet, the authorization cascade covers sub-issue creation as a pre-implementation setup step. No separate authorization is needed.**
+
+### Authorization Cascade Table (Extended)
+
+| Authorization | Sub-issues Exist? | Action |
+|---------------|-------------------|--------|
+| `#34 approved` (parent) | Yes | Cascade to all, proceed with implementation |
+| `#34 approved` (parent) | No | Auto-create sub-issues, then cascade, then proceed with implementation |
+| `#39 approved` (single sub-issue) | N/A | That sub-issue only, complete and HALT |
+| `approved: 1.2` (specific phase) | N/A | That phase only, complete and HALT |
+
+**Sub-issue creation is NOT an implementation action.** It is a tracking/setup action that falls under the existing authorization scope. Creating GitHub Issues for phase tracking does not modify the codebase, does not change files, and does not require separate human approval.
+
+### Pre-Implementation Setup Steps (No Separate Authorization Required)
+
+| Step | Requires Separate Auth? | Why |
+|------|------------------------|-----|
+| Auto-creating sub-issues | ❌ NO | Tracking/setup action, covered by parent authorization |
+| Linking sub-issues to parent | ❌ NO | Part of sub-issue creation workflow |
+| Proceeding to implementation after auto-creation | ❌ NO | Parent authorization continues to implementation |
+
+### Prohibited Halts
+
+- 🚫 PROHIBITED: Halting after authorization to ask for separate permission to create sub-issues. Sub-issue creation is a setup step, not an implementation action requiring separate authorization.
+- 🚫 PROHIBITED: Treating 'empty sub-issues' as a blocking gate that requires human intervention. The auto-create workflow resolves empty sub-issues without human involvement.
+- ✅ REQUIRED: When `get_sub_issues` returns empty for an approved multi-task spec, auto-create sub-issues and proceed to implementation in the same session.
+
 ## Post-Implementation Workflow
 
 ### After Implementation Completes

--- a/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
@@ -9,6 +9,7 @@ Verify sub-issue structure and STATUS gate for multi-task specs before implement
 - Spec exists as GitHub Issue
 - Authorization received for specific subtask (e.g., "approved: 1.2")
 - Subtask number provided or extracted from authorization
+- Authorization received for parent spec (covers sub-issue creation)
 
 ## Exit Criteria
 
@@ -84,6 +85,8 @@ sub_issues = github_issue_read(method="get_sub_issues", issue_number=parent_issu
 
 If empty AND multi-task:
 
+**No separate authorization required.** Parent approval covers sub-issue creation as a setup step.
+
 ```python
 # For each PHASE in spec:
 issue = github_issue_write(
@@ -99,9 +102,21 @@ github_sub_issue_write(
 )
 ```
 
+Auto-creating sub-issues for an approved multi-task spec does NOT require separate authorization. The parent's authorization covers this setup step.
+
 ### Step 5: Post Comment
 
 "Created N sub-issues for phase tracking."
+
+## Auto-Create Authorization
+
+**Auto-creating sub-issues for an approved multi-task spec does NOT require separate authorization.** The parent's authorization covers this setup step.
+
+| Action | Requires Separate Auth? | Why |
+|--------|------------------------|-----|
+| Auto-creating sub-issues | ❌ NO | Tracking/setup action, covered by parent authorization |
+| Linking sub-issues to parent | ❌ NO | Part of sub-issue creation workflow |
+| Proceeding to implementation after auto-creation | ❌ NO | Parent authorization continues to implementation |
 
 ## STATUS Gate Rules
 
@@ -137,7 +152,7 @@ github_sub_issue_write(
 ## Forbidden Actions
 
 - Implementing phase without verified sub-issue structure
-- Proceeding when `get_sub_issues` returns empty for multi-task specs
+- Proceeding **to implementation** when `get_sub_issues` returns empty for multi-task specs **without creating sub-issues first**
 - Creating step-level sub-issues (use PHASE level)
 - Assuming markdown checkboxes = task tracking
 - Implementing when STATUS doesn't match authorized subtask

--- a/.opencode/skills/github-sub-issues/SKILL.md
+++ b/.opencode/skills/github-sub-issues/SKILL.md
@@ -54,10 +54,12 @@ If multi-task: Sub-issues are MANDATORY.
    - Verify phase being implemented is among them
    - Proceed with implementation
 
+**Authorization for the parent spec covers sub-issue creation.** When `get_sub_issues` returns empty for an approved multi-task spec, auto-create sub-issues immediately and proceed — no separate authorization needed.
+
 ### 🚫 FORBIDDEN
 
 - Implementing phase that exists only as text in parent issue body
-- Proceeding when `get_sub_issues` returns empty (for multi-task specs) without creating sub-issues
+- Proceeding **to implementation** when `get_sub_issues` returns empty (for multi-task specs) **without creating sub-issues first**
 - Assuming markdown checkboxes = task tracking
 - Creating step-level sub-issues (create PHASE-level only)
 
@@ -66,6 +68,8 @@ If multi-task: Sub-issues are MANDATORY.
 ## Auto-Create Workflow
 
 **When multi-task spec has NO sub-issues:**
+
+**This step is covered by the parent spec's authorization. No separate 'approved' or 'go' is needed.**
 
 ```
 For each PHASE in spec:
@@ -83,6 +87,12 @@ Proceed to implement first phase
 - Use `.id` field from response (e.g., `4129879155`)
 - NOT the issue number (e.g., `10`)
 - Get via `github_issue_read method=get` response
+
+### Prohibited Halts
+
+- 🚫 PROHIBITED: Halting to ask 'should I create sub-issues?' when the parent spec is already approved. Sub-issue creation is automatic.
+- 🚫 PROHIBITED: Treating sub-issue creation as a separate implementation phase requiring its own authorization cycle.
+- ✅ REQUIRED: Auto-create sub-issues immediately upon finding empty sub-issues on an approved multi-task spec, then proceed to implementation.
 
 ---
 


### PR DESCRIPTION
**Summary:**

Resolved the approval cascade gap where agents halted on approved multi-task specs with zero sub-issues, treating sub-issue creation as a blocking authorization gate instead of a pre-implementation setup step covered by the parent's authorization.

**Outcome:** Agents will auto-create sub-issues and proceed to implementation without halting for separate authorization when encountering an approved multi-task spec with zero sub-issues.

Fixes #572
Fixes #574
Fixes #575
Fixes #576