### PR TITLE
[SPEC] Eliminate WORKTREE_STATUS conditional — make worktree mandatory

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -5,37 +5,39 @@
 
 This file provides critical rules that must never be violated.
 
-## Critical Violation: Worktree Bypass When Layout Is Active
+## Critical Violation: Worktree Bypass — Using stash+checkout Instead of Worktrees
 
-**⚠️ Using `stash + checkout -b` instead of worktrees when the worktree layout is active is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Using `stash + checkout -b` instead of worktrees for ANY feature branch creation is a CRITICAL GUIDELINE VIOLATION.**
 
-When `WORKTREE_STATUS=ready` or `WORKTREE_STATUS=bootstrapped` (or when `worktrees/main/` or `.worktrees/main/` exists), the agent MUST use the `using-git-worktrees` skill for feature branch creation — NEVER fall back to `stash + checkout -b`.
+Worktrees are ALWAYS mandatory for feature branch creation. There is no conditional — no "when the layout is active," no fallback to `stash + checkout -b`, no `WORKTREE_STATUS` check. The agent MUST use the `using-git-worktrees` skill for every feature branch, period.
 
 ### 🚫 FORBIDDEN
 
-- Using `git checkout -b` to create feature branches when the worktree layout is active
+- Using `git checkout -b` to create feature branches — ALWAYS use worktrees instead
 - Using `git stash push -u` then `git checkout -b` as a substitute for worktree-based branch creation
 - Bypassing the Worktree Gate in `git-workflow --task pre-work` Step 4a
 - Creating branches directly in `verify-authorization` instead of delegating to `pre-work`
-- Ignoring the `WORKTREE_STATUS` environment variable from session-init
+- Checking `WORKTREE_STATUS` or filesystem for worktree availability before deciding
+- Using `stash + checkout` as a fallback for ANY reason
+- Ignoring `WORKTREE_FATAL=1` in session init output
 
 ### ✅ REQUIRED
 
-- **Check `WORKTREE_STATUS` env var** (primary) or filesystem (fallback) before creating any feature branch
-- **When layout is active:** Use `using-git-worktrees` skill via `git-workflow --task pre-work` Step 4a
-- **When layout is NOT active:** Use standard stash+checkout workflow
+- **ALWAYS use `using-git-worktrees` skill** for feature branch creation — no exceptions, no conditions
+- **If `WORKTREE_FATAL=1` appears in session init output:** HALT immediately and report the fatal error to the developer — do NOT proceed with any implementation
 - **`verify-authorization` MUST delegate branch creation** to `git-workflow --task pre-work` — never create branches directly
 
 ### Why This Matters
 
 | Violation | Consequence |
 |-----------|-------------|
-| `stash + checkout -b` when worktrees active | Parallel agent conflicts, dirty working trees, lost changes |
+| `stash + checkout -b` for feature branches | Parallel agent conflicts, dirty working trees, lost changes |
 | Skipping Worktree Gate | Other agents unaware of parallel work, merge conflicts |
-| Ignoring `WORKTREE_STATUS` | Session-init output wasted, detection relies only on filesystem |
+| Using `stash+checkout` as fallback | Creates path of least resistance that bypasses worktree isolation |
+| Ignoring `WORKTREE_FATAL=1` | Agent proceeds despite infrastructure failure, corrupts work |
 | Branch creation in `verify-authorization` | Worktree Gate in `pre-work` completely bypassed |
 
