### PR TITLE
[SPEC] Remove hardcoded org/user/identity values from skills

### DIFF
--- a/.opencode/skills/changelog-generator/tasks/since-last-release.md
+++ b/.opencode/skills/changelog-generator/tasks/since-last-release.md
@@ -126,7 +126,7 @@ Look for conventional commit prefixes:
 
 For merge commits like:
 ```
-Merge pull request #120 from NewsRx/spec/cleanup-succinct-output
+Merge pull request #120 from <GIT_OWNER>/spec/example-branch-name
 Fix cleanup task to use succinct confirmation output
 ```
 

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -10,9 +10,9 @@ compatibility: opencode
 
 ## Overview
 
-Plan execution workflow that implements approved plans step-by-step with verification at each stage. This skill ensures systematic implementation, evidence collection, and quality gates. It is adapted from the NewsRx/opencode-gitbucket-superpowers workflow.
+Plan execution workflow that implements approved plans step-by-step with verification at each stage. This skill ensures systematic implementation, evidence collection, and quality gates. It is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow.
 
-**Source Attribution:** This skill is adapted from NewsRx/opencode-gitbucket-superpowers workflow (branch: newsrx).
+**Source Attribution:** This skill is adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
 
 ## Persona
 
@@ -281,7 +281,7 @@ writing-plans (approved) → approval-gate (plan) → executing-plans → verifi
 
 ## Source Attribution
 
-This skill is adapted from the NewsRx/opencode-gitbucket-superpowers repository (branch: newsrx). The original workflow enforces systematic step-by-step execution with evidence collection.
+This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow enforces systematic step-by-step execution with evidence collection.
 
 **Key adaptations for OpenCode:**
 - Integration with existing git-workflow skill for branch management

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -10,9 +10,9 @@ compatibility: opencode
 
 ## Overview
 
-Branch completion workflow that ensures a feature branch is fully ready for PR creation. This skill verifies all changes are committed, tested, pushed, and reviewed before the developer creates a PR. It is adapted from the NewsRx/opencode-gitbucket-superpowers workflow.
+Branch completion workflow that ensures a feature branch is fully ready for PR creation. This skill verifies all changes are committed, tested, pushed, and reviewed before the developer creates a PR. It is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow.
 
-**Source Attribution:** This skill is adapted from NewsRx/opencode-gitbucket-superpowers workflow (branch: newsrx).
+**Source Attribution:** This skill is adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
 
 ## Persona
 
@@ -210,7 +210,7 @@ executing-plans → verification-before-completion → finishing-a-development-b
 
 ## Source Attribution
 
-This skill is adapted from the NewsRx/opencode-gitbucket-superpowers repository (branch: newsrx). The original workflow ensures branches are fully verified before PR creation.
+This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow ensures branches are fully verified before PR creation.
 
 **Key adaptations for OpenCode:**
 - Integration with existing git-workflow skill

--- a/.opencode/skills/git-workflow/tasks/commit-prep.md
+++ b/.opencode/skills/git-workflow/tasks/commit-prep.md
@@ -115,7 +115,7 @@ Co-authored-by: OpenCode (glm-5) <noreply@opencode.ai>
 
 **Example:**
 ```
-Co-authored-by: Michael Conrad <michael@newsrx.com>
+Co-authored-by: <DEV_NAME> <DEV_EMAIL>
 ```
 
 ### Complete Example
@@ -123,7 +123,7 @@ Co-authored-by: Michael Conrad <michael@newsrx.com>
 ```bash
 git commit -m "feat: Add user authentication" \
     --trailer "Co-authored-by: OpenCode (glm-5) <noreply@opencode.ai>" \
-    --trailer "Co-authored-by: Michael Conrad <michael@newsrx.com>"
+    --trailer "Co-authored-by: <DEV_NAME> <DEV_EMAIL>"
 ```
 
 ## When Commits Happen

