### PR TITLE
[SPEC] Audit and fix worktree path resolution across all skills, tasks, and guidelines

### DIFF
--- a/.opencode/.guidelines/branch-first-protocol.md
+++ b/.opencode/.guidelines/branch-first-protocol.md
@@ -44,7 +44,9 @@ This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any f
 # Correct order (using worktree):
 # 1. Sync dev: git checkout dev && git pull origin dev
 # 2. Create worktree: git worktree add .worktrees/spec-my-change -b spec/my-change dev
-# 3. Work in .worktrees/spec-my-change/ (using workdir parameter)
+# 3. Work in .worktrees/spec-my-change/ (using workdir parameter on bash commands)
+# IMPORTANT: For read/edit/write/glob/grep tools, prefix filePath with WORKTREE_PATH:
+#   read(filePath=f"{WORKTREE_PATH}/src/main.py")  — NOT read(filePath="src/main.py")
 ```
 
 ### 🚫 NEVER DO

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -67,7 +67,46 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## Critical Violation: Implementing Without Documentation Verification
+## Critical Violation: Relative File Paths in Worktree Context
+
+**⚠️ Using relative paths with `read`/`edit`/`write`/`glob`/`grep` tools when `WORKTREE_PATH` is set is a CRITICAL GUIDELINE VIOLATION.**
+
+When working in a git worktree, the `read`, `edit`, `write`, `glob`, and `grep` tools do NOT have a `workdir` parameter. These tools resolve relative paths against the workspace root (main repo), NOT the worktree. Using a relative path like `src/main.py` silently operates on the wrong file.
+
+### 🚫 FORBIDDEN
+
+- Using `read(filePath="src/main.py")` in worktree context — reads main repo file, not worktree
+- Using `edit(filePath="src/main.py", ...)` in worktree context — edits main repo file, not worktree
+- Using `write(filePath="src/new.py", ...)` in worktree context — creates file in main repo, not worktree
+- Using `glob(pattern="src/**/*.py")` in worktree context — searches main repo, not worktree
+- Using `grep(pattern="TODO", path="src/")` in worktree context — searches main repo, not worktree
+- Assuming `read`/`edit`/`write`/`glob`/`grep` respect the bash `workdir` parameter
+
+### ✅ REQUIRED
+
+When `WORKTREE_PATH` is set, ALL file operations MUST prefix paths with the worktree path:
+
+| Tool | Wrong (main repo) | Correct (worktree) |
+|------|-------------------|---------------------|
+| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{WORKTREE_PATH}/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` |
+
+**When NOT in a worktree** (working in main repo): Relative paths are correct and function as expected.
+
+### Why This Matters
+
+| Violation | Consequence |
+|-----------|-------------|
+| `read` with relative path in worktree | Reads stale main repo file, believes worktree is unchanged |
+| `edit` with relative path in worktree | Edits main repo file instead of worktree — changes lost on merge |
+| `write` with relative path in worktree | Creates file in main repo — appears in `git status` on `dev` |
+| `glob`/`grep` with relative path | Searches wrong codebase, returns incorrect results |
+| Assuming tools respect `workdir` | `workdir` only applies to `bash` tool — file tools ignore it silently |
+
+**See `using-git-worktrees` skill → "Tool Usage Compliance" section and `mcp-tool-usage` skill → "Worktree Path Resolution" section for complete tool-by-tool guidance.**
 
 **⚠️ Implementing code without verifying against live documentation is a CRITICAL GUIDELINE VIOLATION.**
 

