### PR TITLE
Worktree-integrated three-branch model with submodule consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ docker.app/
 /opencode-guidelines-export/
 /opencode-guidelines-export.zip
 .srclight/
+
+worktrees/

--- a/.opencode/scripts/session_init.py
+++ b/.opencode/scripts/session_init.py
@@ -14,10 +14,17 @@ Extracts git context needed for agent startup:
 - GITBUCKET_HAS_CREDENTIALS: Whether .env has token configured
 - SRCLEIGHT_STATUS: Srclight index health (ok/empty/not_indexed)
 
-Guard checks (auto-create missing files/branches):
+Guard checks (auto-create missing files/branches/worktree):
 - CHANGELOG.md: Create with Keep a Changelog header if missing
 - .opencode/CHANGELOG.md: Create with minimal header if missing
 - dev branch: Create from origin/dev or main/master if missing
+- worktrees/main/: Bootstrap worktree layout if not set up
+
+Worktree layout (#604):
+- Main folder always on dev branch
+- worktrees/main/ is a permanent production reference
+- worktrees/ is in .gitignore
+- WORKTREE_STATUS=output: ready, bootstrapped, skipped, or failed
 
 Usage:
     uv run python .opencode/scripts/session_init.py
@@ -491,13 +498,109 @@ def _ensure_dev_branch() -> str:
     return "failed (no source branch)"
 
 
+def get_current_branch() -> str | None:
+    return run_git_command(["branch", "--show-current"])
+
+
+def is_worktree_setup() -> bool:
+    main_wt = os.path.join(os.getcwd(), "worktrees", "main")
+    if not os.path.isdir(main_wt):
+        return False
+    wt_git = os.path.join(main_wt, ".git")
+    if not os.path.isfile(wt_git):
+        return False
+    return True
+
+
+def _add_to_gitignore(entry: str) -> bool:
+    gitignore_path = os.path.join(os.getcwd(), ".gitignore")
+    if not os.path.isfile(gitignore_path):
+        return False
+    try:
+        with open(gitignore_path) as f:
+            lines = f.read().splitlines()
+        if entry in lines:
+            return False
+        with open(gitignore_path, "a") as f:
+            if lines and lines[-1] != "":
+                f.write("\n")
+            f.write(f"{entry}\n")
+        return True
+    except OSError:
+        return False
+
+
+def bootstrap_worktree_layout() -> None:
+    if is_worktree_setup():
+        print("WORKTREE_STATUS=ready")
+        return
+
+    main_wt_path = os.path.join(os.getcwd(), "worktrees", "main")
+
+    if os.path.isdir(main_wt_path):
+        result = run_git_command(["worktree", "remove", main_wt_path, "--force"])
+        if result is None:
+            print("# ⚠️ Failed to remove stale worktrees/main/ directory", file=sys.stderr)
+            print("WORKTREE_STATUS=failed")
+            return
+
+    main_branch = "main"
+    if run_git_command(["rev-parse", "--verify", "main"]) is None:
+        if run_git_command(["rev-parse", "--verify", "master"]) is not None:
+            main_branch = "master"
+        else:
+            print("# ⚠️ No main or master branch found — skipping worktree bootstrap", file=sys.stderr)
+            print("WORKTREE_STATUS=skipped")
+            return
+
+    current = get_current_branch()
+
+    if current and current != "dev":
+        stash_output = run_git_command(["stash", "push", "-u", "-m", "WIP: before worktree bootstrap"])
+        had_stash = stash_output is not None
+    else:
+        had_stash = False
+
+    if current and current != "dev":
+        run_git_command(["checkout", "dev"])
+
+    result = run_git_command(["worktree", "add", main_wt_path, main_branch])
+    if result is None:
+        print("# ⚠️ Failed to create worktrees/main/ worktree", file=sys.stderr)
+        print("WORKTREE_STATUS=failed")
+        if current and current != "dev":
+            run_git_command(["checkout", current])
+        return
+
+    _add_to_gitignore("worktrees/")
+
+    submod_dirs = get_submodule_dirs()
+    if submod_dirs:
+        init_result = run_git_command(["submodule", "update", "--init"])
+        if init_result is not None:
+            for submod in submod_dirs:
+                submod_path = os.path.join(main_wt_path, submod)
+                if os.path.isdir(submod_path):
+                    run_git_command(["-C", main_wt_path, "submodule", "update", "--init", submod])
+
+    if current and current != "dev":
+        run_git_command(["checkout", current])
+        if had_stash:
+            run_git_command(["stash", "pop"])
+
+    print("WORKTREE_STATUS=bootstrapped")
+    print("# 🔧 Bootstrapped worktree layout:")
+    print(f"#   - worktrees/main/ → {main_branch} branch")
+    print("#   - worktrees/ added to .gitignore")
+
+
 def run_guard_checks() -> None:
-    """Run guard checks for missing CHANGELOG files and dev branch."""
     print("")
     print("# --- Guard Checks ---")
     print(f"CHANGELOG.md: {_ensure_changelog_md()}")
     print(f".opencode/CHANGELOG.md: {_ensure_opencode_changelog_md()}")
     print(f"dev branch: {_ensure_dev_branch()}")
+    bootstrap_worktree_layout()
 
 
 def main() -> int:

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -68,7 +68,31 @@ git checkout dev
 git pull origin dev
 ```
 
-### Step 4: Delete Current Merged Branch
+### Step 4: Remove Feature Worktree (if applicable)
+
+When the worktree layout is active (`worktrees/main/` exists), feature worktrees must
+be cleaned up after PR merge.
+
+```bash
+# Determine worktree name from branch name:
+# spec/604-worktree-model → worktrees/spec-604-worktree-model
+# feature/my-change → worktrees/feature-my-change
+# Rule: Replace / with - in the worktree directory name
+
+SANITIZED=$(echo "<merged-branch-name>" | tr '/' '-')
+WT_PATH="worktrees/${SANITIZED}"
+
+# Check if worktree exists for this branch
+if [ -d "worktrees" ] && git worktree list | grep -q "$WT_PATH"; then
+    git worktree remove "$WT_PATH"
+    echo "Removed worktree: $WT_PATH"
+fi
+
+# Prune stale worktree references
+git worktree prune
+```
+
+### Step 5: Delete Current Merged Branch
 
 ```bash
 # Delete local branch
@@ -81,7 +105,7 @@ git push origin --delete <merged-branch-name> 2>/dev/null || echo "Remote alread
 git fetch --prune
 ```
 
-### Step 5: Clean Other Merged Branches
+### Step 6: Clean Other Merged Branches
 
 **Find merged branches:**
 ```bash
@@ -93,7 +117,7 @@ git branch --merged dev
 git branch -d <branch>
 ```
 
-### Step 6: Verify Clean State
+### Step 7: Verify Clean State
 
 ```bash
 git status --porcelain  # Must be empty

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -308,6 +308,47 @@ Verified all proposed changes were already implemented. No modifications needed.
    - No further steps needed
    - No branch cleanup (no branch was created)
 
+## Worktree Integration (Phase 2 of #604)
+
+### Feature Worktree Creation
+
+When the worktree layout is active (`worktrees/main/` exists), feature branches
+should use worktrees instead of stash+checkout:
+
+**Before (stash-based):**
+1. `git stash -u` → 2. `git checkout -b feature/xyz dev` → 3. Work in same folder
+
+**After (worktree-based):**
+1. Ensure main folder is on `dev`: `git checkout dev && git pull origin dev`
+2. Create worktree: `git worktree add worktrees/feature-xyz -b feature/xyz dev`
+3. Work in `worktrees/feature-xyz/`
+
+### Branch Name to Worktree Name Mapping
+
+Branch names containing `/` must be sanitized for the worktree directory name:
+
+| Branch Name | Worktree Directory |
+|-------------|-------------------|
+| `feature/my-change` | `worktrees/feature-my-change/` |
+| `spec/604-worktree-model` | `worktrees/spec-604-worktree-model/` |
+
+**Rule:** Replace `/` with `-` in the worktree directory name.
+
+### Edge Cases
+
+- **Dev-only work** (no feature branch): Work in main folder directly, no worktree needed
+- **Worktree already exists**: Skip creation, use existing worktree directory
+- **Worktree layout not active**: Fall back to stash+checkout workflow
+
+### Worktree Already Exists Check
+
+```bash
+# Check if worktree for this branch already exists
+git worktree list | grep "feature-xyz"
+```
+
+If found, skip worktree creation and work in the existing directory.
+
 ## Enforcement Mechanisms (NO BYPASS)
 
 | Layer | Mechanism | Scope | Bypassable? |

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -52,11 +52,11 @@ Follow this priority order:
 ### 1. Check Existing Directories
 
 ```bash
-ls -d .worktrees 2>/dev/null     # Preferred (hidden)
-ls -d worktrees 2>/dev/null      # Alternative
+ls -d worktrees 2>/dev/null       # Preferred (from #604 worktree model)
+ls -d .worktrees 2>/dev/null      # Legacy (hidden)
 ```
 
-**If found:** Use that directory. If both exist, `.worktrees` wins.
+**If found:** Use that directory. If both exist, `worktrees` wins (per #604 spec).
 
 ### 2. Check AGENTS.md / Project Config
 
@@ -69,7 +69,7 @@ grep -i "worktree" AGENTS.md .opencode/AGENTS.md 2>/dev/null
 
 ### 3. Default to Project-Local
 
-If no directory exists and no preference found, default to `.worktrees/` (project-local, hidden).
+If no directory exists and no preference found, default to `worktrees/` (per #604 worktree-integrated three-branch model).
 
 ## Safety Verification
 

--- a/scripts/validate-release-tags.sh
+++ b/scripts/validate-release-tags.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# validate-release-tags.sh — Tag validation gate for releases
+#
+# Verifies that all submodules are on tagged commits before a release
+# from the main worktree (worktrees/main/).
+#
+# Usage:
+#   ./scripts/validate-release-tags.sh              # Run from worktrees/main/
+#   ./scripts/validate-release-tags.sh /path/to/wt  # Specify worktree path
+#
+# Exit codes:
+#   0: All submodules on tagged commits
+#   1: One or more submodules not on tagged commits
+#   2: No submodules found or invalid worktree
+
+set -euo pipefail
+
+WORKTREE_DIR="${1:-.}"
+
+if [ ! -d "$WORKTREE_DIR/.git" ] && [ ! -f "$WORKTREE_DIR/.git" ]; then
+    echo "ERROR: Not a git worktree: $WORKTREE_DIR" >&2
+    exit 2
+fi
+
+cd "$WORKTREE_DIR"
+
+if [ ! -f ".gitmodules" ]; then
+    echo "No submodules found — validation passed trivially."
+    exit 0
+fi
+
+FAILED=0
+PASSED=0
+TOTAL=0
+
+while IFS= read -r submodule_path; do
+    TOTAL=$((TOTAL + 1))
+    if [ ! -d "$submodule_path" ]; then
+        echo "WARN: Submodule path missing: $submodule_path" >&2
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    if (cd "$submodule_path" && git describe --exact-match HEAD >/dev/null 2>&1); then
+        TAG=$(cd "$submodule_path" && git describe --exact-match HEAD)
+        echo "  OK: $submodule_path @ $TAG"
+        PASSED=$((PASSED + 1))
+    else
+        COMMIT=$(cd "$submodule_path" && git rev-parse --short HEAD)
+        BRANCH=$(cd "$submodule_path" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "detached")
+        echo "  FAIL: $submodule_path @ $COMMIT ($BRANCH) — NOT on a tagged release"
+        FAILED=$((FAILED + 1))
+    fi
+done < <(git config --file .gitmodules --get-regexp path | awk '{print $2}')
+
+echo ""
+echo "Results: $PASSED/$TOTAL submodules on tagged releases"
+
+if [ "$FAILED" -gt 0 ]; then
+    echo ""
+    echo "ERROR: $FAILED submodule(s) not on tagged commits." >&2
+    echo "Tag all submodules on their main branch before releasing." >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Fixes #604, #605, #606, #607

## Summary

Implements a worktree-integrated three-branch model where the main folder is always on `dev` and `worktrees/main/` serves as a permanent production reference to the `main` branch. Session init auto-bootstraps this layout idempotently.

## Outcome

- Repositories automatically upgrade to worktree layout on next session init
- Feature work uses isolated worktrees instead of stash+checkout cycles
- Release tag validation gate prevents deploying untagged submodule versions