### PR TITLE
[SPEC] Isolated Test Environment for opencode-cli Skill Testing

### DIFF
--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -2,4 +2,5 @@ node_modules
 package.json
 package-lock.json
 bun.lock
+tmp/
 .gitignore

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -7,35 +7,27 @@
 # Runs opencode-cli run sequentially for each test scenario.
 # No server needed - uses standalone mode.
 #
-# PREREQUISITE: Run from a terminal with NO active opencode session.
-# Running from inside an opencode session will fail with "Session not found"
-# due to SQLite database lock contention.
+# Uses with-test-home wrapper to isolate XDG state, allowing tests to
+# run from within an active opencode desktop session without conflicts.
 #
 # Usage:  bash .opencode/tests/test-enforcement.sh
-# Output: tmp/enforcement-test-<timestamp>/results.md
+# Output: .opencode/tmp/enforcement-test-<timestamp>/results.md
 
 set -euo pipefail
 
-PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOGDIR="$PROJECT_DIR/tmp/enforcement-test-$(date +%Y%m%d-%H%M%S)"
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOGDIR="$PROJECT_DIR/.opencode/tmp/enforcement-test-$(date +%Y%m%d-%H%M%S)"
 mkdir -p "$LOGDIR"
 
 TIMEOUT=120
 MODEL="${ENFORCEMENT_TEST_MODEL:-ollama-cloud/glm-5.1}"
+WITH_TEST_HOME="$PROJECT_DIR/.opencode/tests/with-test-home"
 
 echo "=== Enforcement Integration Test ==="
 echo "Log dir: $LOGDIR"
 echo "Model: $MODEL"
-echo "Mode: standalone (no server)"
+echo "Mode: isolated (with-test-home wrapper)"
 echo ""
-
-# Check no active opencode session is locking the DB
-if fuser "$HOME/.local/share/opencode/opencode.db" > /dev/null 2>&1; then
-    echo "WARNING: opencode database appears locked by another process."
-    echo "         This test may fail with 'Session not found'."
-    echo "         Close any active opencode sessions and re-run."
-    echo ""
-fi
 
 # Test scenarios: name -> "prompt message"
 declare -A SCENARIOS
@@ -57,7 +49,7 @@ echo "# Enforcement Integration Test Results" > "$RESULTS_FILE"
 echo "" >> "$RESULTS_FILE"
 echo "Date: $(date -Iseconds)" >> "$RESULTS_FILE"
 echo "Model: $MODEL" >> "$RESULTS_FILE"
-echo "Mode: standalone" >> "$RESULTS_FILE"
+echo "Mode: isolated (with-test-home)" >> "$RESULTS_FILE"
 echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
@@ -79,9 +71,9 @@ for scenario_name in bug-report create-spec simple-question implement-request; d
     echo "**Expected skill:** ${EXPECTED:-none}" >> "$RESULTS_FILE"
     echo "" >> "$RESULTS_FILE"
 
-    # Run opencode-cli in standalone mode
+    # Run opencode-cli in isolated mode via with-test-home wrapper
     # --print-logs goes to stderr, formatted output to stdout
-    timeout $TIMEOUT opencode-cli run "$MESSAGE" \
+    timeout $TIMEOUT bash "$WITH_TEST_HOME" opencode-cli run "$MESSAGE" \
         --model "$MODEL" \
         --print-logs \
         > "$SCENARIO_OUT" 2> "$SCENARIO_LOG" \