--- a/.opencode/guidelines/016-srclight-preference.md
+++ b/.opencode/guidelines/016-srclight-preference.md
@@ -202,6 +202,18 @@ pycharm_rename_refactoring(pathInProject="src/main.py", symbolName="foo", newNam
 # Srclight has NO edit capability
 ```
 
+### Worktree Path Resolution
+
+When `WORKTREE_PATH` is set (working in a git worktree), all file operation tools must prefix paths with the worktree path. See `060-tool-usage.md` for the complete tool-by-tool table.
+
+```
+# ✅ CORRECT: In worktree context, prefix with WORKTREE_PATH
+edit(filePath=f"{WORKTREE_PATH}/src/main.py", oldString="foo", newString="bar")
+
+# ❌ WRONG: Relative path in worktree context resolves to main repo
+edit(filePath="src/main.py", oldString="foo", newString="bar")
+```
+
 ## Edge Cases
 
 ### Srclight Index Unavailable

--- a/.opencode/guidelines/060-tool-usage.md
+++ b/.opencode/guidelines/060-tool-usage.md
@@ -42,6 +42,24 @@ ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance,
 - Never issue a `cd` command. Run all commands from project root using relative paths.
 - **NEVER prefix commands with `cd /home/<user>/git/<repo> &&` or any variant.**
 
+### ⚠️ Worktree Path Resolution for File Operation Tools (CRITICAL)
+
+When working in a git worktree (`WORKTREE_PATH` is set), TIER 1 file operation tools (`read`, `edit`, `write`, `glob`, `grep`) do **NOT** have a `workdir` parameter. Relative paths like `src/main.py` resolve to the **main repo**, not the worktree. This causes silent file operation errors — edits go to the wrong file.
+
+**When `WORKTREE_PATH` is set, ALL file operations MUST prefix paths with the worktree path:**
+
+| Tool | Wrong (operates on main repo) | Correct (targets worktree) |
+|------|-------------------------------|---------------------------|
+| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{WORKTREE_PATH}/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` |
+
+**When NOT in a worktree** (working in main repo): Relative paths are correct and function as expected.
+
+**For `bash` tool:** Continue using `workdir` parameter (already documented in `using-git-worktrees` skill and `000-critical-rules.md`).
+
 ## 3. Temp Files & Cleanliness
 
 ### ✅ ALWAYS DO

--- a/.opencode/guidelines/115-branch-naming.md
+++ b/.opencode/guidelines/115-branch-naming.md
@@ -37,7 +37,10 @@ git checkout dev && git pull origin dev
 # 2. Create feature worktree (using-git-worktrees skill)
 git worktree add .worktrees/spec-my-feature -b spec/my-feature dev
 
-# 3. Work in the worktree (use workdir parameter on all commands)
+# 3. Work in the worktree (use workdir parameter on all bash commands)
+# IMPORTANT: For read/edit/write/glob/grep tools, prefix filePath with WORKTREE_PATH
+#   read(filePath=f"{WORKTREE_PATH}/src/main.py")  — NOT read(filePath="src/main.py")
+#   edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)  — NOT edit(filePath="src/main.py", ...)
 # ... make changes, commit inside .worktrees/spec-my-feature ...
 
 # 4. Push feature branch from worktree

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -59,7 +59,8 @@ All feature branches operate in worktrees. There is no alternative — worktree 
 If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
 1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
-2. Before any push/squash/rebase operation, verify:
+2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{WORKTREE_PATH}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
+3. Before any push/squash/rebase operation, verify:
    ```bash
    git branch --show-current
    # MUST match BRANCH_NAME

--- a/.opencode/skills/git-workflow/tasks/implementation.md
+++ b/.opencode/skills/git-workflow/tasks/implementation.md
@@ -35,6 +35,20 @@ git commit -m "WIP: <descriptive message>"
 
 **No co-author trailers required** during implementation commits - those are added during squash at PR time.
 
+### ⚠️ CRITICAL: File Operation Tool Paths in Worktree
+
+When `WORKTREE_PATH` is set, ALL file operation tool calls (`read`, `edit`, `write`, `glob`, `grep`) MUST prefix paths with the worktree path. These tools have NO `workdir` parameter — relative paths resolve to the main repo, causing silent errors.
+
+| Tool | Wrong (operates on main repo) | Correct (targets worktree) |
+|------|-------------------------------|---------------------------|
+| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{WORKTREE_PATH}/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` |
+
+**For `bash` tool:** Continue using `workdir` parameter as documented in `using-git-worktrees` skill.
+
 ### ⚠️ CRITICAL: Commit Before Push
 
 **The most common workflow failure is pushing without committing.**

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -542,7 +542,8 @@ All feature branches operate in worktrees. There is no alternative — worktree 
 If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
 1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
-2. Before any push/squash/rebase operation, verify:
+2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{WORKTREE_PATH}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
+3. Before any push/squash/rebase operation, verify:
    ```bash
    git branch --show-current
    # MUST match BRANCH_NAME

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -179,7 +179,8 @@ All feature branches operate in worktrees. There is no alternative — worktree 
 If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
 1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
-2. Before any push/squash/rebase operation, verify:
+2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{WORKTREE_PATH}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
+3. Before any push/squash/rebase operation, verify:
    ```bash
    git branch --show-current
    # MUST match BRANCH_NAME

--- a/.opencode/skills/mcp-tool-usage/SKILL.md
+++ b/.opencode/skills/mcp-tool-usage/SKILL.md
@@ -272,11 +272,40 @@ uvx srclight index --embed qwen3-embedding
 
 ## Examples
 
+### ⚠️ CRITICAL: Worktree Path Resolution for TIER 1 Tools
+
+When working in a git worktree (e.g., `.worktrees/spec-my-feature/`), the `read`, `edit`, `write`, `glob`, and `grep` tools do NOT have a `workdir` parameter. Their path parameters resolve relative to the workspace root (main repo), NOT the worktree.
+
+**Using relative paths in worktree context will silently operate on the wrong directory.**
+
+| Tool | ❌ WRONG (resolves to main repo) | ✅ CORRECT (targets worktree) |
+|------|-----------------------------------|------------------------------|
+| `read` | `read(filePath="src/main.py")` | `read(filePath="/abs/path/.worktrees/spec-X/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath="/abs/path/.worktrees/spec-X/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath="/abs/path/.worktrees/spec-X/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=".worktrees/spec-X")` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=".worktrees/spec-X/src/")` |
+
+**Simplified pattern using `WORKTREE_PATH` environment variable:**
+
+When `WORKTREE_PATH` is set (e.g., `.worktrees/spec-my-feature`), use it as a prefix:
+
+- `read(filePath=f"{WORKTREE_PATH}/src/main.py")` — works when `WORKTREE_PATH` is absolute
+- `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` — works with relative `WORKTREE_PATH`
+- `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` — works with relative `WORKTREE_PATH`
+
+**For `bash` tool calls, continue using the `workdir` parameter** (already documented in `using-git-worktrees` skill).
+
+**When NOT in a worktree (working in main repo):** Relative paths like `src/main.py` are correct and function as expected.
+
 ### ✅ CORRECT: Reading a File
 
 ```python
