### PR TITLE
fix: restore YAML frontmatter in brainstorming/SKILL.md

### DIFF
--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -1,6 +1,10 @@
-______________________________________________________________________
-
-## name: brainstorming description: Use when creating a spec, planning a feature, or exploring requirements before implementation. Triggers on: spec, plan, feature, brainstorm, explore, requirements, ideate, think through, what should. type: technique license: MIT compatibility: opencode
+---
+name: brainstorming
+description: Use when creating a spec, planning a feature, or exploring requirements before implementation. Triggers on: spec, plan, feature, brainstorm, explore, requirements, ideate, think through, what should.
+type: technique
+license: MIT
+compatibility: opencode
+---
 
 # Skill: brainstorming
 


### PR DESCRIPTION
## Summary

The `brainstorming` skill's SKILL.md used broken frontmatter (`____` delimiters and `## name:` format) instead of standard YAML `---` delimiters, making the skill invisible to the session-enforcement plugin's `extractFrontmatter()` regex. Agents couldn't discover the brainstorming skill at session start despite it being the most critical skill in the process pipeline.

## Outcome

Restored proper YAML frontmatter so `extractFrontmatter()` correctly parses `name`, `description`, `type`, `license`, and `compatibility` fields. The brainstorming skill will now appear in the enforcement content injected into the first user message, enabling agents to self-discover and invoke it.

Fixes #601