### PR TITLE
[SPEC] Try/Catch/Finally Pattern for Skill Workflows

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -274,6 +274,15 @@ Three tiers: **Tier 1 (Trivial)**: whitespace/formatting → auto-resolve, silen
 
 No feature creep: implement ONLY what is in the approved spec. No unapproved work: wait for explicit "approved" or "go".
 
+## Critical Violation: Skipping Completion Guarantee on Workflow Halt
+
+**⚠️ Halting a skill workflow without invoking `--task completion` is a CRITICAL GUIDELINE VIOLATION.** When a state-modifying skill halts at any point — including error, failure, or early termination — the completion subtask MUST be invoked before halting.
+
+- 🚫 FORBIDDEN: Halting mid-workflow without invoking `--task completion`; skipping completion because "nothing was done"; assuming cleanup happens automatically
+- ✅ REQUIRED: Invoke `--task completion` on the current skill before halting; completion tasks are idempotent and safe to invoke multiple times
+
+**See per-skill `tasks/completion.md` files and `.opencode/skills/completion-core/completion-core.md` for the shared completion operations.**
+
 ## Critical Violation: Skipping Interdependency Analysis for Batch Approvals
 
 **⚠️ Processing multiple approved issues without interdependency analysis is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -29,6 +29,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | `verify-open-questions` | Check for unresolved questions in spec | ~370 |
 | `batch-approval-analysis` | Analyze interdependencies when multiple issues approved simultaneously | ~500 |
 | `post-implementation` | Push branch, generate compare URL, HALT | ~480 |
+| `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~150 |
 
 ## Invocation
 
@@ -40,7 +41,10 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 - `/skill approval-gate --task verify-open-questions` - Check for unresolved questions
 - `/skill approval-gate --task batch-approval-analysis` - Analyze interdependencies for multiple approved issues
 - `/skill approval-gate --task post-implementation` - After implementation done
+- `/skill approval-gate --task completion` - Invoke when workflow halts at any point
 - `/skill approval-gate` - Overview only
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (authorization result comment, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
 ## Operating Protocol
 

--- a/.opencode/skills/approval-gate/tasks/completion.md
+++ b/.opencode/skills/approval-gate/tasks/completion.md
@@ -1,0 +1,37 @@
+# Task: completion
+
+Idempotent completion subtask for approval-gate. Ensures mandatory steps run regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Authorization result determined:** Was a yes/no decision reached?
+2. **Existing comments:** Check if authorization result comment already posted on issue
+
+## Skill-Specific Completion
+
+1. **Post authorization result comment** (if not already posted):
+   - Check issue comments for existing authorization result (byline pattern)
+   - If missing: post result comment with authorization status and scope
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<Authorization verification result and scope>
+
+**Outcome:** <What the result means for stakeholders>
+
+Issue URL: ${BASE_URL}${GIT_OWNER}/${GIT_REPO}/issues/<number>
+```
+
+URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/completion-core/completion-core.md
+++ b/.opencode/skills/completion-core/completion-core.md
@@ -1,0 +1,75 @@
+# Completion Core — Shared Completion Operations
+
+Reference this file from per-skill `tasks/completion.md` files for common completion operations.
+
+## Common Completion Operations
+
+### 1. Push Branch (Idempotent)
+
+Check whether the branch has unpushed commits before pushing:
+
+```bash
+UNPUSHED=$(git log origin/$(git branch --show-current)..HEAD --oneline 2>/dev/null)
+if [ -n "$UNPUSHED" ]; then
+    git push -u origin $(git branch --show-current)
+else
+    echo "Branch already up to date with remote. No push needed."
+fi
+```
+
+If no remote tracking branch exists yet, `git push -u origin <branch>` creates it.
+
+### 2. Generate URL
+
+Two URL patterns depending on workflow type:
+
+**Compare URL** (for git push workflows — implementation, git-workflow, finishing):
+
+```bash
+COMPARE_URL="${GITBUCKET_HTML_URL:-https://github.com/}${GIT_OWNER}/${GIT_REPO}/compare/dev...$(git branch --show-current)"
+```
+
+**Action URL** (for creation workflows — issue creation, approval gate):
+
+- Issue URL: `${GITBUCKET_HTML_URL:-https://github.com/}${GIT_OWNER}/${GIT_REPO}/issues/<number>`
+- PR URL: from `github_create_pull_request` response
+
+### 3. Post Status Comment (Idempotent)
+
+Before posting, check if a comment with the same byline already exists:
+
+```python
+comments = github_issue_read(method="get_comments", owner=GIT_OWNER, repo=GIT_REPO, issue_number=N)
+existing = [c for c in comments if "byline-marker" in c.get("body", "")]
+if not existing:
+    github_add_issue_comment(owner=GIT_OWNER, repo=GIT_REPO, issue_number=N, body="...")
+else:
+    # Comment already posted, skip
+```
+
+Replace `byline-marker` with a unique identifier from the comment content (e.g., the agent byline pattern).
+
+### 4. Report Executive Summary in Chat (Always Runs)
+
+Chat output is idempotent by nature. Always produce:
+
+```
+**Summary:**
+
+<1-2 sentences describing the impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+```
+
+**URL is ALWAYS last** per `000-critical-rules.md`.
+
+## Idempotency Summary
+
+| Operation | Idempotency Mechanism | Applies To |
+|-----------|----------------------|------------|
+| Push branch | Check `git log origin/..HEAD` before pushing | Git workflows only |
+| Generate URL | Check if URL already generated; compare URL for pushes, action URL for creation workflows | All workflows |
+| Post status comment | Check if comment already posted (query for existing byline) | Workflows with issue context |
+| Report executive summary + URL | Always run; idempotent by nature | All workflows |

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -20,12 +20,16 @@ Branch completion workflow that ensures a feature branch is fully ready for PR c
 |------|---------|-------|
 | `prepare` | Prepare branch for PR creation | ~450 |
 | `checklist` | Run completion checklist | ~350 |
