### PR TITLE
feat: rewrite session injection for English prose + restore env-loader

### DIFF
--- a/.opencode/plugins/env-loader.ts
+++ b/.opencode/plugins/env-loader.ts
@@ -1,0 +1,298 @@
+/**
+ * Env-Loader Plugin for OpenCode
+ *
+ * Reads project environment data and injects all key-value pairs into
+ * every shell session via the `shell.env` hook. This is the SOLE provider
+ * of bash environment variables — session-enforcement.ts owns LLM context.
+ *
+ * Sources (independently gathered, no cross-plugin coupling):
+ * - .env file — all parsed key-value pairs including secrets
+ * - input.worktree — WORKTREE_PATH for bash commands
+ * - input.$ (git) — BRANCH_NAME, GIT_OWNER, GIT_REPO, GIT_PLATFORM,
+ *   DEV_NAME, DEV_EMAIL, GITHUB_HTML_URL, GITBUCKET_HTML_URL,
+ *   GITBUCKET_SSH_URL, GITBUCKET_HAS_CREDENTIALS
+ *
+ * Hook: shell.env ONLY — no system.transform, no LLM output.
+ *
+ * Restored from commit f7555bd, extended per issue #712.
+ *
+ * Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+ */
+
+import type { Hooks, PluginInput } from "@opencode-ai/plugin";
+import fs from "fs";
+import path from "path";
+
+const ENV_FILE = ".env";
+
+interface ParseResult {
+  env: Record<string, string>;
+  warnings: string[];
+}
+
+function parseEnvFile(content: string): ParseResult {
+  const env: Record<string, string> = {};
+  const warnings: string[] = [];
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+
+    if (line === "" || line.startsWith("#")) {
+      continue;
+    }
+
+    const eqIdx = line.indexOf("=");
+    if (eqIdx === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, eqIdx).trim();
+    let value = line.slice(eqIdx + 1).trim();
+
+    if (!key) {
+      continue;
+    }
+
+    // Strip inline comments before unquoting
+    value = stripInlineComments(value);
+
+    // Strip surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (key in env) {
+      warnings.push(`Duplicate key "${key}" — last value wins`);
+    }
+
+    env[key] = value;
+  }
+
+  return { env, warnings };
+}
+
+function stripInlineComments(value: string): string {
+  // If value is quoted, don't strip inline comments — hashes inside quotes are literal
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value;
+  }
+  // For unquoted values, strip inline comments: `value # comment`
+  const hashIdx = value.indexOf(" #");
+  if (hashIdx !== -1) {
+    return value.slice(0, hashIdx).trim();
+  }
+  return value;
+}
+
+function isEnvGitignored(projectDir: string): boolean {
+  const gitignorePath = path.join(projectDir, ".gitignore");
+  try {
+    const content = fs.readFileSync(gitignorePath, "utf8");
+    const lines = content.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed === ".env" || trimmed === "/.env") {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// ---------- Git remote URL parsing (TypeScript, for shell.env KEY=VALUE output) ----------
+
+function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
+  // SSH: git@github.com:owner/repo.git
+  const sshMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (sshMatch) {
+    return { owner: sshMatch[1], repo: sshMatch[2] };
+  }
+  // HTTPS: https://github.com/owner/repo.git
+  const httpsMatch = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (httpsMatch) {
+    return { owner: httpsMatch[1], repo: httpsMatch[2] };
+  }
+  return null;
+}
+
+function parseGitBucketUrl(
+  url: string,
+  projectDir: string,
+): { baseUrl: string | null; owner: string; repo: string; sshUrl: string | null } | null {
+  let owner: string | null = null;
+  let repo: string | null = null;
+
+  // SSH with port: ssh://git@hostname:port/owner/repo.git
+  const sshUrlMatch = url.match(/^ssh:\/\/git@([^:/]+):(\d+)\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (sshUrlMatch) {
+    owner = sshUrlMatch[3];
+    repo = sshUrlMatch[4];
+  }
+
+  if (!owner) {
+    // SSH short: git@hostname:owner/repo.git
+    const sshShortMatch = url.match(/^git@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/);
+    if (sshShortMatch) {
+      owner = sshShortMatch[2];
+      repo = sshShortMatch[3];
+    }
+  }
+
+  if (!owner) {
+    // HTTPS: https://hostname/owner/repo.git
+    const httpsMatch = url.match(/^https:\/\/([^/]+)\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+    if (httpsMatch) {
+      owner = httpsMatch[2];
+      repo = httpsMatch[3];
+    }
+  }
+
+  if (!owner || !repo) {
+    return null;
+  }
+
+  // Extract SSH base URL for GitBucket
+  let sshUrl: string | null = null;
+  const sshBaseMatch = url.match(/^(ssh:\/\/git@[^:/]+:\d+)/);
+  if (sshBaseMatch) {
+    sshUrl = sshBaseMatch[1];
+  }
+
+  // Base URL comes from .env, not from remote URL
+  const baseUrl = readGitBucketUrlFromEnv(path.join(projectDir, ENV_FILE));
+
+  return { baseUrl, owner, repo, sshUrl };
+}
+
+function readGitBucketUrlFromEnv(envPath: string): string | null {
+  try {
+    if (fs.existsSync(envPath)) {
+      const content = fs.readFileSync(envPath, "utf8");
+      let htmlUrl: string | null = null;
+      let legacyUrl: string | null = null;
+      for (const line of content.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith("GITBUCKET_HTML_URL=")) {
+          htmlUrl = trimmed.split("=", 2)[1].trim();
+        } else if (trimmed.startsWith("GITBUCKET_URL=")) {
+          legacyUrl = trimmed.split("=", 2)[1].trim();
+        }
+      }
+      return htmlUrl || legacyUrl;
+    }
+  } catch {
+    // Ignore read errors
+  }
+  return null;
+}
+
+export async function EnvLoaderPlugin(input: PluginInput): Promise<Hooks> {
+  const projectDir = input?.directory || process.cwd();
+  const envPath = path.join(projectDir, ENV_FILE);
+
+  return {
+    "shell.env": async (_input, output) => {
+      // --- .env file values ---
+      if (fs.existsSync(envPath)) {
+        const content = fs.readFileSync(envPath, "utf8");
+        const { env, warnings } = parseEnvFile(content);
+
+        for (const [key, value] of Object.entries(env)) {
+          output.env[key] = value;
+        }
+
+        // Flag non-gitignored .env
+        if (!isEnvGitignored(projectDir)) {
+          output.env["ENV_LOADER_SECURITY_WARNING"] =
+            "SECURITY: .env file is NOT in .gitignore. Secrets may be committed to version control. Add '.env' to .gitignore immediately.";
+        }
+
+        if (warnings.length > 0) {
+          console.error("[env-loader] " + warnings.join("; "));
+        }
+      }
+
+      // --- WORKTREE_PATH from PluginInput ---
+      const worktreeDir = input?.worktree || "";
+      const mainRepoDir = input?.directory || "";
+      if (worktreeDir && worktreeDir !== mainRepoDir) {
+        output.env["WORKTREE_PATH"] = worktreeDir;
+      }
+
+      // --- Git values from input.$ shell ---
+      try {
+        // Branch name
+        const branchResult = await input.$.nothrow()`git branch --show-current`;
+        if (branchResult.exitCode === 0) {
+          const branch = branchResult.text().trim();
+          if (branch) {
+            output.env["BRANCH_NAME"] = branch;
+          }
+        }
+
+        // Remote URL
+        const remoteResult = await input.$.nothrow()`git remote get-url origin`;
+        if (remoteResult.exitCode === 0) {
+          const remoteUrl = remoteResult.text().trim();
+
+          if (remoteUrl.includes("github.com")) {
+            output.env["GIT_PLATFORM"] = "github";
+            const parsed = parseGitHubUrl(remoteUrl);
+            if (parsed) {
+              output.env["GIT_OWNER"] = parsed.owner;
+              output.env["GIT_REPO"] = parsed.repo;
+            }
+            output.env["GITHUB_HTML_URL"] = "https://github.com/";
+          } else {
+            output.env["GIT_PLATFORM"] = "gitbucket";
+            const parsed = parseGitBucketUrl(remoteUrl, projectDir);
+            if (parsed) {
+              output.env["GIT_OWNER"] = parsed.owner;
+              output.env["GIT_REPO"] = parsed.repo;
+              if (parsed.baseUrl) {
+                output.env["GITBUCKET_HTML_URL"] = parsed.baseUrl;
+              }
+              if (parsed.sshUrl) {
+                output.env["GITBUCKET_SSH_URL"] = parsed.sshUrl;
+              }
+              // Check credentials from .env
+              const hasToken = output.env["GITBUCKET_TOKEN"] && output.env["GITBUCKET_TOKEN"].length > 0;
+              const hasUrl = output.env["GITBUCKET_HTML_URL"] || output.env["GITBUCKET_URL"];
+              output.env["GITBUCKET_HAS_CREDENTIALS"] = (hasToken && hasUrl) ? "true" : "false";
+            }
+          }
+        }
+
+        // Git user config
+        const nameResult = await input.$.nothrow()`git config user.name`;
+        if (nameResult.exitCode === 0) {
+          const name = nameResult.text().trim();
+          if (name) {
+            output.env["DEV_NAME"] = name;
+          }
+        }
+
+        const emailResult = await input.$.nothrow()`git config user.email`;
+        if (emailResult.exitCode === 0) {
+          const email = emailResult.text().trim();
+          if (email) {
+            output.env["DEV_EMAIL"] = email;
+          }
+        }
+      } catch {
+        // Git commands unavailable — skip git env values
+      }
+    },
+  };
+}
+
+export default EnvLoaderPlugin;
+export { parseEnvFile, isEnvGitignored };

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -1,8 +1,17 @@
 /**
  * Session Enforcement Plugin for OpenCode
  *
- * Unified plugin that combines session initialization and skill enforcement
- * injection. Replaces the retired session-init.ts plugin.
+ * Injects session context into the LLM system prompt and enforces
+ * skill invocation rules. Also detects bare issue references (#N)
+ * and injects mandatory audit pipelines.
+ *
+ * Hook: system.transform — pushes English prose context (from session_init.py
+ *   and PluginInput augmentations) into the LLM system prompt.
+ * Hook: chat.messages.transform — injects skill enforcement content and
+ *   bare issue pipeline directives into user messages.
+ *
+ * NO shell.env hook — env-loader.ts owns all bash environment injection.
+ * NO parsing of session_init.py output — stdout goes verbatim to system prompt.
  *
  * Source attribution:
  * - Session init pattern adapted from existing session-init.ts (project-internal)
@@ -24,31 +33,11 @@ const SCRIPT_PATH = ".opencode/scripts/session_init.py";
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 let cachedOutput: string | null = null;
-let cachedEnv: Record<string, string> | null = null;
 let cacheTimestamp = 0;
 
-function parseEnvFromOutput(stdout: string): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const line of stdout.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed.includes("=") && !trimmed.startsWith("#")) {
-      const eqIdx = trimmed.indexOf("=");
-      const key = trimmed.slice(0, eqIdx).trim();
-      const value = trimmed.slice(eqIdx + 1).trim();
-      if (key && value !== undefined) {
-        env[key] = value;
-      }
-    }
-  }
-  return env;
-}
-
-async function runSessionInit($: PluginInput["$"]): Promise<{
-  output: string;
-  env: Record<string, string>;
-}> {
+async function runSessionInit($: PluginInput["$"]): Promise<string> {
   if (cachedOutput && Date.now() - cacheTimestamp < CACHE_TTL_MS) {
-    return { output: cachedOutput, env: cachedEnv! };
+    return cachedOutput;
   }
 
   try {
@@ -57,26 +46,110 @@ async function runSessionInit($: PluginInput["$"]): Promise<{
 
     if (!stdout || stdout.trim().length === 0) {
       console.error("[session-enforcement] Script returned empty output");
-      return { output: "", env: {} };
+      return "";
     }
 
     if (result.exitCode !== 0) {
       const stderr = result.stderr.toString();
       console.error(`[session-enforcement] Script exited with code ${result.exitCode}: ${stderr}`);
-      return { output: "", env: {} };
+      return "";
     }
 
-    const env = parseEnvFromOutput(stdout);
-
     cachedOutput = stdout;
-    cachedEnv = env;
     cacheTimestamp = Date.now();
 
-    return { output: stdout, env };
+    return stdout;
   } catch (err) {
     console.error("[session-enforcement] Failed to run session_init.py:", err);
-    return { output: "", env: {} };
+    return "";
   }
+}
+
+interface ProjectMetadata {
+  name: string;
+  version: string;
+  pythonVersion: string;
+}
+
+function readProjectMetadata(projectDir: string): ProjectMetadata | null {
+  const pyprojectPath = path.join(projectDir, "pyproject.toml");
+  if (!fs.existsSync(pyprojectPath)) {
+    return null;
+  }
+
+  let name = "";
+  let version = "";
+  let inProjectSection = false;
+
+  try {
+    const content = fs.readFileSync(pyprojectPath, "utf8");
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed === "[project]") {
+        inProjectSection = true;
+        continue;
+      }
+      if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+        inProjectSection = false;
+        continue;
+      }
+      if (inProjectSection) {
+        if (trimmed.startsWith("name")) {
+          const eqIdx = trimmed.indexOf("=");
+          if (eqIdx > 0) {
+            name = trimmed.slice(eqIdx + 1).trim().replace(/^["']|["']$/g, "");
+          }
+        } else if (trimmed.startsWith("version")) {
+          const eqIdx = trimmed.indexOf("=");
+          if (eqIdx > 0) {
+            version = trimmed.slice(eqIdx + 1).trim().replace(/^["']|["']$/g, "");
+          }
+        }
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  if (!name) {
+    return null;
+  }
+
+  let pythonVersion = "";
+  const pythonVersionPath = path.join(projectDir, ".python-version");
+  if (fs.existsSync(pythonVersionPath)) {
+    try {
+      pythonVersion = fs.readFileSync(pythonVersionPath, "utf8").trim();
+    } catch {
+      // Ignore read errors
+    }
+  }
+
+  return { name, version: version || "0.1.0", pythonVersion };
+}
+
+function buildMetadataBlock(projectDir: string): string {
+  const meta = readProjectMetadata(projectDir);
+  if (!meta) {
+    return "";
+  }
+
+  const lines: string[] = [`Project: ${meta.name} v${meta.version}`];
+  if (meta.pythonVersion) {
+    lines.push(`Python: ${meta.pythonVersion}`);
+  }
+  return lines.join("\n");
+}
+
+function buildWorktreeBlock(input: PluginInput): string {
+  const mainRepoDir = input?.directory || "";
+  const worktreeDir = input?.worktree || "";
+
+  if (worktreeDir && worktreeDir !== mainRepoDir) {
+    return `WORKTREE_PATH: ${worktreeDir}\nAll file operations (read, edit, write, glob, grep) MUST use paths prefixed with WORKTREE_PATH. Relative paths resolve to the main repo, not the worktree.`;
+  }
+
+  return "";
 }
 
 /**
@@ -246,7 +319,7 @@ Critical rules:
  * Build the enforcement content injected into the first user message.
  *
  * Adapted from obra/superpowers skill enforcement pattern:
- * https://github.com/obra/superpowers/blob/main/skills/using-superpowers/SKILL.md
+ * https://github.com/obra/superpowers/blob/main/.opencode/plugins/superpowers.js
  *
  * Key principle: "If you think there is even a 1% chance a skill might apply,
  * you ABSOLUTELY MUST invoke the skill." — from obra/superpowers using-superpowers
@@ -315,7 +388,7 @@ Invoke relevant skills BEFORE any response or action. Even a 1% chance means inv
 }
 
 export default async function sessionEnforcementPlugin(input: PluginInput): Promise<Hooks> {
-  // Determine skills directory
+  // Determine skills directory and project directory
   const projectDir = input?.directory || process.cwd();
   const skillsDir = path.join(projectDir, ".opencode", "skills");
 
@@ -323,25 +396,29 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
   const { skills: skillDescriptions, errors: frontmatterErrors } = loadSkillDescriptions(skillsDir);
 
   return {
-    // Inject session context into system prompt (absorbed from session-init.ts)
+    // Inject session context into system prompt (from session_init.py + PluginInput augmentations)
     "experimental.chat.system.transform": async (_input, output) => {
-      const { output: scriptOutput } = await runSessionInit(input.$);
+      const scriptOutput = await runSessionInit(input.$);
       if (scriptOutput) {
         output.system.push(scriptOutput);
+      }
+
+      // Inject worktree context when session is operating in a worktree
+      const worktreeBlock = buildWorktreeBlock(input);
+      if (worktreeBlock) {
+        output.system.push(worktreeBlock);
+      }
+
+      // Inject project metadata (name, version, Python version)
+      const metadataBlock = buildMetadataBlock(projectDir);
+      if (metadataBlock) {
+        output.system.push(metadataBlock);
       }
 
       // Inject frontmatter validation warning if any skills have broken frontmatter
       const warning = buildFrontmatterWarning(frontmatterErrors);
       if (warning) {
         output.system.push(warning);
-      }
-    },
-
-    // Inject environment variables (absorbed from session-init.ts)
-    "shell.env": async (_input, output) => {
-      const { env } = await runSessionInit(input.$);
-      for (const [key, value] of Object.entries(env)) {
-        output.env[key] = value;
       }
     },
 

--- a/.opencode/scripts/session_init.py
+++ b/.opencode/scripts/session_init.py
@@ -1,38 +1,23 @@
 #!/usr/bin/env python3
 """Session initialization script for AI agents.
 
-Extracts git context needed for agent startup:
-- DEV_NAME: Developer's git config name (for commit trailers)
-- DEV_EMAIL: Developer's git config email (for commit trailers)
-- GIT_OWNER: Repository owner (for GitHub/GitBucket API calls)
-- GIT_REPO: Repository name (for GitHub/GitBucket API calls)
-- GIT_HOOKS_PATH: Git hooks path (to verify hooks installed)
-- GIT_REMOTE_URL: Full remote URL (for reference)
-- GITHUB_HTML_URL: GitHub web UI base URL (for GitHub remotes)
-- GITBUCKET_HTML_URL: GitBucket web UI base URL (from .env, NEVER fabricated)
-- GITBUCKET_SSH_URL: GitBucket SSH base URL (host+port, no path, for SSH remotes)
-- GITBUCKET_HAS_CREDENTIALS: Whether .env has token configured
-- SRCLEIGHT_STATUS: Srclight index health (ok/empty/not_indexed)
+Outputs English prose context for LLM consumption on stdout.
+Diagnostic and side-effect output goes to stderr — silent on success.
 
 Guard checks (auto-create missing files/branches/worktree):
 - CHANGELOG.md: Create with Keep a Changelog header if missing
 - .opencode/CHANGELOG.md: Create with minimal header if missing
 - dev branch: Create from origin/dev or main/master if missing
 - .worktrees/main/: Bootstrap worktree layout if not set up
-
- Worktree layout (#604):
- - Main folder always on dev branch
- - .worktrees/main/ is a permanent production reference
- - .worktrees/ is in .gitignore
- - WORKTREE_FATAL=1 is emitted only on setup failure (silent on success)
+- .env gitignore: Warn if .env exists but is not in .gitignore
 
 Usage:
     uv run python .opencode/scripts/session_init.py
 
 Exit codes:
     0: Success
-    1: No remote configured
-    2: Non-GitHub remote detected
+    1: No remote configured or failed to parse owner/repo
+    2: Non-GitHub/GitBucket remote detected
 """
 
 from __future__ import annotations
@@ -78,12 +63,6 @@ def get_user_email() -> str:
     return f"{user}@{hostname}"
 
 
-def get_hooks_path() -> str:
-    """Get git hooks path or empty string if not configured."""
-    hooks = run_git_command(["config", "core.hooksPath"])
-    return hooks or ""
-
-
 def parse_git_remote_url(url: str) -> tuple[str, str] | tuple[None, None]:
     """Parse owner and repo from GitHub remote URL.
 
@@ -94,13 +73,11 @@ def parse_git_remote_url(url: str) -> tuple[str, str] | tuple[None, None]:
     Returns:
         (owner, repo) on success, (None, None) on failure
     """
-    # SSH format: git@github.com:owner/repo.git
     ssh_pattern = r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$"
     match = re.match(ssh_pattern, url)
     if match:
         return match.group(1), match.group(2)
 
-    # HTTPS format: https://github.com/owner/repo.git
     https_pattern = r"^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$"
     match = re.match(https_pattern, url)
     if match:
@@ -138,7 +115,6 @@ def parse_gitbucket_url(
     owner: str | None = None
     repo: str | None = None
 
-    # SSH format: ssh://git@hostname:port/owner/repo.git
     ssh_url_pattern = r"^ssh://git@([^:/]+):(\d+)/([^/]+)/([^/]+?)(?:\.git)?$"
     match = re.match(ssh_url_pattern, url)
     if match:
@@ -146,7 +122,6 @@ def parse_gitbucket_url(
         repo = match.group(4)
 
     if not owner:
-        # SSH format: git@hostname:owner/repo.git (no port, colon separator)
         ssh_short_pattern = r"^git@([^:]+):([^/]+)/([^/]+?)(?:\.git)?$"
         match = re.match(ssh_short_pattern, url)
         if match:
@@ -154,7 +129,6 @@ def parse_gitbucket_url(
             repo = match.group(3)
 
     if not owner:
-        # HTTPS format: https://hostname/owner/repo.git
         https_pattern = r"^https://([^/]+)/([^/]+)/([^/]+?)(?:\.git)?$"
         match = re.match(https_pattern, url)
         if match:
@@ -164,17 +138,13 @@ def parse_gitbucket_url(
     if not owner or not repo:
         return None, None, None
 
-    # Read base URL from .env ONLY — never construct from remote hostname
     base_url = _read_gitbucket_url_from_env()
 
     return base_url, owner, repo
 
 
 def _read_gitbucket_url_from_env() -> str | None:
-    """Read GITBUCKET_HTML_URL (preferred) or GITBUCKET_URL (legacy) from .env file.
-
-    Returns None if neither found.
-    """
+    """Read GITBUCKET_HTML_URL (preferred) or GITBUCKET_URL (legacy) from .env file."""
     try:
         env_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
         if os.path.exists(env_path):
@@ -198,8 +168,6 @@ def extract_ssh_url(url: str) -> str | None:
 
     For ssh://git@tomcat-0002.newsrx.com:29418/org/repo.git
     returns ssh://git@tomcat-0002.newsrx.com:29418
-
-    Returns None if the URL is not an SSH format remote.
     """
     ssh_url_pattern = r"^(ssh://git@[^:/]+:\d+)"
     match = re.match(ssh_url_pattern, url)
@@ -213,46 +181,34 @@ def get_remote_url() -> str | None:
     return run_git_command(["remote", "get-url", "origin"])
 
 
-def check_srclight() -> None:
-    """Check srclight index health via filesystem probe.
+def get_current_branch() -> str | None:
+    """Get current git branch name or None if HEAD is detached."""
+    return run_git_command(["branch", "--show-current"])
 
-    Fast check: looks for the srclight DB file instead of running
-    uvx srclight status (which takes ~30 seconds).
 
-    Outputs SRCLEIGHT_STATUS=<status> line.
-    Reports warnings to stderr if index is missing or unhealthy.
-    """
+def check_srclight() -> str:
+    """Check srclight index health. Returns 'indexed', 'empty', or 'not_indexed'."""
     db_path = os.path.join(os.getcwd(), ".srclight", "index.db")
     if os.path.exists(db_path):
         file_size = os.path.getsize(db_path)
         if file_size > 0:
-            print("SRCLEIGHT_STATUS=ok")
+            return "indexed"
         else:
-            print("SRCLEIGHT_STATUS=empty")
             print(
-                "# ⚠️ Srclight index is empty. Instruct the user to immediately run:"
-                " uvx srclight index --embed qwen3-embedding",
+                "Srclight index is empty. Run: uvx srclight index --embed qwen3-embedding",
                 file=sys.stderr,
             )
+            return "empty"
     else:
-        print("SRCLEIGHT_STATUS=not_indexed")
         print(
-            "# ⚠️ Srclight index not found. Instruct the user to immediately run:"
-            " uvx srclight index --embed qwen3-embedding",
+            "Srclight index not found. Run: uvx srclight index --embed qwen3-embedding",
             file=sys.stderr,
         )
+        return "not_indexed"
 
 
 def get_submodule_dirs() -> list[str]:
-    """Get list of submodule directory paths using git config.
-
-    Uses git's own config parser instead of manual .gitmodules parsing.
-    Handles all format variations (special chars, whitespace, etc.) correctly.
-
-    Returns:
-        List of submodule path strings (e.g., ['test-submodule-1', 'submodules/lib'])
-        Empty list if no submodules configured or .gitmodules missing.
-    """
+    """Get list of submodule directory paths using git config."""
     result = run_git_command(["config", "--file", ".gitmodules", "--get-regexp", "path"])
     if not result:
         return []
@@ -262,23 +218,33 @@ def get_submodule_dirs() -> list[str]:
         parts = line.strip().split()
         if len(parts) >= 2:
             paths.append(parts[-1])
-
     return paths
 
 
 def get_source_hooks_dir() -> str | None:
-    """Get the source hooks directory from .opencode/hooks/.
-
-    Returns None if the directory doesn't exist.
-    """
-    candidate = os.path.join(os.getcwd(), ".opencode", "hooks")
-    if os.path.isdir(candidate):
-        return candidate
+    """Find the .opencode/hooks/ directory or None if missing."""
+    hooks_dir = os.path.join(os.getcwd(), ".opencode", "hooks")
+    if os.path.isdir(hooks_dir):
+        return hooks_dir
     return None
 
 
+def get_hooks_path() -> str:
+    """Get git hooks path or empty string if not configured."""
+    hooks = run_git_command(["config", "core.hooksPath"])
+    return hooks or ""
+
+
+def _hooks_match(src: str, dst: str) -> bool:
+    """Check if two hook files have the same content."""
+    try:
+        return os.path.isfile(dst) and open(src).read() == open(dst).read()
+    except OSError:
+        return False
+
+
 def _copy_hook(src: str, dst: str) -> bool:
-    """Copy a single hook file, making it executable. Returns True on success."""
+    """Copy a hook file, making it executable."""
     try:
         shutil.copy2(src, dst)
         os.chmod(dst, 0o755)
@@ -287,29 +253,8 @@ def _copy_hook(src: str, dst: str) -> bool:
         return False
 
 
-def _hooks_match(src: str, dst: str) -> bool:
-    """Check if two hook files have identical content."""
-    if not os.path.isfile(dst):
-        return False
-    try:
-        with open(src) as a, open(dst) as b:
-            return a.read() == b.read()
-    except OSError:
-        return False
-
-
 def install_hooks() -> None:
-    """Install git hooks from .opencode/hooks/ to .git/hooks/ and submodule hooks dirs.
-
-    Source of truth: .opencode/hooks/ (tracked in git)
-    Deployment targets:
-      - .git/hooks/ (parent repo)
-      - .git/modules/<name>/hooks/ (submodules)
-
-    Copies hooks that are missing or outdated. Skips hooks that match.
-    Reports failures to stderr but does not halt the session.
-    Also unsets core.hooksPath if set (legacy cleanup).
-    """
+    """Install git hooks from .opencode/hooks/. Reports failures to stderr."""
     source_dir = get_source_hooks_dir()
     if not source_dir:
         return
@@ -335,7 +280,7 @@ def install_hooks() -> None:
             if _copy_hook(src, dst):
                 installed_count += 1
             else:
-                print(f"# ⚠️ Failed to install hook {hook_name} into parent repo", file=sys.stderr)
+                print(f"Failed to install hook {hook_name} into parent repo", file=sys.stderr)
                 failed_count += 1
 
     submodules = get_submodule_dirs()
@@ -360,7 +305,7 @@ def install_hooks() -> None:
                     pass
 
         if not os.path.isdir(hooks_target):
-            print(f"# ⚠️ Could not resolve hooks dir for submodule: {submod_path}", file=sys.stderr)
+            print(f"Could not resolve hooks dir for submodule: {submod_path}", file=sys.stderr)
             failed_count += 1
             continue
 
@@ -373,22 +318,17 @@ def install_hooks() -> None:
             if _copy_hook(src, dst):
                 installed_count += 1
             else:
-                print(f"# ⚠️ Failed to install hook {hook_name} into {submod_path}", file=sys.stderr)
+                print(f"Failed to install hook {hook_name} into {submod_path}", file=sys.stderr)
                 failed_count += 1
 
-    if installed_count > 0 or skipped_count > 0 or failed_count > 0:
-        print("")
-        print("# --- Hook Installation ---")
-        if installed_count > 0:
-            print(f"# ✅ Installed {installed_count} hook(s)")
-        if skipped_count > 0:
-            print(f"# ℹ️ {skipped_count} hook(s) already current (skipped)")
-        if failed_count > 0:
-            print(f"# ❌ Failed to install {failed_count} hook(s) — see stderr", file=sys.stderr)
+    if installed_count > 0:
+        print(f"Installed {installed_count} hook(s)", file=sys.stderr)
+    if failed_count > 0:
+        print(f"Failed to install {failed_count} hook(s)", file=sys.stderr)
 
     if get_hooks_path():
         run_git_command(["config", "--unset", "core.hooksPath"])
-        print("# 🧹 Removed legacy core.hooksPath config (hooks now in .git/hooks/)")
+        print("Removed legacy core.hooksPath config (hooks now in .git/hooks/)", file=sys.stderr)
 
 
 def _extract_version_from_pyproject() -> str:
@@ -400,32 +340,27 @@ def _extract_version_from_pyproject() -> str:
                 for line in f:
                     stripped = line.strip()
                     if stripped.startswith("version"):
-                        match = re.match(r'version\s*=\s*["\']([^"\']+)["\']', stripped)
-                        if match:
-                            return match.group(1)
+                        parts = stripped.split("=", 1)
+                        if len(parts) == 2:
+                            return parts[1].strip().strip('"').strip("'")
         except OSError:
             pass
     return "0.1.0"
 
 
 def _ensure_changelog_md() -> str:
-    """Create CHANGELOG.md if missing. Returns 'exists' or 'created'."""
+    """Create CHANGELOG.md if missing. Returns 'exists', 'created', or 'failed'."""
     changelog_path = os.path.join(os.getcwd(), "CHANGELOG.md")
     if os.path.isfile(changelog_path):
         return "exists"
+
     version = _extract_version_from_pyproject()
     content = (
         "# Changelog\n"
         "\n"
         "All notable changes to this project will be documented in this file.\n"
         "\n"
-        "The format is based on\n"
-        "[Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\n"
-        "and this project adheres to\n"
-        "[Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n"
-        "\n"
-        "For AI agent infrastructure changes (`.opencode/` directory), see\n"
-        "[`.opencode/CHANGELOG.md`](.opencode/CHANGELOG.md).\n"
+        "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).\n"
         "\n"
         f"## [{version}] - Unreleased\n"
     )
@@ -434,12 +369,12 @@ def _ensure_changelog_md() -> str:
             f.write(content)
         return "created"
     except OSError as e:
-        print(f"# ⚠️ Failed to create CHANGELOG.md: {e}", file=sys.stderr)
+        print(f"Failed to create CHANGELOG.md: {e}", file=sys.stderr)
         return "failed"
 
 
 def _ensure_opencode_changelog_md() -> str:
-    """Create .opencode/CHANGELOG.md if missing. Returns 'exists' or 'created'."""
+    """Create .opencode/CHANGELOG.md if missing. Returns 'exists', 'created', or 'failed'."""
     opencode_dir = os.path.join(os.getcwd(), ".opencode")
     changelog_path = os.path.join(opencode_dir, "CHANGELOG.md")
     if os.path.isfile(changelog_path):
@@ -461,68 +396,45 @@ def _ensure_opencode_changelog_md() -> str:
             f.write(content)
         return "created"
     except OSError as e:
-        print(f"# ⚠️ Failed to create .opencode/CHANGELOG.md: {e}", file=sys.stderr)
+        print(f"Failed to create .opencode/CHANGELOG.md: {e}", file=sys.stderr)
         return "failed"
 
 
 def _ensure_dev_branch() -> str:
-    """Create dev branch if missing locally. Returns status string."""
-    current = run_git_command(["branch", "--show-current"])
-    if current == "dev":
-        return "exists (current)"
-
-    branches = run_git_command(["branch", "--list", "dev"])
-    if branches and "dev" in branches:
+    """Ensure dev branch exists. Returns 'exists', 'created from main', 'created from master', or 'failed'."""
+    if run_git_command(["rev-parse", "--verify", "dev"]):
         return "exists"
+    if run_git_command(["rev-parse", "--verify", "origin/dev"]):
+        run_git_command(["branch", "dev", "origin/dev"])
+        return "created from origin/dev"
 
-    has_origin_dev = run_git_command(["ls-remote", "--heads", "origin", "dev"])
-    if has_origin_dev:
-        result = run_git_command(["branch", "dev", "origin/dev"])
-        if result is not None:
-            return "created from origin/dev"
-        return "failed"
+    for default_branch in ["main", "master"]:
+        if run_git_command(["rev-parse", "--verify", default_branch]):
+            run_git_command(["branch", "dev", default_branch])
+            return f"created from {default_branch}"
 
-    default_branch = run_git_command(["symbolic-ref", "refs/remotes/origin/HEAD"])
-    if default_branch and "main" in default_branch:
-        source = "main"
-    else:
-        source = "master"
-
-    source_hash = run_git_command(["rev-parse", source])
-    if source_hash:
-        result = run_git_command(["branch", "dev", source_hash])
-        if result is not None:
-            return f"created from {source}"
-        return "failed"
-
-    return "failed (no source branch)"
-
-
-def get_current_branch() -> str | None:
-    return run_git_command(["branch", "--show-current"])
+    print("Failed to create dev branch — no main or master branch found", file=sys.stderr)
+    return "failed"
 
 
 def is_worktree_setup() -> bool:
+    """Check if .worktrees/main/ exists and is a git worktree."""
     main_wt = os.path.join(os.getcwd(), ".worktrees", "main")
-    if not os.path.isdir(main_wt):
-        return False
-    wt_git = os.path.join(main_wt, ".git")
-    if not os.path.isfile(wt_git):
-        return False
-    return True
+    return os.path.isdir(main_wt) and os.path.isdir(os.path.join(main_wt, ".git"))
 
 
 def _add_to_gitignore(entry: str) -> bool:
+    """Add an entry to .gitignore if not already present."""
     gitignore_path = os.path.join(os.getcwd(), ".gitignore")
-    if not os.path.isfile(gitignore_path):
-        return False
     try:
-        with open(gitignore_path) as f:
-            lines = f.read().splitlines()
-        if entry in lines:
-            return False
+        existing_lines: list[str] = []
+        if os.path.isfile(gitignore_path):
+            with open(gitignore_path) as f:
+                existing_lines = f.read().splitlines()
+        if entry in existing_lines:
+            return True
         with open(gitignore_path, "a") as f:
-            if lines and lines[-1] != "":
+            if existing_lines and existing_lines[-1] != "":
                 f.write("\n")
             f.write(f"{entry}\n")
         return True
@@ -530,29 +442,26 @@ def _add_to_gitignore(entry: str) -> bool:
         return False
 
 
-def bootstrap_worktree_layout() -> None:
+def bootstrap_worktree_layout() -> bool:
+    """Bootstrap .worktrees/main/ if not set up. Returns True on success, False on failure."""
     if is_worktree_setup():
-        return
+        return True
 
     main_wt_path = os.path.join(os.getcwd(), ".worktrees", "main")
 
     if os.path.isdir(main_wt_path):
         result = run_git_command(["worktree", "remove", main_wt_path, "--force"])
         if result is None:
-            print("WORKTREE_FATAL=1")
-            print("# ⚠️ FATAL: Failed to remove stale .worktrees/main/ directory", file=sys.stderr)
-            return
+            print("Failed to remove stale .worktrees/main/ directory", file=sys.stderr)
+            return False
 
     main_branch = "main"
     if run_git_command(["rev-parse", "--verify", "main"]) is None:
         if run_git_command(["rev-parse", "--verify", "master"]) is not None:
             main_branch = "master"
         else:
-            print("WORKTREE_FATAL=1")
-            print(
-                "# ⚠️ FATAL: No main or master branch found — worktree setup requires a default branch", file=sys.stderr
-            )
-            return
+            print("No main or master branch found — worktree setup requires a default branch", file=sys.stderr)
+            return False
 
     current = get_current_branch()
 
@@ -567,11 +476,10 @@ def bootstrap_worktree_layout() -> None:
 
     result = run_git_command(["worktree", "add", main_wt_path, main_branch])
     if result is None:
-        print("WORKTREE_FATAL=1")
-        print("# ⚠️ FATAL: Failed to create .worktrees/main/ worktree", file=sys.stderr)
+        print("Failed to create .worktrees/main/ worktree", file=sys.stderr)
         if current and current != "dev":
             run_git_command(["checkout", current])
-        return
+        return False
 
     _add_to_gitignore(".worktrees/")
 
@@ -589,90 +497,101 @@ def bootstrap_worktree_layout() -> None:
         if had_stash:
             run_git_command(["stash", "pop"])
 
+    return True
 
-def run_guard_checks() -> None:
-    print("")
-    print("# --- Guard Checks ---")
-    print(f"CHANGELOG.md: {_ensure_changelog_md()}")
-    print(f".opencode/CHANGELOG.md: {_ensure_opencode_changelog_md()}")
-    print(f"dev branch: {_ensure_dev_branch()}")
-    bootstrap_worktree_layout()
+
+def _check_env_gitignored() -> bool:
+    """Check if .env exists and is in .gitignore. Returns True if safe (gitignored or doesn't exist)."""
+    if not os.path.isfile(os.path.join(os.getcwd(), ".env")):
+        return True
+    gitignore_path = os.path.join(os.getcwd(), ".gitignore")
+    if not os.path.isfile(gitignore_path):
+        return False
+    try:
+        with open(gitignore_path) as f:
+            for line in f:
+                stripped = line.strip()
+                if stripped == ".env" or stripped == "/.env":
+                    return True
+    except OSError:
+        pass
+    return False
+
+
+def run_guard_checks() -> list[str]:
+    """Run guard checks silently. Returns list of problem descriptions."""
+    problems: list[str] = []
+    changelog_status = _ensure_changelog_md()
+    if changelog_status == "failed":
+        problems.append("CHANGELOG.md: failed to create")
+    opencode_changelog_status = _ensure_opencode_changelog_md()
+    if opencode_changelog_status == "failed":
+        problems.append(".opencode/CHANGELOG.md: failed to create")
+    dev_branch_status = _ensure_dev_branch()
+    if "failed" in dev_branch_status:
+        problems.append(f"dev branch: {dev_branch_status}")
+    if not _check_env_gitignored():
+        problems.append("WARNING: .env is NOT in .gitignore — secrets may be committed to version control")
+    return problems
 
 
 def main() -> int:
-    """Extract and output git context."""
-    # Get remote URL first - this is required
+    """Extract and output git context as English prose for LLM consumption."""
     remote_url = get_remote_url()
     if not remote_url:
-        print("ERROR: No git remote configured", file=sys.stderr)
-        print("Run: git remote add origin <url>", file=sys.stderr)
+        print("No git remote configured. Run: git remote add origin <url>", file=sys.stderr)
         return 1
 
-    # Get git config values with fallbacks
     user_name = get_user_name()
     user_email = get_user_email()
-    hooks_path = get_hooks_path()
 
-    # Output in the specified format
-    print("# Session Init - Git Context")
-    print(f"DEV_NAME={user_name}")
-    print(f"DEV_EMAIL={user_email}")
-    print(f"GIT_HOOKS_PATH={hooks_path}")
-    print(f"GIT_REMOTE_URL={remote_url}")
+    srclight_status = check_srclight()
+    install_hooks()
+    guard_problems = run_guard_checks()
+    worktree_ok = bootstrap_worktree_layout()
 
-    # Check if GitHub remote
+    current_branch = get_current_branch() or "unknown"
+
     if is_github_remote(remote_url):
-        # Parse owner/repo from remote
         owner, repo = parse_git_remote_url(remote_url)
         if not owner or not repo:
-            print("ERROR: Failed to parse owner/repo from remote URL", file=sys.stderr)
+            print("Could not determine repository owner from remote URL.", file=sys.stderr)
             print(f"Remote URL: {remote_url}", file=sys.stderr)
             return 1
 
-        print(f"GIT_OWNER={owner}")
-        print(f"GIT_REPO={repo}")
-        print("GIT_PLATFORM=github")
-        print("GITHUB_HTML_URL=https://github.com/")
-        print("")
-        print("# ============================")
-        print("# GITHUB REPOSITORY DETECTED")
-        print("# ============================")
-        print("# 📋 Invoke: /skill github-issue-creation before creating issues")
-        print("# 📋 See: .opencode/skills/github-issue-creation/SKILL.md")
-        check_srclight()
-        install_hooks()
-        run_guard_checks()
+        print(f"Repository: {repo} (GitHub)")
+        print(f"Owner: {owner}")
+        print(f'Use owner="{owner}" and repo="{repo}" for all GitHub tool calls.')
+        print("HTML base: https://github.com/")
+        print(f"Developer: {user_name} ({user_email})")
+        print(f"Current branch: {current_branch}")
+
+        if worktree_ok:
+            print("Worktrees: available")
+        else:
+            print("Worktrees: setup failed — HALT and report to developer before proceeding")
+
+        if srclight_status == "indexed":
+            print("Srclight: indexed")
+        else:
+            print("Srclight: NOT indexed — tell the developer to run: uvx srclight index --embed qwen3-embedding")
+
+        for problem in guard_problems:
+            print(problem)
+
         return 0
 
-    # GitBucket remote detected
     if is_gitbucket_remote(remote_url):
         result = parse_gitbucket_url(remote_url)
         base_url, owner, repo = result
         if not owner or not repo:
-            print("WARNING: Failed to parse owner/repo from remote URL", file=sys.stderr)
+            print("Could not determine repository owner from remote URL.", file=sys.stderr)
             print(f"Remote URL: {remote_url}", file=sys.stderr)
-            print("GIT_PLATFORM=gitbucket")
-            print("GITBUCKET_URL=")
-            print("GITBUCKET_HAS_CREDENTIALS=false")
-            print("")
-            print("# ==============================")
-            print("# GITBUCKET REPOSITORY DETECTED")
-            print("# ==============================")
-            print("# 📋 Invoke: /skill gitbucket-api before using GitBucket Python API")
-            print("# 📋 See: .opencode/skills/gitbucket-api/SKILL.md")
-            return 0
+            return 1
 
         if not base_url:
-            print(
-                "WARNING: GITBUCKET_HTML_URL not found in .env — URL generation unavailable",
-                file=sys.stderr,
-            )
-            print(
-                "Add GITBUCKET_HTML_URL=<web-ui-base-url> to .env to enable URL generation",
-                file=sys.stderr,
-            )
+            print("GITBUCKET_HTML_URL not found in .env — URL generation unavailable", file=sys.stderr)
 
-        # Check if credentials exist in .env
         has_credentials = False
         try:
             env_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
@@ -685,30 +604,35 @@ def main() -> int:
         except OSError:
             pass
 
-        print(f"GIT_OWNER={owner}")
-        print(f"GIT_REPO={repo}")
-        print("GIT_PLATFORM=gitbucket")
-        print(f"GITBUCKET_HTML_URL={base_url or ''}")
+        print(f"Repository: {repo} (GitBucket)")
+        print(f"Owner: {owner}")
+        print(f'Use owner="{owner}" and repo="{repo}" for all GitBucket tool calls.')
+        if base_url:
+            print(f"HTML base: {base_url}")
         ssh_url = extract_ssh_url(remote_url)
         if ssh_url:
-            print(f"GITBUCKET_SSH_URL={ssh_url}")
-        print(f"GITBUCKET_HAS_CREDENTIALS={'true' if has_credentials else 'false'}")
-        print("")
-        print("# ============================")
-        print("# GITBUCKET REPOSITORY DETECTED")
-        print("# ============================")
-        print("# 📋 Invoke: /skill gitbucket-api before using GitBucket Python API")
-        print("# 📋 GitBucket API has specific authentication patterns and limitations")
-        print("# 📋 See: .opencode/skills/gitbucket-api/SKILL.md")
-        check_srclight()
-        install_hooks()
-        run_guard_checks()
+            print(f"SSH base: {ssh_url}")
+        print(f"API credentials: {'configured' if has_credentials else 'NOT configured'}")
+        print(f"Developer: {user_name} ({user_email})")
+        print(f"Current branch: {current_branch}")
+
+        if worktree_ok:
+            print("Worktrees: available")
+        else:
+            print("Worktrees: setup failed — HALT and report to developer before proceeding")
+
+        if srclight_status == "indexed":
+            print("Srclight: indexed")
+        else:
+            print("Srclight: NOT indexed — tell the developer to run: uvx srclight index --embed qwen3-embedding")
+
+        for problem in guard_problems:
+            print(problem)
+
         return 0
 
-    # Unknown remote type
-    print("WARNING: Unknown remote type", file=sys.stderr)
+    print("Unknown remote type", file=sys.stderr)
     print(f"Remote URL: {remote_url}", file=sys.stderr)
-    print("GIT_PLATFORM=unknown")
     return 2
 
 


### PR DESCRIPTION
## Summary

Rewrites `session_init.py` to output English prose instead of bash `KEY=VALUE` format, simplifies `session-enforcement.ts` by removing all parsing, and restores the accidentally-deleted `env-loader.ts` plugin with bash environment injection.

## Outcome

- LLM receives clean English context (owner, repo, platform, branch, worktree state, srclight status) instead of unparseable `KEY=VALUE` lines
- No `parseEnvFromOutput()`, `cachedEnv`, or `shell.env` hook remains in session-enforcement.ts
- `env-loader.ts` provides all bash environment variables independently (no coupling with session-enforcement)
- WORKTREE_PATH is injected into both `system.transform` (LLM) and `shell.env` (bash)
- Project metadata (name, version, python) injected into system prompt
- `.env` gitignore guard check added to session_init.py

## Fixes

Fixes #710
Fixes #712