-# ✅ CORRECT: Use opencode built-in for file read
+# ✅ CORRECT: Use opencode built-in for file read (main repo)
 read(filePath="src/main.py")
+
+# ✅ CORRECT: Use absolute path for worktree file
+read(filePath=f"/abs/path/{WORKTREE_PATH}/src/main.py")
 ```
 
 ### ✅ CORRECT: Searching Python Code
@@ -306,6 +335,25 @@ edit(filePath="notebook.ipynb", ...)  # PROHIBITED
 ```python
 # ✅ CORRECT: Semantic rename via JetBrains MCP (no opencode equivalent)
 pycharm_rename_refactoring(pathInProject="src/main.py", symbolName="old_name", newName="new_name")
+```
+
+### ❌ WRONG: Relative Path in Worktree Context
+
+```python
+# ❌ WRONG: Relative path resolves to MAIN REPO, not worktree
+# When WORKTREE_PATH is set, this reads/writes the MAIN REPO file
+read(filePath="src/main.py")           # WRONG in worktree context
+edit(filePath="src/main.py", ...)      # WRONG in worktree context
+write(filePath="src/new.py", ...)      # WRONG in worktree context
+glob(pattern="src/**/*.py")            # WRONG in worktree context
+grep(pattern="TODO", path="src/")      # WRONG in worktree context
+
+# ✅ CORRECT: Prefix with WORKTREE_PATH for worktree operations
+read(filePath=f"{WORKTREE_PATH}/src/main.py")
+edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)
+write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)
+glob(pattern="src/**/*.py", path=WORKTREE_PATH)
+grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")
 ```
 
 ### ❌ WRONG: JetBrains MCP for Basic File Operation

--- a/.opencode/skills/subagent-driven-development/tasks/implementer-prompt.md
+++ b/.opencode/skills/subagent-driven-development/tasks/implementer-prompt.md
@@ -47,7 +47,13 @@ Task tool (general-purpose):
     If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
     1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
-    2. Before any push/squash/rebase operation, verify:
+2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{WORKTREE_PATH}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
+       - `read(filePath=f"{{WORKTREE_PATH}}/src/main.py")` — NOT `read(filePath="src/main.py")`
+       - `edit(filePath=f"{{WORKTREE_PATH}}/src/main.py", ...)` — NOT `edit(filePath="src/main.py", ...)`
+       - `write(filePath=f"{{WORKTREE_PATH}}/src/new.py", ...)` — NOT `write(filePath="src/new.py", ...)`
+       - `glob(pattern="src/**/*.py", path="{{WORKTREE_PATH}}")` — NOT `glob(pattern="src/**/*.py")`
+       - `grep(pattern="TODO", path=f"{{WORKTREE_PATH}}/src/")` — NOT `grep(pattern="TODO", path="src/")`
+     3. Before any push/squash/rebase operation, verify:
        ```
        git branch --show-current
        # MUST match BRANCH_NAME

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -203,13 +203,29 @@ These environment variables are consumed by:
 
 Per AGENTS.md and `060-tool-usage.md`, `cd` commands are a zero-tolerance violation. When executing commands inside a worktree:
 
