### PR TITLE
feat: skill-creator principles — word counts, sub-agent encouragement, correctness-first economics

### DIFF
--- a/.opencode/CHANGELOG.md
+++ b/.opencode/CHANGELOG.md
@@ -13,3 +13,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Session init plugin** (#710, #720) - Anti-hallucination context: Remote URL, worktree detection paths, hooks path, in-worktree awareness
 - **Session init uvx compatibility** (#721) - Proper shebang, pyproject.toml entry point, uvx invocation
 - **env-loader worktree documentation** (#723) - Document input.$ cwd behavior for worktree sessions
+- **Skill-creator principles** (#711) - Add Measurement Standard (word counts), Context Window Hygiene (sub-agent encouragement), Correctness-First Economics (flat-rate billing) to skill-creator SKILL.md and init template. Propagate word-count measurement to code-size-enforcement, coherence-auditor, fragment-manager, git-workflow, guideline-auditor.

--- a/.opencode/skills/code-size-enforcement/SKILL.md
+++ b/.opencode/skills/code-size-enforcement/SKILL.md
@@ -10,7 +10,7 @@ compatibility: opencode
 
 ## Overview
 
-Ensures code artifacts stay within size limits for maintainability and readability. Covers Python functions (40 lines), notebook cells (50 lines), and source files (300 lines). Grandfather policy exempts existing files; only new and modified files must comply.
+Ensures code artifacts stay within size limits for maintainability and readability. Covers Python functions (~100 words), notebook cells (~120 words), and source files (~750 words). Grandfather policy exempts existing files; only new and modified files must comply.
 
 ## Tasks
 
@@ -29,35 +29,35 @@ Ensures code artifacts stay within size limits for maintainability and readabili
 
 | Artifact | Limit | Measurement |
 |----------|-------|-------------|
-| **Python functions** | 40 lines | Excluding docstrings, imports, blank lines |
-| **Notebook cells** | 50 lines | Including whitespace, excluding cell header |
-| **Source files** | 300 lines | Total file, excluding blank lines and file-start comments |
+| **Python functions** | ~100 words | `wc -w` on function body, excluding docstrings, imports, blank lines |
+| **Notebook cells** | ~120 words | `wc -w` on cell source, excluding cell header |
+| **Source files** | ~750 words | `wc -w` on file, excluding blank lines and file-start comments |
 
 ## What Counts and Doesn't Count
 
-**Functions count:** Function body lines (code + inline comments), nested functions/classes, multi-line non-docstring string literals.
+**Functions count:** Function body words (code + inline comments), nested functions/classes, multi-line non-docstring string literals.
 **Functions don't count:** Docstrings, import statements outside the function, blank lines, type hints on their own lines.
 
-**Notebook cells count:** All lines in cell source, comments, whitespace. NOT: cell metadata or outputs.
+**Notebook cells count:** All words in cell source, comments. NOT: cell metadata or outputs.
 
-**Source files count:** Total lines excluding blank lines, module-level docstrings, file-start copyright/license comments.
+**Source files count:** Total words excluding blank lines, module-level docstrings, file-start copyright/license comments.
 
 ## Permitted Detection Methods
 
 | Method | Purpose | Example |
 |--------|---------|---------|
-| `wc -l <file>` | File line count | `wc -l src/module.py` |
-| `srclight_symbols_in_file` | Function/class listing | Shows symbol structure and line ranges |
-| `the-notebook-mcp_notebook_get_outline` | Notebook cell structure | See cell indices and line counts |
+| `wc -w <file>` | File word count | `wc -w src/module.py` |
+| `srclight_symbols_in_file` | Function/class listing | Shows symbol structure and word counts |
+| `the-notebook-mcp_notebook_get_outline` | Notebook cell structure | See cell indices and word counts |
 | `git diff --stat` | Change size | For modified files |
 
 ## Forbidden Patterns
 
 | Pattern | Limit |
 |---------|-------|
-| Monolithic functions | > 40 lines |
-| Monolithic notebook cells | > 50 lines |
-| Monolithic files | > 300 lines |
+| Monolithic functions | > ~100 words |
+| Monolithic notebook cells | > ~120 words |
+| Monolithic files | > ~750 words |
 | Deep nesting | > 3 levels |
 | God classes/files | Single file importing many unrelated modules |
 

--- a/.opencode/skills/code-size-enforcement/tasks/check-limits.md
+++ b/.opencode/skills/code-size-enforcement/tasks/check-limits.md
@@ -11,39 +11,39 @@ Measure and verify that code artifacts comply with size limits before commit or 
 ```bash
 # Get function sizes via srclight
 srclight_symbols_in_file(path="src/module.py")
-# Output includes function names and line ranges
+# Output includes function names and word counts
 ```
 
-For line counts, use `wc -l` on specific function ranges.
+For word counts, use `wc -w` on specific function ranges.
 
 ### Source Files
 
 ```bash
-# Count total lines
-wc -l src/module.py
+# Count total words
+wc -w src/module.py
 
-# Count non-blank lines (for 300-line limit)
+# Count non-blank words (for ~750-word limit)
 grep -c '.' src/module.py
 ```
 
 ### Notebook Cells
 
-Use `the-notebook-mcp_notebook_get_outline` to see cell structure, then `the-notebook-mcp_notebook_read_cell` to count lines for each cell.
+Use `the-notebook-mcp_notebook_get_outline` to see cell structure, then `the-notebook-mcp_notebook_read_cell` to count words for each cell.
 
 ## Size Limits Reference
 
 | Artifact | Limit | Measurement |
 |----------|-------|-------------|
-| **Python functions** | 40 lines | Excluding docstrings, imports, blank lines |
-| **Notebook cells** | 50 lines | Including whitespace, excluding cell header |
-| **Source files** | 300 lines | Total file, excluding blank lines and file-start comments |
+| **Python functions** | ~100 words | Excluding docstrings, imports, blank lines |
+| **Notebook cells** | ~120 words | Including whitespace, excluding cell header |
+| **Source files** | ~750 words | Total file, excluding blank lines and file-start comments |
 
 ## What Counts Toward Limits
 
 **Functions:**
-- Function body lines (code + inline comments)
-- Nested functions/classes contribute to outer function's line count
-- Multi-line string literals (non-docstrings) count as lines
+- Function body words (code + inline comments)
+- Nested functions/classes contribute to outer function's word count
+- Multi-line string literals (non-docstrings) count as words
 
 **What does NOT count for functions:**
 - Docstrings (the `"""..."""` block immediately after `def`)
@@ -52,11 +52,11 @@ Use `the-notebook-mcp_notebook_get_outline` to see cell structure, then `the-not
 - Type hints on their own lines
 
 **Notebook cells:**
-- All lines in cell source including comments and whitespace
+- All words in cell source including comments
 - Does NOT include cell metadata or outputs
 
 **Source files:**
-- Total lines excluding blank lines
+- Total words excluding blank lines
 - Excluding module-level docstrings
 - Excluding file-start comments (copyright, license)
 

--- a/.opencode/skills/code-size-enforcement/tasks/decompose.md
+++ b/.opencode/skills/code-size-enforcement/tasks/decompose.md
@@ -6,14 +6,14 @@ Provide decomposition patterns and guidance for oversized code artifacts.
 
 ## Decomposition Patterns
 
-### Oversized Functions (> 40 lines)
+### Oversized Functions (> ~100 words)
 
 Extract helper functions using the "Extract Method" refactoring pattern:
 
 ```python
-# BEFORE (45 lines - exceeds 40 line limit)
+# BEFORE (~120 words - exceeds ~100 word limit)
 def process_data(data: dict) -> dict:
-    # ... 45 lines of processing ...
+    # ... ~120 words of processing ...
 
 # AFTER (decomposed)
 def process_data(data: dict) -> dict:
@@ -22,13 +22,13 @@ def process_data(data: dict) -> dict:
     return enrich_data(transformed)
 
 def validate_data(data: dict) -> dict:
-    # ... 15 lines ...
+    # ... ~35 words ...
 
 def transform_data(data: dict) -> dict:
-    # ... 15 lines ...
+    # ... ~35 words ...
 
 def enrich_data(data: dict) -> dict:
-    # ... 10 lines ...
+    # ... ~20 words ...
 ```
 
 Principles:
@@ -36,19 +36,19 @@ Principles:
 - Use descriptive names for decomposed functions
 - The outer function becomes an orchestrator calling helpers
 
-### Oversized Notebook Cells (> 50 lines)
+### Oversized Notebook Cells (> ~120 words)
 
 Split cells doing multiple things into focused cells:
 
 ```python
-# BEFORE (single 60-line cell doing data loading and processing)
-# Cell 1: Load and process data (60 lines)
+# BEFORE (single ~150-word cell doing data loading and processing)
+# Cell 1: Load and process data (~150 words)
 
 # AFTER (split into focused cells)
-# Cell 1: Load data (15 lines)
-# Cell 2: Validate data (10 lines)
-# Cell 3: Transform data (15 lines)
-# Cell 4: Display summary (10 lines)
+# Cell 1: Load data (~35 words)
+# Cell 2: Validate data (~25 words)
+# Cell 3: Transform data (~35 words)
+# Cell 4: Display summary (~20 words)
 ```
 
 Principles:
@@ -56,19 +56,19 @@ Principles:
 - Use intermediate variables only when necessary for clarity
 - Consider extracting complex logic to `.py` modules
 
-### Oversized Files (> 300 lines)
+### Oversized Files (> ~750 words)
 
 Split monolithic files into package structure:
 
 ```python
-# BEFORE: monolithic_file.py (350 lines)
+# BEFORE: monolithic_file.py (~800 words)
 
 # AFTER: package structure
 monolithic/
     __init__.py
-    core.py      # main logic (150 lines)
-    helpers.py   # utility functions (100 lines)
-    types.py     # type definitions (50 lines)
+    core.py      # main logic (~350 words)
+    helpers.py   # utility functions (~250 words)
+    types.py     # type definitions (~120 words)
 ```
 
 Principles:

--- a/.opencode/skills/coherence-auditor/SKILL.md
+++ b/.opencode/skills/coherence-auditor/SKILL.md
@@ -58,15 +58,16 @@ LLM Coherence Auditor ensuring guidelines, skills, and AI agent behavior work to
 
 | Priority | Criteria |
 |----------|----------|
-| HIGH | Duplication ≥2 AND (complexity ≥medium OR tokens ≥200) |
+| HIGH | Duplication ≥2 AND (complexity ≥medium OR words ≥150) |
 | MEDIUM | Duplication ≥2 OR single-file complexity ≥medium |
-| LOW | Single-file, low complexity, small tokens |
+| LOW | Single-file, low complexity, small word count |
 
-## Token Estimation
+## Word Count Measurement
 
-- Text: ~1.3 tokens per word
-- Code blocks: ~1.5 tokens per code token
-- Tables: ~4 tokens per cell + structure tokens
+- Use `wc -w` as the canonical measurement method
+- Text: word count via `wc -w`
+- Code blocks: word count via `wc -w` (includes code tokens as words)
+- Tables: word count via `wc -w`
 
 ## Critical: Fresh-Start Context Preservation
 

--- a/.opencode/skills/coherence-auditor/tasks/create-report.md
+++ b/.opencode/skills/coherence-auditor/tasks/create-report.md
@@ -38,10 +38,10 @@ Scope: .opencode/guidelines/[, .opencode/skills/]
 <List each issue with file, issue class, priority, status, action>
 
 ## Baseline Metrics (maintenance mode only)
-- Total guideline tokens: N
-- Total skill tokens: N
-- Combined tokens: N
-- Drift from baseline: <+/-N tokens> (<+/-N%>)
+- Total guideline words: N
+- Total skill words: N
+- Combined words: N
+- Drift from baseline: <+/-N words> (<+/-N%>)
 ```
 
 ### Step 2: Report to Chat

--- a/.opencode/skills/coherence-auditor/tasks/extract-analyze.md
+++ b/.opencode/skills/coherence-auditor/tasks/extract-analyze.md
@@ -17,13 +17,12 @@ Calculate metrics and rank extraction candidates identified during scan phase.
 
 ## Procedure
 
-### Step 1: Calculate Token Counts
+### Step 1: Calculate Word Counts
 
 For each candidate:
-- Count lines (excluding headers/blank lines)
-- Estimate tokens: ≈4 tokens per line
-- Code blocks: ≈1.5 tokens per code token
-- Tables: ≈4 tokens per cell
+- Count words via `wc -w` (excluding headers/blank lines)
+- Code blocks: count words via `wc -w`
+- Tables: count words via `wc -w`
 
 ### Step 2: Determine Duplication Factor
 
@@ -44,7 +43,7 @@ For each candidate:
 | Duplication factor ≥3 | 3× | HIGH |
 | Duplication factor =2 | 2× | MEDIUM |
 | Complexity = high | 2× | Priority +1 |
-| Token count ≥500 | 2× | Priority +1 |
+| Word count ≥400 | 2× | Priority +1 |
 | Single file, simple | 1× | LOW |
 
 ## Context Required

--- a/.opencode/skills/coherence-auditor/tasks/extract-scan.md
+++ b/.opencode/skills/coherence-auditor/tasks/extract-scan.md
@@ -34,23 +34,22 @@ Scan for:
 ### Step 3: Calculate Metrics
 
 For each candidate:
-- Lines of content (excluding headers)
-- Estimated token count (≈4 tokens per line)
+- Word count (via `wc -w`, excluding headers)
 - Duplication factor (1=single-file, 2=cross-referenced, 3+=multi-file)
 - Complexity score (low/medium/high)
 
 ### Step 4: Rank Candidates
 
-- **HIGH**: Duplication factor ≥2 AND (complexity ≥medium OR token count ≥200)
+- **HIGH**: Duplication factor ≥2 AND (complexity ≥medium OR word count ≥150)
 - **MEDIUM**: Duplication factor ≥2 OR (single-file with complexity ≥medium)
-- **LOW**: Single-file, low complexity, small token count
+- **LOW**: Single-file, low complexity, small word count
 
 ### Step 5: Output Audit Report
 
 Write to `./tmp/coherence-audit-YYYYMMDD-extraction.md` with:
 - Total candidates found
 - Priority breakdown (HIGH/MEDIUM/LOW)
-- Estimated token savings
+- Estimated word savings
 - Detailed candidate listing
 
 ## Context Required

--- a/.opencode/skills/coherence-auditor/tasks/maintenance-detect.md
+++ b/.opencode/skills/coherence-auditor/tasks/maintenance-detect.md
@@ -12,7 +12,7 @@ Detect drift between guidelines and skills during maintenance mode by comparing 
 
 ## Exit Criteria
 
-- Token drift calculated (±% from baseline)
+- Word drift calculated (±% from baseline)
 - Duplicate content flagged
 - Missing skill references identified
 - Report created in `./tmp/coherence-audit-YYYYMMDD-maintenance.md`
@@ -21,7 +21,7 @@ Detect drift between guidelines and skills during maintenance mode by comparing 
 
 ### Step 1: Load Baseline
 
-- Previous token count
+- Previous word count
 - Previous skill list
 - Previous guideline-skill reference map
 
@@ -47,11 +47,11 @@ For each guideline:
 - DRIFT-DETECTED: Guideline changed independently of skill
 - ORPHANED-PROCEDURE: Procedure removed from guideline but still in skill
 
-### Step 4: Calculate Token Drift
+### Step 4: Calculate Word Drift
 
-- Previous baseline: N tokens
-- Current total: M tokens
-- Drift: M - N tokens, percentage: (M-N)/N × 100%
+- Previous baseline: N words
+- Current total: M words
+- Drift: M - N words, percentage: (M-N)/N × 100%
 - Flag if deviation >10%
 
 ## Context Required

--- a/.opencode/skills/fragment-manager/SKILL.md
+++ b/.opencode/skills/fragment-manager/SKILL.md
@@ -103,7 +103,7 @@ fragments:
       lines: NN
     content:
       type: text-block
-      estimated_tokens: NNN
+      estimated_words: NNN
       description: "Fragment description"
     destinations:
       - path: .opencode/skills/skill-name/SKILL.md

--- a/.opencode/skills/fragment-manager/tasks/create-fragment.md
+++ b/.opencode/skills/fragment-manager/tasks/create-fragment.md
@@ -39,7 +39,7 @@ Create new fragment master from existing content in skills.
    
    <!--
    Fragment ID: fragment-id
-   Estimated tokens: NNN
+    Estimated words: NNN
    Type: text-block
    Sync status: synchronized
    -->
@@ -69,7 +69,7 @@ fragments:
       lines: NN
     content:
       type: text-block
-      estimated_tokens: NNN
+      estimated_words: NNN
       description: "Fragment description"
     destinations:
       - path: .opencode/skills/some-skill/SKILL.md

--- a/.opencode/skills/fragment-manager/tasks/read-fragment.md
+++ b/.opencode/skills/fragment-manager/tasks/read-fragment.md
@@ -21,7 +21,7 @@ Extract:
 - Master file path
 - Hash
 - Content type
-- Estimated tokens
+- Estimated words
 - Description
 - Sync status
 - Last sync timestamp

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -418,7 +418,7 @@ If `[skip changelog]` is present, proceed directly to Step 3 (skip changelog gen
 **Why This Is Critical:**
 
 - Sub-task execution isolates the skill's thinking from main context
-- Prevents skill output from consuming main session tokens
+- Prevents skill output from consuming main session context window
 - Skill runs in its own context and writes CHANGELOG.md
 - Main context receives minimal confirmation only
 
@@ -494,7 +494,7 @@ This checkpoint ensures:
 | Commit categorization | NOT: intermediate reasoning |
 | Technical → User-friendly translation | NOT: commit details analyzed |
 | Noise filtering | NOT: generated text |
-| Thinking tokens consumed | Minimal result token only |
+| Context consumed by sub-task | Minimal result only |
 
 Then continue to Step 3 (squash).
 

--- a/.opencode/skills/guideline-auditor/SKILL.md
+++ b/.opencode/skills/guideline-auditor/SKILL.md
@@ -61,7 +61,7 @@ When reviewing each guideline file, also check for potential context overflow is
 - **Wordy preamble or rationale**: Explanatory prose embedded in a directive file that could be trimmed or moved to a
   separate reference doc, freeing context budget for actionable rules.
 - **Repetitive elaboration**: The same constraint restated multiple times within a single file in slightly different
-  words, inflating token count without adding clarity.
+  words, inflating word count without adding clarity.
 
 For each `CONTEXT-OVERFLOW` issue, the report must include:
 

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -57,7 +57,7 @@ Applies to NEW skills AND EDITS to existing skills. No exceptions — not for "s
 1. **Description field:** "Use when..." format, triggering conditions only, NO workflow summaries
 2. **Keyword coverage:** Include error messages, symptoms, synonyms, tool names
 3. **Descriptive naming:** Active voice, verb-first
-4. **Token efficiency:** Move details to references, use cross-references
+4. **Word efficiency:** Move details to references, use cross-references
 5. **Target word counts:** getting-started <150, frequently-loaded <200, other skills <500
 
 ## Anti-Patterns
@@ -69,6 +69,34 @@ Applies to NEW skills AND EDITS to existing skills. No exceptions — not for "s
 | Code in flowcharts | Can't copy-paste | Markdown code blocks |
 | Generic labels | Lack semantic meaning | Descriptive names |
 | Workflow in description | Agents follow description, skip body | Triggering conditions only |
+
+## Measurement Standard
+
+Word count is the universal unit for skill size measurement. Use `wc -w` as the canonical measurement method.
+
+- **Why words, not tokens:** Token counts vary by tokenizer, model, and encoding. Word counts are stable, reproducible, and model-agnostic.
+- **Why words, not lines:** Line length varies by formatting conventions. A 40-line function and a 100-word function are not comparable — words measure semantic density.
+- **Measurement command:** `wc -w <file>` — available on every platform, no dependencies.
+- **Skill metadata:** Report size in words (e.g., `| Task | Purpose | Words |` table in SKILL.md).
+- **Size targets:** getting-started <150 words, frequently-loaded <200 words, other skills <500 words.
+
+## Context Window Hygiene
+
+Strongly encourage sub-agents and sub-tasks for skill operations that risk consuming significant context.
+
+- **Sub-task isolation:** Skills that perform analysis, audits, or multi-step workflows should dispatch work to sub-tasks. The main session receives a minimal result, not intermediate reasoning.
+- **Why:** LLM context windows are finite. A skill that consumes 2000 words of intermediate reasoning in the main session leaves less room for subsequent work. Sub-tasks isolate that consumption.
+- **Pattern:** Skill invocation spawns a sub-task → sub-task processes and produces compact result → main session receives result only.
+- **When to use sub-tasks:** Any skill task exceeding ~300 words of output, any multi-file analysis, any workflow with 3+ sequential operations.
+
+## Correctness-First Economics
+
+GPU/CPU billing is flat-rate per inference, not per word. There is no economic incentive to be concise at the expense of correctness.
+
+- **Correctness > conciseness:** A correct 200-word explanation is better than an ambiguous 100-word one. Never sacrifice clarity or completeness to reduce word count.
+- **No per-token cost pressure:** LLM inference is billed per request, not per token generated. Writing more words does not cost more. Writing wrong words costs human time to fix — that IS expensive.
+- **Redundancy for enforcement:** Repetition of critical rules across skill sections is not waste — it is enforcement insurance. An LLM that misses a rule in one section may catch it in another.
+- **Anti-pattern:** Cutting a rule or explanation to "save tokens" when the rule exists because agents violated it without the extra context.
 
 ## Operating Protocol
 

--- a/.opencode/skills/skill-creator/scripts/init_skill.py
+++ b/.opencode/skills/skill-creator/scripts/init_skill.py
@@ -62,6 +62,30 @@ Delete this entire "Structuring This Skill" section when done - it's just guidan
 - Concrete examples with realistic user requests
 - References to scripts/templates/references as needed]
 
+## Measurement Standard
+
+Word count is the universal unit for skill size measurement. Use `wc -w` as the canonical measurement method.
+
+- **Why words, not tokens:** Token counts vary by tokenizer, model, and encoding. Word counts are stable, reproducible, and model-agnostic.
+- **Why words, not lines:** Line length varies by formatting conventions. Words measure semantic density.
+- **Measurement command:** `wc -w <file>`
+- **Size targets:** getting-started <150 words, frequently-loaded <200 words, other skills <500 words.
+
+## Context Window Hygiene
+
+Strongly encourage sub-agents and sub-tasks for skill operations that risk consuming significant context.
+
+- **Sub-task isolation:** Dispatch analysis, audits, or multi-step workflows to sub-tasks. Main session receives minimal result, not intermediate reasoning.
+- **When to use sub-tasks:** Any skill task exceeding ~300 words of output, any multi-file analysis, any workflow with 3+ sequential operations.
+
+## Correctness-First Economics
+
+GPU/CPU billing is flat-rate per inference, not per word. Correctness > conciseness.
+
+- **No per-token cost pressure:** Writing more words does not cost more. Writing wrong words costs human time to fix.
+- **Redundancy for enforcement:** Repetition of critical rules across sections is enforcement insurance.
+- **Anti-pattern:** Cutting a rule to "save tokens" when the rule exists because agents violated it.
+
 ## Resources
 
 This skill includes example resource directories that demonstrate how to organize different types of bundled resources:
@@ -220,9 +244,7 @@ def init_skill(skill_name, path):
 
     # Create SKILL.md from template
     skill_title = title_case_skill_name(skill_name)
-    skill_content = SKILL_TEMPLATE.format(
-        skill_name=skill_name, skill_title=skill_title
-    )
+    skill_content = SKILL_TEMPLATE.format(skill_name=skill_name, skill_title=skill_title)
 
     skill_md_path = skill_dir / "SKILL.md"
     try:
@@ -263,9 +285,7 @@ def init_skill(skill_name, path):
     print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
     print("\nNext steps:")
     print("1. Edit SKILL.md to complete the TODO items and update the description")
-    print(
-        "2. Customize or delete the example files in scripts/, references/, and assets/"
-    )
+    print("2. Customize or delete the example files in scripts/, references/, and assets/")
     print("3. Run the validator when ready to check the skill structure")
 
     return skill_dir
@@ -273,9 +293,7 @@ def init_skill(skill_name, path):
 
 def main():
     if len(sys.argv) < 4 or sys.argv[2] != "--path":
-        print(
-            "Usage: uv run python .opencode/skills/skill-creator/scripts/init_skill.py <skill-name> --path <path>"
-        )
+        print("Usage: uv run python .opencode/skills/skill-creator/scripts/init_skill.py <skill-name> --path <path>")
         print("\nSkill name requirements:")
         print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
         print("  - Lowercase letters, digits, and hyphens only")


### PR DESCRIPTION
## Summary

Codify three foundational principles in skill-creator SKILL.md and propagate word-count measurement across all skills that previously used token counts or line counts.

## Outcome

- skill-creator SKILL.md: Measurement Standard (word counts), Context Window Hygiene (sub-agent encouragement), Correctness-First Economics (flat-rate billing)
- code-size-enforcement: limits converted from lines to words (~100/~120/~750)
- coherence-auditor: token thresholds → word thresholds, Token Estimation → Word Count Measurement
- fragment-manager: estimated_tokens → estimated_words
- git-workflow: token/cost language → context window hygiene
- guideline-auditor: inflating token count → inflating word count

Fixes #711