### PR TITLE
[SPEC] Conflict Resolution Workflow — Prevent Silent Intent Erosion During Rebase/Merge

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -764,6 +764,64 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
+## Critical Violation: Blind Conflict Resolution
+
+**⚠️ Resolving git conflicts using "ours"/"theirs" heuristics without classifying conflict tier is a CRITICAL GUIDELINE VIOLATION.**
+
+When an agent performs a rebase, merge, cherry-pick, or any git operation that produces conflicts, it MUST classify each conflict before resolving it. Blindly accepting "ours" or "theirs" without understanding what is being lost can silently erase committed work and spec intent.
+
+### 🚫 FORBIDDEN
+
+- Resolving ALL conflicts with `git checkout --theirs` or `git checkout --ours` without classification
+- Using `git rebase --strategy-option=theirs/ours` as a blanket resolution
+- Accepting one side of a conflict without reading what the other side contains
+- Skipping conflict classification because "conflicts are just formatting"
+- Proceeding after conflict resolution without verifying spec compliance
+- Creating commits that resolve conflicts by dropping changes silently
+
+### ✅ REQUIRED
+
+**See `conflict-resolution` skill for the complete procedural workflow including classification, notification, and verification.**
+
+Key requirements:
+- **Classify EVERY conflict** into one of three tiers before resolving
+- **Tier 1 (Trivial):** Whitespace, formatting, reordering → auto-resolve, silent
+- **Tier 2 (Textual but safe):** Same intent, different text → auto-resolve, note in chat
+- **Tier 3 (Intent conflict):** Different goals or spec compliance at risk → HALT, flag for developer review
+- **Post-resolution verification:** After resolving conflicts, verify the result still satisfies the original spec
+- **Notify developer:** Chat summary for Tier 2 and Tier 3; GitHub Issue for complex Tier 3
+
+### Conflict Classification Tiers
+
+| Tier | Name | Criteria | Agent Action |
+|------|------|----------|-------------|
+| 1 | **Trivial** | Whitespace, formatting, reordering of unchanged lines | Auto-resolve, silent |
+| 2 | **Textual but safe** | Same intent on both sides, just different text (e.g., both rename same variable) | Auto-resolve, note in chat |
+| 3 | **Intent conflict** | Different goals, or resolution could alter spec compliance | Halt, flag for developer review |
+
+### Notification Strategy
+
+| Conflict Severity | Notification | Persistence |
+|-------------------|-------------|-------------|
+| Tier 1 (Trivial) | None | None |
+| Tier 2 (Textual but safe) | Chat summary | None |
+| Tier 3 — Minor (devil in the details) | Chat with specifics | None |
+| Tier 3 — Complex (architectural) | Chat summary + GitHub Issue | Persistent issue for review |
+
+### Why This Matters
+
+| Violation | Consequence |
+|-----------|-------------|
+| Blind "theirs" resolution | All feature branch changes silently erased |
+| Blind "ours" resolution | All parent branch changes silently erased |
+| Syntactically correct but semantically wrong | Spec intent violated without detection |
+| No notification to developer | No visibility into what was resolved or lost |
+| No spec compliance check | Rebased result may not satisfy original spec |
+
+**See `conflict-resolution` skill for the complete procedural workflow.**
+
+______________________________________________________________________
+
 ## Critical: Engineering Mindset Required
 
 **⚠️ All work must be approached with proper engineering discipline.**

