### PR TITLE
Make all .opencode/tools PEP 723 self-contained scripts

### DIFF
--- a/.opencode/guidelines/016-srclight-preference.md
+++ b/.opencode/guidelines/016-srclight-preference.md
@@ -89,9 +89,9 @@ Use `.opencode/tools/guidelines` commands for searching developer guidelines:
 
 | Task | Command |
 | -- | -- |
-| Search guidelines | `uv run python .opencode/tools/guidelines search <term>` |
-| Read guideline | `uv run python .opencode/tools/guidelines read <filename>` |
-| List guidelines | `uv run python .opencode/tools/guidelines read --list` |
+| Search guidelines | `./.opencode/tools/guidelines search <term>` |
+| Read guideline | `./.opencode/tools/guidelines read <filename>` |
+| List guidelines | `./.opencode/tools/guidelines read --list` |
 
 ## Tool Selection Matrix
 
@@ -174,7 +174,7 @@ pycharm_search_in_files_by_text(searchText="article parsing")
 grep(pattern="MCP", glob="**/*.md")
 
 # ✅ ALSO CORRECT: Use .opencode/tools/guidelines for .opencode/guidelines/
-# Run: uv run python .opencode/tools/guidelines search MCP
+# Run: ./.opencode/tools/guidelines search MCP
 
 # ❌ WRONG: Srclight does not index .md files
 srclight_search_symbols(query="MCP")  # Returns no results for .md files
@@ -242,7 +242,7 @@ Srclight does not support filename search.
 
 ```
 # For .opencode/guidelines/*.md files:
-# Run: uv run python .opencode/tools/guidelines search <term>
+# Run: ./.opencode/tools/guidelines search <term>
 
 # For other .md files:
 grep(pattern="<term>", glob="**/*.md")

--- a/.opencode/guidelines/060-tool-usage.md
+++ b/.opencode/guidelines/060-tool-usage.md
@@ -7,7 +7,7 @@ The following guidelines are loaded on-demand by skills, not permanently in cont
 - `065-verification-honesty.md` — Loaded by verification-dependent skills when invoked
 - `067-context-completeness.md` — Loaded by issue/PR review skills when invoked
 
-When a skill indicates "Load guideline:" in its pre-conditions, use the `read` tool or `uv run python .opencode/tools/guidelines read` command to load it before proceeding.
+When a skill indicates "Load guideline:" in its pre-conditions, use the `read` tool or `./.opencode/tools/guidelines read` command to load it before proceeding.
 
 ## 1. Tool Priority Hierarchy
 
@@ -34,10 +34,10 @@ ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance,
 
 ### ✅ ALWAYS DO
 
-- **Reading or searching guideline files MUST use `uv run python .opencode/tools/guidelines`** — never raw `open`, `cat`, or `grep` on `.opencode/guidelines/` files.
-- `uv run python .opencode/tools/guidelines read <filename>` — print a single guideline file.
-- `uv run python .opencode/tools/guidelines search <term>` — search all guideline files for a term.
-- `uv run python .opencode/tools/guidelines search <term> --file <filename>` — search within one file.
+- **Reading or searching guideline files MUST use `./.opencode/tools/guidelines`** — never raw `open`, `cat`, or `grep` on `.opencode/guidelines/` files.
+- `./.opencode/tools/guidelines read <filename>` — print a single guideline file.
+- `./.opencode/tools/guidelines search <term>` — search all guideline files for a term.
+- `./.opencode/tools/guidelines search <term> --file <filename>` — search within one file.
 
 ### ⚠️ ASK FIRST
 
@@ -79,7 +79,7 @@ When working in a git worktree (`WORKTREE_PATH` is set), TIER 1 file operation t
 
 - All temporary scripts and output files MUST be written ONLY to `./tmp/` (project root). NO OTHER FOLDERS OR PATHS ARE PERMITTED.
 - Create the directory if needed: `mkdir -p ./tmp`.
-- **Mandatory pre-submit root cleanliness check:** Before calling `submit`, run `uv run python .opencode/tools/file-exists .output.txt` and confirm it is MISSING. If it exists, move it to `./tmp/.output.txt` immediately.
+- **Mandatory pre-submit root cleanliness check:** Before calling `submit`, run `./.opencode/tools/file-exists .output.txt` and confirm it is MISSING. If it exists, move it to `./tmp/.output.txt` immediately.
 - **ALWAYS clean up temp files after modification tasks are complete.**
 
 ### 🚫 NEVER DO

--- a/.opencode/guidelines/070-environment.md
+++ b/.opencode/guidelines/070-environment.md
@@ -6,11 +6,21 @@
   `uv run python`. Package ops: add dependencies by editing `pyproject.toml` then running `uv sync` — never `uv add`. `pip` prohibited. No `sys.path` hacks or manual
   path additions.
 - **Never use `python3` or `python` directly** — always `uv run python`. Never prefix commands with absolute paths or `cd /absolute/path &&`. See `060-tool-usage.md § Python Interpreter` and `§ Path Rules` for the full zero-tolerance rules.
-- Reusable agent scripts live in `.opencode/tools/` (project root). Invoke with `uv run python .opencode/tools/<script>`.
+- Reusable agent scripts live in `.opencode/tools/` (project root). Invoke with `./.opencode/tools/<script>`.
 - When `pyproject.toml` changes, purge `.venv` and run `uv sync` as a standalone command (never embedded in git hooks,
   commit scripts, or automated pipelines).
 - **Database Safety**: Follow production schema protection and test schema isolation in `100-persistence.md`.
   NEVER run test/experimental code against the production schema.
+
+## PEP 723 Self-Contained Scripts (MANDATORY)
+
+All Python entry points in `.opencode/tools/` MUST be self-contained PEP 723 scripts with:
+- Shebang: `#!/usr/bin/env -S uv run --script`
+- PEP 723 `# /// script` metadata block with `requires-python` and `dependencies`
+- Zero dependency on project `pyproject.toml` or `uv.lock`
+- Execute permission (`chmod +x`)
+
+New tools MUST follow this pattern. Do NOT use `uv run python .opencode/tools/X`.
 
 ## Isolated Tool Environments
 