-**See `git-workflow` skill `--task pre-work` Step 4a for the complete Worktree Gate procedure and decision matrix.**
+**See `git-workflow` skill `--task pre-work` Step 4a for the complete Worktree Gate procedure.**
 
 ______________________________________________________________________
 

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -256,7 +256,7 @@ function buildEnforcementContent(skillDescriptions: Array<{ name: string; descri
   const processSkills = skillDescriptions.filter(s =>
     ["approval-gate", "brainstorming", "writing-plans", "executing-plans",
      "verification-before-completion", "finishing-a-development-branch",
-     "git-workflow", "systematic-debugging", "spec-auditor",
+     "git-workflow", "using-git-worktrees", "systematic-debugging", "spec-auditor",
      "github-issue-creation", "github-sub-issues"].includes(s.name)
   );
   const implSkills = skillDescriptions.filter(s => !processSkills.includes(s));

--- a/.opencode/scripts/session_init.py
+++ b/.opencode/scripts/session_init.py
@@ -20,11 +20,11 @@ Guard checks (auto-create missing files/branches/worktree):
 - dev branch: Create from origin/dev or main/master if missing
 - worktrees/main/: Bootstrap worktree layout if not set up
 
-Worktree layout (#604):
-- Main folder always on dev branch
-- worktrees/main/ is a permanent production reference
-- worktrees/ is in .gitignore
-- WORKTREE_STATUS=output: ready, bootstrapped, skipped, or failed
+ Worktree layout (#604):
+ - Main folder always on dev branch
+ - worktrees/main/ is a permanent production reference
+ - worktrees/ is in .gitignore
+ - WORKTREE_FATAL=1 is emitted only on setup failure (silent on success)
 
 Usage:
     uv run python .opencode/scripts/session_init.py
@@ -532,7 +532,6 @@ def _add_to_gitignore(entry: str) -> bool:
 
 def bootstrap_worktree_layout() -> None:
     if is_worktree_setup():
-        print("WORKTREE_STATUS=ready")
         return
 
     main_wt_path = os.path.join(os.getcwd(), "worktrees", "main")
@@ -540,8 +539,8 @@ def bootstrap_worktree_layout() -> None:
     if os.path.isdir(main_wt_path):
         result = run_git_command(["worktree", "remove", main_wt_path, "--force"])
         if result is None:
-            print("# ⚠️ Failed to remove stale worktrees/main/ directory", file=sys.stderr)
-            print("WORKTREE_STATUS=failed")
+            print("WORKTREE_FATAL=1")
+            print("# ⚠️ FATAL: Failed to remove stale worktrees/main/ directory", file=sys.stderr)
             return
 
     main_branch = "main"
@@ -549,8 +548,10 @@ def bootstrap_worktree_layout() -> None:
         if run_git_command(["rev-parse", "--verify", "master"]) is not None:
             main_branch = "master"
         else:
-            print("# ⚠️ No main or master branch found — skipping worktree bootstrap", file=sys.stderr)
-            print("WORKTREE_STATUS=skipped")
+            print("WORKTREE_FATAL=1")
+            print(
+                "# ⚠️ FATAL: No main or master branch found — worktree setup requires a default branch", file=sys.stderr
+            )
             return
 
     current = get_current_branch()
@@ -566,8 +567,8 @@ def bootstrap_worktree_layout() -> None:
 
     result = run_git_command(["worktree", "add", main_wt_path, main_branch])
     if result is None:
-        print("# ⚠️ Failed to create worktrees/main/ worktree", file=sys.stderr)
-        print("WORKTREE_STATUS=failed")
+        print("WORKTREE_FATAL=1")
+        print("# ⚠️ FATAL: Failed to create worktrees/main/ worktree", file=sys.stderr)
         if current and current != "dev":
             run_git_command(["checkout", current])
         return
@@ -587,11 +588,6 @@ def bootstrap_worktree_layout() -> None:
         run_git_command(["checkout", current])
         if had_stash:
             run_git_command(["stash", "pop"])
-
-    print("WORKTREE_STATUS=bootstrapped")
-    print("# 🔧 Bootstrapped worktree layout:")
-    print(f"#   - worktrees/main/ → {main_branch} branch")
-    print("#   - worktrees/ added to .gitignore")
 
 
 def run_guard_checks() -> None:

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -46,7 +46,7 @@ git status       # VERIFY clean working tree
 
 **🚫 CRITICAL: Do NOT create branches directly in verify-authorization.**
 
-Branch creation is DELEGATED to `git-workflow --task pre-work`, which includes the Worktree Gate (Step 4a). Creating branches here bypasses that gate — a CRITICAL VIOLATION when the worktree layout is active.
+Branch creation is DELEGATED to `git-workflow --task pre-work`, which includes the Worktree Gate (Step 4a). Creating branches here bypasses that gate — a CRITICAL VIOLATION.
 
 **After git state verification:**
 1. Record that git state is verified and clean

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -68,10 +68,9 @@ git checkout dev
 git pull origin dev
 ```
 
-### Step 4: Remove Feature Worktree (if applicable)
+### Step 4: Remove Feature Worktree
 
-When the worktree layout is active (`worktrees/main/` exists), feature worktrees must
-be cleaned up after PR merge.
+Feature worktrees must be cleaned up after PR merge.
 
 ```bash
 # Determine worktree name from branch name:

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -511,6 +511,30 @@ git commit -m "<descriptive message>" \
     --trailer "Co-authored-by: <Human-Name> <human-email>"
 ```
 
+### Step 3.5: Rebase on Current Dev (MANDATORY)
+
+After squashing and before pushing, re-verify the branch is on top of current `dev`:
+
+```bash
+git fetch origin
+git rebase origin/dev
+```
+
+**Why this matters:**
+- Another agent may have merged a PR into `dev` between review and PR creation
+- The squash commit must be based on the current `dev` tip, not a stale one
+- Prevents the PR from having unexpected merge conflicts or stale base
+
+**If conflicts occur during rebase:**
+1. HALT and report conflicts to the developer
+2. List the conflicting files
+3. Request resolution — the developer must decide how to proceed
+4. After resolution, re-run squash if needed, then retry push
+
+**This step is MANDATORY.** Even if the review-prep rebase just ran, `dev` may have been updated since.
+
+**For worktree-based branches:** The rebase runs inside the worktree directory. The `origin/dev` reference is shared across all worktrees, so `git fetch origin` and `git rebase origin/dev` work correctly from any worktree.
+
 ### Step 4: Push to Remote
 
 ```bash

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -218,44 +218,19 @@ git checkout -b spec/<short-name>  # or feature/<description>
 - Ensure working tree is clean after sync
 - If `dev` doesn't exist locally, create it from `main`: `git checkout -b dev origin/dev`
 
-### Step 4a: Worktree Gate (MANDATORY when layout is active)
+### Step 4a: Worktree Gate (MANDATORY — ALWAYS)
 
-**When the worktree layout is active, feature branch creation MUST create a worktree — not just a branch in the main folder. Bypassing this gate when the layout is active is a CRITICAL VIOLATION (see `000-critical-rules.md`).**
+**Feature branch creation MUST use worktrees — no exceptions, no conditions. Bypassing this gate is a CRITICAL VIOLATION (see `000-critical-rules.md`).**
 
-**Detection (primary = env var, fallback = filesystem):**
-```bash
-# Primary: Use WORKTREE_STATUS from session-init
-# WORKTREE_STATUS values: "ready", "bootstrapped", "skipped", "failed"
-# If WORKTREE_STATUS is empty/unset, fall back to filesystem check
+1. Invoke `using-git-worktrees` skill (ALWAYS, for ANY feature branch)
+2. If worktree creation fails or `WORKTREE_FATAL=1` is detected in session init output, HALT and report the fatal error to the developer — do NOT proceed with any implementation
 
-# Filesystem fallback:
-ls -d worktrees/main .worktrees/main 2>/dev/null
-```
+**There is NO fallback to stash+checkout.** If worktree setup fails, the infrastructure is broken and must be fixed before any work can proceed.
 
-**Decision matrix:**
-
-| Condition | Action |
-|-----------|--------|
-| `WORKTREE_STATUS=ready` or `WORKTREE_STATUS=bootstrapped` + feature branch | **MANDATORY:** Use `using-git-worktrees` skill |
-| Filesystem detects `worktrees/main/` or `.worktrees/main/` + feature branch | **MANDATORY:** Use `using-git-worktrees` skill |
-| `WORKTREE_STATUS=skipped` or `WORKTREE_STATUS=failed` | Use standard stash+checkout workflow |
-| No `WORKTREE_STATUS` env var AND no filesystem worktree dirs | Use standard stash+checkout workflow |
-| Worktree layout active + dev-only work | Work in main folder (no worktree needed) |
-
-**If worktree layout is active and creating a feature branch:**
-1. Invoke `using-git-worktrees` skill — it is MANDATORY, not optional
-2. The worktree skill handles branch creation, isolation, and setup
-3. Do NOT fall back to stash+checkout workflow when layout is active
-
-**Why mandatory:** The OR escape hatch (worktree OR stash+checkout) gives agents a path of least resistance. When the layout is active, worktree isolation is the correct default — it prevents conflicting work between parallel agents.
-
-**Why session-init variable:** `WORKTREE_STATUS` is emitted by `session_init.py` during every session. It reflects the actual state of the worktree layout at session start. Using it avoids redundant filesystem checks and ensures agents consume session-init output rather than ignoring it.
-
-**If no worktree layout is active**, proceed with standard branch creation:
-
-```bash
-git checkout -b spec/<short-name>
-```
+**If `WORKTREE_FATAL=1` appears in session init output:**
+- HALT immediately
+- Report the fatal error to the developer
+- Do NOT attempt any implementation until the worktree infrastructure is fixed
 
 ### Step 5: Verify Clean Working Tree
 
@@ -351,7 +326,7 @@ Verified all proposed changes were already implemented. No modifications needed.
 
 ### Feature Worktree Creation
 
-When the worktree layout is active (`worktrees/main/` or `.worktrees/main/` exists), feature branches MUST use worktrees instead of stash+checkout. This is enforced by the Worktree Gate in Step 4a.
+Feature branches MUST use worktrees instead of stash+checkout. This is ALWAYS enforced by the Worktree Gate in Step 4a.
 
 **Before (stash-based):**
 1. `git stash -u` → 2. `git checkout -b feature/xyz dev` → 3. Work in same folder
@@ -376,7 +351,7 @@ Branch names containing `/` must be sanitized for the worktree directory name:
 
 - **Dev-only work** (no feature branch): Work in main folder directly, no worktree needed
 - **Worktree already exists**: Skip creation, use existing worktree directory
-- **Worktree layout not active**: Fall back to stash+checkout workflow
+- **`WORKTREE_FATAL=1` detected**: HALT immediately, report fatal error to developer, do NOT proceed
 
 ### Worktree Already Exists Check
 

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -142,6 +142,30 @@ ls ./tmp/
 - `./tmp/*.log` (log files)
 - `./tmp/.*` (hidden files like `.output.txt`)
 
+### Step 1.5: Rebase on Current Dev (MANDATORY)
+
+Before pushing for review, sync the feature branch with the current state of `dev`:
+
+```bash
+git fetch origin
+git rebase origin/dev
+```
+
+**Why this matters:**
+- Other agents may have merged work into `dev` since branch creation
+- The compare URL must reflect an accurate diff against current `dev`
+- Merge conflicts surfacing at review time are better than at PR creation time
+- The developer reviews the actual changes that will be in the PR
+
+**If conflicts occur during rebase:**
+1. HALT and report conflicts to the developer
+2. List the conflicting files
+3. Request resolution before proceeding
+
+**This step is MANDATORY even if no other agents are known to be working.** Dev may have been updated by human merges, other agents, or CI.
+
+**For worktree-based branches:** The rebase runs inside the worktree directory. The `origin/dev` reference is shared across all worktrees, so `git fetch origin` and `git rebase origin/dev` work correctly from any worktree.
+
 ### Step 2: Verify Branch Is Pushed
 
 **Before generating compare URL, verify branch is on remote.**

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -33,7 +33,7 @@ Fresh subagent per task = no context pollution between tasks. You precisely craf
 **Before dispatching any subagent, these gates MUST be satisfied:**
 
 1. **approval-gate** — Authorization verified (`approved` or `go` received)
-2. **git-workflow --task pre-work** — Branch created, working tree clean (includes Worktree Gate: when worktree layout is active, feature branches MUST use `using-git-worktrees`)
+2. **git-workflow --task pre-work** — Branch created, working tree clean (includes Worktree Gate: feature branches MUST use `using-git-worktrees`)
 3. **Plan exists** — Writing-plans output available with TDD tasks
 
 **After all tasks complete, these gates are MANDATORY:**
@@ -128,7 +128,7 @@ This project uses the `feature→dev→main` three-branch workflow:
 | Phase | Skill | Purpose |
 |-------|-------|---------|
 | Pre-implementation | `approval-gate` | Verify authorization |
-| Branch creation | `git-workflow --task pre-work` (includes Worktree Gate) | Create feature branch (worktree when layout active) |
+| Branch creation | `git-workflow --task pre-work` (includes Worktree Gate) | Create feature branch (ALWAYS via worktree) |
 | Per-task | Implementer → spec review → code quality review loop | Execute tasks |
 | Post-implementation | `verification-before-completion --task verify` | Evidence collection |
 | Completion | `finishing-a-development-branch --task checklist` | Branch readiness |

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: Use when starting feature work that needs isolation from current workspace, before executing implementation plans, or when working with multiple agents in parallel. Triggers on: worktree, isolated workspace, parallel agent, worktree setup, branch isolation, concurrent work, set up worktree.
+description: Use when creating any feature branch. Always invoke before git-workflow pre-work. Triggers on: branch, feature branch, pre-work, worktree, new branch, checkout.
 type: technique
 license: MIT
 compatibility: opencode
@@ -47,29 +47,13 @@ After work is complete and PR is merged, the worktree cleanup is handled by the 
 
 ## Directory Selection Process
 
-Follow this priority order:
+Worktrees are ALWAYS created in `worktrees/` (per #604 worktree-integrated three-branch model). There is NO fallback to stash+checkout.
 
-### 1. Check Existing Directories
+**If `WORKTREE_FATAL=1` appears in session init output:** HALT immediately and report the fatal error to the developer. Do NOT proceed with any implementation.
 
-```bash
-ls -d worktrees 2>/dev/null       # Preferred (from #604 worktree model)
-ls -d .worktrees 2>/dev/null      # Legacy (hidden)
-```
+### Directory: `worktrees/`
 
-**If found:** Use that directory. If both exist, `worktrees` wins (per #604 spec).
-
-### 2. Check AGENTS.md / Project Config
-
-```bash
-# Check for worktree directory preference in project files
-grep -i "worktree" AGENTS.md .opencode/AGENTS.md 2>/dev/null
-```
-
-**If preference specified:** Use it without asking.
-
-### 3. Default to Project-Local
-
-If no directory exists and no preference found, default to `worktrees/` (per #604 worktree-integrated three-branch model).
+The project uses `worktrees/` as the worktree directory (per #604 spec). The `session_init.py` script bootstraps `worktrees/main/` automatically. All feature worktrees are created under `worktrees/`.
 
 ## Safety Verification
 
@@ -191,11 +175,9 @@ git worktree list
 
 | Situation | Action |
 |-----------|--------|
-| `.worktrees/` exists | Use it (verify ignored) |
-| `worktrees/` exists | Use it (verify ignored) |
-| Both exist | Use `.worktrees/` |
-| Neither exists | Create `.worktrees/` and add to `.gitignore` |
-| Directory not ignored | Add to `.gitignore` + commit |
+| `worktrees/` exists (expected) | Use it |
+| `worktrees/` not ignored | Add to `.gitignore` |
+| `WORKTREE_FATAL=1` in session init | HALT and report to developer |
 | Tests fail during baseline | Report failures + ask |
 | No `pyproject.toml` | Skip dependency install |
 
@@ -220,6 +202,23 @@ git worktree list
 
 - **Problem:** Other agents unaware of parallel workspace
 - **Fix:** Always announce "Using the using-git-worktrees skill to set up an isolated workspace" at start
+
+## Fatal Error Protocol
+
+**If `WORKTREE_FATAL=1` appears in session init output or worktree creation fails:**
+
+1. HALT immediately — do NOT proceed with any implementation
+2. Report the fatal error to the developer
+3. Do NOT fall back to stash+checkout — worktrees are MANDATORY, not optional
+4. The developer must fix the worktree infrastructure before any work can proceed
+
+**Worktree setup failure means the repository infrastructure is broken.** Proceeding without worktrees risks:
+- Parallel agent conflicts
+- Dirty working trees
+- Lost changes
+- Branch contamination
+
+There is NO fallback to stash+checkout. Fix the infrastructure, then proceed.
 
 ## Integration
 
@@ -260,9 +259,10 @@ This cleanup happens as part of the standard `git-workflow --task cleanup` seque
 - Handle worktree cleanup in this skill (delegated to `finishing-a-development-branch`)
 
 **Always:**
-- Follow directory priority: existing > AGENTS.md > default `.worktrees/`
+- Use `worktrees/` directory (per #604 spec, no fallback)
 - Verify directory is ignored for project-local
 - Auto-detect and run `uv sync` for project setup
 - Announce worktree creation at start
 - Create branch from `dev` (not `main`)
 - Verify clean test baseline
+- HALT immediately if `WORKTREE_FATAL=1` appears in session init


### PR DESCRIPTION
## Summary

Eliminates the `WORKTREE_STATUS` conditional enum, making worktree usage mandatory for all feature branch creation with no fallback to `stash+checkout`. Adds mandatory dev-rebase steps before both review push and PR push to ensure feature branches stay current with `dev`.

## Outcome

Agents can no longer skip worktree usage or fall back to stash+checkout. Feature branches are always based on current `dev` at every push point, preventing stale-base PRs and merge conflicts between parallel agents.

Fixes #641
Fixes #643
Fixes #644
Fixes #645
Fixes #646
Fixes #647
Fixes #648
Fixes #649