--- a/.opencode/skills/conflict-resolution/SKILL.md
+++ b/.opencode/skills/conflict-resolution/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: conflict-resolution
+description: Use when resolving git conflicts during rebase, merge, or cherry-pick operations. Triggers on: conflict, merge conflict, rebase conflict, resolve conflict, cherry-pick conflict, conflict resolution, intent conflict, conflict classification.
+---
+
+# Skill: conflict-resolution
+
+## Overview
+
+Procedural workflow for classifying and resolving git conflicts with proper intent preservation. Prevents silent erosion of committed work during rebase, merge, cherry-pick, or any git operation that produces conflicts.
+
+## Persona
+
+You are a Conflict Resolution Specialist. Your focus is ensuring no committed work or spec intent is silently lost during git conflict resolution.
+
+## Invocation
+
+- **Automatic**: Invoked by `git-workflow` tasks when conflicts are detected during rebase/merge
+- **Manual**: Agent invokes when encountering conflicts in any git operation
+
+## Conflict Classification Tiers
+
+Before resolving ANY conflict, classify it:
+
+| Tier | Name | Criteria | Agent Action |
+|------|------|----------|-------------|
+| 1 | **Trivial** | Whitespace, formatting, reordering of unchanged lines | Auto-resolve, silent |
+| 2 | **Textual but safe** | Same intent on both sides, just different text (e.g., both rename same variable) | Auto-resolve, note in chat |
+| 3 | **Intent conflict** | Different goals, or resolution could alter spec compliance | HALT, flag for developer review |
+
+## Procedure
+
+### Step 1: Detect Conflicts
+
+When a git operation reports conflicts:
+
+```bash
+git status --porcelain | grep "^UU\|^AA\|^DU\|^UD"
+```
+
+List all conflicting files. Proceed to classify each one.
+
+### Step 2: Classify Each Conflict
+
+For EACH conflicting file, read both sides of the conflict:
+
+```bash
+git diff --name-only --diff-filter=U
+```
+
+Then examine conflict markers in the file. Determine the tier:
+
+**Tier 1 — Trivial (auto-resolve, silent):**
+- Whitespace-only differences
+- Formatting changes (indentation, trailing whitespace)
+- Reordering of unchanged lines
+- Import ordering changes
+
+**Tier 2 — Textual but safe (auto-resolve, notify chat):**
+- Same intent expressed differently (e.g., both sides rename the same variable to the same name)
+- Duplicate additions (both sides add the same or equivalent content)
+- Minor wording differences in comments/docstrings that don't change behavior
+
+**Tier 3 — Intent conflict (HALT, flag for developer):**
+- Different goals between the two sides
+- Resolution could alter spec compliance
+- Architectural decisions differ between branches
+- Feature branch changes would be erased by accepting "theirs"
+- Parent branch changes would be erased by accepting "ours"
+- Any uncertainty about whether the resolution preserves spec intent
+
+**Classification rule:** When in doubt, classify UP to the next tier. If unsure whether something is Tier 2 or Tier 3, treat it as Tier 3.
+
+### Step 3: Resolve According to Tier
+
+**Tier 1 — Trivial:**
+
+```bash
+# Accept whichever side is more consistent
+git checkout --theirs <file>  # or --ours, depending on context
+git add <file>
+```
+
+No notification required. Proceed silently.
+
+**Tier 2 — Textual but safe:**
+
+```bash
+# Accept whichever side is more consistent or merge manually
+git checkout --theirs <file>  # or --ours
+git add <file>
+```
+
+Notify in chat:
+
+```
+**Conflict Resolution (Tier 2 - Textual):**
+- File: <path>
+- Reason: <why it's textual but safe>
+- Resolution: <which side was accepted>
+```
+
+**Tier 3 — Intent conflict:**
+
+1. **HALT** — do NOT resolve the conflict
+2. **Read both sides carefully** — understand what each branch intended
+3. **Assess complexity:**
+   - **Minor (devil in the details):** Few files, narrow scope, no architectural impact
+   - **Complex (architectural):** Multiple files, architectural decisions, spec compliance at risk
+4. **Report to developer in chat:**
+
+```
+**⚠️ Intent Conflict Detected (Tier 3):**
+- File: <path>
+- Feature branch intent: <what the feature branch was trying to do>
+- Parent branch intent: <what the parent branch changed>
+- Agent assessment: <minor or complex>
+- Agent recommendation: <which side to prefer and why, or flag for developer decision>
+```
+
+5. **For complex intent conflicts**, also create a GitHub Issue:
+
+```python
+github_issue_write(
+    method="create",
+    title=f"[Conflict] <descriptive-title> during rebase of <branch>",
+    body=f"## Conflict During Rebase\n\nBranch: <branch>\nRebasing onto: dev\n\n## Tier 3 - Intent Conflict\n\nFile: <path>\nFeature branch intent: <...>\nParent branch intent: <...>\n\n## Assessment\n\n<agent analysis of the conflict and recommendation>\n\n## Context\n\nRebasing spec/<branch> onto updated dev. This conflict requires developer review to determine correct resolution.",
+    labels=["conflict-resolution"]
+)
+```
+
+6. **WAIT** for developer guidance before resolving Tier 3 conflicts
+7. After developer provides guidance, resolve the conflict and continue
+
+### Step 4: Post-Resolution Verification
+
+After ALL conflicts are resolved and before continuing the rebase/merge:
+
+1. **Verify spec compliance**: Read the rebased/merged files and check they still satisfy the original spec
+
+```bash
+# Check for key elements from the spec
+grep -c "<spec-key-term>" <resolved-file>
+```
+
+2. **Verify no dropped changes**: Check that no committed work was silently erased
+
+```bash
+# Compare result against feature branch's original state
+git diff <feature-branch-original>...HEAD -- <resolved-file>
+```
+
+3. **Report verification results in chat:**
+
+```
+**Post-Resolution Verification:**
+- Files resolved: <count>
+- Tier 1 (trivial): <count>
+- Tier 2 (textual): <count>
+- Tier 3 (intent): <count>
+- Spec compliance: ✅ Verified / ❌ Needs review
+- Dropped changes: None detected / ⚠️ <description>
+```
+
+### Step 5: Continue Git Operation
+
+After verification passes:
+
+```bash
+git rebase --continue   # or: git merge --continue, git cherry-pick --continue
+```
+
+If verification fails, report the issue and HALT for developer review.
+
+## Notification Format
+
+### Chat Notification (Tier 2)
+
+```
+**Conflict Resolution (Tier 2 - Textual):**
+- File: <path>
+- Reason: <why it's textual but safe>
+- Resolution: <which side was accepted>
+```
+
+### Chat Notification (Tier 3 Minor)
+
+```
+**⚠️ Intent Conflict Detected (Tier 3 - Minor):**
+- File: <path>
+- Feature branch intent: <what>
+- Parent branch intent: <what>
+- Resolution: <agent recommendation, awaiting developer confirmation>
+```
+
+### Chat + GitHub Issue (Tier 3 Complex)
+
+Chat notification plus persistent GitHub Issue with `conflict-resolution` label for tracking.
+
+## Integration Points
+
+| Skill | When |
+|-------|------|
+| `git-workflow` `--task review-prep` | Automatically invokes this skill when rebase produces conflicts |
+| `git-workflow` `--task implementation` | May invoke if mid-implementation merge produces conflicts |
+
+## Anti-Patterns
+
+**🚫 NEVER:**
+- Resolve ALL conflicts with `git checkout --theirs` / `git checkout --ours`
+- Use `git rebase --strategy-option=theirs/ours` as blanket resolution
+- Skip reading the conflict content before resolving
+- Assume formatting conflicts are always trivial (could hide intent changes)
+- Continue rebase after resolving intent conflicts without verifying spec compliance
+- Create commits that silently drop committed work
+
+**✅ ALWAYS:**
+- Classify every conflict into a tier before resolving
+- When in doubt, classify UP (Tier 2 vs Tier 3 → Tier 3)
+- Verify spec compliance after resolving all conflicts
+- Notify developer for Tier 3 conflicts
+- Create GitHub Issue for complex Tier 3 conflicts
+- Preserve feature branch intent unless developer says otherwise
+
+## Context
+
+**See `000-critical-rules.md` → "Critical Violation: Blind Conflict Resolution" for the zero-tolerance rule.**
+
+Base directory for this skill: file:///home/muksihs/git/snea-shoebox-editor/.opencode/skills/conflict-resolution

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Use when creating a branch, committing changes, pushing work, or creating a PR. Triggers on: branch, commit, push, PR, pull request, pre-work, review-prep, feature branch, dev branch, squash.
+description: Use when creating a branch, committing changes, pushing work, or creating a PR. Also use when git rebase/merge produces conflicts — invoke conflict-resolution skill for classification. Triggers on: branch, commit, push, PR, pull request, pre-work, review-prep, feature branch, dev branch, squash, conflict, merge conflict, rebase conflict.
 type: discipline-enforcing
 license: MIT
 compatibility: opencode
