### PR TITLE
[SPEC-FIX] Mandatory worktree enforcement when layout is active

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -5,6 +5,40 @@
 
 This file provides critical rules that must never be violated.
 
+## Critical Violation: Worktree Bypass When Layout Is Active
+
+**⚠️ Using `stash + checkout -b` instead of worktrees when the worktree layout is active is a CRITICAL GUIDELINE VIOLATION.**
+
+When `WORKTREE_STATUS=ready` or `WORKTREE_STATUS=bootstrapped` (or when `worktrees/main/` or `.worktrees/main/` exists), the agent MUST use the `using-git-worktrees` skill for feature branch creation — NEVER fall back to `stash + checkout -b`.
+
+### 🚫 FORBIDDEN
+
+- Using `git checkout -b` to create feature branches when the worktree layout is active
+- Using `git stash push -u` then `git checkout -b` as a substitute for worktree-based branch creation
+- Bypassing the Worktree Gate in `git-workflow --task pre-work` Step 4a
+- Creating branches directly in `verify-authorization` instead of delegating to `pre-work`
+- Ignoring the `WORKTREE_STATUS` environment variable from session-init
+
+### ✅ REQUIRED
+
+- **Check `WORKTREE_STATUS` env var** (primary) or filesystem (fallback) before creating any feature branch
+- **When layout is active:** Use `using-git-worktrees` skill via `git-workflow --task pre-work` Step 4a
+- **When layout is NOT active:** Use standard stash+checkout workflow
+- **`verify-authorization` MUST delegate branch creation** to `git-workflow --task pre-work` — never create branches directly
+
+### Why This Matters
+
+| Violation | Consequence |
+|-----------|-------------|
+| `stash + checkout -b` when worktrees active | Parallel agent conflicts, dirty working trees, lost changes |
+| Skipping Worktree Gate | Other agents unaware of parallel work, merge conflicts |
+| Ignoring `WORKTREE_STATUS` | Session-init output wasted, detection relies only on filesystem |
+| Branch creation in `verify-authorization` | Worktree Gate in `pre-work` completely bypassed |
+
+**See `git-workflow` skill `--task pre-work` Step 4a for the complete Worktree Gate procedure and decision matrix.**
+
+______________________________________________________________________
+
 ## Critical Violation: Skipping Git Pre-Check Before ANY Work
 
 **⚠️ Working on files without checking git state is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -21,7 +21,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | Task | Purpose | Words |
 |------|---------|-------|
 | `verify-qa-mode` | Detect spec-less implementation requests, switch to Q/A mode | ~800 |
-| `verify-authorization` | Check explicit auth and needs-approval label | ~400 |
+| `verify-authorization` | Check explicit auth and needs-approval label; delegates branch creation to `git-workflow --task pre-work` | ~400 |
 | `verify-sub-issues` | Verify sub-issue structure for multi-task specs | ~480 |
 | `verify-codebase` | Re-evaluate codebase state, detect staleness | ~400 |
 | `verify-blockers` | Check for blocking issues/dependencies | ~320 |

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -27,7 +27,7 @@ git branch --show-current
 git status
 ```
 
-**If on `main` with ANY pending changes (modified, deleted, untracked):**
+**If on `main` or `dev` with ANY pending changes (modified, deleted, untracked):**
 
 ```bash
 git stash push -u -m "WIP: before <branch-name>"
@@ -44,12 +44,15 @@ git status       # VERIFY clean working tree
 
 **If EITHER check fails ⇒ STOP. Report failure. Let user resolve.**
 
-**Then proceed:**
+**🚫 CRITICAL: Do NOT create branches directly in verify-authorization.**
 