--- a/.opencode/skills/github-comments/SKILL.md
+++ b/.opencode/skills/github-comments/SKILL.md
@@ -112,7 +112,7 @@ Use standard bylines (Created, Completed, Updated) for:
 **Recommendation:** Update regex to allow hyphens in username patterns.
 
 ---
-🤖 ✎ on behalf of Michael Conrad
+🤖 ✎ on behalf of <DEV_NAME>
 ```
 
 **Issue Comment Posted for User:**
@@ -122,7 +122,7 @@ Use standard bylines (Created, Completed, Updated) for:
 Based on the investigation, the feature is ready for implementation. The API endpoints are designed and the database schema is finalized.
 
 ---
-🤖 ✎ on behalf of Michael Conrad
+🤖 ✎ on behalf of <DEV_NAME>
 ```
 
 ### Issue/PR Body Attribution (Lifecycle Status)

--- a/.opencode/skills/receiving-code-review/SKILL.md
+++ b/.opencode/skills/receiving-code-review/SKILL.md
@@ -10,9 +10,9 @@ compatibility: opencode
 
 ## Overview
 
-Workflow for responding to code review feedback on pull requests. This skill ensures all reviewer comments are addressed systematically, changes are minimal and targeted, and no scope creep occurs during review response. It is adapted from the NewsRx/opencode-gitbucket-superpowers workflow.
+Workflow for responding to code review feedback on pull requests. This skill ensures all reviewer comments are addressed systematically, changes are minimal and targeted, and no scope creep occurs during review response. It is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow.
 
-**Source Attribution:** This skill is adapted from NewsRx/opencode-gitbucket-superpowers workflow (branch: newsrx).
+**Source Attribution:** This skill is adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
 
 ## Persona
 
