### PR TITLE
feat: parallel worktree-aware workflow for sub-agent dispatch

### DIFF
--- a/.opencode/.guidelines/branch-first-protocol.md
+++ b/.opencode/.guidelines/branch-first-protocol.md
@@ -1,15 +1,14 @@
 # Fragment: Branch-First Protocol
 
-**🚫 ZERO TOLERANCE: Branch Before Edit**
+**🚫 ZERO TOLERANCE: Branch Before Edit (via Worktree)**
 
-**The agent MUST create a feature branch BEFORE ANY filesystem change.**
+**The agent MUST create a feature worktree BEFORE ANY filesystem change.**
 
 This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any file, creating any file, or making ANY change to the project:
 
-1. **Check current branch**: `git branch --show-current`
-2. **If on `main`**: STOP — you MUST create a feature branch first
-3. **Create branch**: `git checkout -b spec/<short-name>` or `git checkout -b feature/<description>`
-4. **ONLY THEN**: Proceed with file changes
+1. **Invoke `using-git-worktrees` skill** — creates isolated worktree (MANDATORY, no exceptions)
+2. **All work happens in the worktree** — never in the main working directory
+3. **ONLY THEN**: Proceed with file changes inside the worktree
 
 **What Counts as a "Change"?**
 - Editing any file (code, config, docs, tests)
@@ -22,8 +21,8 @@ This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any f
 - **Using file-editing MCP tools** (`pycharm_replace_text_in_file`, `pycharm_create_new_file`, etc.) — these ARE filesystem changes
 
 **⚠️ MCP Tools Are NOT an Exception**
-- `pycharm_replace_text_in_file` → edits files → MUST be on feature branch
-- `pycharm_create_new_file` → creates files → MUST be on feature branch
+- `pycharm_replace_text_in_file` → edits files → MUST be in worktree
+- `pycharm_create_new_file` → creates files → MUST be in worktree
 - `github_issue_write` → GitHub Issues, NOT local files → NOT a filesystem change
 - `github_add_issue_comment` → GitHub comments → NOT a filesystem change
 
@@ -33,47 +32,43 @@ This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any f
 - No exceptions for docs, tests, configs, or guidelines
 - No exceptions for hotfixes or urgent changes
 - No exceptions for typo fixes or whitespace changes
-- The branch IS the safety net — without it, mistakes have no rollback
+- The worktree IS the safety net — without it, mistakes have no rollback
 
 **Violation = Hard Stop**
 - If you catch yourself about to edit files while on `main`, STOP immediately
-- Report "I need to create a branch first" and wait for the branch creation
-- Never proceed past this checkpoint without a feature branch
+- Report "I need to create a worktree first" and invoke `using-git-worktrees`
+- Never proceed past this checkpoint without an active worktree
 
 ### ✅ ALWAYS DO
 ```
-# Correct order:
-git checkout main && git pull origin main
-git checkout -b spec/my-change      # ← FIRST
-# NOW edit files, write code, etc.   # ← SECOND
+# Correct order (using worktree):
+# 1. Sync dev: git checkout dev && git pull origin dev
+# 2. Create worktree: git worktree add .worktrees/spec-my-change -b spec/my-change dev
+# 3. Work in .worktrees/spec-my-change/ (using workdir parameter)
 ```
 
 ### 🚫 NEVER DO
 ```
-# WRONG ORDER — VIOLATION:
-# edit files, write code...           # ← WRONG: No branch yet
-git checkout -b spec/my-change        # ← Too late!
+# WRONG — VIOLATION (stash+checkout):
+git stash -u
+git checkout -b spec/my-change
+# Work in main working directory
+
+# WRONG — VIOLATION (checkout without worktree):
+git checkout dev && git pull origin dev
+git checkout -b spec/my-change dev
+# Work in main working directory
 ```
 
-## Preserve External Changes: Stash ALL Unrelated Changes FIRST
+## Worktree Isolation (Replaces Stash)
 
-**When ANY files are modified on `main` (or current branch), the agent MUST stash them BEFORE creating a new branch.**
+Worktrees provide complete isolation — no stash is needed. Each worktree has its own working directory, so main tree changes are never affected.
 
-### ⚠️ MANDATORY: Stash First, Ask Questions Never
-
-**Before ANY branch creation, this sequence is MANDATORY:**
-
-1. `git status` — Check for modifications
-2. **ALWAYS stash ALL pending changes (modified, deleted, untracked):**
-   - `git stash push -u -m "WIP: before <branch-name>"`
-   - **The `-u` flag includes untracked files — MANDATORY.**
-   - `git stash list` — **VERIFY stash was created**
-   - `git status` — **VERIFY working tree is clean** (must show "nothing to commit, working tree clean")
-3. **Then and ONLY then**: Create branch
+**If `WORKTREE_PATH` is not set or empty after worktree creation: FATAL ERROR → FLAG DEV → HALT.**
 
 <!--
 Fragment ID: branch-first-protocol
-Estimated tokens: 425
+Estimated tokens: 380
 Type: text-block
 Sync status: synchronized
 -->

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -15,16 +15,16 @@ Worktrees are ALWAYS mandatory for feature branch creation. There is no conditio
 
 - Using `git checkout -b` to create feature branches — ALWAYS use worktrees instead
 - Using `git stash push -u` then `git checkout -b` as a substitute for worktree-based branch creation
-- Bypassing the Worktree Gate in `git-workflow --task pre-work` Step 4a
 - Creating branches directly in `verify-authorization` instead of delegating to `pre-work`
-- Checking `WORKTREE_STATUS` or filesystem for worktree availability before deciding
-- Using `stash + checkout` as a fallback for ANY reason
+- Using `stash + checkout` for ANY reason — this method does not exist as an option
 - Ignoring `WORKTREE_FATAL=1` in session init output
+- Operating in the main working directory for feature work
 
 ### ✅ REQUIRED
 
 - **ALWAYS use `using-git-worktrees` skill** for feature branch creation — no exceptions, no conditions
 - **If `WORKTREE_FATAL=1` appears in session init output:** HALT immediately and report the fatal error to the developer — do NOT proceed with any implementation
+- **If `WORKTREE_PATH` is not set or empty after worktree creation:** FATAL ERROR → FLAG DEV → HALT — do not proceed without a valid worktree path
 - **`verify-authorization` MUST delegate branch creation** to `git-workflow --task pre-work` — never create branches directly
 
 ### Why This Matters
@@ -32,12 +32,11 @@ Worktrees are ALWAYS mandatory for feature branch creation. There is no conditio
 | Violation | Consequence |
 |-----------|-------------|
 | `stash + checkout -b` for feature branches | Parallel agent conflicts, dirty working trees, lost changes |
-| Skipping Worktree Gate | Other agents unaware of parallel work, merge conflicts |
-| Using `stash+checkout` as fallback | Creates path of least resistance that bypasses worktree isolation |
+| Operating in main working directory | No isolation between agents, merge conflicts |
 | Ignoring `WORKTREE_FATAL=1` | Agent proceeds despite infrastructure failure, corrupts work |