+| `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~200 |
 
 ## Invocation
 
 - `/skill finishing-a-development-branch` — Overview only
 - `/skill finishing-a-development-branch --task prepare` — Prepare branch for PR
 - `/skill finishing-a-development-branch --task checklist` — Run completion checklist
+- `/skill finishing-a-development-branch --task completion` — Invoke when workflow halts at any point
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (push, compare URL, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
 ## Operating Protocol
 

--- a/.opencode/skills/finishing-a-development-branch/tasks/completion.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/completion.md
@@ -1,0 +1,42 @@
+# Task: completion
+
+Idempotent completion subtask for finishing-a-development-branch. Ensures mandatory steps run regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Push status:** Check for unpushed commits
+   ```bash
+   git log origin/$(git branch --show-current)..HEAD --oneline 2>/dev/null
+   ```
+2. **Compare URL generated:** Check if compare URL was already produced
+3. **Existing comments:** Check if completion comment already posted on issue
+
+## Skill-Specific Completion
+
+1. **Verify push** — ensure all commits are on remote
+2. **Generate compare URL** (dev...branch)
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for steps 3-6:
+
+1. Push branch (with idempotency check)
+2. Generate compare URL (dev...branch)
+3. Post status comment on issue (with idempotency check)
+4. Report executive summary in chat (always runs)
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<Branch readiness verification result>
+
+**Outcome:** <What stakeholders get — branch is ready/not ready for PR>
+
+Compare URL: ${BASE_URL}${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch>
+```
+
+URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -25,6 +25,7 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
 | `review-prep` | Push branch, generate compare URL for review | ~560 |
 | `pr-creation` | Squash, push, create PR via GitHub MCP | ~640 |
 | `cleanup` | Delete merged branches, clean stale refs | ~800 |