+### Bash Tool (workdir parameter)
+
 | Method | Example | Compliant? |
 |--------|---------|------------|
 | `workdir` parameter on Bash tool | `workdir=".worktrees/$BRANCH_NAME"` | ✅ YES |
 | Relative path from project root | `uv run --directory .worktrees/$BRANCH_NAME pytest` | ✅ YES |
 | `cd .worktrees/$BRANCH_NAME && ...` | `cd .worktrees/xyz && uv sync` | 🚫 NO — zero tolerance |
 
-**Rule:** Every tool call that operates inside a worktree directory MUST use `workdir="<worktree-path>"`. No exceptions.
+### File Operation Tools (filePath parameter) — CRITICAL
+
+**The `read`, `edit`, `write`, `glob`, and `grep` tools do NOT have a `workdir` parameter.** When `WORKTREE_PATH` is set, relative paths resolve to the **main repo**, causing silent errors — edits go to the wrong file.
+
+| Tool | ❌ WRONG (main repo) | ✅ CORRECT (worktree) |
+|------|----------------------|---------------------|
+| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{WORKTREE_PATH}/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` |
+
+**Rule:** When `WORKTREE_PATH` is set, every file operation tool call MUST prefix paths with the worktree path. No exceptions.
+
+When **NOT** in a worktree (working in main repo), relative paths function correctly as-is.
 
 ## Verification Step
 


### PR DESCRIPTION
## Summary

Add worktree path resolution guidance for `read`/`edit`/`write`/`glob`/`grep` tools across all skills, tasks, and guidelines. These tools lack a `workdir` parameter, so relative paths resolve to the main repo instead of the worktree — causing silent file operation errors where edits go to the wrong file.

## Outcome

Agents working in worktrees will now have explicit guidance in 12 files (4 guidelines, 5 skills, 3 skill tasks) to prefix `filePath`/`path` parameters with `WORKTREE_PATH` for file operation tools, preventing the documented failure mode where reads, edits, and writes silently target the main repo.

## Files Changed

- `000-critical-rules.md` — New critical violation entry for relative file paths in worktree context
- `060-tool-usage.md` — Worktree path resolution rules for TIER 1 tools
- `016-srclight-preference.md` — Worktree path resolution example
- `115-branch-naming.md` — Comment on filePath prefixing in worktree
- `mcp-tool-usage/SKILL.md` — Worktree Path Resolution section for TIER 1 tools
- `using-git-worktrees/SKILL.md` — Expanded Tool Usage Compliance section
- `subagent-driven-development/tasks/implementer-prompt.md` — filePath rule in Worktree Mode
- `git-workflow/tasks/implementation.md` — File operation tool path pattern
- `git-workflow/tasks/review-prep.md` — filePath rule in Worktree Mode
- `git-workflow/tasks/pr-creation.md` — filePath rule in Worktree Mode
- `finishing-a-development-branch/SKILL.md` — filePath rule
- `branch-first-protocol.md` — Comment on filePath prefixing

Fixes #686