### PR TITLE
fix: worktree skill cd violations and enforcement gate (#613)

### DIFF
--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -218,6 +218,36 @@ git checkout -b spec/<short-name>  # or feature/<description>
 - Ensure working tree is clean after sync
 - If `dev` doesn't exist locally, create it from `main`: `git checkout -b dev origin/dev`
 
+### Step 4a: Worktree Gate (MANDATORY when layout is active)
+
+**When the worktree layout is active (`worktrees/main/` or `.worktrees/main/` exists), feature branch creation MUST create a worktree — not just a branch in the main folder.**
+
+**Detection:**
+```bash
+ls -d worktrees/main .worktrees/main 2>/dev/null
+```
+
+**If worktree layout is active and creating a feature branch:**
+1. Invoke `using-git-worktrees` skill — it is MANDATORY, not optional
+2. The worktree skill handles branch creation, isolation, and setup
+3. Do NOT fall back to stash+checkout workflow when layout is active
+
+**Decision matrix:**
+
+| Condition | Action |
+|-----------|--------|
+| Worktree layout active + feature branch | **MANDATORY:** Use `using-git-worktrees` skill |
+| Worktree layout active + dev-only work | Work in main folder (no worktree needed) |
+| No worktree layout | Use standard stash+checkout workflow (below) |
+
+**Why mandatory:** The OR escape hatch (worktree OR stash+checkout) gives agents a path of least resistance. When the layout is active, worktree isolation is the correct default — it prevents conflicting work between parallel agents.
+
+**If no worktree layout is active**, proceed with standard branch creation:
+
+```bash
+git checkout -b spec/<short-name>
+```
+
 ### Step 5: Verify Clean Working Tree
 
 **Before yielding back to orchestration layer, verify:**
@@ -308,12 +338,11 @@ Verified all proposed changes were already implemented. No modifications needed.
    - No further steps needed
    - No branch cleanup (no branch was created)
 
-## Worktree Integration (Phase 2 of #604)
+## Worktree Integration
 
 ### Feature Worktree Creation
 
-When the worktree layout is active (`worktrees/main/` exists), feature branches
-should use worktrees instead of stash+checkout:
+When the worktree layout is active (`worktrees/main/` or `.worktrees/main/` exists), feature branches MUST use worktrees instead of stash+checkout. This is enforced by the Worktree Gate in Step 4a.
 
 **Before (stash-based):**
 1. `git stash -u` → 2. `git checkout -b feature/xyz dev` → 3. Work in same folder

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -33,7 +33,7 @@ Fresh subagent per task = no context pollution between tasks. You precisely craf
 **Before dispatching any subagent, these gates MUST be satisfied:**
 
 1. **approval-gate** — Authorization verified (`approved` or `go` received)
-2. **git-workflow --task pre-work** OR **using-git-worktrees** — Branch created, working tree clean
+2. **git-workflow --task pre-work** — Branch created, working tree clean (includes Worktree Gate: when worktree layout is active, feature branches MUST use `using-git-worktrees`)
 3. **Plan exists** — Writing-plans output available with TDD tasks
 
 **After all tasks complete, these gates are MANDATORY:**
@@ -128,7 +128,7 @@ This project uses the `feature→dev→main` three-branch workflow:
 | Phase | Skill | Purpose |
 |-------|-------|---------|
 | Pre-implementation | `approval-gate` | Verify authorization |
-| Branch creation | `git-workflow --task pre-work` or `using-git-worktrees` | Create feature branch |
+| Branch creation | `git-workflow --task pre-work` (includes Worktree Gate) | Create feature branch (worktree when layout active) |
 | Per-task | Implementer → spec review → code quality review loop | Execute tasks |
 | Post-implementation | `verification-before-completion --task verify` | Evidence collection |
 | Completion | `finishing-a-development-branch --task checklist` | Branch readiness |
@@ -218,7 +218,7 @@ This skill integrates with the repo's mandatory workflow:
 approval-gate (authorization)
     ↓
 subagent-driven-development (this skill)
-    → pre-work: git-workflow or using-git-worktrees
+    → pre-work: git-workflow --task pre-work (includes Worktree Gate)
     → per-task: implementer → spec review → code quality review
     → post-implementation: verification-before-completion
     → completion: finishing-a-development-branch

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -129,19 +129,21 @@ git worktree list
 
 ### 6. Run Project Setup
 
-Auto-detect and run appropriate setup for this Python project:
+Auto-detect and run appropriate setup for this Python project. Use `workdir` parameter on tool calls — NEVER `cd`:
 
 ```bash
-cd .worktrees/$BRANCH_NAME
-
-# This project uses uv
+# Use workdir parameter on Bash tool call:
+# workdir=".worktrees/$BRANCH_NAME"
 if [ -f pyproject.toml ]; then uv sync; fi
 ```
 
 ### 7. Verify Clean Baseline with Tests
 
+Use `workdir` parameter on tool calls — NEVER `cd`:
+
 ```bash
-cd .worktrees/$BRANCH_NAME
+# Use workdir parameter on Bash tool call:
+# workdir=".worktrees/$BRANCH_NAME"
 uv run pytest test/ -x
 ```
 
@@ -156,7 +158,34 @@ Worktree ready at .worktrees/spec/554-git-worktrees-skill
 Tests passing (<N> tests, 0 failures)
 Branch: spec/554-git-worktrees-skill (from dev)
 Ready to implement <feature-name>
+All commands use workdir=".worktrees/$BRANCH_NAME" — never cd
 ```
+
+## Tool Usage Compliance
+
+**⚠️ CRITICAL: All commands in worktrees MUST use `workdir` parameter or relative paths from project root. NEVER use `cd` commands.**
+
+Per AGENTS.md and `060-tool-usage.md`, `cd` commands are a zero-tolerance violation. When executing commands inside a worktree:
+
+| Method | Example | Compliant? |
+|--------|---------|------------|
+| `workdir` parameter on Bash tool | `workdir=".worktrees/$BRANCH_NAME"` | ✅ YES |
+| Relative path from project root | `uv run --directory .worktrees/$BRANCH_NAME pytest` | ✅ YES |
+| `cd .worktrees/$BRANCH_NAME && ...` | `cd .worktrees/xyz && uv sync` | 🚫 NO — zero tolerance |
+
+**Rule:** Every tool call that operates inside a worktree directory MUST use `workdir="<worktree-path>"`. No exceptions.
+
+## Verification Step
+
+After worktree creation (step 5), verify the worktree actually exists before proceeding:
+
+```bash
+git worktree list
+# MUST show the new worktree entry
+# If missing → HALT and report — do NOT proceed with implementation in main folder
+```
+
+**If verification fails:** The worktree was not created successfully. HALT and report the failure. Do NOT fall back to working in the main folder — that defeats the isolation purpose.
 
 ## Quick Reference
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/613-worktree-enforcement
+
+- **Worktree Enforcement Gate** - Make worktree usage mandatory when layout is active instead of advisory, remove OR escape hatch from subagent-driven-development, fix cd command violations in using-git-worktrees skill
+- Add Tool Usage Compliance section and verification step to using-git-worktrees skill
+- Add Worktree Gate to git-workflow pre-work task that requires worktrees when layout is active
+
 ### spec/600-auto-create-changelog-dev
 
 - **Session Init Guard Checks** - Auto-create missing CHANGELOG.md, .opencode/CHANGELOG.md, and dev branch during session initialization, preventing silent failures from dead links and branch errors


### PR DESCRIPTION
**Summary:**

Fixes two defects in the worktree skill that prevented agents from using it: cd command violations that broke AGENTS.md compliance, and an advisory-only enforcement model that let agents skip worktree setup entirely.

**Outcome:** Agents working on feature branches will now be required to use worktrees when the layout is active, and the worktree skill no longer contains zero-tolerance cd violations.

Fixes #613
Fixes #616
Fixes #617