### PR TITLE
[SPEC] Issue Review Skill (#302)

### DIFF
--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -289,7 +289,7 @@ When a bug report requires code changes:
 
 ## Cross-References
 
-- Related skills: `git-workflow` (branch operations, cleanup with parent closure check), `pr-creation-workflow` (PR timing)
+- Related skills: `git-workflow` (branch operations, cleanup with parent closure check), `pr-creation-workflow` (PR timing), `issue-review` (reads authorization status in gather task)
 - Related guidelines: `010-approval-gate.md`, `120-github-issue-first.md`, `000-critical-rules.md`, `124-github-archive-workflow.md` (parent closure pre-check)
 
 ## Parent Closure Pre-Check Reference

--- a/.opencode/skills/issue-review/SKILL.md
+++ b/.opencode/skills/issue-review/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: issue-review
+description: Use when reviewing a GitHub issue for comments, audits, or Q/A. Triggers on: review issue, review spec, check issue, issue review, audit issue.
+type: orchestrator
+license: MIT
+compatibility: opencode
+---
+
+# Skill: issue-review
+
+## Overview
+
+Unified "review" command for GitHub Issues. Gathers issue data, classifies the review path via content analysis (not label conventions), delegates to appropriate downstream skills, and handles Q/A for non-spec issues. One entry point replaces manual orchestration of comment reading, audit detection, and audit execution.
+
+## Persona
+
+You are an Issue Review Orchestrator. Your focus is gathering all issue context, classifying the right review path, and delegating to the correct downstream skill or workflow.
+
+## Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| `gather` | Collect all issue data (body, comments, labels, sub-issues, auth status) | ~500 |
+| `triage` | Two-pass classification: pattern signals + AI verification | ~600 |
+| `audit` | Delegate to `spec-auditor` with triage hints | ~350 |
+| `qa` | Ask clarifying questions one at a time in chat | ~500 |
+
+## Invocation
+
+- `/skill issue-review --issue N` — Full review (gather → triage → dispatch)
+- `/skill issue-review --issue N --task gather` — Data collection only
+- `/skill issue-review --issue N --task triage` — Classification only (requires prior gather)
+- `/skill issue-review --issue N --task audit` — Audit delegation only (requires prior triage)
+- `/skill issue-review --issue N --task qa` — Q/A mode only
+- `/skill issue-review` — Overview only
+
+## Operating Protocol
+
+1. **Mandatory issue parameter:** This skill MUST be invoked with `--issue N` where N is the GitHub Issue number to review.
+
+2. **Automatic workflow:** When invoked without `--task`, the full workflow runs:
+   - `gather` → `triage` → path dispatch → recursive sub-issue handling
+
+3. **Comments read first (CRITICAL):** `gather` reads ALL comments before any triage decision, per `067-context-completeness.md`.
+
+4. **No label dependency:** Triage uses content analysis, not `[SPEC]` prefix or other label conventions.
+
+5. **Sub-issue recursion:** When sub-issues exist, the full workflow runs on each sub-issue independently.
+
+## Orchestration Flow
+
+```
+review #N
+  ├── gather (issue + sub-issues data)
+  ├── triage (pattern signals + AI verification → path decision)
+  ├── path dispatch:
+  │   ├── audit → spec-auditor with hints → exec summary to chat
+  │   ├── qa → one-at-a-time questions in chat → exec summary to issue
+  │   ├── just-review → exec summary of current state to chat
+  │   └── already-handled → full re-verification → status to chat
+  └── recurse for sub-issues (gather → triage → dispatch for each)
+```
+
+## Triage Paths
+
+| Path | When | Output Target |
+|------|------|---------------|
+| `audit` | Content looks like a spec (phases/steps, success criteria, edge cases) | Chat exec summary |
+| `qa` | Bug report, unclear request, or issue needing clarification | Chat questions, then issue exec summary |
+| `just-review` | Already-audited spec with no new relevant comments | Chat exec summary |
+| `already-handled` | Issue appears complete (approved + implemented) | Chat re-verification status |
+
+## Path Dispatch Details
+
+### Audit Path
+
+Invoke `spec-auditor --issue N` with triage hints about which subtasks are relevant:
+
+| Spec Type | Hint |
+|-----------|------|
+| Simple bug-fix spec | "likely baseline only" |
+| Feature with phases | "baseline + concerns likely relevant" |
+| Complex multi-phase spec | "all subtasks likely relevant" |
+
+Hints inform but do not override — `spec-auditor` retains its own subtask selection logic.
+
+**CRITICAL:** Audit findings are internal agent guidance — DO NOT post to GitHub comments (per `000-critical-rules.md`). Produce prose exec summary for chat only.
+
+### Q/A Path
+
+Ask questions one at a time in chat. Q/A depth depends on content:
+
+| Content Type | Q/A Depth |
+|--------------|-----------|
+| Simple bug report | Scope questions only |
+| Feature with technical implications | Scope + feasibility |
+| Feature idea that could become a spec | Scope + feasibility + offer to scaffold spec |
+
+On resolution, post exec summary to issue (durable outcomes only, not Q&A chatter). HALT after posting.
+
+### Just-Review Path
+
+Produce prose exec summary of current state including: authorization status, last audit summary, open questions, overall health assessment.
+
+### Already-Handled Path
+
+**Full re-verification — NEVER rely on history, comments, or memory.**
+
+1. Verify GitHub state: issue closed, PR merged, sub-issues status
+2. Verify implementation: check that files mentioned in spec exist in codebase
+3. Verify tests: check test status for affected areas
+4. If fully verified: report "confirmed complete"
+5. If gaps found: report what needs attention, suggest re-triage
+
+## Final Report Format (CRITICAL)
+
+All outputs follow prose format per `000-critical-rules.md`:
+
+```
+<optional details and analysis>
+
+<exec summary>
+
+<URL if relevant>
+
+🤖 <AgentName> (<ModelID>) <status>
+```
+
+No template files. No structured schema output. Prose throughout.
+
+## Cross-References
+
+- `spec-auditor`: Called by `audit` task for spec quality checks
+- `approval-gate`: Referenced for authorization status in `gather`
+- `067-context-completeness`: Mandates reading all comments before acting
+
+Base directory for this skill: `.opencode/skills/issue-review/`

--- a/.opencode/skills/issue-review/tasks/audit.md
+++ b/.opencode/skills/issue-review/tasks/audit.md
@@ -1,0 +1,82 @@
+# Task: audit
+
+## Purpose
+
+Delegate to `spec-auditor` with triage hints about which subtasks are relevant based on the triage classification.
+
+## Entry Criteria
+
+- Triage selected the `audit` path
+- Triage output available (path, confidence, reasoning, hints)
+
+## Exit Criteria
+
+- `spec-auditor` invoked with context
+- Audit findings collected
+- Prose exec summary produced for chat
+
+## Procedure
+
+### Step 1: Receive Triage Output
+
+The triage task provides:
+- Path: `audit`
+- Confidence level
+- Reasoning
+- Hints about spec complexity
+
+### Step 2: Format Triage Hints for spec-auditor
+
+Map triage observations to hints for `spec-auditor`:
+
+| Spec Type from Triage | Hint for spec-auditor |
+|----------------------|----------------------|
+| Simple bug-fix spec | "likely baseline only" |
+| Feature with phases | "baseline + concerns likely relevant" |
+| Complex multi-phase spec | "all subtasks likely relevant" |
+| Spec with external dependencies | "baseline + traceability + operational" |
+| Single-task spec (no phases) | "likely baseline only" |
+
+Hints INFORM but do NOT override — `spec-auditor` retains its own subtask selection logic.
+
+### Step 3: Invoke spec-auditor
+
+```
+/skill spec-auditor --issue N
+```
+
+Pass triage context as part of the invocation. The agent includes the hint about which subtasks are likely relevant based on the spec's nature.
+
+### Step 4: Collect Audit Findings
+
+Gather all findings from spec-auditor subtasks. These are internal agent guidance.
+
+### Step 5: CRITICAL — Do NOT Post Findings to GitHub
+
+**Audit findings are internal agent guidance — DO NOT post to GitHub comments (per `000-critical-rules.md`).**
+
+Findings inform the agent's behavior but are NOT stakeholder communication. Posting audit findings as issue comments is a FORBIDDEN action.
+
+### Step 6: Produce Prose Exec Summary for Chat
+
+Write a prose exec summary of the audit results for chat output. Include:
+
+1. What was audited (issue number, spec type)
+2. Key findings (grouped by severity if multiple)
+3. Recommended actions (without prescribing implementation)
+
+Format per `000-critical-rules.md`:
+
+```
+<analysis summary>
+
+<exec summary>
+
+🤖 <AgentName> (<ModelID>) 🔍
+```
+
+## Cross-References
+
+- `spec-auditor`: Called for actual spec quality checks
+- `000-critical-rules.md`: Audit findings must NOT be posted to GitHub
+- `067-context-completeness.md`: All comments were read during gather

--- a/.opencode/skills/issue-review/tasks/gather.md
+++ b/.opencode/skills/issue-review/tasks/gather.md
@@ -1,0 +1,108 @@
+# Task: gather
+
+## Purpose
+
+Collect all issue data needed by downstream tasks. This is a pure data-collection step — no decisions.
+
+## Entry Criteria
+
+- Issue number provided via `--issue N`
+- GitHub MCP available for issue/comment operations
+
+## Exit Criteria
+
+- All issue data collected
+- Standard data set extracted for triage
+- Sub-issue data recursively gathered if present
+
+## Procedure
+
+### Step 1: Read Issue Body
+
+```
+github_issue_read(method="get", issue_number=N)
+```
+
+### Step 2: Read All Comments
+
+```
+github_issue_read(method="get_comments", issue_number=N)
+```
+
+Record comment count for evidence. Note: per `067-context-completeness.md`, ALL comments MUST be read before any triage decision.
+
+### Step 3: Read Labels and Authorization Status
+
+```
+github_issue_read(method="get_labels", issue_number=N)
+```
+
+Extract:
+- `needs-approval` label presence
+- Any categorization labels (enhancement, bug, architecture, etc.)
+- Authorization status from comments (look for "approved", "go", `#N approved` patterns)
+
+### Step 4: Detect Sub-issues
+
+```
+github_issue_read(method="get_sub_issues", issue_number=N)
+```
+
+If sub-issues exist, store their issue numbers for recursive gathering.
+
+### Step 5: Recursively Gather Sub-issue Data
+
+For each sub-issue, repeat Steps 1-4:
+- Read sub-issue body
+- Read sub-issue comments
+- Read sub-issue labels
+- Check for further nesting (unlikely but handled)
+
+### Step 6: Extract Standard Data Set
+
+From all gathered data, extract prose descriptions of:
+
+1. **Issue type classification hints:**
+   - Phases/steps present in body (e.g., "Phase 1:", "Phase 2:")
+   - Success criteria section present
+   - Bug report language patterns ("crash", "error", "broken", "steps to reproduce")
+
+2. **Comment themes:**
+   - Questions asked by commenters
+   - Revisions or spec changes noted
+   - Blockers reported
+   - Audit findings (comments containing finding-class patterns like "finding:", "violation:", "CRITICAL")
+   - Authorization comments ("approved", "go")
+
+3. **Last audit timestamp:**
+   - Most recent comment containing audit finding patterns
+   - Used by `just-review` path to assess staleness
+
+4. **Authorization status:**
+   - Explicit approval comments found (quote them)
+   - `needs-approval` label present or absent
+
+5. **Spec structure signals:**
+   - Has phases? (count them)
+   - Has success criteria?
+   - Has edge cases?
+   - Has affected files table?
+   - Has risk assessment?
+
+### Step 7: Return Data for Downstream
+
+Prose description of gathered data — no structured schema required. The agent carries context forward to the triage task.
+
+## Output Format
+
+Prose summary of all gathered data, organized by the five categories above. Include comment count and specific authorization evidence for audit trail.
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| No comments | Proceed normally — comment count = 0 |
+| Issue is closed | Note state; triage decides if stale or complete |
+| Sub-issues present | Gather each; triage runs independently per sub-issue |
+| No sub-issues | Skip recursive gathering |
+| API error | Report error and HALT; do not proceed with partial data |

--- a/.opencode/skills/issue-review/tasks/qa.md
+++ b/.opencode/skills/issue-review/tasks/qa.md
@@ -1,0 +1,99 @@
+# Task: qa
+
+## Purpose
+
+Handle non-spec issues by asking clarifying questions one at a time in chat. On resolution, post durable outcomes to the issue.
+
+## Entry Criteria
+
+- Triage selected the `qa` path
+- Issue data gathered (body, comments, labels)
+
+## Exit Criteria
+
+- Clarifying questions asked one at a time in chat
+- Resolution reached OR user ends Q/A
+- Exec summary posted to issue (durable outcomes only)
+- HALT after posting summary
+
+## Q/A Depth Selection
+
+Analyze content to determine depth:
+
+| Content Type | Depth | Questions Cover |
+|--------------|-------|-----------------|
+| Simple bug report | Scope only | What's wrong, expected behavior, steps to reproduce |
+| Feature with technical implications | Scope + feasibility | Above + constraints, edge cases, integration points |
+| Feature idea that could become a spec | Scope + feasibility + scaffold | Above + offer to write a spec from the answers |
+
+Output reasoning for the depth choice before starting Q/A.
+
+## Procedure
+
+### Step 1: Determine Q/A Depth
+
+Analyze the issue content:
+
+- Bug report language ("crash", "error", "broken") → scope only
+- Feature request with technical detail → scope + feasibility
+- Vague feature idea or "we should..." → scope + feasibility + scaffold offer
+
+Announce the depth choice and reasoning in chat.
+
+### Step 2: Generate Questions
+
+Based on depth, prepare questions. **Ask ONE question at a time in chat.** Do NOT list all questions at once.
+
+**Scope questions:**
+- What is the expected behavior?
+- What is the current (broken) behavior?
+- What are the steps to reproduce?
+
+**Feasibility questions (added for depth 2+):**
+- Are there technical constraints?
+- What edge cases should be considered?
+- What existing systems does this integrate with?
+
+**Scaffold offer (depth 3 only):**
+- After scope + feasibility resolved, offer: "Would you like me to create a spec from these answers?"
+
+### Step 3: Ask Questions One at a Time
+
+For each question:
+1. Ask in chat
+2. Wait for user response
+3. Follow up if the answer is unclear
+4. Move to next question when satisfied
+
+### Step 4: On Resolution, Compose Exec Summary
+
+When Q/A resolves (or user ends it), compose a prose exec summary capturing:
+- Decisions made during Q/A
+- Clarifications that emerged
+- Scope boundaries confirmed
+- Any spec changes suggested
+
+### Step 5: Post Exec Summary to Issue
+
+Post the exec summary as an issue comment. This is a **durable outcome** — it records what was decided for future readers.
+
+**Only post durable outcomes, NOT the Q&A chatter.** The back-and-forth in chat is operational; the issue comment is the record.
+
+### Step 6: HALT
+
+HALT after posting the summary. Wait for the developer to act on the outcomes.
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| User doesn't respond to question | HALT; do not repeat or rephrase without prompting |
+| User provides incomplete answer | Ask one targeted follow-up in chat |
+| Q/A reveals the issue IS a spec | Stop Q/A, suggest re-triage to `audit` path |
+| User says "never mind" or "closed" | Post summary noting cancellation, HALT |
+| Multiple unrelated questions | Focus on most relevant first; note others for follow-up |
+
+## Cross-References
+
+- `000-critical-rules.md`: Q&A chatter goes to chat; durable outcomes go to issue
+- `approval-gate`: If Q/A reveals authorization is needed, note it in summary

--- a/.opencode/skills/issue-review/tasks/triage.md
+++ b/.opencode/skills/issue-review/tasks/triage.md
@@ -1,0 +1,106 @@
+# Task: triage
+
+## Purpose
+
+Classify the review path based on content analysis, not label conventions. Two-pass approach: pattern signals first, then AI content verification.
+
+## Entry Criteria
+
+- Gathered data from `gather` task available
+- Issue body and comments have been read
+
+## Exit Criteria
+
+- Triage path selected (audit, qa, just-review, or already-handled)
+- Confidence level assigned (high, medium, low)
+- Reasoning documented
+
+## Triage Paths
+
+| Path | When |
+|------|------|
+| `audit` | Content looks like a spec (phases/steps, success criteria, edge cases) |
+| `qa` | Bug report, unclear request, or issue needing clarification |
+| `just-review` | Already-audited spec with no new relevant comments |
+| `already-handled` | Issue appears complete (approved + implemented) |
+
+## Procedure
+
+### Pass 1 — Pattern Signals (Fast Classification)
+
+Scan gathered data for these signals:
+
+| Signal | Points Toward |
+|--------|---------------|
+| Body contains "Phase 1:", "Phase 2:", etc. | `audit` |
+| Body has "Success Criteria" section | `audit` |
+| Body has "Edge Cases" section | `audit` |
+| Body has "Affected Files" table | `audit` |
+| Body has "Risk Assessment" table | `audit` |
+| Comments contain "approved" or "go" | Check if also implemented → `already-handled` |
+| Comments contain audit finding patterns | `just-review` (if no new non-audit comments) |
+| `needs-approval` label present, no explicit auth | `just-review` (report auth status) |
+| Body uses bug report language ("crash", "error", "broken") | `qa` |
+| Issue is closed AND PR merged | `already-handled` |
+| Body is unclear, vague, or request for information | `qa` |
+| Title has `[SPEC]` but body is a bug report | `qa` (title ≠ content) |
+
+**IMPORTANT:** Do NOT use the `[SPEC]` prefix or any label as the sole classification signal. Content analysis is the authoritative classifier.
+
+### Pass 2 — AI Content Verification (Confirm or Redirect)
+
+Read the body and comments. Ask: **"Does the Pass 1 classification match what the content actually describes?"**
+
+Redirection examples:
+
+| Pass 1 Result | Pass 2 Observation | Redirect To |
+|----------------|--------------------|-------------| 
+| `audit` (based on checkboxes) | Content is really a bug report | `qa` |
+| `just-review` | Body has no formal sections but describes a clear feature spec | `audit` |
+| `audit` | Comments contain audit findings AND unanswered questions | `audit` + flag for `qa` afterward |
+| `already-handled` | Only partially implemented | `audit` (spec still active) |
+| `just-review` | New scope-relevant comments since last audit | `audit` |
+
+### Output Format
+
+State results in this format:
+
+```
+Triage: <path> (<confidence>)
+Reason: <one sentence explaining why>
+Verification: <one sentence confirming or noting redirect from Pass 1>
+```
+
+Examples:
+
+```
+Triage: audit (high confidence)
+Reason: Body contains 6 phases with success criteria and edge cases.
+Verification: Content describes a structured feature spec — confirmed audit path.
+
+Triage: qa (medium confidence)
+Reason: Body appears to be a spec but actually describes an error condition with no structured phases.
+Verification: Redirected from audit — title says [SPEC] but content is a bug report.
+```
+
+### Sub-issue Triage
+
+Each sub-issue gets its own independent triage decision. A parent may be `audit` while a sub-issue is `qa`.
+
+## Confidence Levels
+
+| Level | Meaning |
+|-------|---------|
+| High | Clear match between signals and content; no ambiguity |
+| Medium | Signals point one way but content has some ambiguity |
+| Low | Conflicting signals; agent should proceed cautiously and note uncertainty |
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| No comments, no phases, no bug language | `qa` (unclear intent, ask for clarification) |
+| Issue is closed | Check if `already-handled` or stale |
+| Mixed signals (phases + bug language) | AI verification breaks tie; document reasoning |
+| Title says spec but body is bug | Redirect to `qa` |
+| Body lacks formal sections but clear feature | Redirect to `audit` |

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -171,7 +171,7 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 
 ## Cross-References
 
-- Related skills: `brainstorming` (pre-spec), `writing-plans` (clean-room generation for fidelity subtask)
+- Related skills: `brainstorming` (pre-spec), `writing-plans` (clean-room generation for fidelity subtask), `issue-review` (delegates to spec-auditor via audit task)
 - Related guidelines: `000-critical-rules.md` (auditor enforcement), `140-planning-spec-creation.md`
 - Delegated from: `plan-fidelity-auditor` (now `fidelity` subtask), `concern-separation-auditor` (now `concerns` subtask)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ Skill invocation is driven by self-discovery from SKILL.md frontmatter (see "Ski
 | `test-driven-development` | TDD red-green-refactor workflow | User requests TDD approach |
 | `receiving-code-review` | Address review feedback precisely | PR receives review comments |
 | `requesting-code-review` | Prepare and submit review requests | User says "request review" |
+| `issue-review` | Unified review command for GitHub Issues | Review issue, audit spec, check issue |
 
 **Implementation-workflow** coordinates git-workflow tasks (pre-work, review-prep, pr-creation) and yields structured context between stages. Authorization is checked once by `approval-gate`, then passed through the orchestration chain — no redundant re-checks.
 


### PR DESCRIPTION
## Summary

Add unified `issue-review` skill that provides a single entry point for reviewing GitHub Issues. The skill gathers issue data, classifies the review path via content analysis (not label conventions), delegates to appropriate downstream skills, and handles Q/A for non-spec issues.

## Outcome

Developers can invoke `/skill issue-review --issue N` to get a unified review workflow instead of manually orchestrating comment reading, audit detection, and audit execution.

**Files added:**
- `.opencode/skills/issue-review/SKILL.md` — Orchestration, persona, task table, frontmatter with self-discovery triggers, just-review and already-handled paths
- `.opencode/skills/issue-review/tasks/gather.md` — Data collection task (body, comments, labels, sub-issues, auth status)
- `.opencode/skills/issue-review/tasks/triage.md` — Two-pass classification (pattern signals + AI verification)
- `.opencode/skills/issue-review/tasks/audit.md` — Delegation to spec-auditor with triage hints
- `.opencode/skills/issue-review/tasks/qa.md` — One-at-a-time questions in chat, exec summary to issue

**Files modified:**
- `AGENTS.md` — Added `issue-review` to workflow skills table
- `.opencode/skills/spec-auditor/SKILL.md` — Cross-reference to issue-review
- `.opencode/skills/approval-gate/SKILL.md` — Cross-reference to issue-review

Fixes #302
Fixes #632
Fixes #633
Fixes #634
Fixes #635
Fixes #636
Fixes #637
Fixes #638
Fixes #639