@@ -196,7 +206,7 @@ This rule applies universally to:
 - **`.output.txt` files must be placed in `./tmp/` (e.g., `./tmp/.output.txt`), never at the project root (`.output.txt` is a violation).**
 - **Mandatory pre-submit root cleanliness check:** Before calling `submit`, confirm the project root is clean:
   (1) Never create `.output.txt`, `temp_*.py`, or any other temp/diagnostic file at the project root — always use `./tmp/` at time of creation.
-  (2) Run `uv run python .opencode/tools/file-exists .output.txt` — if it exists, move it to `./tmp/.output.txt` immediately (`mv .output.txt ./tmp/.output.txt`).
+  (2) Run `./.opencode/tools/file-exists .output.txt` — if it exists, move it to `./tmp/.output.txt` immediately (`mv .output.txt ./tmp/.output.txt`).
   (3) Check for any `temp_*.py` files at the project root (`ls temp_*.py 2>/dev/null`) — if any exist, move them to `./tmp/` before submitting.
 
 ### ⚠️ MANDATORY: Temp Files Cleanup After Task Completion

--- a/.opencode/guidelines/100-persistence.md
+++ b/.opencode/guidelines/100-persistence.md
@@ -50,7 +50,7 @@ Applies to `pubmed_data_3` and all new persistence code.
 - Migration versions: date-based `yyyymmddhhmmss` format in UTC. Simple increments prohibited.
 - **Migration location**: ALL schema migrations are defined inline in `src/commons/persistence/pg/schema.py` as
   `_Migration` entries in the `_MIGRATIONS` list. There is no external migrations directory. Do not search elsewhere.
