### PR TITLE
[SPEC] Compare URL base fix (#621) + Reference ≠ Sub-issue auth cascade (#676)

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -5,3 +5,8 @@ All notable changes to the `.opencode/` directory (skills, guidelines, agent con
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.2.0] - Unreleased
+
+### Changed
+
+- **Compare URL base branch** (`post-implementation.md`, `implementation-workflow/SKILL.md`) - Fix feature branch compare URLs from `compare/main` to `compare/dev` to match the three-branch model
+- **Authorization cascade rules** (`approval-gate/SKILL.md`, `000-critical-rules.md`, `010-approval-gate.md`) - Add Reference ≠ Authorization Cascade rule requiring formal sub-issue links, not text references, for authorization cascade. Add Confirmation ≠ Authorization rule distinguishing observation confirmations from implementation authorization.

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -277,6 +277,34 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
+## Critical Violation: Wrong Compare URL Base Branch
+
+**⚠️ Using `main` as the base branch in compare URLs for feature branches is a CRITICAL GUIDELINE VIOLATION.**
+
+In the three-branch model (feature → dev → main), feature branches are created from `dev` and target `dev`. Compare URLs for feature branches MUST use `dev` as the base, not `main`.
+
+### 🚫 FORBIDDEN
+
+- Using `compare/main...` in compare URLs for feature branches
+- Generating compare URLs with `main` as base when reviewing feature branch diffs
+- Copying compare URL templates that use `main` as base
+
+### ✅ REQUIRED
+
+- Feature branch compare URLs MUST use `compare/dev...<branch-name>`
+- Only release PRs (dev → main) use `compare/main...dev`
+- Compare URL template: `https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>`
+
+### Why This Matters
+
+| Violation | Consequence |
+|-----------|-------------|
+| `compare/main...` for feature branch | Shows inflated diff including all dev-integrated work, misleading reviewer |
+| `compare/main...` for feature branch | May appear to have conflicts with code already in dev |
+| Wrong base branch | Developer sees incorrect diff scope and may reject valid changes |
+
+______________________________________________________________________
+
 ## Critical Violation: Fabricating URLs — ZERO TOLERANCE
 
 **⚠️ Generating URLs from memory, guesswork, or hardcoded patterns is a CRITICAL GUIDELINE VIOLATION.**
@@ -703,6 +731,66 @@ When the agent catches itself about to edit code without an approved spec:
 | Continue after bug discovery | Branch contamination, lost work |
 
 **See `approval-gate` skill for the complete discovery protocol and authorization boundaries, including the analysis → implementation authorization decision table.**
+
+______________________________________________________________________
+
+## Critical Violation: Conflating Issue References with Authorization Cascade
+
+**⚠️ Treating issue references (mentions in body/comments) as sub-issue relationships that trigger authorization cascade is a CRITICAL GUIDELINE VIOLATION.**
+
+### 🚫 FORBIDDEN
+
+- Cascading authorization to an issue merely because it's mentioned in another issue's body or comments
+- Treating a bug report's remediation section referencing a spec issue as a sub-issue relationship
+- Assuming `#NNN` in issue text creates an authorization link
+- Cascading authorization without verifying formal sub-issue links via `github_issue_read(method=get_sub_issues)`
+
+### ✅ REQUIRED
+
+- **Only formal sub-issue links (created via `github_sub_issue_write`) trigger authorization cascade**
+- Before cascading, verify the relationship via `github_issue_read(method=get_sub_issues)` — if empty, do NOT cascade
+- Issue mentions in body/comments are references, NOT authorization links
+- Each issue requires its own explicit authorization
+
+### Why This Matters
+
+| Violation | Consequence |
+|-----------|-------------|
+| Mention reference treated as sub-issue | Unauthorized implementation of referenced spec |
+| Bug report references spec | Agent implements spec without approval |
+| Skipping `get_sub_issues` verification | Cascade happens without formal link, violates authorization scope |
+
+**See `approval-gate` skill → "Reference ≠ Authorization Cascade" for the complete verification procedure.**
+
+______________________________________________________________________
+
+## Critical Violation: Confirmation ≠ Authorization
+
+**⚠️ When a user confirms an observation or answers a clarifying question about agent behavior, that confirmation does NOT constitute authorization for implementation.**
+
+### 🚫 FORBIDDEN
+
+- Treating "yes, that's what happened" as authorization to implement
+- Treating "correct" (answering a question) as authorization
+- Treating "sounds like we should X" (discussion conclusion) as authorization
+- Interpreting any confirmation-of-observation as implementation approval
+
+### ✅ REQUIRED
+
+- Only explicit approval phrases authorize implementation: "approved", "go", "#NNN approved"
+- Confirmation of an observation is NOT implementation authorization
+- Discussion conclusions are NOT authorization — stay in discussion mode
+- When in doubt, ASK for explicit authorization rather than assuming it
+
+### Why This Matters
+
+| User says | Correct interpretation | Incorrect interpretation |
+|-----------|----------------------|--------------------------|
+| "yes, that's correct" | Confirmation of observation | ❌ Authorization to proceed |
+| "sounds like we need X" | Discussion conclusion | ❌ Authorization to implement X |
+| "I agree with your analysis" | Agreement with reasoning | ❌ Authorization to act |
+
+**See `approval-gate` skill → "Confirmation ≠ Authorization" for the complete enforcement table.**
 
 ______________________________________________________________________
 

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -51,6 +51,8 @@ The `needs-approval` label is a **tracking tool**, not a permanent gate. Its pur
 - **Single-use**: Authorization for current phase/task only within that issue
 - **External input invalidates**: Bug reports require re-authorization
 - **Revision ≠ implementation**: Spec updates don't authorize code changes
+- **Reference ≠ authorization cascade**: Issue mentions in body/comments do NOT cascade authorization
+- **Confirmation ≠ authorization**: Confirming an observation does NOT authorize implementation
 
 **🚫 CRITICAL: Old authorizations do NOT apply:**
 - "Approved #332" in previous session → NOT VALID for new session

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -90,6 +90,33 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | **Plan-bound** | Changes to plan invalidate authorization |
 | **External input invalidates** | Bug reports, PR feedback require re-authorization |
 | **Revision ≠ implementation** | Spec updates don't authorize code changes |
+| **Reference ≠ authorization cascade** | Issue mentions in body/comments do NOT cascade authorization |
+| **Confirmation ≠ authorization** | Confirming an observation does NOT authorize implementation |
+
+### Reference ≠ Authorization Cascade
+
+**Only formal sub-issue links (created via `github_sub_issue_write`) trigger authorization cascade.** Text references in issue bodies or comments do NOT.
+
+| Relationship | Authorization cascade? | GitHub feature |
+|---|---|---|
+| Parent → sub-issue (formal link via `github_sub_issue_write`) | ✅ YES | GitHub sub-issue UI shows link |
+| Bug report references spec (mention in body/comments) | ❌ NO | Mere text reference |
+| Issue depends on another issue (mentioned in body) | ❌ NO | Mere text reference |
+| Issue blocks another issue (GitHub keyword) | ❌ NO | Dependency, not authorization |
+
+**Verification step (MANDATORY):** Before cascading authorization, verify the sub-issue relationship exists via `github_issue_read(method=get_sub_issues)`. If the API returns empty for the parent, do NOT cascade — even if the parent mentions other issue numbers in its body.
+
+### Confirmation ≠ Authorization
+
+When a user confirms an observation or answers a clarifying question about agent behavior, that confirmation does NOT constitute authorization for referenced issues.
+
+| User says | Is this authorization? | Correct action |
+|-----------|----------------------|----------------|
+| "approved" or "go" | ✅ YES | Proceed with implementation |
+| "#123 approved" | ✅ YES | Proceed with implementation of #123 |
+| "yes, that's what happened" (confirming observation) | ❌ NO | Acknowledge, do NOT implement |
+| "correct" (answering clarifying question) | ❌ NO | Acknowledge, do NOT implement |
+| "sounds like we should X" (discussion conclusion) | ❌ NO | Stay in discussion mode |
 
 ## Multi-Task Spec Authorization (CRITICAL)
 

--- a/.opencode/skills/approval-gate/tasks/post-implementation.md
+++ b/.opencode/skills/approval-gate/tasks/post-implementation.md
@@ -78,7 +78,7 @@ This pushes the branch WITHOUT creating a PR.
 Using session values (GIT_OWNER, GIT_REPO):
 
 ```
-https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/main...<branch-name>
+https://github.com/${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
 ```
 
 ### Step 4: Report Completion
@@ -106,7 +106,7 @@ Post to chat (exec summary + URL):
 
 **Outcome:** <What changed for stakeholders>
 
-Compare URL: https://github.com/<owner>/<repo>/compare/main...<branch-name>
+Compare URL: https://github.com/<owner>/<repo>/compare/dev...<branch-name>
 ```
 
 ### Step 5: HALT

--- a/.opencode/skills/implementation-workflow/SKILL.md
+++ b/.opencode/skills/implementation-workflow/SKILL.md
@@ -237,7 +237,7 @@ implementation_complete: true
 **Expected yield from review-prep:**
 ```yaml
 status: success
-compare_url: "https://github.com/owner/repo/compare/main...branch"
+compare_url: "https://github.com/owner/repo/compare/dev...branch"
 exec_summary: |
   **Summary:**
   
@@ -263,7 +263,7 @@ Integrated workflow skills from Superpowers repository.
 
 Created 4 core skills for brainstorming, planning, execution, and verification.
 
-Compare URL: https://github.com/owner/repo/compare/main...branch
+Compare URL: https://github.com/owner/repo/compare/dev...branch
 ```
 
 **Issue comment:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/621-compare-url-base
+
+- **Compare URL Base Branch Fix** - Fix feature branch compare URLs to use `dev` as base instead of `main`, matching the three-branch model (feature→dev→main) and preventing inflated diffs that mislead reviewers
+- Add Wrong Compare URL Base Branch critical violation to 000-critical-rules.md
+
+### spec/676-reference-authorization-cascade
+
+- **Reference ≠ Authorization Cascade** - Add rule that only formal sub-issue links (via `github_sub_issue_write`) trigger authorization cascade, not mere text references in issue bodies or comments
+- Add mandatory verification step requiring `get_sub_issues` check before cascading authorization
+- Add Confirmation ≠ Authorization rule distinguishing observation confirmations from implementation authorization
+- Add both critical violations to 000-critical-rules.md and 010-approval-gate.md
+
 ### spec/668-batch-approval
 
 - **Batch Approval Orchestration** - Add interdependency analysis for multiple approved issues, classifying them as must-precede, independent, conflict-risk, or meta/non-code, and producing a dependency graph with parallel-safe group identification before implementation begins


### PR DESCRIPTION
## Summary

Fix feature branch compare URLs to use `dev` as base branch instead of `main`, and add authorization cascade rules preventing issue references from triggering unauthorized implementation.

## Outcome

- Feature branch compare URLs now correctly show diff against `dev` (three-branch model)
- Authorization cascade only triggers on formal sub-issue links, not text references
- Observation confirmations no longer treated as implementation authorization
- Critical violations documented for both violations

Fixes #621
Fixes #676