### PR TITLE
Fix #733: spec-creation write task creates GitHub Issue instead of dumping to chat

### DIFF
--- a/.opencode/skills/spec-creation/SKILL.md
+++ b/.opencode/skills/spec-creation/SKILL.md
@@ -28,7 +28,7 @@ You are a Spec Architect. Your focus is structuring investigation results into a
 | `decompose` | Break into discrete units; define interfaces first (APIs, data contracts, schemas) | #2, #5 | Only for trivial bug fixes with one obvious fix |
 | `traceability` | Map requirements to sections, tests, implementation steps | #3 | Only for single-requirement specs |
 | `risk` | Analyze risk, blast radius, failure propagation, operational needs | #8, #9 | Only for simple bug fixes with no deployment impact |
-| `write` | Assemble spec with acceptance criteria, ambiguity elimination, deliverable structure | #4, #6, #10 | No — mandatory assembly step |
+| `write` | Assemble spec, create GitHub Issue, output exec summary + URL + byline | #4, #6, #10 | No — mandatory assembly step |
 | `change-control` | Version spec, document rationale and impact analysis for changes | #12 | Only for initial spec creation (not revisions) |
 
 ## Invocation
@@ -56,7 +56,7 @@ You are a Spec Architect. Your focus is structuring investigation results into a
 
 3. **Task completion gate:** Each task produces a structured output. The `write` task assembles these outputs into the final spec. Do NOT invoke `write` until prerequisite tasks are complete.
 
-4. **Exit condition:** Spec written, self-reviewed, user-reviewed. HALT and wait for approval before proceeding to writing-plans.
+4. **Exit condition:** Spec written to GitHub Issue, self-reviewed, user-reviewed on the issue. HALT and wait for approval before proceeding to writing-plans.
 
 ## Simplicity Heuristic
 
@@ -101,12 +101,15 @@ You are a Spec Architect. Your focus is structuring investigation results into a
    - Are acceptance criteria defined?
 
 1. **After `write` task:**
+   - GitHub Issue created with `[SPEC]` prefix and `needs-approval` label?
+   - Chat output is exec summary + URL + byline ONLY? (no full spec dump)
    - Spec self-review completed? (placeholder scan, consistency check, ambiguity check)
-   - User review requested?
+   - User directed to review on the GitHub Issue (not in chat)?
 
 1. **What does NOT bypass spec-creation:**
    - "skip spec-creation" → NOT allowed (even simple specs need `requirements` + `write`)
    - "brainstorming already wrote the spec" → Brainstorming no longer writes specs; this skill does
+   - "just show me the spec in chat" → NOT allowed; spec MUST be persisted as GitHub Issue
 
 ### Enforcement Messages
 
@@ -122,6 +125,7 @@ To invoke: /skill spec-creation --task requirements
 
 ## Cross-References
 
+- **Calls:** `github-issue-creation` (spec persistence — `write` task invokes pre-creation → single-task-check → creation)
 - **Preceded by:** `brainstorming` (exploration only — Steps 7-9 moved here)
 - **Followed by:** `spec-auditor` (quality audit — verifies what this skill produces)
 - **Parallel with:** `approval-gate` (authorization — waits for spec to be approved)

--- a/.opencode/skills/spec-creation/tasks/write.md
+++ b/.opencode/skills/spec-creation/tasks/write.md
@@ -11,9 +11,10 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
 ## Exit Criteria
 
-- Spec written as GitHub Issue
+- GitHub Issue created with `[SPEC]` prefix and `needs-approval` label
 - Self-review completed (placeholder scan, consistency, scope, ambiguity)
-- User review requested
+- Chat output is ONLY: `<exec summary>` + `<issue URL>` + `<byline>` (no full spec dump)
+- User reviews spec ON THE ISSUE (not in chat)
 - Ready for spec-auditor and approval-gate
 
 ## Procedure
@@ -75,17 +76,42 @@ After writing the spec, review with fresh eyes:
 
 Fix any issues inline. No need to re-review — just fix and move on.
 
-### Step 6: User Review
+### Step 6: Create GitHub Issue
 
-Ask the user to review the written spec:
+Invoke `github-issue-creation` skill to persist the spec as a GitHub Issue:
 
-> "Spec written. Please review it and let me know if you want to make any changes before we proceed to audit and approval."
+1. Invoke `github-issue-creation --task pre-creation` to validate (check for conflicts, superseded issues, missing sections)
+2. If validation fails → HALT and report. Fix issues and re-validate.
+3. If validation passes → invoke `github-issue-creation --task single-task-check` to determine sub-issue needs
+4. Invoke `github-issue-creation --task creation` to create the GitHub Issue
+5. Record the issue number and URL
 
-Wait for the user's response. If they request changes, make them and re-run the self-review. Only proceed once the user approves.
+**Chat output is ONLY:**
 
-### Step 7: Transition
+```
+<exec summary>
 
-After user approval of the spec:
+<issue URL>
+
+🤖 <AgentName> (<ModelID>) ✨
+```
+
+**🚫 NEVER:**
+- Dump full spec content to chat as the "review" step
+- Claim spec is "written" without a GitHub Issue URL
+- Ask the user to review the spec in chat
+
+### Step 7: User Review on Issue
+
+The user reviews the spec ON THE GITHUB ISSUE, not in chat.
+
+- If user requests revisions via issue comments: update the issue body, then post update summary + URL + byline to chat
+- If user approves the spec on the issue: proceed to Step 8
+- Do NOT re-dump the spec to chat for any reason
+
+### Step 8: Transition
+
+After user approval of the spec on the GitHub Issue:
 - Invoke `spec-auditor` for quality audit
 - Then proceed to `approval-gate` for authorization
 - Then `writing-plans` for implementation planning
@@ -94,4 +120,5 @@ After user approval of the spec:
 
 - Preceded by: `requirements` (mandatory), `decompose`, `traceability`, `risk` (or explicitly skipped)
 - Extends: brainstorming Steps 7-9 (adapted, not verbatim move)
+- Calls: `github-issue-creation` (pre-creation → single-task-check → creation)
 - Followed by: `spec-auditor`, then `approval-gate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### Fixed
+
+- **spec-creation write task now creates GitHub Issue instead of dumping to chat** (#733) - Fix spec-creation skill's write task to invoke github-issue-creation skill and output exec summary + URL + byline instead of dumping full spec content to chat.
+
 ### spec/session-init-batch
 
 - **Session Injection Anti-Hallucination Context + uvx Compatibility + Worktree Detection** (#710, #712, #720, #721, #722, #723) - Rewrite session_init.py output to eliminate LLM hallucination-driven error-retry cycles. Add Remote URL, worktree detection with Working directory/Main repo paths, hooks path (problems-only), and fix bootstrap_worktree_layout for in-worktree execution. Make session_init.py uvx-compatible with proper shebang and pyproject.toml entry point. Switch session-enforcement.ts to uvx invocation. Document env-loader.ts input.$ cwd behavior.


### PR DESCRIPTION
**Summary:**

Fixes the spec-creation skill to persist specs as GitHub Issues via the github-issue-creation skill, instead of dumping full spec text to chat where it can't be meaningfully reviewed.

**Outcome:** Developers can review specs on the issues board via URL, instead of trying to review ephemeral chat output.

Fixes #733