-```bash
-git checkout main && git pull origin main
-git checkout -b spec/<short-name>
-```
+Branch creation is DELEGATED to `git-workflow --task pre-work`, which includes the Worktree Gate (Step 4a). Creating branches here bypasses that gate — a CRITICAL VIOLATION when the worktree layout is active.
+
+**After git state verification:**
+1. Record that git state is verified and clean
+2. Proceed to Step 2 (authorization verification)
+3. After ALL verification steps, invoke `git-workflow --task pre-work` for branch creation
+4. `pre-work` will handle: stash, sync with `dev`, worktree gate check, and branch/worktree creation
 
 ### Step 2: Verify Authorization Is Explicit
 

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -220,27 +220,36 @@ git checkout -b spec/<short-name>  # or feature/<description>
 
 ### Step 4a: Worktree Gate (MANDATORY when layout is active)
 
-**When the worktree layout is active (`worktrees/main/` or `.worktrees/main/` exists), feature branch creation MUST create a worktree — not just a branch in the main folder.**
+**When the worktree layout is active, feature branch creation MUST create a worktree — not just a branch in the main folder. Bypassing this gate when the layout is active is a CRITICAL VIOLATION (see `000-critical-rules.md`).**
 
-**Detection:**
+**Detection (primary = env var, fallback = filesystem):**
 ```bash
+# Primary: Use WORKTREE_STATUS from session-init
+# WORKTREE_STATUS values: "ready", "bootstrapped", "skipped", "failed"
+# If WORKTREE_STATUS is empty/unset, fall back to filesystem check
+
+# Filesystem fallback:
 ls -d worktrees/main .worktrees/main 2>/dev/null
 ```
+
+**Decision matrix:**
+
+| Condition | Action |
+|-----------|--------|
+| `WORKTREE_STATUS=ready` or `WORKTREE_STATUS=bootstrapped` + feature branch | **MANDATORY:** Use `using-git-worktrees` skill |
+| Filesystem detects `worktrees/main/` or `.worktrees/main/` + feature branch | **MANDATORY:** Use `using-git-worktrees` skill |
+| `WORKTREE_STATUS=skipped` or `WORKTREE_STATUS=failed` | Use standard stash+checkout workflow |
+| No `WORKTREE_STATUS` env var AND no filesystem worktree dirs | Use standard stash+checkout workflow |
+| Worktree layout active + dev-only work | Work in main folder (no worktree needed) |
 
 **If worktree layout is active and creating a feature branch:**
 1. Invoke `using-git-worktrees` skill — it is MANDATORY, not optional
 2. The worktree skill handles branch creation, isolation, and setup
 3. Do NOT fall back to stash+checkout workflow when layout is active
 
-**Decision matrix:**
-
-| Condition | Action |
-|-----------|--------|
-| Worktree layout active + feature branch | **MANDATORY:** Use `using-git-worktrees` skill |
-| Worktree layout active + dev-only work | Work in main folder (no worktree needed) |
-| No worktree layout | Use standard stash+checkout workflow (below) |
-
 **Why mandatory:** The OR escape hatch (worktree OR stash+checkout) gives agents a path of least resistance. When the layout is active, worktree isolation is the correct default — it prevents conflicting work between parallel agents.
+
+**Why session-init variable:** `WORKTREE_STATUS` is emitted by `session_init.py` during every session. It reflects the actual state of the worktree layout at session start. Using it avoids redundant filesystem checks and ensures agents consume session-init output rather than ignoring it.
 
 **If no worktree layout is active**, proceed with standard branch creation:
 


### PR DESCRIPTION
**Summary:**

Closes the orchestration bypass gap where `approval-gate/verify-authorization` created branches directly with `git checkout -b`, skipping the Worktree Gate in `git-workflow/pre-work` Step 4a. Branch creation now delegates to `pre-work`, which uses `WORKTREE_STATUS` from session-init as the primary worktree detection method.

**Outcome:** When the worktree layout is active (`WORKTREE_STATUS=ready`), agents will always use worktrees for feature branches — never fall back to `stash + checkout -b`. No path from "approved" to "branch created" bypasses the worktree gate.

Fixes #620