### PR TITLE
Fix #741: add worktree awareness to all sub-agent dispatch and skill creation

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -30,6 +30,15 @@ Worktrees are ALWAYS mandatory for feature branch creation. **See `using-git-wor
 - 🚫 FORBIDDEN: Relative paths with file operation tools when `WORKTREE_PATH` is set; assuming tools respect `workdir`
 - ✅ REQUIRED: Prefix ALL paths with `WORKTREE_PATH` when in worktree context
 
+## Critical Violation: Sub-Agents Ignoring Worktree Context
+
+**⚠️ Sub-agents that modify the main repo instead of the worktree are a CRITICAL GUIDELINE VIOLATION.**
+
+When a main agent is operating in a worktree and dispatches a sub-agent, the sub-agent MUST receive `WORKTREE_PATH` in its dispatch context and use it as the base directory for ALL file operations and git commands.
+
+- 🚫 FORBIDDEN: Spawning sub-agents without `WORKTREE_PATH` when operating in a worktree; sub-agents that stage/commit to the main repo's working directory; skills that perform git or file operations without a "Worktree Mode" section
+- ✅ REQUIRED: Pass `WORKTREE_PATH` in ALL sub-agent dispatch prompts when set; sub-agents verify `git rev-parse --show-toplevel` matches `WORKTREE_PATH` before mutating state; all new skills MUST include worktree awareness per `skill-creator` skill requirements
+
 ## Critical Violation: Implementing Without Verifying Against Live Documentation
 
 **⚠️ Implementing code without verifying API signatures, environment variables, or function parameters against live documentation is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -95,7 +95,7 @@ This skill is a **heavy skill** — its task files contain significant detail th
 5. Sub-agent executes verification in isolation, returns authorization result
 6. Main agent receives result — no full approval-gate content in main context
 
-**Sub-agent context parameters:** Pass issue number, `GIT_OWNER`, `GIT_REPO` from session init.
+**Sub-agent context parameters:** Pass issue number, `WORKTREE_PATH`, `GIT_OWNER`, `GIT_REPO` from session init. When `WORKTREE_PATH` is set, sub-agents MUST receive it and use it as the base directory for all file operations and git commands.
 
 ## Cross-References
 

--- a/.opencode/skills/changelog-generator/SKILL.md
+++ b/.opencode/skills/changelog-generator/SKILL.md
@@ -112,6 +112,23 @@ guidelines from CHANGELOG_STYLE.md
 
 **Inspired by:** Manik Aggarwal's use case from Lenny's Newsletter
 
+## Worktree Mode
+
+When invoked from a worktree context (`WORKTREE_PATH` is set):
+
+- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
+- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
+- `git` commands run from the worktree directory, NOT the main repo
+- `CHANGELOG.md` path MUST be prefixed with `WORKTREE_PATH/`
+
+**Verification guard:** Before any git operation, run:
+```bash
+git rev-parse --show-toplevel
+```
+If the output does NOT match `WORKTREE_PATH`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
+
+If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+
 ## Tips
 
 - Run from your git repository root

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -96,6 +96,8 @@ This skill is a **heavy skill** — its task files contain significant detail th
 
 **Sub-agent context parameters:** Pass `WORKTREE_PATH`, `BRANCH_NAME`, `GIT_OWNER`, `GIT_REPO`, `DEV_NAME`, `DEV_EMAIL` from session init.
 
+**⚠️ Worktree pass-through is MANDATORY:** When spawning sub-agents from a worktree context, `WORKTREE_PATH` MUST be included in the dispatch prompt. Sub-agents that perform git operations without `WORKTREE_PATH` will silently modify the main repo — this is a CRITICAL GUIDELINE VIOLATION (see #741).
+
 ## Cross-References
 
 - Related skills: `approval-gate` (authorization), `pr-creation-workflow` (PR timing), `changelog-generator` (changelog generation), `conflict-resolution` (conflict classification during rebase/merge)

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -89,6 +89,48 @@ Strongly encourage sub-agents and sub-tasks for skill operations that risk consu
 - **Pattern:** Skill invocation spawns a sub-task → sub-task processes and produces compact result → main session receives result only.
 - **When to use sub-tasks:** Any skill task exceeding ~300 words of output, any multi-file analysis, any workflow with 3+ sequential operations.
 
+## Worktree Awareness Requirement
+
+**All new and updated skills MUST include worktree awareness.** This is a mandatory quality gate for the `validate` task.
+
+### Required in every skill that:
+
+1. **Performs git operations** — Must include a "Worktree Mode" section explaining how to handle `WORKTREE_PATH`
+2. **Dispatches sub-agents** — Must pass `WORKTREE_PATH` in the dispatch context/prompt
+3. **Reads or writes files** — Must document path prefixing rules when `WORKTREE_PATH` is set
+
+### Worktree Mode Template
+
+Every skill SKILL.md should include (adapt as appropriate for the skill's operations):
+
+```markdown
+## Worktree Mode
+
+When `WORKTREE_PATH` is set:
+- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
+- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
+- `git` commands run from the worktree directory, NOT the main repo
+
+If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+```
+
+### Sub-Agent Dispatch Template
+
+When a skill dispatches sub-agents, the prompt MUST include:
+
+```
+WORKTREE_PATH: <value or 'not set'>
+If WORKTREE_PATH is set, all file operations and git commands MUST use it as the base directory.
+```
+
+### Validation Gate
+
+The `validate` task (`quick_validate.py`) SHOULD check for:
+- Skills with `bash` or `git` operations that lack a "Worktree Mode" section
+- Skills that dispatch sub-agents but don't pass `WORKTREE_PATH` in context
+
+**Rationale:** Sub-agents that don't receive worktree context silently modify the main repo instead of the feature branch. This is a context window safety issue (see #741).
+
 ## Correctness-First Economics
 
 GPU/CPU billing is flat-rate per inference, not per word. There is no economic incentive to be concise at the expense of correctness.

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -168,6 +168,7 @@ When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 - No changes to project source code, scripts, or notebooks
 - No new specs, expansions, or "improvements" beyond what findings require
 - Must use GitHub MCP tools for all issue operations
+- **Worktree awareness check:** Skills that perform git operations, read/write files, or dispatch sub-agents MUST include a "Worktree Mode" section and pass `WORKTREE_PATH` in sub-agent dispatch contexts. Missing worktree awareness is a medium-severity finding.
 
 ## Sub-Agent Spawning
 
@@ -180,7 +181,7 @@ This skill is a **heavy skill** — quality audits with all subtasks consume sig
 5. Sub-agent executes audit in isolation, returns findings as structured report
 6. Main agent receives findings — no full audit content in main context
 
-**Sub-agent context parameters:** Pass issue number, `GIT_OWNER`, `GIT_REPO` from session init.
+**Sub-agent context parameters:** Pass issue number, `WORKTREE_PATH`, `GIT_OWNER`, `GIT_REPO` from session init. When `WORKTREE_PATH` is set, sub-agents MUST receive it and use it as the base directory for all file operations and git commands.
 
 ## Cross-References
 

--- a/.opencode/skills/spec-auditor/tasks/fidelity.md
+++ b/.opencode/skills/spec-auditor/tasks/fidelity.md
@@ -26,7 +26,7 @@ Invoke `writing-plans --task clean-room` as a subtask:
 task(
   subagent_type="general",
   description="Generate clean-room plan for issue N",
-  prompt="Use the writing-plans skill --task clean-room to generate a plan from the problem statement in ./tmp/clean-room-input-N.md. Return the generated plan."
+  prompt="Use the writing-plans skill --task clean-room to generate a plan from the problem statement in ./tmp/clean-room-input-N.md. WORKTREE_PATH: <WORKTREE_PATH value or 'not set'>. If WORKTREE_PATH is set, all file operations MUST use it as the base directory. Return the generated plan."
 )
 ```
 

