### PR TITLE
[SPEC-FIX] Ban --recursive flag from all git submodule commands in skills and guidelines

### DIFF
--- a/.opencode/guidelines/060-tool-usage.md
+++ b/.opencode/guidelines/060-tool-usage.md
@@ -69,6 +69,7 @@ ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance,
 - **ZERO TOLERANCE — NEVER edit or modify production data or database seed files.** All changes to production data MUST be performed by a human developer.
 - **Multi-line shell loops are strictly forbidden.** Never use `for`, `while`, or `until`.
 - **NEVER use `sed` for file edits — it is unreliable for structured formats.** The Edit tool handles escaping and encoding correctly; sed does not.
+- **NEVER use `--recursive` with any git submodule command** (e.g., `git submodule update --init --recursive`, `git clone --recursive`). The `--recursive` flag can pull in unintended nested submodules, cause unexpected network traffic, break reproducibility by implicitly resolving submodule chains, and conflict with explicit submodule management. Always use `git submodule update --init` (without `--recursive`) or explicit per-submodule operations.
 
 ## 5. Verification & Audit
 


### PR DESCRIPTION
## Summary

Added prohibition against the `--recursive` flag in git submodule commands to the agent guidelines (`060-tool-usage.md`). The `--recursive` flag can pull in unintended nested submodules, cause unexpected network traffic, break reproducibility, and conflict with explicit submodule management strategies.

## Outcome

Agents will now have an explicit rule preventing use of `--recursive` with git submodule commands, keeping submodule operations predictable and controlled.

Fixes #594