--- a/.opencode/tests/with-test-home
+++ b/.opencode/tests/with-test-home
@@ -1,0 +1,114 @@
+#!/bin/bash
+# with-test-home — Run a command in an isolated XDG environment for opencode-cli testing.
+#
+# Creates a project-relative temporary home directory with clean XDG state,
+# eliminating SQLite session conflicts between opencode desktop and CLI.
+#
+# Usage:
+#   bash .opencode/tests/with-test-home <command> [args...]
+#   bash .opencode/tests/with-test-home --clean
+#   bash .opencode/tests/with-test-home --clean-all
+#   bash .opencode/tests/with-test-home --keep <command> [args...]   (default)
+#
+# Options:
+#   --keep       Preserve test home after execution (default)
+#   --clean      Remove the most recent test home directory
+#   --clean-all  Remove ALL test home directories under .opencode/tmp/
+#
+# Exit codes:
+#   0  - Command succeeded (or clean succeeded)
+#   1  - Script error or command failed
+#   2  - Usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TMP_DIR="$PROJECT_DIR/.opencode/tmp"
+
+usage() {
+    echo "Usage: bash .opencode/tests/with-test-home [--keep|--clean|--clean-all] <command> [args...]" >&2
+    echo "" >&2
+    echo "  --keep       Preserve test home after execution (default)" >&2
+    echo "  --clean      Remove the most recent test home directory" >&2
+    echo "  --clean-all  Remove ALL test home directories under .opencode/tmp/" >&2
+    exit 2
+}
+
+do_clean() {
+    local latest
+    latest="$(find "$TMP_DIR" -maxdepth 1 -mindepth 1 -type d -name 'test-home-*' 2>/dev/null | sort | tail -1)"
+    if [ -z "$latest" ]; then
+        echo "No test home directories found to clean." >&2
+        return 0
+    fi
+    echo "Removing: $latest" >&2
+    rm -rf "$latest"
+    echo "Clean removed: $(basename "$latest")" >&2
+    return 0
+}
+
+do_clean_all() {
+    local count
+    count="$(find "$TMP_DIR" -maxdepth 1 -mindepth 1 -type d -name 'test-home-*' 2>/dev/null | wc -l)"
+    if [ "$count" -eq 0 ]; then
+        echo "No test home directories found to clean." >&2
+        return 0
+    fi
+    echo "Removing $count test home directories..." >&2
+    find "$TMP_DIR" -maxdepth 1 -mindepth 1 -type d -name 'test-home-*' -exec rm -rf {} +
+    echo "All test home directories removed." >&2
+    return 0
+}
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+case "${1:-}" in
+    --clean)
+        do_clean
+        exit $?
+        ;;
+    --clean-all)
+        do_clean_all
+        exit $?
+        ;;
+    --keep)
+        shift
+        ;;
+    --)
+        shift
+        ;;
+esac
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+TEST_HOME="$TMP_DIR/test-home-$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "$TEST_HOME/.config"
+mkdir -p "$TEST_HOME/.cache"
+mkdir -p "$TEST_HOME/.local/share"
+mkdir -p "$TEST_HOME/.local/state"
+
+echo "Test home: $TEST_HOME" >&2
+
+env -i \
+    HOME="$TEST_HOME" \
+    XDG_CONFIG_HOME="$TEST_HOME/.config" \
+    XDG_CACHE_HOME="$TEST_HOME/.cache" \
+    XDG_DATA_HOME="$TEST_HOME/.local/share" \
+    XDG_STATE_HOME="$TEST_HOME/.local/state" \
+    PATH="$PATH" \
+    USER="$USER" \
+    TERM="${TERM:-xterm-256color}" \
+    "$@"
+
+EXIT_CODE=$?
+
+echo "Test home preserved at: $TEST_HOME" >&2
+echo "Use 'bash .opencode/tests/with-test-home --clean' to remove." >&2
+
+exit $EXIT_CODE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,8 +187,13 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 | Dead code scan | `uvx vulture src/` | Python ONLY |
 | Markdown lint | `uvx pymarkdownlnt scan -r .opencode/guidelines/ docs/` | Markdown ONLY |
 | Markdown format | `uvx mdformat .opencode/guidelines/ docs/` | Markdown ONLY |
+| Skill enforcement test | `bash .opencode/tests/test-enforcement.sh` | opencode-cli |
+| Isolated opencode-cli run | `bash .opencode/tests/with-test-home opencode-cli run '<message>'` | opencode-cli |
+| Clean test artifacts | `bash .opencode/tests/with-test-home --clean` | opencode-cli |
 
 **Never** use bare `python`, `python3`, or `pip`. Always prefix with `uv run` for project commands.
+
+**Isolated test environment:** The `with-test-home` wrapper isolates opencode-cli XDG state into a project-relative temporary home (`./opencode/tmp/test-home-<timestamp>`), eliminating SQLite session conflicts with the desktop app. This allows skill enforcement tests to run from within an active opencode session.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/573-isolated-test-env
+
+- Add `.opencode/tests/with-test-home` wrapper script for isolated XDG state during opencode-cli testing
+- Refactor `.opencode/tests/test-enforcement.sh` to use with-test-home, removing PREREQUISITE session limitation
+- Add `tmp/` to `.opencode/.gitignore` to exclude test artifacts
+- Add skill enforcement test commands to AGENTS.md Build/Lint/Test table
+
 ### spec/570-context-completeness
 
 - Add `067-context-completeness.md` guideline requiring agents to read ALL comments before acting on any resource (issue, PR, discussion)


### PR DESCRIPTION
**Summary:**

Enables opencode-cli skill testing from within an active opencode desktop session by isolating XDG state into a project-relative temporary home directory, eliminating the "Session not found" SQLite lock contention that previously blocked in-session testing.

**Outcome:** AI agents and developers can now run `bash .opencode/tests/test-enforcement.sh` from any terminal — including active opencode sessions — without session conflicts.

Fixes #573
Fixes #578
Fixes #579
Fixes #580