@@ -152,7 +152,7 @@ PR review received → receiving-code-review (address) → push changes → (rev
 
 ## Source Attribution
 
-This skill is adapted from the NewsRx/opencode-gitbucket-superpowers repository (branch: newsrx). The original workflow ensures review feedback is addressed precisely without scope expansion.
+This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow ensures review feedback is addressed precisely without scope expansion.
 
 **Key adaptations for OpenCode:**
 - Integration with existing git-workflow skill

--- a/.opencode/skills/requesting-code-review/SKILL.md
+++ b/.opencode/skills/requesting-code-review/SKILL.md
@@ -10,9 +10,9 @@ compatibility: opencode
 
 ## Overview
 
-Workflow for preparing and requesting code reviews. This skill ensures PR descriptions have proper context, reviewers can understand changes quickly, and review requests are targeted and informative. It is adapted from the NewsRx/opencode-gitbucket-superpowers workflow.
+Workflow for preparing and requesting code reviews. This skill ensures PR descriptions have proper context, reviewers can understand changes quickly, and review requests are targeted and informative. It is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow.
 
-**Source Attribution:** This skill is adapted from NewsRx/opencode-gitbucket-superpowers workflow (branch: newsrx).
+**Source Attribution:** This skill is adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
 
 ## Persona
 
@@ -228,7 +228,7 @@ finishing-a-development-branch → PR created by user → requesting-code-review
 
 ## Source Attribution
 
-This skill is adapted from the NewsRx/opencode-gitbucket-superpowers repository (branch: newsrx). The original workflow ensures review requests are comprehensive and targeted.
+This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow ensures review requests are comprehensive and targeted.
 
 **Key adaptations for OpenCode:**
 - Integration with existing git-workflow skill for branch management

--- a/.opencode/skills/systematic-debugging/SKILL.md
+++ b/.opencode/skills/systematic-debugging/SKILL.md
@@ -12,7 +12,7 @@ compatibility: opencode
 
 Systematic debugging process that enforces root cause analysis, hypothesis testing, and minimal fixes. This skill prevents "vibe debugging" — making random changes without understanding the problem. All bugs must be diagnosed before fixing, and fixes must be minimal and targeted.
 
-**Source Attribution:** This skill is adapted from NewsRx/opencode-gitbucket-superpowers workflow (branch: newsrx).
+**Source Attribution:** This skill is adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
 
 ## Persona
 
@@ -247,7 +247,7 @@ Bug reported → systematic-debugging (diagnose) → systematic-debugging (fix) 
 
 ## Source Attribution
 
-This skill is adapted from the NewsRx/opencode-gitbucket-superpowers repository (branch: newsrx). The original workflow enforces systematic debugging to prevent random code changes and ensure root cause fixes.
+This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow enforces systematic debugging to prevent random code changes and ensure root cause fixes.
 
 **Key adaptations for OpenCode:**
 - Integration with existing approval-gate and git-workflow skills

--- a/.opencode/skills/test-driven-development/SKILL.md
+++ b/.opencode/skills/test-driven-development/SKILL.md
@@ -12,7 +12,7 @@ compatibility: opencode
 
 Test-driven development (TDD) workflow that enforces writing tests before implementation code. Tests define the contract, implementation satisfies the contract, and refactoring maintains quality. This is an optional quality gate skill invoked contextually when the development approach benefits from TDD.
 
-**Source Attribution:** This skill is adapted from NewsRx/opencode-gitbucket-superpowers workflow (branch: newsrx).
+**Source Attribution:** This skill is adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
 
 ## Persona
 
@@ -210,7 +210,7 @@ This is an **optional** quality gate skill. It is not automatically enforced.
 
 ## Source Attribution
 
-This skill is adapted from the NewsRx/opencode-gitbucket-superpowers repository (branch: newsrx). The original workflow enforces test-driven development to ensure correctness and prevent regression.
+This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow enforces test-driven development to ensure correctness and prevent regression.
 
 **Key adaptations for OpenCode:**
 - Integrated with existing test framework (`pytest`)

--- a/.opencode/skills/verification-before-completion/SKILL.md
+++ b/.opencode/skills/verification-before-completion/SKILL.md
@@ -10,9 +10,9 @@ compatibility: opencode
 
 ## Overview
 
-Evidence-based verification workflow that prevents premature completion claims. This skill ensures ALL success criteria are verified with actual evidence before ANY task or phase is marked complete. It is adapted from the NewsRx/opencode-gitbucket-superpowers workflow.
+Evidence-based verification workflow that prevents premature completion claims. This skill ensures ALL success criteria are verified with actual evidence before ANY task or phase is marked complete. It is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow.
 
-**Source Attribution:** This skill is adapted from NewsRx/opencode-gitbucket-superpowers workflow (branch: newsrx).
+**Source Attribution:** This skill is adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
 
 ## Persona
 
@@ -289,7 +289,7 @@ md5sum path/to/file
 
 ## Source Attribution
 
-This skill is adapted from the NewsRx/opencode-gitbucket-superpowers repository (branch: newsrx). The original workflow enforces evidence-based verification to prevent premature completion claims.
+This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow enforces evidence-based verification to prevent premature completion claims.
 
 **Key adaptations for OpenCode:**
 - Integration with existing executing-plans and git-workflow skills


### PR DESCRIPTION
## Summary

Replace all hardcoded org names, usernames, and email addresses in `.opencode/skills/` with typed placeholders that map to session-init variables. This prevents agents from inferring incorrect values (e.g., using `NewsRx` as the GitHub owner when the actual owner is `Brothertown-Language`).

### Changes

- `NewsRx/opencode-gitbucket-superpowers` → `<UPSTREAM_ORG>/<UPSTREAM_REPO>` in 7 SKILL.md files (finishing-a-development-branch, verification-before-completion, requesting-code-review, receiving-code-review, test-driven-development, executing-plans, systematic-debugging)
- `Michael Conrad` + `michael@newsrx.com` → `<DEV_NAME>` / `<DEV_EMAIL>` in git-workflow/tasks/commit-prep.md
- `Michael Conrad` → `<DEV_NAME>` in github-comments/SKILL.md (2 occurrences)
- `NewsRx/spec/cleanup-succinct-output` → `<GIT_OWNER>/spec/example-branch-name` in changelog-generator/tasks/since-last-release.md

Fixes #543