### PR TITLE
fix: session injection anti-hallucination context + uvx compatibility + worktree detection

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -10,3 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Compare URL base branch** (`post-implementation.md`, `implementation-workflow/SKILL.md`) - Fix feature branch compare URLs from `compare/main` to `compare/dev` to match the three-branch model
 - **Authorization cascade rules** (`approval-gate/SKILL.md`, `000-critical-rules.md`, `010-approval-gate.md`) - Add Reference ≠ Authorization Cascade rule requiring formal sub-issue links, not text references, for authorization cascade. Add Confirmation ≠ Authorization rule distinguishing observation confirmations from implementation authorization.
+- **Session init plugin** (#710, #720) - Anti-hallucination context: Remote URL, worktree detection paths, hooks path, in-worktree awareness
+- **Session init uvx compatibility** (#721) - Proper shebang, pyproject.toml entry point, uvx invocation
+- **env-loader worktree documentation** (#723) - Document input.$ cwd behavior for worktree sessions

--- a/.opencode/plugins/env-loader.ts
+++ b/.opencode/plugins/env-loader.ts
@@ -227,7 +227,7 @@ export async function EnvLoaderPlugin(input: PluginInput): Promise<Hooks> {
         output.env["WORKTREE_PATH"] = worktreeDir;
       }
 
-      // --- Git values from input.$ shell ---
+      // input.$ runs git commands in the session working directory (worktree when active)
       try {
         // Branch name
         const branchResult = await input.$.nothrow()`git branch --show-current`;

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -29,7 +29,6 @@ import type { Hooks, PluginInput } from "@opencode-ai/plugin";
 import fs from "fs";
 import path from "path";
 
-const SCRIPT_PATH = ".opencode/scripts/session_init.py";
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 let cachedOutput: string | null = null;
@@ -41,7 +40,7 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
   }
 
   try {
-    const result = await $.nothrow()`uv run python ${SCRIPT_PATH}`;
+    const result = await $.nothrow()`uvx session-init`;
     const stdout = result.text();
 
     if (!stdout || stdout.trim().length === 0) {
@@ -60,7 +59,7 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
 
     return stdout;
   } catch (err) {
-    console.error("[session-enforcement] Failed to run session_init.py:", err);
+    console.error("[session-enforcement] Failed to run session-init:", err);
     return "";
   }
 }

--- a/.opencode/scripts/session_init.py
+++ b/.opencode/scripts/session_init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run python
 """Session initialization script for AI agents.
 
 Outputs English prose context for LLM consumption on stdout.
@@ -12,7 +12,7 @@ Guard checks (auto-create missing files/branches/worktree):
 - .env gitignore: Warn if .env exists but is not in .gitignore
 
 Usage:
-    uv run python .opencode/scripts/session_init.py
+    uvx session-init
 
 Exit codes:
     0: Success
@@ -418,9 +418,34 @@ def _ensure_dev_branch() -> str:
 
 
 def is_worktree_setup() -> bool:
-    """Check if .worktrees/main/ exists and is a git worktree."""
     main_wt = os.path.join(os.getcwd(), ".worktrees", "main")
-    return os.path.isdir(main_wt) and os.path.isdir(os.path.join(main_wt, ".git"))
+    git_entry = os.path.join(main_wt, ".git")
+    return os.path.isdir(main_wt) and os.path.exists(git_entry)
+
+
+def detect_worktree() -> tuple[bool, str | None, str | None]:
+    toplevel = run_git_command(["rev-parse", "--show-toplevel"])
+    if not toplevel:
+        return False, None, None
+
+    git_path = os.path.join(toplevel, ".git")
+    if os.path.isfile(git_path):
+        try:
+            with open(git_path) as f:
+                content = f.read().strip()
+            if content.startswith("gitdir: "):
+                gitdir = content[8:]
+                if not os.path.isabs(gitdir):
+                    gitdir = os.path.join(toplevel, gitdir)
+                worktrees_dir = os.path.dirname(os.path.abspath(gitdir))
+                git_dir = os.path.dirname(worktrees_dir)
+                if os.path.basename(git_dir) == ".git" and os.path.basename(worktrees_dir) == "worktrees":
+                    main_repo = os.path.dirname(git_dir)
+                    return True, toplevel, main_repo
+        except OSError:
+            pass
+
+    return False, None, None
 
 
 def _add_to_gitignore(entry: str) -> bool:
@@ -442,8 +467,20 @@ def _add_to_gitignore(entry: str) -> bool:
         return False
 
 
+def get_worktree_display() -> str:
+    in_wt, wt_path, _ = detect_worktree()
+    if in_wt:
+        return f"Worktrees: {wt_path}"
+    if is_worktree_setup():
+        return "Worktrees: .worktrees/main/"
+    return ""
+
+
 def bootstrap_worktree_layout() -> bool:
-    """Bootstrap .worktrees/main/ if not set up. Returns True on success, False on failure."""
+    in_wt, _, _ = detect_worktree()
+    if in_wt:
+        return True
+
     if is_worktree_setup():
         return True
 
@@ -536,7 +573,6 @@ def run_guard_checks() -> list[str]:
 
 
 def main() -> int:
-    """Extract and output git context as English prose for LLM consumption."""
     remote_url = get_remote_url()
     if not remote_url:
         print("No git remote configured. Run: git remote add origin <url>", file=sys.stderr)
@@ -551,6 +587,9 @@ def main() -> int:
     worktree_ok = bootstrap_worktree_layout()
 
     current_branch = get_current_branch() or "unknown"
+    in_wt, wt_path, main_repo = detect_worktree()
+    wt_display = get_worktree_display()
+    hooks_path = get_hooks_path()
 
     if is_github_remote(remote_url):
         owner, repo = parse_git_remote_url(remote_url)
@@ -563,13 +602,23 @@ def main() -> int:
         print(f"Owner: {owner}")
         print(f'Use owner="{owner}" and repo="{repo}" for all GitHub tool calls.')
         print("HTML base: https://github.com/")
+        print(f"Remote: {remote_url}")
         print(f"Developer: {user_name} ({user_email})")
         print(f"Current branch: {current_branch}")
 
-        if worktree_ok:
-            print("Worktrees: available")
+        if in_wt and wt_path and main_repo:
+            print(f"Working directory: {wt_path}")
+            print(f"Main repo: {main_repo}")
+        elif worktree_ok:
+            if wt_display:
+                print(wt_display)
+            else:
+                print("Worktrees: available")
         else:
             print("Worktrees: setup failed — HALT and report to developer before proceeding")
+
+        if hooks_path:
+            print(f"Hooks path: {hooks_path}")
 
         if srclight_status == "indexed":
             print("Srclight: indexed")
@@ -609,6 +658,7 @@ def main() -> int:
         print(f'Use owner="{owner}" and repo="{repo}" for all GitBucket tool calls.')
         if base_url:
             print(f"HTML base: {base_url}")
+        print(f"Remote: {remote_url}")
         ssh_url = extract_ssh_url(remote_url)
         if ssh_url:
             print(f"SSH base: {ssh_url}")
@@ -616,10 +666,19 @@ def main() -> int:
         print(f"Developer: {user_name} ({user_email})")
         print(f"Current branch: {current_branch}")
 
-        if worktree_ok:
-            print("Worktrees: available")
+        if in_wt and wt_path and main_repo:
+            print(f"Working directory: {wt_path}")
+            print(f"Main repo: {main_repo}")
+        elif worktree_ok:
+            if wt_display:
+                print(wt_display)
+            else:
+                print("Worktrees: available")
         else:
             print("Worktrees: setup failed — HALT and report to developer before proceeding")
+
+        if hooks_path:
+            print(f"Hooks path: {hooks_path}")
 
         if srclight_status == "indexed":
             print("Srclight: indexed")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/session-init-batch
+
+- **Session Injection Anti-Hallucination Context + uvx Compatibility + Worktree Detection** (#710, #712, #720, #721, #722, #723) - Rewrite session_init.py output to eliminate LLM hallucination-driven error-retry cycles. Add Remote URL, worktree detection with Working directory/Main repo paths, hooks path (problems-only), and fix bootstrap_worktree_layout for in-worktree execution. Make session_init.py uvx-compatible with proper shebang and pyproject.toml entry point. Switch session-enforcement.ts to uvx invocation. Document env-loader.ts input.$ cwd behavior.
+- FIX: session_init.py "Worktrees: available" replaced with actual path (e.g. .worktrees/main/)
+- FIX: session_init.py bootstrap_worktree_layout() fails when run inside a worktree
+- FIX: session_init.py shebang wrong and no pyproject.toml entry point for uvx
+- FIX: session-enforcement.ts hardcoded relative path breaks in worktrees
+- ADD: Remote URL line in session output (anti-hallucination)
+- ADD: In-worktree detection with Working directory/Main repo paths
+- ADD: Hooks path output only when core.hooksPath is non-standard
+
 ### spec/724-batch-approval-fix
 
 - **Batch Approval Analysis: Autonomous Execution + Pre-Analysis Screening + Edge Cases** - Fix batch-approval-analysis to proceed autonomously after authorization (no confirmation prompts), add pre-analysis screening for superseded/moot/conflicting/partially-implemented issues, and handle edge cases (cross-issue sub-issues, stale spec assumptions, merge-time conflicts, revision status)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "tqdm>=4.67.1",
 ]
 
+[project.scripts]
+session-init = ".opencode.scripts.session_init:main"
+
 [project.optional-dependencies]
 local = [
     "pgserver>=0.1.4",


### PR DESCRIPTION
## Summary

Rewrite session_init.py to eliminate LLM hallucination-driven error-retry cycles, make it uvx-compatible, and fix broken worktree output. Also fix session-enforcement.ts invocation path and document env-loader.ts worktree behavior.

## Outcome

- session_init.py outputs anti-hallucination context: Remote URL, worktree paths (Working directory + Main repo), hooks path (problems-only)
- session_init.py is uvx-compatible: proper shebang, pyproject.toml `[project.scripts]` entry point
- session_init.py detects in-worktree execution and reports both paths instead of failing
- session-enforcement.ts invokes via `uvx session-init` (path-independent)
- env-loader.ts documents input.$ cwd behavior for worktree sessions

Fixes #710
Fixes #712
Fixes #720
Fixes #721
Fixes #722
Fixes #723