+| `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~200 |
 
 ## Invocation
 
@@ -33,7 +34,10 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
 - `/skill git-workflow --task review-prep` - AFTER implementation done (automatic, no decision point)
 - `/skill git-workflow --task pr-creation` - When user says "create a PR"
 - `/skill git-workflow --task cleanup` - After PR merge confirmed
+- `/skill git-workflow --task completion` - Invoke when workflow halts at any point
 - `/skill git-workflow` - Overview only
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (status report, URL, verification gates) are never skipped. It is idempotent and safe to invoke multiple times.
 
 ## Operating Protocol
 

--- a/.opencode/skills/git-workflow/tasks/completion.md
+++ b/.opencode/skills/git-workflow/tasks/completion.md
@@ -1,0 +1,48 @@
+# Task: completion
+
+Idempotent completion subtask for git-workflow. Ensures mandatory steps run regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Git status:** Check for uncommitted changes
+   ```bash
+   git status --porcelain
+   ```
+2. **Push status:** Check for unpushed commits
+   ```bash
+   git log origin/$(git branch --show-current)..HEAD --oneline 2>/dev/null
+   ```
+3. **Existing comments:** Check if completion comment already posted on issue (if applicable)
+
+## Skill-Specific Completion
+
+1. **If review-prep not yet run:** Delegate to `git-workflow --task review-prep`
+   - This handles: commit, push, compare URL generation
+   - Check if compare URL was already generated (look for URL in recent chat output)
+   - If missing: invoke review-prep
+2. **If on cleanup path:** Verify PR merge via GitHub API before closing issues
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for steps 3-6:
+
+1. Push branch (with idempotency check)
+2. Generate compare URL (dev...branch)
+3. Post status comment on issue (with idempotency check, if issue context available)
+4. Report executive summary in chat (always runs)
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<Git operation result and its impact>
+
+**Outcome:** <What changed for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+```
+
+URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/github-issue-creation/SKILL.md
+++ b/.opencode/skills/github-issue-creation/SKILL.md
@@ -24,6 +24,7 @@ You are an Issue Creation Enforcer. Your focus is ensuring all GitHub issue crea
 | `creation` | Create issue with proper title, labels, byline | ~200 |
 | `post-creation` | Invoke auditors, create sub-issues for multi-task specs | ~180 |
 | `single-task-check` | Determine if spec needs sub-issues or is single-task | ~160 |
+| `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~200 |
 
 ## Invocation
 
@@ -31,7 +32,10 @@ You are an Issue Creation Enforcer. Your focus is ensuring all GitHub issue crea
 - `/skill github-issue-creation --task creation` - Create issue with enforcement
 - `/skill github-issue-creation --task post-creation` - After creation (auditors, sub-issues)
 - `/skill github-issue-creation --task single-task-check` - Check if spec is single-task
+- `/skill github-issue-creation --task completion` - Invoke when workflow halts at any point
 - `/skill github-issue-creation` - Overview only
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (labels, auditors, sub-issues, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
 ## Operating Protocol
 

--- a/.opencode/skills/github-issue-creation/tasks/completion.md
+++ b/.opencode/skills/github-issue-creation/tasks/completion.md
@@ -1,0 +1,49 @@
+# Task: completion
+
+Idempotent completion subtask for github-issue-creation. Ensures mandatory steps run regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Issue created:** Check if the GitHub Issue already exists
+   - Search by title or check recent issue list
+2. **Labels applied:** Check if `needs-approval` label is present
+3. **Sub-issues created:** Check if multi-task spec has sub-issues (via `get_sub_issues`)
+4. **Auditor invoked:** Check if spec-auditor comment exists on issue
+
+## Skill-Specific Completion
+
+1. **Apply `needs-approval` label** (if not already present):
+   ```python
+   labels = github_issue_read(method="get_labels", issue_number=N)
+   if "needs-approval" not in [l["name"] for l in labels]:
+       # Add label
+   ```
+2. **Invoke spec-auditor** (if not already run):
+   - Check if spec-auditor comment exists on the issue
+   - If missing: invoke spec-auditor
+3. **Create sub-issues** (if multi-task and not already created):
+   - Check `get_sub_issues` result
+   - If empty and spec is multi-task: invoke `github-sub-issues` skill
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Issue URL as the action URL (ALWAYS last)
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<What issue was created and its purpose>
+
+**Outcome:** <What stakeholders get from the new issue>
+
+Issue URL: ${BASE_URL}${GIT_OWNER}/${GIT_REPO}/issues/<number>
+```
+
+URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/implementation-workflow/SKILL.md
+++ b/.opencode/skills/implementation-workflow/SKILL.md
@@ -28,6 +28,7 @@ Orchestration layer that coordinates the implementation workflow by sequencing s
 | `orchestrate` | Full implementation workflow sequence with verification gates | ~900 |
 | `context-passing` | Reference for yield-back context shapes between subtasks | ~200 |
 | `purification-and-enforcement` | Git-workflow scope boundaries and enforcement rules | ~300 |
