### PR TITLE
fix: standardize worktree directory to .worktrees/ — no legacy fallback

### DIFF
--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -74,15 +74,15 @@ Feature worktrees must be cleaned up after PR merge.
 
 ```bash
 # Determine worktree name from branch name:
-# spec/604-worktree-model → worktrees/spec-604-worktree-model
-# feature/my-change → worktrees/feature-my-change
+# spec/<name> → .worktrees/spec-<name>
+# feature/<name> → .worktrees/feature-<name>
 # Rule: Replace / with - in the worktree directory name
 
 SANITIZED=$(echo "<merged-branch-name>" | tr '/' '-')
-WT_PATH="worktrees/${SANITIZED}"
+WT_PATH=".worktrees/${SANITIZED}"
 
 # Check if worktree exists for this branch
-if [ -d "worktrees" ] && git worktree list | grep -q "$WT_PATH"; then
+if [ -d ".worktrees" ] && git worktree list | grep -q "$WT_PATH"; then
     git worktree remove "$WT_PATH"
     echo "Removed worktree: $WT_PATH"
 fi

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -333,8 +333,8 @@ Feature branches MUST use worktrees instead of stash+checkout. This is ALWAYS en
 
 **After (worktree-based):**
 1. Ensure main folder is on `dev`: `git checkout dev && git pull origin dev`
-2. Create worktree: `git worktree add worktrees/feature-xyz -b feature/xyz dev`
-3. Work in `worktrees/feature-xyz/`
+2. Create worktree: `git worktree add .worktrees/feature-xyz -b feature/xyz dev`
+3. Work in `.worktrees/feature-xyz/`
 
 ### Branch Name to Worktree Name Mapping
 
@@ -342,8 +342,8 @@ Branch names containing `/` must be sanitized for the worktree directory name:
 
 | Branch Name | Worktree Directory |
 |-------------|-------------------|
-| `feature/my-change` | `worktrees/feature-my-change/` |
-| `spec/604-worktree-model` | `worktrees/spec-604-worktree-model/` |
+| `feature/<name>` | `.worktrees/feature-<name>/` |
+| `spec/<name>` | `.worktrees/spec-<name>/` |
 
 **Rule:** Replace `/` with `-` in the worktree directory name.
 

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -47,17 +47,17 @@ After work is complete and PR is merged, the worktree cleanup is handled by the 
 
 ## Directory Selection Process
 
-Worktrees are ALWAYS created in `worktrees/` (per #604 worktree-integrated three-branch model). There is NO fallback to stash+checkout.
+Worktrees are ALWAYS created in `.worktrees/`. There is NO fallback to stash+checkout.
 
 **If `WORKTREE_FATAL=1` appears in session init output:** HALT immediately and report the fatal error to the developer. Do NOT proceed with any implementation.
 
-### Directory: `worktrees/`
+### Directory: `.worktrees/`
 
-The project uses `worktrees/` as the worktree directory (per #604 spec). The `session_init.py` script bootstraps `worktrees/main/` automatically. All feature worktrees are created under `worktrees/`.
+The project uses `.worktrees/` as the worktree directory. The `session_init.py` script bootstraps `.worktrees/main/` automatically. All feature worktrees are created under `.worktrees/`.
 
 ## Safety Verification
 
-### For Project-Local Directories (.worktrees or worktrees)
+### For `.worktrees/` Directory
 
 **MUST verify directory is ignored before creating worktree:**
 
@@ -98,7 +98,7 @@ project=$(basename "$(git rev-parse --show-toplevel)")
 
 ```bash
 # Determine branch name (spec/<name> or feature/<name>)
-BRANCH_NAME="spec/554-git-worktrees-skill"
+BRANCH_NAME="spec/<short-name>"
 
 # Create worktree with new branch from dev
 git worktree add .worktrees/$BRANCH_NAME -b $BRANCH_NAME dev
@@ -138,9 +138,9 @@ uv run pytest test/ -x
 ### 8. Report Location
 
 ```
-Worktree ready at .worktrees/spec/554-git-worktrees-skill
+Worktree ready at .worktrees/spec-<short-name>
 Tests passing (<N> tests, 0 failures)
-Branch: spec/554-git-worktrees-skill (from dev)
+Branch: spec/<short-name> (from dev)
 Ready to implement <feature-name>
 All commands use workdir=".worktrees/$BRANCH_NAME" — never cd
 ```
@@ -175,8 +175,9 @@ git worktree list
 
 | Situation | Action |
 |-----------|--------|
-| `worktrees/` exists (expected) | Use it |
-| `worktrees/` not ignored | Add to `.gitignore` |
+| `.worktrees/` exists | Use it |
+| `.worktrees/` not ignored | Add to `.gitignore` |
+| `.worktrees/` missing | Create it and add to `.gitignore` |
 | `WORKTREE_FATAL=1` in session init | HALT and report to developer |
 | Tests fail during baseline | Report failures + ask |
 | No `pyproject.toml` | Skip dependency install |
@@ -259,7 +260,7 @@ This cleanup happens as part of the standard `git-workflow --task cleanup` seque
 - Handle worktree cleanup in this skill (delegated to `finishing-a-development-branch`)
 
 **Always:**
-- Use `worktrees/` directory (per #604 spec, no fallback)
+- Use `.worktrees/` directory (no fallback)
 - Verify directory is ignored for project-local
 - Auto-detect and run `uv sync` for project setup
 - Announce worktree creation at start


### PR DESCRIPTION
## Summary

Standardize all worktree directory references to `.worktrees/` (hidden, plural) across skills and guidelines, removing legacy `worktrees/` dual-path confusion.

## Outcome

Agents will no longer encounter contradictory guidance about which directory to use. Single convention: `.worktrees/`.

**Changes:**
- `using-git-worktrees/SKILL.md`: Single `.worktrees/` directory, removed priority/fallback logic and hardcoded branch names
- `git-workflow/tasks/pre-work.md`: Unconditional worktree mandate, `.worktrees/` paths only
- `git-workflow/tasks/cleanup.md`: `WT_PATH=".worktrees/${SANITIZED}"`
- `000-critical-rules.md`: `.worktrees/main/` detection path, unconditional mandate retained from dev

Fixes #650