@@ -662,8 +662,8 @@ pre-work → implementation → review-prep → pr-creation → cleanup
 
 ## Cross-References
 
-- Related skills: `approval-gate` (authorization), `pr-creation-workflow` (PR timing), `changelog-generator` (changelog generation)
-- Related guidelines: `110-git-branch-first.md`, `111-git-commit-workflow.md`, `113-git-pr-workflow.md`, `114-git-branch-cleanup.md`, `124-github-archive-workflow.md`
+- Related skills: `approval-gate` (authorization), `pr-creation-workflow` (PR timing), `changelog-generator` (changelog generation), `conflict-resolution` (conflict classification during rebase/merge)
+- Related guidelines: `000-critical-rules.md` (blind conflict resolution rule), `110-git-branch-first.md`, `111-git-commit-workflow.md`, `113-git-pr-workflow.md`, `114-git-branch-cleanup.md`, `124-github-archive-workflow.md`
 - Session init: `.opencode/plugins/session-enforcement.ts` (for GIT_OWNER, GIT_REPO, DEV_NAME, DEV_EMAIL)
 
 ## Changelog Generation (Sub-Task Integration)

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -157,10 +157,16 @@ git rebase origin/dev
 - Merge conflicts surfacing at review time are better than at PR creation time
 - The developer reviews the actual changes that will be in the PR
 
-**If conflicts occur during rebase:**
-1. HALT and report conflicts to the developer
-2. List the conflicting files
-3. Request resolution before proceeding
+**If conflicts occur during rebase, invoke `/skill conflict-resolution` to classify and resolve them:**
+
+1. **Invoke conflict-resolution skill** — classify each conflict into tier (trivial, textual, intent)
+2. **Resolve Tier 1 and Tier 2 conflicts** — auto-resolve, notify via chat
+3. **HALT for Tier 3 (intent) conflicts** — flag for developer review, create GitHub Issue for complex conflicts
+4. **After all conflicts resolved** — verify rebased result satisfies original spec (see Step 4 in conflict-resolution skill)
+
+**🚫 NEVER resolve ALL conflicts with `git checkout --theirs` or `git checkout --ours` without classification. This is a CRITICAL VIOLATION.**
+
+**See `conflict-resolution` skill for the complete procedural workflow.**
 
 **This step is MANDATORY even if no other agents are known to be working.** Dev may have been updated by human merges, other agents, or CI.
 


### PR DESCRIPTION
**Summary:**

Prevents agents from silently erasing committed work during rebase/merge by adding a three-tier conflict classification workflow (trivial, textual, intent) with mandatory escalation for intent conflicts.

**Outcome:** Agents will classify every git conflict before resolving, halt for developer review on intent conflicts, and verify spec compliance after resolution. No more blind "ours"/"theirs" resolutions that silently drop feature branch changes.

Fixes #653
Fixes #654
Fixes #655
Fixes #656
Fixes #657