+| `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~200 |
 
 ## Invocation
 
@@ -35,6 +36,9 @@ Orchestration layer that coordinates the implementation workflow by sequencing s
 - `/skill implementation-workflow --task orchestrate` - Same as above
 - `/skill implementation-workflow --task context-passing` - Reference context shapes
 - `/skill implementation-workflow --task purification-and-enforcement` - Reference boundaries and enforcement
+- `/skill implementation-workflow --task completion` - Invoke when workflow halts at any point
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (status report, URL, verification gates) are never skipped. It is idempotent and safe to invoke multiple times.
 
 ## Operating Protocol
 

--- a/.opencode/skills/implementation-workflow/tasks/completion.md
+++ b/.opencode/skills/implementation-workflow/tasks/completion.md
@@ -1,0 +1,49 @@
+# Task: completion
+
+Idempotent completion subtask for implementation-workflow. Ensures mandatory steps run regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Git status:** Check for uncommitted changes
+   ```bash
+   git status --porcelain
+   ```
+2. **Push status:** Check for unpushed commits
+   ```bash
+   git log origin/$(git branch --show-current)..HEAD --oneline 2>/dev/null
+   ```
+3. **Existing comments:** Check if completion comment already posted on issue
+
+## Skill-Specific Completion
+
+1. **If verification-before-completion not yet invoked:** Invoke `--task verify`
+   - Check if verification evidence exists in issue comments or `./tmp/`
+   - If missing: invoke verification before proceeding
+2. **If finishing-a-development-branch not yet invoked:** Invoke `--task checklist`
+   - Check if branch readiness checklist has been run
+   - If missing: invoke checklist before proceeding
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for steps 3-6:
+
+1. Push branch (with idempotency check)
+2. Generate compare URL (dev...branch)
+3. Post status comment on issue (with idempotency check)
+4. Report executive summary in chat (always runs)
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<What was implemented and its impact>
+
+**Outcome:** <What changed for stakeholders>
+
+Compare URL: ${BASE_URL}${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch>
+```
+
+URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/verification-before-completion/SKILL.md
+++ b/.opencode/skills/verification-before-completion/SKILL.md
@@ -24,12 +24,16 @@ You are a Verification Gatekeeper. Your focus is ensuring NO completion claim wi
 |------|---------|-------|
 | `verify` | Verify all success criteria have evidence | ~700 |
 | `collect` | Collect evidence for incomplete criteria | ~500 |
+| `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~150 |
 
 ## Invocation
 
 - `/skill verification-before-completion` — Overview only
 - `/skill verification-before-completion --task verify` — Verify completion readiness
 - `/skill verification-before-completion --task collect` — Collect missing evidence
+- `/skill verification-before-completion --task completion` — Invoke when workflow halts at any point
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (verification result comment, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
 ## Operating Protocol
 

--- a/.opencode/skills/verification-before-completion/tasks/completion.md
+++ b/.opencode/skills/verification-before-completion/tasks/completion.md
@@ -1,0 +1,37 @@
+# Task: completion
+
+Idempotent completion subtask for verification-before-completion. Ensures mandatory steps run regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Verification result determined:** Was an evidence-based verification completed?
+2. **Existing comments:** Check if verification result comment already posted on issue
+
+## Skill-Specific Completion
+
+1. **Post verification result comment** (if not already posted):
+   - Check issue comments for existing verification result (byline pattern)
+   - If missing: post result comment with evidence summary
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) if applicable (ALWAYS last)
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<Verification result: pass/fail with criteria count>
+
+**Outcome:** <What stakeholders know — task is verified/not verified>
+
+Issue URL: ${BASE_URL}${GIT_OWNER}/${GIT_REPO}/issues/<number>
+```
+
+URL is ALWAYS last per `000-critical-rules.md`.


### PR DESCRIPTION
## Summary

Add try/catch/finally completion guarantee pattern to 6 state-modifying skills, ensuring mandatory steps (push, URL, status comment, verification gates) are never skipped regardless of where a workflow halts.

## Outcome

- **Shared completion core** (`.opencode/skills/completion-core/completion-core.md`) — idempotent push, URL generation, status comment, and executive summary operations
- **Per-skill completion tasks** — 6 `tasks/completion.md` files with skill-specific cleanup + delegation to shared core
- **Pre-instruct paragraphs** — COMPLETION GUARANTEE in all 6 SKILL.md files (implementation-workflow, git-workflow, github-issue-creation, approval-gate, finishing-a-development-branch, verification-before-completion)
- **Invocation table updates** — `--task completion` added to all 6 skills
- **New critical violation** — "Skipping Completion Guarantee on Workflow Halt" added to `000-critical-rules.md`

All 12 success criteria (SC1-SC12) verified.

Fixes #591