--- a/.opencode/skills/subagent-driven-development/tasks/code-quality-reviewer-prompt.md
+++ b/.opencode/skills/subagent-driven-development/tasks/code-quality-reviewer-prompt.md
@@ -16,6 +16,12 @@ Task tool (general-purpose):
   prompt: |
     You are reviewing code quality for an implementation that has passed spec compliance review.
 
+    ## Worktree Context
+
+    WORKTREE_PATH: <WORKTREE_PATH value or 'not set'>
+
+    If WORKTREE_PATH is set, ALL file reads MUST prefix paths with WORKTREE_PATH/. ALL bash commands MUST use workdir=WORKTREE_PATH. If WORKTREE_PATH is not set, use project root.
+
     ## What Was Requested
 
     [FULL TEXT of task requirements]

--- a/.opencode/skills/subagent-driven-development/tasks/spec-reviewer-prompt.md
+++ b/.opencode/skills/subagent-driven-development/tasks/spec-reviewer-prompt.md
@@ -12,6 +12,12 @@ Task tool (general-purpose):
   prompt: |
     You are reviewing whether an implementation matches its specification.
 
+    ## Worktree Context
+
+    WORKTREE_PATH: <WORKTREE_PATH value or 'not set'>
+
+    If WORKTREE_PATH is set, ALL file reads MUST prefix paths with WORKTREE_PATH/. ALL bash commands MUST use workdir=WORKTREE_PATH. If WORKTREE_PATH is not set, use project root.
+
     ## What Was Requested
 
     [FULL TEXT of task requirements]

--- a/.opencode/skills/verification-before-completion/SKILL.md
+++ b/.opencode/skills/verification-before-completion/SKILL.md
@@ -75,6 +75,23 @@ When invoked, this skill requires the following guidelines to be loaded on-deman
 
 - **Load guideline:** `.opencode/guidelines/065-verification-honesty.md` — Required before any verification claim (mandatory per verification honesty rule)
 
+## Worktree Mode
+
+When invoked from a worktree context (`WORKTREE_PATH` is set):
+
+- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
+- ALL `read`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
+- Test/lint/typecheck commands MUST run from the worktree directory
+- `./tmp/` paths MUST resolve within the worktree, not the main repo
+
+**Verification guard:** Before running any command, verify:
+```bash
+git -C $WORKTREE_PATH rev-parse --show-toplevel
+```
+If the result does NOT match `WORKTREE_PATH`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
+
+If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+
 ## Cross-References
 
 - Related skills: `executing-plans` (implementation), `git-workflow` (branch push), `approval-gate` (authorization)


### PR DESCRIPTION
**Summary:**

Fixes sub-agents silently modifying the main repo instead of the worktree by adding mandatory worktree awareness across all skills that dispatch sub-agents or perform git/file operations.

**Outcome:** Skills now include Worktree Mode sections, sub-agent dispatch passes WORKTREE_PATH, skill-creator requires worktree awareness in new skills, and spec-auditor checks for it during audits.

Fixes #741