-| Branch creation in `verify-authorization` | Worktree Gate in `pre-work` completely bypassed |
+| Branch creation in `verify-authorization` | Worktree creation in `pre-work` completely bypassed |
 
-**See `git-workflow` skill `--task pre-work` Step 4a for the complete Worktree Gate procedure.**
+**See `git-workflow` skill `--task pre-work` for the complete worktree creation procedure.**
 
 ______________________________________________________________________
 
@@ -47,24 +46,24 @@ ______________________________________________________________________
 
 ### 🚫 FORBIDDEN
 
-- Starting ANY work (implementation, verification, editing) WITHOUT checking git state first
-- Assuming working tree is clean without `git status` verification
+- Starting ANY work (implementation, verification, editing) WITHOUT creating a worktree first
+- Operating in the main working directory for feature work — ALWAYS use worktrees
 - Creating files while on `main` or `dev` branch
 - Editing files while on `main` or `dev` branch
-- Skipping stash when pending changes exist
+- Using `git checkout -b` instead of worktree creation
 
 ### ✅ MANDATORY
 
-**See `git-workflow` skill `--task pre-work` for the mandatory pre-check sequence, stash verification, and branch creation steps.**
+**See `git-workflow` skill `--task pre-work` for the mandatory worktree creation and environment variable verification steps.**
 
 ### Why This Matters
 
 | Scenario | Consequence |
 |----------|-------------|
 | Edit files on `main` | Cannot create branch, changes stuck on `main` |
-| Skip git status check | Untracked files lost when switching branches |
-| Forget `-u` flag | Untracked files NOT stashed, lost forever |
-| Skip stash verification | Modifications silently lost |
+| Skip worktree creation | No isolation between agents, merge conflicts |
+| Use stash+checkout instead of worktree | Parallel agent conflicts, dirty working trees |
+| Skip `WORKTREE_PATH` verification | Agent operates in wrong directory, corrupts work |
 
 ______________________________________________________________________
 

--- a/.opencode/guidelines/115-branch-naming.md
+++ b/.opencode/guidelines/115-branch-naming.md
@@ -26,28 +26,29 @@
 
 ## Branching Workflow
 
+**ALL feature branch creation uses worktrees (mandatory, no exceptions).** See `using-git-worktrees` skill.
+
 ### Feature Development
 
 ```bash
-# 1. Sync with dev
+# 1. Sync main working tree with dev
 git checkout dev && git pull origin dev
 
-# 2. Create feature branch
-git checkout -b spec/my-feature
+# 2. Create feature worktree (using-git-worktrees skill)
+git worktree add .worktrees/spec-my-feature -b spec/my-feature dev
 
-# 3. Work on feature
-# ... make changes, commit ...
+# 3. Work in the worktree (use workdir parameter on all commands)
+# ... make changes, commit inside .worktrees/spec-my-feature ...
 
-# 4. Push feature branch
+# 4. Push feature branch from worktree
 git push -u origin spec/my-feature
 
 # 5. Create PR targeting dev
 # PR base: dev (not main)
 
-# 6. After PR merge, delete feature branch
-git checkout dev && git pull origin dev
-git branch -d spec/my-feature
-git push origin --delete spec/my-feature
+# 6. After PR merge, cleanup (git-workflow --task cleanup)
+git worktree remove .worktrees/spec-my-feature
+git worktree prune
 ```
 
 ### Release Workflow (Human-Only)
@@ -55,11 +56,11 @@ git push origin --delete spec/my-feature
 **Releases merge from `dev` to `main` via human-triggered workflow:**
 
 1. Human decides to release from `dev`
-2. Create release branch from `dev`: `git checkout -b release/v1.2.3`
+2. Create release worktree: `git worktree add .worktrees/release-v1.2.3 -b release/v1.2.3 dev`
 3. Run CI tests on release branch
 4. Merge release branch to `main`
 5. Tag release on `main`
-6. Delete release branch
+6. Delete release worktree and branch
 
 **AI DOES NOT:**
 - Create release branches
@@ -72,9 +73,9 @@ git push origin --delete spec/my-feature
 **Hotfixes create PAIRED branches to both `dev` and `main`:**
 
 1. Create paired issues (one for `dev`, one for `main`)
-2. Create hotfix branch from `main`: `git checkout -b hotfix/urgent-fix`
+2. Create hotfix worktree from `main`: `git worktree add .worktrees/hotfix-urgent-fix -b hotfix/urgent-fix main`
 3. Make fix, create PR to `main`
-4. Create IDENTICAL hotfix branch from `dev`: `git checkout -b hotfix/urgent-fix-dev`
+4. Create IDENTICAL hotfix worktree from `dev`: `git worktree add .worktrees/hotfix-urgent-fix-dev -b hotfix/urgent-fix-dev dev`
 5. Make SAME fix, create PR to `dev`
 6. BOTH PRs must merge before issues close
 
@@ -102,12 +103,12 @@ git push origin --delete spec/my-feature
 - Keep `dev` in sync with features
 - `dev` is NOT for direct commits — only via PR
 
-**Sync workflow:**
+**Sync workflow (in main working tree):**
 ```bash
-# After merging feature PR to dev
+# After merging feature PR to dev (cleanup removes worktree first)
 git checkout dev && git pull origin dev
 
-# Before starting new feature
+# Before starting new feature (syncing main tree for worktree creation)
 git checkout dev && git pull origin dev
 ```
 

--- a/.opencode/skills/approval-gate/tasks/batch-approval-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/batch-approval-analysis.md
@@ -112,8 +112,10 @@ Format:
 1. #630 — must precede #621
 
 **Phase 2 (Parallel-safe):**