-  To add a migration, generate a version timestamp with `uv run python .opencode/tools/schema-version` — **immediately before
+  To add a migration, generate a version timestamp with `./.opencode/tools/schema-version` — **immediately before
   adding a migration, not earlier. NEVER run `schema-version` speculatively (analysis, exploration, curiosity, or as
   a side-effect of any other task that does not need a timestamp).** Then append a
   `_Migration(version=..., description=..., statements=[...])` entry to

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -5,13 +5,13 @@
  * skill invocation rules. Also detects bare issue references (#N)
  * and injects mandatory audit pipelines.
  *
- * Hook: system.transform — pushes English prose context (from session_init.py
+ * Hook: system.transform — pushes English prose context (from session-init
  *   and PluginInput augmentations) into the LLM system prompt.
  * Hook: chat.messages.transform — injects skill enforcement content and
  *   bare issue pipeline directives into user messages.
  *
  * NO shell.env hook — env-loader.ts owns all bash environment injection.
- * NO parsing of session_init.py output — stdout goes verbatim to system prompt.
+ * NO parsing of session-init output — stdout goes verbatim to system prompt.
  *
  * Source attribution:
  * - Session init pattern adapted from existing session-init.ts (project-internal)
@@ -40,7 +40,7 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
   }
 
   try {
-    const result = await $.nothrow()`uvx session-init`;
+    const result = await $.nothrow()`uv run .opencode/tools/session-init`;
     const stdout = result.text();
 
     if (!stdout || stdout.trim().length === 0) {
@@ -395,7 +395,7 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
   const { skills: skillDescriptions, errors: frontmatterErrors } = loadSkillDescriptions(skillsDir);
 
   return {
-    // Inject session context into system prompt (from session_init.py + PluginInput augmentations)
+    // Inject session context into system prompt (from session-init + PluginInput augmentations)
     "experimental.chat.system.transform": async (_input, output) => {
       const scriptOutput = await runSessionInit(input.$);
       if (scriptOutput) {

--- a/.opencode/skills/coherence-auditor/SKILL.md
+++ b/.opencode/skills/coherence-auditor/SKILL.md
@@ -53,14 +53,14 @@ LLM Coherence Auditor ensuring guidelines, skills, and AI agent behavior work to
 | STALE-SKILL | Skill references outdated guideline section |
 | DRIFT-DETECTED | Guideline changed independently of skill |
 | ORPHANED-PROCEDURE | Procedure removed from guideline but still in skill |
-| SESSION-INIT-MISMATCH | Skill/guideline references a session-init variable name that doesn't appear in `session_init.py` output, or `session_init.py` outputs a prose label instead of the canonical variable name |
+| SESSION-INIT-MISMATCH | Skill/guideline references a session-init variable name that doesn't appear in `.opencode/tools/session-init` output, or `.opencode/tools/session-init` outputs a prose label instead of the canonical variable name |
 
 ### Session Init Variable Alignment Check (maintenance mode)
 
 When running in maintenance mode, the coherence auditor SHOULD verify:
 
-1. All session-init variable names referenced in `.opencode/guidelines/` and `.opencode/skills/` (e.g., `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`) appear as `KEY:` prefixes in `session_init.py` stdout output
-2. `session_init.py` does NOT output prose-only labels (e.g., `Owner:`, `Repository:`) for variables referenced by canonical names in guidelines
+1. All session-init variable names referenced in `.opencode/guidelines/` and `.opencode/skills/` (e.g., `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`) appear as `KEY:` prefixes in `.opencode/tools/session-init` stdout output
+2. `.opencode/tools/session-init` does NOT output prose-only labels (e.g., `Owner:`, `Repository:`) for variables referenced by canonical names in guidelines
 3. `env-loader.ts` `output.env` keys match the same canonical names
 
 A mismatch is a MEDIUM-severity finding of class SESSION-INIT-MISMATCH.
@@ -100,7 +100,7 @@ After creating audit log:
 **Optional pre-step:** Before auditing, invoke the symbolic analysis engine for formal evidence:
 
 ```bash
-uv run python .opencode/tools/symbolic conflicts
+./.opencode/tools/symbolic conflicts
 ```
 
 The `sym-conflicts` analysis provides formal contradiction detection via sympy boolean satisfiability. Results are used as **evidence** (not verdict) during coherence audits — they identify overlapping conditions with conflicting actions, replacing ad-hoc prose comparison.

--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -95,7 +95,7 @@ Co-authored with AI: OpenCode (ollama-cloud/glm-5)
 **Optional pre-step:** Before auditing, invoke the symbolic analysis engine for formal evidence:
 
 ```bash
-uv run python .opencode/tools/symbolic flow
+./.opencode/tools/symbolic flow
 ```
 
 - `sym-flow`: Builds a networkx DiGraph from rule triggers/requires and detects activation graph anomalies. Cross-concern triggers (edges linking rules in different concern areas) indicate potential concern mixing.

--- a/.opencode/skills/gitbucket-api/tasks/error-recovery.md
+++ b/.opencode/skills/gitbucket-api/tasks/error-recovery.md
@@ -72,7 +72,7 @@ json=["bug", "enhancement"]  # ✅
 
 ## Session Init Detection
 
-Session init script (`.opencode/scripts/session_init.py`) detects GitBucket from remote URL and outputs:
+Session init script (`.opencode/tools/session-init`) detects GitBucket from remote URL and outputs:
 
 ```
 GIT_PLATFORM=gitbucket

--- a/.opencode/skills/gitbucket-api/tasks/session-integration.md
+++ b/.opencode/skills/gitbucket-api/tasks/session-integration.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Session init script (`.opencode/scripts/session_init.py`) provides GitBucket credentials from environment and git remote.
+Session init script (`.opencode/tools/session-init`) provides GitBucket credentials from environment and git remote.
 
 ## Credential Sources (Priority Order)
 
@@ -204,5 +204,5 @@ except NotFoundError:
 
 - `tools/auth.py` - Credential loading, platform-specific paths
 - `tools/session.py` - Session integration
-- `.opencode/scripts/session_init.py` - Session init script
+- `.opencode/tools/session-init` - Session init script
 

--- a/.opencode/skills/gitbucket-api/tools/session.py
+++ b/.opencode/skills/gitbucket-api/tools/session.py
@@ -10,7 +10,7 @@ import subprocess
 def get_session_values() -> dict[str, str]:
     """Extract values from session init script.
 
-    Runs `uv run python .opencode/scripts/session_init.py` and parses output.
+    Runs `uv run .opencode/tools/session-init` and parses output.
 
     Returns:
         Dict with GITBUCKET_URL, GITBUCKET_TOKEN, GIT_OWNER, GIT_REPO, etc.
@@ -29,7 +29,7 @@ def get_session_values() -> dict[str, str]:
         ValueError: Expected variable not found in output
     """
     result = subprocess.run(
-        ["uv", "run", "python", ".opencode/scripts/session_init.py"],
+        ["uv", "run", ".opencode/tools/session-init"],
         capture_output=True,
         text=True,
         check=True,

--- a/.opencode/skills/guideline-auditor/SKILL.md
+++ b/.opencode/skills/guideline-auditor/SKILL.md
@@ -329,8 +329,8 @@ This auditor skill coordinates with the project's approval gate workflow:
 **Optional pre-step:** Before auditing, invoke the symbolic analysis engine for formal evidence:
 
 ```bash
-uv run python .opencode/tools/symbolic drift
-uv run python .opencode/tools/symbolic complete
+./.opencode/tools/symbolic drift
+./.opencode/tools/symbolic complete
 ```
 
 - `sym-drift`: Detects YAML blocks where the file has been modified after the `last_updated` timestamp, indicating stale formalization.

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -133,15 +133,15 @@ The `validate` task (`quick_validate.py`) SHOULD check for:
 
 ## Session Init Variable Alignment Requirement
 
-Skills and guidelines reference session-init variables by exact name (e.g., `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`). These names MUST match the `KEY: value` output of `session_init.py` exactly 1:1.
+Skills and guidelines reference session-init variables by exact name (e.g., `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`). These names MUST match the `KEY: value` output of `.opencode/tools/session-init` exactly 1:1.
 
 **When creating or updating a skill that references session-init variables:**
 
 1. **Use canonical variable names only** — never invent new names or use prose labels (e.g., use `GIT_OWNER`, not `Owner:`)
-2. **Verify new variable references exist in session_init.py output** — if a skill needs a session-init variable that doesn't appear in `session_init.py`, the variable MUST be added to both `session_init.py` and `env-loader.ts` before the skill ships
+2. **Verify new variable references exist in session-init output** — if a skill needs a session-init variable that doesn't appear in `.opencode/tools/session-init`, the variable MUST be added to both `.opencode/tools/session-init` and `env-loader.ts` before the skill ships
 3. **The canonical variable list is:** `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`
 
-**Why:** Agents extract values from session init output by matching variable names. A name mismatch (e.g., guideline says `GIT_OWNER` but session_init outputs `Owner:`) causes agents to fall back to inferring values from git remotes, which is a critical rule violation.
+**Why:** Agents extract values from session init output by matching variable names. A name mismatch (e.g., guideline says `GIT_OWNER` but session-init outputs `Owner:`) causes agents to fall back to inferring values from git remotes, which is a critical rule violation.
 
 ## Correctness-First Economics
 

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -209,8 +209,8 @@ Co-authored with AI: OpenCode (ollama-cloud/glm-5)
 **Optional pre-step:** Before auditing, invoke the symbolic analysis engine for formal evidence:
 
 ```bash
-uv run python .opencode/tools/symbolic states
-uv run python .opencode/tools/symbolic flow
+./.opencode/tools/symbolic states
+./.opencode/tools/symbolic flow
 ```
 
 - `sym-states`: Validates state machines extracted from yaml+symbolic blocks — checks reachability from start_state, detects dead/unreachable states, flags dangling references in transitions.

--- a/.opencode/skills/sync-guidelines/tasks/classify.md
+++ b/.opencode/skills/sync-guidelines/tasks/classify.md
@@ -38,7 +38,7 @@ A file is **project-specific** if it:
 
 Examples of project-specific content:
 - `pubmed_data_3/` — project database path
-- `<repo>` — project name (from session_init.py)
+- `<repo>` — project name (from session-init)
 - `project_root /` — project-specific path handling
 - Project-specific table names or schemas
 

--- a/.opencode/tests/test-pep723-tools.sh
+++ b/.opencode/tests/test-pep723-tools.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOOLS_DIR=".opencode/tools"
+PASS=0
+FAIL=0
+
+check_shebang() {
+    local file="$1"
+    if head -1 "$file" | grep -q '^#!/usr/bin/env -S uv run --script$'; then
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $file missing PEP 723 shebang"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_pep723_metadata() {
+    local file="$1"
+    if grep -q '^# /// script$' "$file" && grep -q '^# requires-python' "$file" && grep -q '^# dependencies' "$file"; then
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $file missing PEP 723 metadata"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_execute() {
+    local file="$1"
+    if [ -x "$file" ]; then
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $file not executable"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_python_version_pinned() {
+    local file="$1"
+    if grep -q '^# requires-python = "~=3\.12"' "$file"; then
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $file python version not pinned with ~="
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_no_old_references() {
+    local matches
+    matches=$(grep -rn "uv run python .opencode/tools" .opencode/guidelines/ AGENTS.md .opencode/skills/ 2>/dev/null | grep -v "Do NOT use" || true)
+    if [ -n "$matches" ]; then
+        echo "FAIL: Old 'uv run python .opencode/tools' references found:"
+        echo "$matches"
+        FAIL=$((FAIL + 1))
+    else
+        PASS=$((PASS + 1))
+    fi
+}
+
+ENTRY_POINTS=(
+    guidelines memory md py jupyter help file-exists
+    schema-version jupyter-start jupyter-stop symbolic session-init
+)
+
+for tool in "${ENTRY_POINTS[@]}"; do
+    file="$TOOLS_DIR/$tool"
+    check_shebang "$file"
+    check_pep723_metadata "$file"
+    check_execute "$file"
+    check_python_version_pinned "$file"
+done
+
+check_no_old_references
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.opencode/tools/file-exists
+++ b/.opencode/tools/file-exists
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Check whether one or more file/directory paths exist and report EXISTS or MISSING.
 
-Usage: uv run python .opencode/tools/file-exists <path> [<path> ...]
+Usage: ./.opencode/tools/file-exists <path> [<path> ...]
 """
 from __future__ import annotations
 
@@ -19,7 +23,7 @@ def main() -> None:
 
     paths = [a for a in sys.argv[1:] if not a.startswith("-")]
     if not paths:
-        print("Usage: uv run python .opencode/tools/file-exists <path> [<path> ...]")
+        print("Usage: ./.opencode/tools/file-exists <path> [<path> ...]")
         sys.exit(1)
 
     all_exist = True

--- a/.opencode/tools/guidelines
+++ b/.opencode/tools/guidelines
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
-DESCRIPTION: Guidelines tools dispatcher. Usage: uv run python .opencode/tools/guidelines <action> [args...]
+DESCRIPTION: Guidelines tools dispatcher. Usage: ./.opencode/tools/guidelines <action> [args...]
 Actions: read, load, list, show, search, edit
-Example: uv run python .opencode/tools/guidelines search <term>
+Example: ./.opencode/tools/guidelines search <term>
 """
 from __future__ import annotations
 import os
@@ -31,12 +35,12 @@ def _suggest_search_for_unknown_action(action: str, rest: list[str]) -> str | No
     query = " ".join(query_parts).strip()
     if not query:
         return None
-    return f'Hint: did you mean `uv run python .opencode/tools/guidelines search "{query}"`?'
+    return f'Hint: did you mean `./.opencode/tools/guidelines search "{query}"`?'
 
 
 def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
     result = subprocess.run(
-        [sys.executable, str(script)] + forwarded_args,
+        ["uv", "run", str(script)] + forwarded_args,
         capture_output=True,
         text=True,
         env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},

--- a/.opencode/tools/help
+++ b/.opencode/tools/help
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: List all agent tools in .opencode/tools/ with their descriptions.
 
-Usage: uv run python .opencode/tools/help
+Usage: ./.opencode/tools/help
 """
 from __future__ import annotations
 
@@ -44,7 +48,7 @@ def main() -> None:
         print("No tools found in .opencode/tools/.")
         return
 
-    print(f"Agent tools in .opencode/tools/  (run with: uv run python .opencode/tools/<tool>)\n")
+    print(f"Agent tools in .opencode/tools/  (run with: ./.opencode/tools/<tool>)\n")
     for script in scripts:
         desc = get_description(script)
         print(f"  {script.name:<24} — {desc}")

--- a/.opencode/tools/impl/guidelines-edit
+++ b/.opencode/tools/impl/guidelines-edit
@@ -1,9 +1,13 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Edit a guideline file by replacing a section or appending content.
-Usage: uv run python .opencode/tools/guidelines edit <filename> --find-file <path> --replace-file <path>
-       uv run python .opencode/tools/guidelines edit <filename> --append-file <path>
-       uv run python .opencode/tools/guidelines edit <filename> --find-regex-file <path> --replace-file <path>
+Usage: ./.opencode/tools/guidelines edit <filename> --find-file <path> --replace-file <path>
+       ./.opencode/tools/guidelines edit <filename> --append-file <path>
+       ./.opencode/tools/guidelines edit <filename> --find-regex-file <path> --replace-file <path>
 WARNING: Use file-based options (--find-file, --replace-file, --append-file, --find-regex-file) exclusively.
          Direct text on CLI (--find, --replace, --append, --find-regex) is FORBIDDEN.
 Options:
@@ -22,7 +26,7 @@ import os as _os
 
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print(
-        "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/guidelines ...). "
+        "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/guidelines ...). "
         "Direct invocation is not permitted.",
         file=__import__("sys").stderr,
     )

--- a/.opencode/tools/impl/guidelines-read
+++ b/.opencode/tools/impl/guidelines-read
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Print the contents of a guideline file from .opencode/guidelines/.
-Usage: uv run python .opencode/tools/guidelines read <filename>
-Example: uv run python .opencode/tools/guidelines read 041
+Usage: ./.opencode/tools/guidelines read <filename>
+Example: ./.opencode/tools/guidelines read 041
 Note: Prefer 3-digit shorthand when available (for example `041` instead of full filename).
 """
 
@@ -11,7 +15,7 @@ import os as _os
 
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print(
-        "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+        "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/guidelines ...). "
         "Direct invocation is not permitted.",
         file=__import__("sys").stderr,
     )

--- a/.opencode/tools/impl/guidelines-search
+++ b/.opencode/tools/impl/guidelines-search
@@ -1,21 +1,25 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Search guideline files using BM25 ranking with optional section blocks and context lines.
-Usage: uv run python .opencode/tools/guidelines search <query> [--file <filename>] [--top N] [--section-names] [--section-blocks] [--context-lines N] [--minimal] [--surrounding N]
-       uv run python .opencode/tools/guidelines search <filename.md> <query>
+Usage: ./.opencode/tools/guidelines search <query> [--file <filename>] [--top N] [--section-names] [--section-blocks] [--context-lines N] [--minimal] [--surrounding N]
+       ./.opencode/tools/guidelines search <filename.md> <query>
 Note: Prefer 3-digit guideline filename shorthand when available (for example `041`).
       Searches recursively in subdirectories (git/, planning/, errors/, github/).
 Flags:
   --minimal          Output match line only (no context)
   --surrounding N    Alias for --context-lines N
   --context-lines N  Set context lines (default: 1)
-Examples: uv run python .opencode/tools/guidelines search "pyclbr"
-          uv run python .opencode/tools/guidelines search "grep" --file 041
-          uv run python .opencode/tools/guidelines search 041 "grep"
-          uv run python .opencode/tools/guidelines search "notebook editing" --top 10
-          uv run python .opencode/tools/guidelines search "pre-plan" --section-blocks
-          uv run python .opencode/tools/guidelines search "branch" --minimal
-          uv run python .opencode/tools/guidelines search "error" --surrounding 3
+Examples: ./.opencode/tools/guidelines search "pyclbr"
+          ./.opencode/tools/guidelines search "grep" --file 041
+          ./.opencode/tools/guidelines search 041 "grep"
+          ./.opencode/tools/guidelines search "notebook editing" --top 10
+          ./.opencode/tools/guidelines search "pre-plan" --section-blocks
+          ./.opencode/tools/guidelines search "branch" --minimal
+          ./.opencode/tools/guidelines search "error" --surrounding 3
 """
 
 from __future__ import annotations
@@ -23,7 +27,7 @@ import os as _os
 
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print(
-        "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+        "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/guidelines ...). "
         "Direct invocation is not permitted.",
         file=__import__("sys").stderr,
     )

--- a/.opencode/tools/impl/guidelines-show
+++ b/.opencode/tools/impl/guidelines-show
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Show guideline files with their brief summary header.
-Usage: uv run python .opencode/tools/guidelines show [<file> ...]
-Example: uv run python .opencode/tools/guidelines show 010 040
+Usage: ./.opencode/tools/guidelines show [<file> ...]
+Example: ./.opencode/tools/guidelines show 010 040
 Note: Prefer 3-digit shorthand for guideline files when available (for example `041`).
 """
 
@@ -11,7 +15,7 @@ import os as _os
 
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
     print(
-        "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+        "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/guidelines ...). "
         "Direct invocation is not permitted.",
         file=__import__("sys").stderr,
     )

--- a/.opencode/tools/impl/jupyter-start
+++ b/.opencode/tools/impl/jupyter-start
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Start Jupyter server on port 18888 (XSRF disabled, no token) for notebook editing.
 
-Usage: uv run python .opencode/tools/jupyter start [--help]
+Usage: ./.opencode/tools/jupyter start [--help]
 
 Checks if port 18888 is already listening. If not, starts the server in the
 background and logs to tmp/jupyter.log. Prints the server URL on success.
@@ -10,7 +14,7 @@ background and logs to tmp/jupyter.log. Prints the server URL on success.
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/jupyter ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 

--- a/.opencode/tools/impl/jupyter-stop
+++ b/.opencode/tools/impl/jupyter-stop
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Stop the Jupyter server running on port 18888.
 
-Usage: uv run python .opencode/tools/jupyter stop [--help]
+Usage: ./.opencode/tools/jupyter stop [--help]
 
 Sends SIGTERM to any process listening on port 18888. Waits up to 5 seconds
 to confirm the port is released, then reports success or failure.
@@ -10,7 +14,7 @@ to confirm the port is released, then reports success or failure.
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/jupyter ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 

--- a/.opencode/tools/impl/md-add
+++ b/.opencode/tools/impl/md-add
@@ -1,13 +1,17 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Insert a new section (header + body) into a markdown file.
-Usage: uv run python .opencode/tools/md add <file.md> --header "New Header" --level N (--content <text> | --content-file <path>) [--after "Header" | --before "Header" | --append] [--help]
+Usage: ./.opencode/tools/md add <file.md> --header "New Header" --level N (--content <text> | --content-file <path>) [--after "Header" | --before "Header" | --append] [--help]
 Default position: --append (add at end of file).
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/md ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import re

--- a/.opencode/tools/impl/md-delete
+++ b/.opencode/tools/impl/md-delete
@@ -1,12 +1,16 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Delete a section (header line + body) from a markdown file by header.
-Usage: uv run python .opencode/tools/md delete <file.md> --header "Header Text" [--level N] [--help]
+Usage: ./.opencode/tools/md delete <file.md> --header "Header Text" [--level N] [--help]
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/md ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import re

--- a/.opencode/tools/impl/md-new
+++ b/.opencode/tools/impl/md-new
@@ -1,12 +1,16 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Create a new markdown file with an optional H1 title. Fails if file already exists.
-Usage: uv run python .opencode/tools/md new <file.md> [--title "Title Text"] [--help]
+Usage: ./.opencode/tools/md new <file.md> [--title "Title Text"] [--help]
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/md ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys

--- a/.opencode/tools/impl/md-read
+++ b/.opencode/tools/impl/md-read
@@ -1,12 +1,16 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Read a section from a markdown file by header, or list all headers.
-Usage: uv run python .opencode/tools/md read <file.md> (--header "Header Text" [--level N] | --list) [--help]
+Usage: ./.opencode/tools/md read <file.md> (--header "Header Text" [--level N] | --list) [--help]
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/md ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import re

--- a/.opencode/tools/impl/md-write
+++ b/.opencode/tools/impl/md-write
@@ -1,14 +1,18 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Replace the body of a section in a markdown file, preserving the header line.
-Usage: uv run python .opencode/tools/md write <file.md> --header "Header Text" (--content <text> | --content-file <path>) [--level N] [--help]
+Usage: ./.opencode/tools/md write <file.md> --header "Header Text" (--content <text> | --content-file <path>) [--level N] [--help]
 WARNING: Use --content-file <path> for any content containing newlines or special characters
          to avoid shell escaping and literal \n issues.
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/md ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import re

--- a/.opencode/tools/impl/memory-clear
+++ b/.opencode/tools/impl/memory-clear
@@ -1,12 +1,16 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Clear the Session State section of .opencode/memory.md.
-Usage: uv run python .opencode/tools/memory clear
+Usage: ./.opencode/tools/memory clear
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/memory ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys

--- a/.opencode/tools/impl/memory-read
+++ b/.opencode/tools/impl/memory-read
@@ -1,12 +1,16 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Print the full contents of .opencode/memory.md.
-Usage: uv run python .opencode/tools/memory read
+Usage: ./.opencode/tools/memory read
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/memory ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys

--- a/.opencode/tools/impl/memory-update
+++ b/.opencode/tools/impl/memory-update
@@ -1,16 +1,20 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Update a single key: value line in .opencode/memory.md.
 If the key exists, its line is replaced. If not, it is appended to the matching section.
-Usage: uv run python .opencode/tools/memory update <section> <key> (<value> | --value-file <path>)
+Usage: ./.opencode/tools/memory update <section> <key> (<value> | --value-file <path>)
 WARNING: Use --value-file <path> for complex text to avoid shell escaping issues.
 Sections: project_context, key_symbols, persistent_notes, session_state
-Example: uv run python .opencode/tools/memory update session_state task "refine topic seeds"
+Example: ./.opencode/tools/memory update session_state task "refine topic seeds"
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/memory ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys

--- a/.opencode/tools/impl/memory-write
+++ b/.opencode/tools/impl/memory-write
@@ -1,13 +1,17 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Overwrite .opencode/memory.md with content from stdin or a file argument.
-Usage: uv run python .opencode/tools/memory write [file]
-       echo "content" | uv run python .opencode/tools/memory write
+Usage: ./.opencode/tools/memory write [file]
+       echo "content" | ./.opencode/tools/memory write
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/memory ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys

--- a/.opencode/tools/impl/py-ls
+++ b/.opencode/tools/impl/py-ls
@@ -1,17 +1,21 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: List packages and modules under a path (replaces `ls` for Python source trees).
-Usage: uv run python .opencode/tools/py ls [<path>] [--all]
-Example: uv run python .opencode/tools/py ls src/commons
-         uv run python .opencode/tools/py ls src/commons/persistence
-         uv run python .opencode/tools/py ls  (lists top-level packages in src/)
+Usage: ./.opencode/tools/py ls [<path>] [--all]
+Example: ./.opencode/tools/py ls src/commons
+         ./.opencode/tools/py ls src/commons/persistence
+         ./.opencode/tools/py ls  (lists top-level packages in src/)
 Options:
   --all   Include non-package directories and non-.py files too
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/py ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys

--- a/.opencode/tools/impl/py-mkpkg
+++ b/.opencode/tools/impl/py-mkpkg
@@ -1,14 +1,18 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Create a Python package (directory + __init__.py). Creates all intermediate packages too.
-Usage: uv run python .opencode/tools/py mkpkg <path> [<path2> ...]
-Example: uv run python .opencode/tools/py mkpkg src/commons/query
-         uv run python .opencode/tools/py mkpkg src/commons/query test/commons/query
+Usage: ./.opencode/tools/py mkpkg <path> [<path2> ...]
+Example: ./.opencode/tools/py mkpkg src/commons/query
+         ./.opencode/tools/py mkpkg src/commons/query test/commons/query
 """
 from __future__ import annotations
 import os as _os
 if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
-    print("ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/nb ...). "
+    print("ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/py ...). "
           "Direct invocation is not permitted.", file=__import__('sys').stderr)
     __import__('sys').exit(1)
 import sys

--- a/.opencode/tools/impl/sym-analyze
+++ b/.opencode/tools/impl/sym-analyze
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Run all symbolic analyses in sequence (extract, conflicts, flow, states, complete, drift). Single entry point.
-Usage: uv run python .opencode/tools/symbolic analyze [--dir PATH] [--output PATH] [--verbose]
+Usage: ./.opencode/tools/symbolic analyze [--dir PATH] [--output PATH] [--verbose]
 """
 
 from __future__ import annotations
@@ -30,7 +34,7 @@ def _load_module(module_file: str):
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/impl/sym-complete
+++ b/.opencode/tools/impl/sym-complete
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Completeness check. Finds uncovered normative terms, dangling cross-refs, rules without prose.
-Usage: uv run python .opencode/tools/symbolic complete
+Usage: ./.opencode/tools/symbolic complete
 """
 
 from __future__ import annotations
@@ -106,7 +110,7 @@ def check_completeness(rules: list, scan_dir: Path) -> list[CompletenessGap]:
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/impl/sym-conflicts
+++ b/.opencode/tools/impl/sym-conflicts
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = ["sympy>=1.12"]
+# ///
 """
 DESCRIPTION: Contradiction detection via sympy boolean satisfiability. Checks overlapping conditions with conflicting actions.
-Usage: uv run python .opencode/tools/symbolic conflicts
+Usage: ./.opencode/tools/symbolic conflicts
 """
 
 from __future__ import annotations
@@ -188,7 +192,7 @@ def detect_conflicts(rules: list) -> list[Conflict]:
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/impl/sym-drift
+++ b/.opencode/tools/impl/sym-drift
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Drift detection. Compares YAML last_updated timestamps against file mtime.
-Usage: uv run python .opencode/tools/symbolic drift
+Usage: ./.opencode/tools/symbolic drift
 """
 
 from __future__ import annotations
@@ -81,7 +85,7 @@ def detect_drift(scan_dir: Path) -> list[DriftEntry]:
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/impl/sym-extract
+++ b/.opencode/tools/impl/sym-extract
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Extract yaml+symbolic fenced blocks from markdown files. Schema validation with graceful skip on errors.
-Usage: uv run python .opencode/tools/symbolic extract [--dir PATH] [--verbose]
+Usage: ./.opencode/tools/symbolic extract [--dir PATH] [--verbose]
 """
 
 from __future__ import annotations
@@ -181,7 +185,7 @@ def extract_yaml_blocks(scan_dir: Path, verbose: bool = False) -> ExtractResult:
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/impl/sym-extract-dot
+++ b/.opencode/tools/impl/sym-extract-dot
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = ["networkx>=3.1"]
+# ///
 """
 DESCRIPTION: Digraph block parser. Extracts dot/digraph fenced blocks from markdown and converts to networkx DiGraph.
-Usage: uv run python .opencode/tools/symbolic extract-dot
+Usage: ./.opencode/tools/symbolic extract-dot
 """
 
 from __future__ import annotations
@@ -77,7 +81,7 @@ def extract_digraphs(scan_dir: Path) -> list[tuple[str, nx.DiGraph, str]]:
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/impl/sym-flow
+++ b/.opencode/tools/impl/sym-flow
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = ["networkx>=3.1"]
+# ///
 """
 DESCRIPTION: Activation flow analysis via networkx. Builds DiGraph from rules (triggers/requires) and detects anomalies.
-Usage: uv run python .opencode/tools/symbolic flow
+Usage: ./.opencode/tools/symbolic flow
 """
 
 from __future__ import annotations
@@ -100,7 +104,7 @@ def analyze_flow(graph: nx.DiGraph) -> list[FlowAnomaly]:
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/impl/sym-report
+++ b/.opencode/tools/impl/sym-report
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = ["networkx>=3.1"]
+# ///
 """
 DESCRIPTION: HTML+SVG report generator. Renders analysis results as self-contained HTML with inline CSS and SVG diagrams.
-Usage: uv run python .opencode/tools/symbolic report [--output PATH] [--format html|text]
+Usage: ./.opencode/tools/symbolic report [--output PATH] [--format html|text]
 """
 
 from __future__ import annotations
@@ -339,7 +343,7 @@ def generate_text_report(analysis_data: dict) -> str:
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/impl/sym-states
+++ b/.opencode/tools/impl/sym-states
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = ["networkx>=3.1"]
+# ///
 """
 DESCRIPTION: State machine extraction and validation. Checks reachability, dead states, dangling references.
-Usage: uv run python .opencode/tools/symbolic states
+Usage: ./.opencode/tools/symbolic states
 """
 
 from __future__ import annotations
@@ -105,7 +109,7 @@ def validate_state_machines(state_machines: list, rules: list | None = None) -> 
 def main() -> None:
     if _os.environ.get("OPENCODE_TOOLS_DISPATCHER") != "1":
         print(
-            "ERROR: This script must be run via its dispatcher (e.g. uv run python .opencode/tools/symbolic ...). "
+            "ERROR: This script must be run via its dispatcher (e.g. ./.opencode/tools/symbolic ...). "
             "Direct invocation is not permitted.",
             file=sys.stderr,
         )

--- a/.opencode/tools/jupyter
+++ b/.opencode/tools/jupyter
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
-DESCRIPTION: Jupyter server tools dispatcher. Usage: uv run python .opencode/tools/jupyter <action> [args...]
+DESCRIPTION: Jupyter server tools dispatcher. Usage: ./.opencode/tools/jupyter <action> [args...]
 Actions: start, stop
-Example: uv run python .opencode/tools/jupyter start
+Example: ./.opencode/tools/jupyter start
 """
 from __future__ import annotations
 import os
@@ -20,7 +24,7 @@ ACTIONS = {
 
 def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
     result = subprocess.run(
-        [sys.executable, str(script)] + forwarded_args,
+        ["uv", "run", str(script)] + forwarded_args,
         capture_output=True,
         text=True,
         env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},

--- a/.opencode/tools/jupyter-start
+++ b/.opencode/tools/jupyter-start
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Start Jupyter server on port 18888 (XSRF disabled, no token) for notebook editing.
 
-Usage: uv run python .opencode/tools/jupyter-start [--help]
+Usage: ./.opencode/tools/jupyter-start [--help]
 
 Checks if port 18888 is already listening. If not, starts the server in the
 background and logs to tmp/jupyter.log. Prints the server URL on success.

--- a/.opencode/tools/jupyter-stop
+++ b/.opencode/tools/jupyter-stop
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Stop the Jupyter server running on port 18888.
 
-Usage: uv run python .opencode/tools/jupyter-stop [--help]
+Usage: ./.opencode/tools/jupyter-stop [--help]
 
 Sends SIGTERM to any process listening on port 18888. Waits up to 5 seconds
 to confirm the port is released, then reports success or failure.

--- a/.opencode/tools/md
+++ b/.opencode/tools/md
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
-DESCRIPTION: Markdown tools dispatcher. Usage: uv run python .opencode/tools/md <action> [args...]
+DESCRIPTION: Markdown tools dispatcher. Usage: ./.opencode/tools/md <action> [args...]
 Actions: read, write, add, delete, new
-Example: uv run python .opencode/tools/md read <file.md> [--section <header>]
+Example: ./.opencode/tools/md read <file.md> [--section <header>]
 """
 from __future__ import annotations
 import os
@@ -23,7 +27,7 @@ ACTIONS = {
 
 def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
     result = subprocess.run(
-        [sys.executable, str(script)] + forwarded_args,
+        ["uv", "run", str(script)] + forwarded_args,
         capture_output=True,
         text=True,
         env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},

--- a/.opencode/tools/memory
+++ b/.opencode/tools/memory
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
-DESCRIPTION: Memory tools dispatcher. Usage: uv run python .opencode/tools/memory <action> [args...]
+DESCRIPTION: Memory tools dispatcher. Usage: ./.opencode/tools/memory <action> [args...]
 Actions: read, write, update (alias: set), clear
-Example: uv run python .opencode/tools/memory read
+Example: ./.opencode/tools/memory read
 """
 from __future__ import annotations
 import os
@@ -23,7 +27,7 @@ ACTIONS = {
 
 def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
     result = subprocess.run(
-        [sys.executable, str(script)] + forwarded_args,
+        ["uv", "run", str(script)] + forwarded_args,
         capture_output=True,
         text=True,
         env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
@@ -50,7 +54,7 @@ def main() -> None:
                 seen_scripts.add(script)
                 try:
                     result = subprocess.run(
-                        [sys.executable, str(script_path), "--help"],
+                        ["uv", "run", str(script_path), "--help"],
                         capture_output=True, text=True,
                         env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
                     )

--- a/.opencode/tools/py
+++ b/.opencode/tools/py
@@ -1,9 +1,13 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
-DESCRIPTION: Python source tools dispatcher. Usage: uv run python .opencode/tools/py <action> [args...]
+DESCRIPTION: Python source tools dispatcher. Usage: ./.opencode/tools/py <action> [args...]
 Actions: ls, mkpkg
-Example: uv run python .opencode/tools/py ls src/commons
-         uv run python .opencode/tools/py mkpkg src/commons/query
+Example: ./.opencode/tools/py ls src/commons
+         ./.opencode/tools/py mkpkg src/commons/query
 """
 from __future__ import annotations
 import os
@@ -21,7 +25,7 @@ ACTIONS = {
 
 def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
     result = subprocess.run(
-        [sys.executable, str(script)] + forwarded_args,
+        ["uv", "run", str(script)] + forwarded_args,
         capture_output=True,
         text=True,
         env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},

--- a/.opencode/tools/schema-version
+++ b/.opencode/tools/schema-version
@@ -1,7 +1,11 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
 DESCRIPTION: Print current UTC datetime as YYYYMMDDHHMMSS. ONLY run when explicitly instructed to create a migration. NEVER run speculatively.
-Usage: uv run python .opencode/tools/schema-version
+Usage: ./.opencode/tools/schema-version
 
 Use this value as the VERSION constant when writing a new migration script.
 Never copy a version number from memory or a previous migration — always run

--- a/.opencode/tools/session-init
+++ b/.opencode/tools/session-init
@@ -1,4 +1,8 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """Session initialization script for AI agents.
 
 Outputs KEY: value pairs for LLM consumption on stdout. Variable names match
@@ -21,7 +25,7 @@ Guard checks (auto-create missing files/branches/worktree):
 - .env gitignore: Warn if .env exists but is not in .gitignore
 
 Usage:
-    uvx session-init
+    ./.opencode/tools/session-init
 
 Exit codes:
     0: Success

--- a/.opencode/tools/symbolic
+++ b/.opencode/tools/symbolic
@@ -1,8 +1,12 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """
-DESCRIPTION: Symbolic analysis engine for guidelines and skills. Usage: uv run python .opencode/tools/symbolic <action> [options]
+DESCRIPTION: Symbolic analysis engine for guidelines and skills. Usage: ./.opencode/tools/symbolic <action> [options]
 Actions: extract, extract-dot, conflicts, flow, states, complete, drift, analyze, report, help
-Example: uv run python .opencode/tools/symbolic analyze
+Example: ./.opencode/tools/symbolic analyze
 """
 from __future__ import annotations
 import os
@@ -37,7 +41,7 @@ def _get_description(script_path: Path) -> str:
 
 def _run_action(script: Path, forwarded_args: list[str], summary: str) -> int:
     result = subprocess.run(
-        [sys.executable, str(script)] + forwarded_args,
+        ["uv", "run", str(script)] + forwarded_args,
         capture_output=True,
         text=True,
         env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ### Changed
 
+- **PEP 723 Self-Contained Tool Scripts** (#753) - Converted all 13 `.opencode/tools/` entry points (6 dispatchers + 5 standalones + session-init) and 26 impl scripts to self-contained PEP 723 scripts with `#!/usr/bin/env -S uv run --script` shebangs and inline metadata (`requires-python = "~=3.12"`, `dependencies`). Moved session-init from `.opencode/scripts/session_init.py` to `.opencode/tools/session-init`. Removed broken `[project.scripts]` from pyproject.toml. Updated all 6 dispatchers to invoke impl scripts via `uv run` instead of `sys.executable`. Updated session-enforcement.ts plugin to use `uv run .opencode/tools/session-init`. Added PEP 723 mandatory requirement to 070-environment.md. Created validation script `.opencode/tests/test-pep723-tools.sh`.
+
 - **Subagent-Driven-Development** (#734) - Updated to reference divide-and-conquer as primary orchestration skill. Fixed missing YAML frontmatter opening delimiter. Replaced implementation-workflow cross-references.
 - **Batch Orchestration Migration** (#734) - Migrated branch-per-issue, merge dependencies, squash-merge, frozen branches, and intent-and-context metadata from implementation-workflow into divide-and-conquer assemble-batch task.
 - **Cross-Reference Updates** (#734) - Updated all guidelines and skills referencing implementation-workflow or batch-orchestrate to reference divide-and-conquer and assemble-batch respectively.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ dependencies = [
     "tqdm>=4.67.1",
 ]
 
-[project.scripts]
-session-init = ".opencode.scripts.session_init:main"
 
 [project.optional-dependencies]
 local = [


### PR DESCRIPTION
**Summary:**

Converts all `.opencode/tools/` Python entry points to self-contained PEP 723 scripts that are invocable via `./.opencode/tools/X` with zero dependency on the project's `pyproject.toml` or `uv.lock`, enabling cross-project reuse and eliminating the broken `uvx session-init` path.

**Outcome:** Developers can copy `.opencode/tools/` to any repo and tools just work. The `session-enforcement.ts` plugin and all documentation now reference the new invocation pattern.

Fixes #753
Fixes #755