### PR TITLE
Purge TodoWrite from active skills

### DIFF
--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -42,8 +42,6 @@ Execute an approved implementation plan by dispatching fresh subagents per task,
 ```
 Read plan, extract all tasks with full text and context
     ↓
-Create TodoWrite with all tasks
-    ↓
 For each task:
     ↓
     Dispatch implementer subagent (tasks/implementer-prompt.md)
@@ -55,8 +53,6 @@ For each task:
     ↓
     Dispatch code quality reviewer subagent (tasks/code-quality-reviewer-prompt.md)
         ↓ (if quality fails → implementer fixes → re-review)
-    ↓
-    Mark task complete in TodoWrite
     ↓
 After all tasks:
     ↓

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/purge-todowrite
+
+- **TodoWrite Purge** - Remove unreliable `todowrite`/`TodoWrite` tracking references from active skills, eliminating stale state issues caused by the tool's unreliable state maintenance
+
 ### spec/621-compare-url-base
 
 - **Compare URL Base Branch Fix** - Fix feature branch compare URLs to use `dev` as base instead of `main`, matching the three-branch model (feature→dev→main) and preventing inflated diffs that mislead reviewers


### PR DESCRIPTION
## Summary

Remove `todowrite`/`TodoWrite` tracking references from `.opencode/skills/subagent-driven-development/SKILL.md`. The todowrite tool does not reliably maintain state and has been purged per developer direction.

## Outcome

- Zero `todowrite`/`TodoWrite` references in `.opencode/skills/**/*.md`, `.opencode/guidelines/**/*.md`, and `AGENTS.md`
- `subagent-driven-development/SKILL.md` still describes a working workflow without todowrite tracking
- Superseded issues #383, #466, #552 already closed

Fixes #700