-- #662 (`.opencode/skills/`)
-- #614 (`src/`)
+
+Each parallel issue includes dispatch context:
+- #662 (`.opencode/skills/`) → `worktree_path: .worktrees/spec-662`
+- #614 (`src/`) → `worktree_path: .worktrees/spec-614`
 
 **Phase 3 (After #630):**
 - #621 (`.opencode/guidelines/`)
@@ -131,6 +133,41 @@ After presenting the plan, execute according to the dependency order:
 1. **Sequential issues**: Execute one at a time in dependency order
 2. **Parallel-safe groups**: Use `subagent-driven-development` skill
 3. **Report completion**: After ALL issues complete, report ONCE and HALT ONCE
+
+### Step 6.5: Capture Dev Base Hash (Before Dispatch)
+
+Before dispatching any parallel worktrees, the orchestrating agent MUST capture the current dev branch hash:
+
+```bash
+git rev-parse origin/dev
+```
+
+This `dev_base_hash` MUST be included in the dispatch context for each parallel issue. See Step 7 for the complete dispatch context schema.
+
+### Step 7: Dispatch Context for Parallel Issues
+
+For each issue in a parallel-safe group, the dispatch context MUST include worktree information:
+
+```yaml
+# Dispatch Context Per Issue
+issue: <number>
+branch: "spec/<short-name>"
+worktree_path: ".worktrees/spec-<short-name>"
+dev_base_hash: "<7-char-sha>"
+env_vars:
+  WORKTREE_PATH: ".worktrees/spec-<short-name>"
+  BRANCH_NAME: "spec/<short-name>"
+  GIT_OWNER: "<from-session>"
+  GIT_REPO: "<from-session>"
+  DEV_NAME: "<from-session>"
+  DEV_EMAIL: "<from-session>"
+```
+
+The `worktree_path` is derived from the branch name by replacing `/` with `-`:
+- Branch `spec/foo` → Worktree path `.worktrees/spec-foo`
+- Branch `feature/bar` → Worktree path `.worktrees/feature-bar`
+
+The `dev_base_hash` ensures all parallel worktrees start from the same base commit on `dev`.
 
 ## Single-Issue Shortcut
 

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -13,7 +13,7 @@ Check for explicit authorization and needs-approval label status before implemen
 
 - Authorization verified as explicit and for correct issue
 - needs-approval label status checked
-- Git state verified clean (stash if needed)
+- Git state verified (worktree environment ready)
 - Authorization recorded for scope tracking
 
 ## Procedure
@@ -27,32 +27,19 @@ git branch --show-current
 git status
 ```
 
-**If on `main` or `dev` with ANY pending changes (modified, deleted, untracked):**
+**If on `main` or `dev`:** This is expected — feature branches are created in worktrees, not by switching branches in the main tree. Proceed to Step 2.
 
-```bash
-git stash push -u -m "WIP: before <branch-name>"
-git stash list   # VERIFY stash created
-git status       # VERIFY clean working tree
-```
-
-**Verification Requirements:**
-
-| Check | Command | Expected Result |
-|-------|---------|------------------|
-| Stash created | `git stash list` | Shows stash entry |
-| Working tree clean | `git status --porcelain` | Empty output |
-
-**If EITHER check fails ⇒ STOP. Report failure. Let user resolve.**
+**If on a feature branch already:** Verify you're in the correct worktree. Check `WORKTREE_PATH` environment variable.
 
 **🚫 CRITICAL: Do NOT create branches directly in verify-authorization.**
 
-Branch creation is DELEGATED to `git-workflow --task pre-work`, which includes the Worktree Gate (Step 4a). Creating branches here bypasses that gate — a CRITICAL VIOLATION.
+Branch creation is DELEGATED to `git-workflow --task pre-work`, which creates worktrees via the `using-git-worktrees` skill. Creating branches here bypasses worktree isolation — a CRITICAL VIOLATION.
 
 **After git state verification:**
-1. Record that git state is verified and clean
+1. Record that git state is verified
 2. Proceed to Step 2 (authorization verification)
-3. After ALL verification steps, invoke `git-workflow --task pre-work` for branch creation
-4. `pre-work` will handle: stash, sync with `dev`, worktree gate check, and branch/worktree creation
+3. After ALL verification steps, invoke `git-workflow --task pre-work` for worktree creation
+4. `pre-work` will handle: sync with `dev`, worktree creation, and environment variable setup
 
 ### Step 2: Verify Authorization Is Explicit
 

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -52,6 +52,21 @@ You are a Branch Finalizer. Your focus is ensuring no uncommitted changes, all v
 
 ## Prepare Branch Workflow
 
+### Worktree Mode (MANDATORY — NO EXCEPTIONS)
+
+All feature branches operate in worktrees. There is no alternative — worktree is the only method.
+
+If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+
+1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
+2. Before any push/squash/rebase operation, verify:
+   ```bash
+   git branch --show-current
+   # MUST match BRANCH_NAME
+   ```
+3. `git rev-parse --show-toplevel` MUST return the worktree path
+4. NEVER operate in the main working directory during implementation
+
 ### Step 1: Verify All Changes Committed
 
 ```bash

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -47,7 +47,7 @@ implementation-workflow (orchestration layer)
 ```
 
 **What git-workflow DOES:**
-- Git operations (stash, branch, commit, push)
+- Git operations (worktree, branch, commit, push)
 - Git state checks (branch verification, working tree status)
 - Git cleanup (delete merged branches)
 
@@ -136,7 +136,7 @@ Example violation: User said "Continue if you have next steps, or ask for clarif
 
 | Task | Purpose | Words |
 |------|---------|-------|
-| `pre-work` | Verify branch state, stash changes, create feature branch | ~640 |
+| `pre-work` | Verify authorization, create worktree | ~420 |
 | `implementation` | Handle WIP commits during implementation | ~400 |
 | `review-prep` | Push branch, generate compare URL for review | ~560 |
 | `pr-creation` | Squash, push, create PR via GitHub MCP | ~640 |
@@ -563,10 +563,9 @@ Once you've merged it, let me know and I'll start work on Tasks 6-13...
 
 ### ✅ ALWAYS DO
 
-- **Stash ALL modifications before branch creation** — Use `git stash push -u` to include untracked files
-- **Verify stash exists** (`git stash list`)
-- **Verify working tree is clean** (`git status --porcelain` must return empty)
-- **These checks are MANDATORY before ANY branch operation**
+- **Create worktree for feature branches** — Use `using-git-worktrees` skill (MANDATORY, no exceptions)
+- **Verify `WORKTREE_PATH` is set** — FATAL ERROR if empty, do not proceed without it
+- **Verify worktree branch** — `git branch --show-current` must match `BRANCH_NAME`
 - **SQUASH TO SINGLE COMMIT BEFORE ANY PR** — See `pr-creation-workflow` skill for pre-PR checklist
 - **Commit ALL changes before pushing** (`git add -A && git commit`)
 - **Push after committing** - ensures GitHub compare works correctly

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -88,7 +88,7 @@ Feature worktrees must be cleaned up after PR merge.
 # feature/<name> → .worktrees/feature-<name>
 # Rule: Replace / with - in the worktree directory name
 
-SANITIZED=$(echo "<merged-branch-name>" | tr '/' '-')
+SANITIZED=$(echo "<merged-branch-name>" | tr '/')
 WT_PATH=".worktrees/${SANITIZED}"
 
 # Check if worktree exists for this branch
@@ -96,10 +96,42 @@ if [ -d ".worktrees" ] && git worktree list | grep -q "$WT_PATH"; then
     git worktree remove "$WT_PATH"
     echo "Removed worktree: $WT_PATH"
 fi
-
-# Prune stale worktree references
-git worktree prune
 ```
+
+### Step 4.5: Check for Active Parallel Worktrees
+
+After removing the specific worktree, check if other agents may still be active:
+
+```bash
+# Check for remaining feature worktrees
+REMAINING=$(git worktree list | grep -c ".worktrees/spec-\|.worktrees/feature-")
+if [ "$REMAINING" -gt 0 ]; then
+    echo "Other feature worktrees still active: $REMAINING remaining"
+    echo "Skipping git worktree prune — other agents may still be working"
+    # Do NOT run git worktree prune
+    # Do NOT run git checkout dev in main tree during parallel work
+else
+    echo "No other feature worktrees remaining"
+    git worktree prune
+fi
+```
+
+**Why this check matters:**
+- In parallel sub-agent mode, other agents may still be working in their worktrees
+- Premature `git worktree prune` could corrupt active worktrees
+- Only prune when ALL parallel work is confirmed complete
+- The orchestrator (per `subagent-driven-development` skill) runs `git worktree prune` after ALL sub-agents complete
+
+**Individual agent (during parallel work):**
+1. Remove only YOUR specific worktree: `git worktree remove .worktrees/<your-branch-name>`
+2. Do NOT run `git worktree prune` — other agents may still be active
+3. Do NOT run `git checkout dev` in main working tree during parallel work
+
+**Orchestrator (after ALL parallel work completes):**
+1. Verify no feature worktrees remain: `git worktree list`
+2. If only `.worktrees/main` remains: safe to prune
+3. Run: `git worktree prune`
+4. Run: `git checkout dev && git pull origin dev` (sync main working tree)
 
 ### Step 5: Delete Current Merged Branch
 
@@ -501,7 +533,7 @@ This parent issue cannot be closed because the following sub-issue(s) remain inc
 | Remote branch already deleted | Skip remote deletion, clean local |
 | Local has extra commits | Warn user, ask before deleting |
 | Multiple PRs from same branch | Wait until ALL PRs merged |
-| Stash exists from pre-work | Preserve stash, inform user |
+| Stash exists from pre-work | N/A — worktrees eliminate need for stash |
 
 ## Automatic Cleanup Detection
 
@@ -614,14 +646,13 @@ When implementing an approved spec:
 
 1. **Branch Naming**: Derive from spec filename or issue — `spec/<short-name>` (e.g., `plans/SPEC-mesh-descriptor-lookup.md` → `spec/mesh-descriptor-lookup` or Issue #15 → `spec/project-first-strategy`)
 
-2. **Branch Creation**: Before any implementation, create and checkout the branch:
+2. **Branch Creation**: Before any implementation, create a worktree:
    ```bash
-   git checkout dev
-   git pull origin main
-   git checkout -b spec/<short-name>
+   git checkout dev && git pull origin dev
+   git worktree add .worktrees/spec-<short-name> -b spec/<short-name> dev
    ```
 
-3. **Work in Isolation**: All implementation commits go on the spec branch, never on main
+3. **Work in Isolation**: All implementation commits go in the worktree, never in the main working directory
 
 4. **Easy Rollback**: If implementation fails, simply `git checkout dev && git branch -D spec/<short-name>`
 
@@ -638,7 +669,7 @@ Use PR workflow instead of local merge:
 4. **Then create PR**: Only after branch is clean and rebased
 
 **PR Workflow Steps:**
-1. Create feature branch: `git checkout -b feature/issue-123-description`
+1. Create feature worktree: `git worktree add .worktrees/feature-issue-123 -b feature/issue-123-description dev`
 2. Commit changes to feature branch
 3. Push to remote: `git push origin feature/issue-123-description`
 4. Create PR: `github_create_pull_request` with `Fixes #123` in description

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -535,6 +535,23 @@ git rebase origin/dev
 
 **For worktree-based branches:** The rebase runs inside the worktree directory. The `origin/dev` reference is shared across all worktrees, so `git fetch origin` and `git rebase origin/dev` work correctly from any worktree.
 
+### Worktree Mode (MANDATORY — NO EXCEPTIONS)
+
+All feature branches operate in worktrees. There is no alternative — worktree is the only method.
+
+If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+
+1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
+2. Before any push/squash/rebase operation, verify:
+   ```bash
+   git branch --show-current
+   # MUST match BRANCH_NAME
+   ```
+3. `git rev-parse --show-toplevel` MUST return the worktree path
+4. NEVER operate in the main working directory during implementation
+5. `origin/dev` may have moved since worktree creation (due to parallel PR merges) — always rebase on current `origin/dev`
+6. If conflicts arise from `dev` movement, invoke `conflict-resolution` skill
+
 ### Step 4: Push to Remote
 
 ```bash
@@ -786,7 +803,7 @@ User says "pr merged" → Agent invokes /skill git-workflow → Agent EXECUTES c
 
 **There is NO emergency bypass.** If you need to make an urgent fix:
 
-1. Create a feature branch from `dev`: `git checkout dev && git pull origin dev && git checkout -b hotfix/urgent-fix`
+1. Create a hotfix worktree: `git worktree add .worktrees/hotfix-urgent-fix -b hotfix/urgent-fix dev`
 1. Make your changes and commit
 1. Push and create PR with `hotfix` label (targeting `dev`)
 1. Request expedited review

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -2,18 +2,17 @@
 
 ## Purpose
 
-Verify branch state, preserve changes, create feature branch BEFORE any implementation work begins.
+Create feature branch in a worktree BEFORE any implementation work begins. Verify authorization, sync dev, and create isolated workspace via worktree.
 
 ## 🚫 ZERO TOLERANCE: Branch Before Edit
 
-**The agent MUST create a feature branch BEFORE ANY filesystem change.**
+**The agent MUST create a feature worktree BEFORE ANY filesystem change.**
 
 This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any file, creating any file, or making ANY change to the project:
 
-1. **Check current branch**: `git branch --show-current`
-2. **If on `main`**: STOP — you MUST create a feature branch first
-3. **Create branch**: `git checkout -b spec/<short-name>` or `git checkout -b feature/<description>`
-4. **ONLY THEN**: Proceed with file changes
+1. **Invoke `using-git-worktrees` skill** — creates isolated worktree (MANDATORY, no exceptions)
+2. **All work happens in the worktree** — never in the main working directory
+3. **ONLY THEN**: Proceed with file changes inside the worktree
 
 **What Counts as a "Change"?**
 - Editing any file (code, config, docs, tests)
@@ -26,101 +25,36 @@ This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any f
 - **Using file-editing MCP tools** (`pycharm_replace_text_in_file`, `pycharm_create_new_file`, etc.) — these ARE filesystem changes
 
 **⚠️ MCP Tools Are NOT an Exception**
-- `pycharm_replace_text_in_file` → edits files → MUST be on feature branch
-- `pycharm_create_new_file` → creates files → MUST be on feature branch
+- `pycharm_replace_text_in_file` → edits files → MUST be in worktree
+- `pycharm_create_new_file` → creates files → MUST be in worktree
 - `github_issue_write` → GitHub Issues, NOT local files → NOT a filesystem change
 - `github_add_issue_comment` → GitHub comments → NOT a filesystem change
 
-**Why FIRST?**
-- No exceptions for "small" changes
-- No exceptions for "just one file"
-- No exceptions for docs, tests, configs, or guidelines
-- No exceptions for hotfixes or urgent changes
-- No exceptions for typo fixes or whitespace changes
-- The branch IS the safety net — without it, mistakes have no rollback
-
 **Violation = Hard Stop**
 - If you catch yourself about to edit files while on `main`, STOP immediately
-- Report "I need to create a branch first" and wait for the branch creation
-- Never proceed past this checkpoint without a feature branch
+- Report "I need to create a worktree first" and wait for worktree creation
+- Never proceed past this checkpoint without an active worktree
 
 ### ✅ ALWAYS DO
 ```
-# Correct order:
-git checkout main && git pull origin main
-git checkout -b spec/my-change      # ← FIRST
-# NOW edit files, write code, etc.   # ← SECOND
+# Using using-git-worktrees skill:
+# 1. Sync dev: git checkout dev && git pull origin dev
+# 2. Create worktree: git worktree add .worktrees/spec-my-change -b spec/my-change dev
+# 3. Work in .worktrees/spec-my-change/ (using workdir parameter)
 ```
 
 ### 🚫 NEVER DO
 ```
-# WRONG ORDER — VIOLATION:
-# edit files, write code...           # ← WRONG: No branch yet
-git checkout -b spec/my-change        # ← Too late!
+# WRONG — VIOLATION (stash+checkout):
+git stash -u
+git checkout -b spec/my-change
+# Work in main working directory
+
+# WRONG — VIOLATION (checkout without worktree):
+git checkout dev && git pull origin dev
+git checkout -b spec/my-change dev
+# Work in main working directory
 ```
-
-## Preserve External Changes: Stash ALL Unrelated Changes FIRST
-
-**When ANY files are modified on `main` (or current branch), the agent MUST stash them BEFORE creating a new branch.**
-
-### ⚠️ MANDATORY: Stash First, Ask Questions Never
-
-**Before ANY branch creation, this sequence is MANDATORY:**
-
-1. `git status` — Check for modifications
-2. **ALWAYS stash ALL pending changes (modified, deleted, untracked):**
-   - `git stash push -u -m "WIP: before <branch-name>"`
-   - **The `-u` flag includes untracked files — MANDATORY.**
-   - `git stash list` — **VERIFY stash was created**
-   - `git status` — **VERIFY working tree is clean** (must show "nothing to commit, working tree clean")
-3. **Then and ONLY then**: Create branch
-4. **Do NOT pop the stash** on the new branch — those changes belong to the previous branch context
-
-### ⚠️ CRITICAL: Never Restore, Never Discard
-
-**`git restore` on externally-modified files DESTROYS THOSE CHANGES PERMANENTLY.**
-
-```
-WRONG SEQUENCE:
-git status                           # Shows external changes in project-config.ini
-git restore project-config.ini       # ← DESTROYS external changes permanently
-git checkout -b feature/my-change
-
-ALSO WRONG:
-git status                           # Shows external changes
-git checkout -b feature/my-change    # ← Branch created with dirty working tree
-git stash push -m "preserving"       # ← WRONG: Too late, wrong branch context
-
-CORRECT SEQUENCE:
-git status                           # Shows modified files
-git stash push -m "WIP: external changes before my-change"  # ← Stash FIRST
-git stash list                       # ← VERIFY: Must show stash entry
-git status                           # ← VERIFY: Must show clean working tree
-git checkout -b feature/my-change    # ← THEN create branch
-# Do your work, commit, push, create PR...
-# Stash remains for later restoration on appropriate branch
-```
-
-### ⚠️ VERIFICATION IS MANDATORY
-
-**After stashing, you MUST verify:**
-
-```bash
-git stash push -m "WIP: external changes before feature-x"
-git stash list   # ← MUST show the stash
-git status       # ← MUST show "nothing to commit, working tree clean"
-```
-
-If `git status` still shows modifications, **STOP** — the stash failed. Do not proceed to branch creation.
-
-### Do NOT Pop Stash on New Branch
-
-The stash preserves changes that belong to the previous context. Those changes may need to be:
-- Committed separately on a different branch
-- Reviewed by the user
-- Discarded intentionally by the user
-
-**Let the user decide when/where to restore the stash.**
 
 ## Operating Protocol
 
@@ -133,7 +67,6 @@ The stash preserves changes that belong to the previous context. Those changes m
 - User has authorized implementation (explicit `approved` or `go`)
 - Authorization is for the correct issue
 - Sub-issue structure verified (for multi-task specs)
-- Working tree is clean (no uncommitted changes)
 
 ## Three-Branch Workflow Context
 
@@ -149,112 +82,66 @@ The stash preserves changes that belong to the previous context. Those changes m
 
 ## Procedure
 
-### Step 1: Check Git State (Pure Git Operations)
+### Step 1: Verify Authorization Context
 
 **This task receives authorization context from orchestration layer. DO NOT re-check authorization.**
 
-```bash
-git branch --show-current
-git status
-```
+### Step 2: Sync Dev Branch
 
-If on `main` → stash changes then create feature branch.
-
-### Step 2: Stash ALL Pending Changes (MANDATORY)
-
-**ALWAYS stash before ANY branch operation. No exceptions.**
+The main working tree must be on `dev` and up-to-date so worktree creation has the correct base:
 
 ```bash
-git stash push -u -m "WIP: before <branch-name>"
+git checkout dev
+git pull origin dev
 ```
 
-**The `-u` flag includes untracked files. This is mandatory.**
+If `dev` doesn't exist locally, create it from `main`: `git checkout -b dev origin/dev`
 
-**What gets stashed:**
-- Modified files
-- Deleted files
-- Untracked files
-- Staged changes
+### Step 3: Create Feature Worktree (MANDATORY — NO EXCEPTIONS)
 
-### Step 3: Verify Stash Succeeded
+**Feature branch creation MUST use worktrees — no exceptions, no conditions, no fallback.**
 
-```bash
-git stash list  # VERIFY stash created
-git status      # VERIFY clean working tree
-```
+Invoke `using-git-worktrees` skill (ALWAYS, for ANY feature branch):
 
-**CRITICAL VERIFICATION:**
+1. Invoke `using-git-worktrees` skill
+2. The skill creates the worktree: `git worktree add .worktrees/spec-<name> -b spec/<name> dev`
+3. The skill exports `WORKTREE_PATH`, `BRANCH_NAME`, `DEV_BASE_HASH` as environment variables
+4. If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT**
 
-| Check | Command | Expected Result |
-|-------|---------|------------------|
-| Stash exists | `git stash list` | Shows stash entry |
-| Working tree clean | `git status --porcelain` | Empty output |
-
-**If EITHER check fails → STOP. Report failure. Let user resolve.**
-
-### Step 4: Sync and Create Feature Branch
-
-**Three-Branch Workflow:**
-- Feature branches branch from `dev` (staging/integration)
-- `dev` branches from `main`
-- AI must sync with `dev` before creating feature branch
-
-```bash
-# Sync with dev branch (staging/integration)
-git checkout dev && git pull origin dev
-
-# Create feature branch from dev
-git checkout -b spec/<short-name>  # or feature/<description>
-```
-
-**Why Branch from Dev:**
-- `dev` is the staging/integration branch (evergreen, never deleted)
-- Feature branches merge to `dev`, not directly to `main`
-- Releases merge from `dev` to `main` via human-triggered workflow
-- Branching from `dev` ensures you have the latest integrated changes
-
-**Sync Requirements:**
-- ALWAYS `git pull origin dev` before creating feature branch
-- Ensure working tree is clean after sync
-- If `dev` doesn't exist locally, create it from `main`: `git checkout -b dev origin/dev`
-
-### Step 4a: Worktree Gate (MANDATORY — ALWAYS)
-
-**Feature branch creation MUST use worktrees — no exceptions, no conditions. Bypassing this gate is a CRITICAL VIOLATION (see `000-critical-rules.md`).**
-
-1. Invoke `using-git-worktrees` skill (ALWAYS, for ANY feature branch)
-2. If worktree creation fails or `WORKTREE_FATAL=1` is detected in session init output, HALT and report the fatal error to the developer — do NOT proceed with any implementation
-
-**There is NO fallback to stash+checkout.** If worktree setup fails, the infrastructure is broken and must be fixed before any work can proceed.
-
-**If `WORKTREE_FATAL=1` appears in session init output:**
+**If worktree creation fails or `WORKTREE_FATAL=1` is detected:**
 - HALT immediately
 - Report the fatal error to the developer
 - Do NOT attempt any implementation until the worktree infrastructure is fixed
+- There is NO fallback to stash+checkout
 
-### Step 5: Verify Clean Working Tree
+### Step 4: Verify Worktree Environment
 
 **Before yielding back to orchestration layer, verify:**
 
 ```bash
-git status --porcelain
+# Inside the worktree (using workdir parameter):
+git branch --show-current
+# MUST show the feature branch name
+
+git rev-parse --show-toplevel
+# MUST show the worktree path
+
+echo $WORKTREE_PATH
+# MUST NOT be empty — FATAL ERROR if empty
 ```
 
-**Expected output:** Empty (nothing to commit, working tree clean)
+**If ANY check fails → STOP and report.**
 
-**If dirty:**
-- STOP and report
-- Let orchestration layer decide next action
+### Step 5: Report Ready
 
-### Step 6: Report Ready
-
-Report: "Ready for implementation on branch: <branch-name>"
+Report: "Ready for implementation in worktree: <worktree-path> on branch: <branch-name>"
 
 **Yield back to orchestration layer:**
 ```yaml
 status: success
 branch: <branch-name>
-stash_created: <true/false>
+worktree_path: .worktrees/<sanitized-branch-name>
+dev_base_hash: <7-char-sha>
 working_tree_clean: true
 ready_for: "implementation"
 ```
@@ -265,7 +152,6 @@ ready_for: "implementation"
 ```yaml
 authorization: confirmed (from approval-gate)
 issue: <issue-number>
-working_tree_status: checked
 ```
 
 This task does NOT re-check authorization. Authorization was verified by `approval-gate` before this task was invoked.
@@ -276,7 +162,8 @@ This task does NOT re-check authorization. Authorization was verified by `approv
 ```yaml
 status: success | failure
 branch: "spec/<feature-name>" | "feature/<feature-name>"
-stash_created: true | false
+worktree_path: ".worktrees/<sanitized-branch-name>"
+dev_base_hash: "<7-char-sha>"
 working_tree_clean: true
 ready_for: "implementation"
 ```
@@ -292,8 +179,8 @@ The orchestration layer (`implementation-workflow`) receives this yield and pass
    - Confirm no modifications needed
    - Document verification in issue comment
 
-2. **Skip branch creation entirely:**
-   - Do NOT create feature branch
+2. **Skip worktree creation entirely:**
+   - Do NOT create feature worktree
    - Do NOT push anything
    - Do NOT create PR
 
@@ -320,25 +207,11 @@ Verified all proposed changes were already implemented. No modifications needed.
 
 4. **HALT after closing:**
    - No further steps needed
-   - No branch cleanup (no branch was created)
+   - No worktree cleanup (no worktree was created)
 
-## Worktree Integration
+## Branch Name to Worktree Name Mapping
 
-### Feature Worktree Creation
-
-Feature branches MUST use worktrees instead of stash+checkout. This is ALWAYS enforced by the Worktree Gate in Step 4a.
-
-**Before (stash-based):**
-1. `git stash -u` → 2. `git checkout -b feature/xyz dev` → 3. Work in same folder
-
-**After (worktree-based):**
-1. Ensure main folder is on `dev`: `git checkout dev && git pull origin dev`
-2. Create worktree: `git worktree add .worktrees/feature-xyz -b feature/xyz dev`
-3. Work in `.worktrees/feature-xyz/`
-
-### Branch Name to Worktree Name Mapping
-
-Branch names containing `/` must be sanitized for the worktree directory name:
+Branch names containing `/` are sanitized for the worktree directory name:
 
 | Branch Name | Worktree Directory |
 |-------------|-------------------|
@@ -347,20 +220,14 @@ Branch names containing `/` must be sanitized for the worktree directory name:
 
 **Rule:** Replace `/` with `-` in the worktree directory name.
 
-### Edge Cases
-
-- **Dev-only work** (no feature branch): Work in main folder directly, no worktree needed
-- **Worktree already exists**: Skip creation, use existing worktree directory
-- **`WORKTREE_FATAL=1` detected**: HALT immediately, report fatal error to developer, do NOT proceed
-
 ### Worktree Already Exists Check
 
 ```bash
 # Check if worktree for this branch already exists
-git worktree list | grep "feature-xyz"
+git worktree list | grep "spec-xyz"
 ```
 
-If found, skip worktree creation and work in the existing directory.
+If found, report collision and HALT — do not reuse another branch's worktree.
 
 ## Enforcement Mechanisms (NO BYPASS)
 
@@ -371,42 +238,24 @@ If found, skip worktree creation and work in the existing directory.
 | **GitHub** | Branch protection rules | Requires PR | No |
 
 **There is NO emergency bypass.** If you need to make an urgent fix:
-1. Create a feature branch: `git checkout -b hotfix/urgent-fix`
-2. Make your changes and commit
+1. Create a worktree: `git worktree add .worktrees/hotfix-urgent-fix -b hotfix/urgent-fix dev`
+2. Make your changes and commit in the worktree
 3. Push and create PR with `hotfix` label
 4. Request expedited review
 
 ## Context Required
 
-- Related skills: `approval-gate` (authorization check)
+- Related skills: `approval-gate` (authorization check), `using-git-worktrees` (worktree creation)
 - Related tasks: `cleanup` (branch cleanup after PR merge)
-
-## Common Issues
-
-| Issue | Resolution |
-|-------|------------|
-| Stash failed | STOP. Report failure. Let user resolve manually. |
-| Wrong branch detected | STOP. Do not commit. Stash changes, switch to correct branch. |
-| Accidental main commit | Create recovery branch, reset main, switch to recovery branch. |
-
-## Safety Checks
-
-Before proceeding, verify ALL:
-
-- Current branch is NOT `main`
-- Working tree IS clean (`git status --porcelain` returns empty)
-- Branch name follows convention (`spec/` or `feature/` prefix)
-
-**If ANY check fails → STOP and report.**
 
 ## Enforcement Checklist
 
 **Before starting any work, verify:**
 
 - ✅ Authorization received (explicit `approved`, `go`, or `"#N approved"`)
-- ✅ Current branch is NOT `main` (or stash and create feature branch)
-- ✅ Working tree is clean (`git status --porcelain` returns empty)
-- ✅ Stash created if needed (`git stash list` shows entry)
-- ✅ Feature branch created from `main`
+- ✅ Worktree created (not on `main` or `dev`)
+- ✅ `WORKTREE_PATH` environment variable is set and non-empty (FATAL ERROR if empty)
+- ✅ `git branch --show-current` in worktree shows feature branch
+- ✅ Feature branch created from `dev`
 
 **These checks are MANDATORY. If ANY check fails → STOP and report.**

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -172,6 +172,23 @@ git rebase origin/dev
 
 **For worktree-based branches:** The rebase runs inside the worktree directory. The `origin/dev` reference is shared across all worktrees, so `git fetch origin` and `git rebase origin/dev` work correctly from any worktree.
 
+## Worktree Mode (MANDATORY — NO EXCEPTIONS)
+
+All feature branches operate in worktrees. There is no alternative — worktree is the only method.
+
+If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+
+1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
+2. Before any push/squash/rebase operation, verify:
+   ```bash
+   git branch --show-current
+   # MUST match BRANCH_NAME
+   ```
+3. `git rev-parse --show-toplevel` MUST return the worktree path
+4. NEVER operate in the main working directory during implementation
+5. `origin/dev` may have moved since worktree creation (due to parallel PR merges) — always rebase on current `origin/dev`
+6. If conflicts arise from `dev` movement, invoke `conflict-resolution` skill
+
 ### Step 2: Verify Branch Is Pushed
 
 **Before generating compare URL, verify branch is on remote.**

--- a/.opencode/skills/implementation-workflow/SKILL.md
+++ b/.opencode/skills/implementation-workflow/SKILL.md
@@ -104,7 +104,8 @@ working_tree_status: checked
 ```yaml
 status: success
 branch: "spec/workflow-skills-integration"
-stash_created: false
+worktree_path: ".worktrees/spec-workflow-skills-integration"
+dev_base_hash: "abc1234"
 working_tree_clean: true
 ready_for: "implementation"
 ```
@@ -385,7 +386,7 @@ See `000-critical-rules.md` → "Skipping Post-Implementation Verification Skill
 ### ⚠️ CRITICAL: No Implementation Logic in Git-Workflow
 
 Git-workflow skills MUST remain pure git operations:
-- ✅ Git commands (stash, branch, commit, push)
+- ✅ Git commands (worktree, branch, commit, push)
 - ✅ Git status checks
 - ✅ Git cleanup
 - ❌ File editing
@@ -535,7 +536,7 @@ implementation-workflow/orchestrate:
 implementation-workflow/orchestrate:
     → Calls pre-work
         → pre-work detects dirty working tree
-        → pre-work stashes changes
-        → pre-work yields: {stash_created: true, branch: "spec/X"}
+        → pre-work creates worktree
+        → pre-work yields: {worktree_path: ".worktrees/spec-X", branch: "spec/X"}
     → Continues with implementation...
 ```

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -97,12 +97,57 @@ The batch execution plan from `batch-approval-analysis` provides:
 - The agent reports progress on ALL issues ONCE at the end (not per issue)
 - Meta/non-code issues are excluded from implementation but noted in the final report
 
+### Sub-Agent Dispatch Context
+
+Each sub-agent dispatched for parallel work MUST receive complete worktree context:
+
+```yaml
+# Sub-Agent Dispatch Context
+issue: <number>
+branch: "spec/<short-name>"
+worktree_path: ".worktrees/spec-<short-name>"
+dev_base_hash: "<7-char-sha>"
+env_vars:
+  WORKTREE_PATH: ".worktrees/spec-<short-name>"
+  BRANCH_NAME: "spec/<short-name>"
+  GIT_OWNER: "<from-session>"
+  GIT_REPO: "<from-session>"
+  DEV_NAME: "<from-session>"
+  DEV_EMAIL: "<from-session>"
+```
+
+**Invariants:**
+- `WORKTREE_PATH` is MANDATORY — no exceptions, no fallbacks
+- If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT**. The agent must not proceed without a valid worktree path
+- No sub-agent may operate without a valid `WORKTREE_PATH`
+- `dev_base_hash` MUST be captured before the first worktree is created
+- All bash commands MUST use `workdir="{{WORKTREE_PATH}}"` parameter
+
+### Dev Base Hash Capture
+
+Before dispatching any parallel worktrees, the orchestrating agent MUST:
+
+1. Capture `git rev-parse origin/dev` before dispatching any worktrees
+2. Pass `dev_base_hash` in dispatch context
+3. Each worktree creation should verify `origin/dev` matches or is newer than captured hash
+
+If `dev` has moved between capture and worktree creation, use the current `origin/dev` (always use latest).
+
+### Post-Parallel Cleanup
+
+After ALL parallel sub-agents complete:
+
+1. Verify no feature worktrees remain: `git worktree list`
+2. If only `.worktrees/main` remains: safe to prune
+3. Run: `git worktree prune`
+4. Run: `git checkout dev && git pull origin dev` (sync main working tree)
+
 ## Pre-Implementation Gates (MANDATORY)
 
 **Before dispatching any subagent, these gates MUST be satisfied:**
 
 1. **approval-gate** — Authorization verified (`approved` or `go` received)
-2. **git-workflow --task pre-work** — Branch created, working tree clean (includes Worktree Gate: feature branches MUST use `using-git-worktrees`)
+2. **git-workflow --task pre-work** — Branch created via worktree (`using-git-worktrees` MANDATORY)
 3. **Plan exists** — Writing-plans output available with TDD tasks
 
 **After all tasks complete, these gates are MANDATORY:**
@@ -198,7 +243,7 @@ This project uses the `feature→dev→main` three-branch workflow:
 | Phase | Skill | Purpose |
 |-------|-------|---------|
 | Pre-implementation | `approval-gate` | Verify authorization |
-| Branch creation | `git-workflow --task pre-work` (includes Worktree Gate) | Create feature branch (ALWAYS via worktree) |
+| Branch creation | `git-workflow --task pre-work` (uses `using-git-worktrees`) | Create feature worktree (ALWAYS via worktree) |
 | Per-task | Implementer → spec review → code quality review loop | Execute tasks |
 | Post-implementation | `verification-before-completion --task verify` | Evidence collection |
 | Completion | `finishing-a-development-branch --task checklist` | Branch readiness |
@@ -288,7 +333,7 @@ This skill integrates with the repo's mandatory workflow:
 approval-gate (authorization)
     ↓
 subagent-driven-development (this skill)
-    → pre-work: git-workflow --task pre-work (includes Worktree Gate)
+    → pre-work: git-workflow --task pre-work (creates worktree via using-git-worktrees)
     → per-task: implementer → spec review → code quality review
     → post-implementation: verification-before-completion
     → completion: finishing-a-development-branch

--- a/.opencode/skills/subagent-driven-development/tasks/implementer-prompt.md
+++ b/.opencode/skills/subagent-driven-development/tasks/implementer-prompt.md
@@ -40,6 +40,26 @@ Task tool (general-purpose):
 
     Work from: [directory]
 
+    ## Worktree Mode (MANDATORY — NO EXCEPTIONS)
+
+    All feature branches operate in worktrees. There is no alternative — worktree is the only method.
+
+    If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+
+    1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
+    2. Before any push/squash/rebase operation, verify:
+       ```
+       git branch --show-current
+       # MUST match BRANCH_NAME
+       ```
+    3. `git rev-parse --show-toplevel` MUST return the worktree path
+    4. NEVER operate in the main working directory during implementation
+
+    **Environment variables available:**
+    - `WORKTREE_PATH`: Path to worktree directory (e.g., `.worktrees/spec-feature`)
+    - `BRANCH_NAME`: Name of feature branch (e.g., `spec/feature`)
+    - `DEV_BASE_HASH`: Hash of dev branch at dispatch time
+
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.
     It's always OK to pause and clarify. Don't guess or make assumptions.
 

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -47,7 +47,7 @@ After work is complete and PR is merged, the worktree cleanup is handled by the 
 
 ## Directory Selection Process
 
-Worktrees are ALWAYS created in `.worktrees/`. There is NO fallback to stash+checkout.
+Worktrees are ALWAYS created in `.worktrees/`. There is no alternative method. Stash+checkout is FORBIDDEN.
 
 **If `WORKTREE_FATAL=1` appears in session init output:** HALT immediately and report the fatal error to the developer. Do NOT proceed with any implementation.
 
@@ -93,6 +93,40 @@ Always create worktrees from an up-to-date `dev` branch.
 ```bash
 project=$(basename "$(git rev-parse --show-toplevel)")
 ```
+
+### 3.5. Check for Worktree Name Collisions
+
+Before creating a new worktree, check if a worktree for this branch already exists:
+
+```bash
+# Sanitize branch name for worktree directory (replace / with -)
+BRANCH_NAME_SANITIZED=$(echo "$BRANCH_NAME" | tr '/' '-')
+WT_PATH=".worktrees/$BRANCH_NAME_SANITIZED"
+
+if git worktree list | grep -q "$WT_PATH"; then
+    echo "Worktree $WT_PATH already exists. Checking branch match..."
+    CURRENT_BRANCH=$(git -C "$WT_PATH" branch --show-current 2>/dev/null)
+    if [ "$CURRENT_BRANCH" != "$BRANCH_NAME" ]; then
+        echo "HALT: Worktree collision: $WT_PATH exists for branch $CURRENT_BRANCH, expected $BRANCH_NAME"
+        # Report to developer — do not proceed
+    else
+        echo "Worktree $WT_PATH exists for correct branch. Reusing existing worktree."
+        # Skip to Step 6 (Project Setup)
+    fi
+fi
+```
+
+If a collision is detected with a different branch name, HALT and report to the developer. Do not proceed with worktree creation.
+
+### 3.6. Capture Dev Base Hash (Parallel Dispatch)
+
+When multiple worktrees will be created for parallel dispatch (from `batch-approval-analysis`), capture the dev branch hash BEFORE creating any worktrees:
+
+```bash
+DEV_BASE_HASH=$(git rev-parse --short 7 origin/dev)
+```
+
+Pass this hash in the dispatch context so all parallel worktrees start from the same base commit.
 
 ### 4. Create Worktree
 
@@ -145,6 +179,24 @@ Ready to implement <feature-name>
 All commands use workdir=".worktrees/$BRANCH_NAME" — never cd
 ```
 
+### 9. Export Worktree Environment Variables (MANDATORY)
+
+After worktree creation, export environment variables that ALL downstream skills and sub-agents require. These are NOT optional — every skill that operates in a worktree MUST read these variables.
+
+```bash
+export WORKTREE_PATH=".worktrees/$BRANCH_NAME_SANITIZED"
+export BRANCH_NAME="$BRANCH_NAME"
+export DEV_BASE_HASH=$(git rev-parse --short 7 origin/dev)
+```
+
+**If `WORKTREE_PATH` is not set or empty after this step: FATAL ERROR → FLAG DEV → HALT.** There is no alternative — worktree is the only method for feature branches.
+
+These environment variables are consumed by:
+- `git-workflow` tasks (review-prep, pr-creation, cleanup)
+- `finishing-a-development-branch` skill
+- `subagent-driven-development` dispatch context
+- `batch-approval-analysis` execution plan
+
 ## Tool Usage Compliance
 
 **⚠️ CRITICAL: All commands in worktrees MUST use `workdir` parameter or relative paths from project root. NEVER use `cd` commands.**
@@ -166,10 +218,10 @@ After worktree creation (step 5), verify the worktree actually exists before pro
 ```bash
 git worktree list
 # MUST show the new worktree entry
-# If missing → HALT and report — do NOT proceed with implementation in main folder
+# If missing → HALT and report — do NOT proceed without a valid worktree
 ```
 
-**If verification fails:** The worktree was not created successfully. HALT and report the failure. Do NOT fall back to working in the main folder — that defeats the isolation purpose.
+**If verification fails:** The worktree was not created successfully. HALT and report the failure — do not proceed without a valid worktree.
 
 ## Quick Reference
 
@@ -210,7 +262,7 @@ git worktree list
 
 1. HALT immediately — do NOT proceed with any implementation
 2. Report the fatal error to the developer
-3. Do NOT fall back to stash+checkout — worktrees are MANDATORY, not optional
+3. Worktrees are the ONLY method for feature branches — stash+checkout is FORBIDDEN
 4. The developer must fix the worktree infrastructure before any work can proceed
 
 **Worktree setup failure means the repository infrastructure is broken.** Proceeding without worktrees risks:
@@ -219,7 +271,7 @@ git worktree list
 - Lost changes
 - Branch contamination
 
-There is NO fallback to stash+checkout. Fix the infrastructure, then proceed.
+Fix the worktree infrastructure, then proceed. Stash+checkout is FORBIDDEN
 
 ## Integration
 
@@ -260,7 +312,7 @@ This cleanup happens as part of the standard `git-workflow --task cleanup` seque
 - Handle worktree cleanup in this skill (delegated to `finishing-a-development-branch`)
 
 **Always:**
-- Use `.worktrees/` directory (no fallback)
+- Use `.worktrees/` directory (the only method)
 - Verify directory is ignored for project-local
 - Auto-detect and run `uv sync` for project setup
 - Announce worktree creation at start


### PR DESCRIPTION
## Summary

Makes worktree usage unconditional (no stash+checkout fallback) and adds worktree context to sub-agent dispatch for parallel-safe branch operations.

## Outcome

- All feature branch work now operates exclusively in worktrees — `git checkout -b` is replaced with `git worktree add` throughout all guidelines and skills
- Sub-agent dispatch includes `WORKTREE_PATH`, `BRANCH_NAME`, and `dev_base_hash` context so parallel agents never conflict in the main working directory
- Collision detection prevents two agents from creating worktrees with the same branch name
- Coordinated cleanup protocol ensures orphaned worktrees are removed after merge
- Every conditional "When WORKTREE_PATH is set" has been replaced with "MANDATORY — NO EXCEPTIONS" and a `FATAL ERROR → FLAG DEV → HALT` path
- All stash operations, verification steps, and `stash_created` fields removed as dead code

## Fixes

Fixes #674
Fixes #677
Fixes #678
Fixes #679