### PR TITLE
Fix #761 #698: mock path updates and hard-delete unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ### Changed
 
+### Fixed
+
+- **Mock Import Paths in Frontend Tests** (#761) - Updated 34 `@patch("src.database.get_session")` mock decorators in `test_upload_mdf_page.py` (15) and `test_upload_review_d1.py` (19) to use `@patch("src.database.connection.get_session")`, matching the post-#758 import path structure.
+
+### Added
+
+- **Hard-Delete Unit Tests** (#698) - Added 5 unit tests for `LinguisticService.hard_delete_record()` covering cleanup of all three search tables (SearchEntry, HeadwordSearchEntry, GlossSearchEntry), EditHistory cleanup, nonexistent record edge case, and MatchupQueue suggestion nullification.
+
 - **Database Import Paths** (#758) - Removed all convenience re-exports from `src/database/__init__.py` and `src/database/models/__init__.py`. All consumer files now use concrete import paths (e.g., `from src.database.models.core import Record` instead of `from src.database import Record`), eliminating IDE confusion and "Find Usages" misdirection.
 - **Environment Variable Rename** (#759) - Renamed `JUNIE_PRIVATE_DB` to `OPENCODE` and replaced all "Junie" references with "OpenCode" across source, tests, scripts, and docs. Legacy AI tool references no longer appear in the codebase.
 - **Database Initialization** (#758) - Added explicit model imports to `init_db()` so SQLAlchemy can resolve foreign keys without relying on `__init__.py` re-exports. Auto-enables `pgvector` extension when using local PostgreSQL (pgserver).

--- a/tests/frontend/test_upload_mdf_page.py
+++ b/tests/frontend/test_upload_mdf_page.py
@@ -12,7 +12,7 @@ SAMPLE_FILE = Path("src/seed_data/natick_sample_100.txt")
 class TestUploadMdfRoleGuard(unittest.TestCase):
     """C-2: Only editor/admin may access the page."""
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.error")
     @patch("streamlit.session_state", {"user_role": "viewer"})
     def test_viewer_blocked(self, mock_error, _mock_session):
@@ -21,7 +21,7 @@ class TestUploadMdfRoleGuard(unittest.TestCase):
         mock_error.assert_called_once()
         self.assertIn("permission", mock_error.call_args[0][0].lower())
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.error")
     @patch("streamlit.session_state", {})
     def test_no_role_blocked(self, mock_error, _mock_session):
@@ -29,7 +29,7 @@ class TestUploadMdfRoleGuard(unittest.TestCase):
         upload_mdf()
         mock_error.assert_called_once()
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.session_state", {"user_role": "editor"})
     @patch("streamlit.sidebar")
     @patch("streamlit.selectbox", return_value="TestSource")
@@ -43,7 +43,7 @@ class TestUploadMdfRoleGuard(unittest.TestCase):
         # Header is in sidebar now, or replaced by file_uploader label
         mock_sidebar.__enter__.assert_called()
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.session_state", {"user_role": "admin"})
     @patch("streamlit.sidebar")
     @patch("streamlit.selectbox", return_value="TestSource")
@@ -60,7 +60,7 @@ class TestUploadMdfRoleGuard(unittest.TestCase):
 class TestUploadMdfSourceSelector(unittest.TestCase):
     """C-4 / C-4a: Source selector with create-new option."""
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.session_state", {"user_role": "editor"})
     @patch("streamlit.sidebar")
     @patch("streamlit.file_uploader", return_value=None)
@@ -83,7 +83,7 @@ class TestUploadMdfSourceSelector(unittest.TestCase):
         options = mock_selectbox.call_args[0][1]
         self.assertEqual(options, ["Select a source...", "+ Add new source…", "Alpha", "Beta"])
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.session_state", {"user_role": "editor"})
     @patch("streamlit.sidebar")
     @patch("streamlit.file_uploader", return_value=None)
@@ -106,7 +106,7 @@ class TestUploadMdfSourceSelector(unittest.TestCase):
 class TestUploadMdfFileUploader(unittest.TestCase):
     """C-3: File uploader accepts .txt/.mdf and shows preview."""
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.session_state", {"user_role": "editor"})
     @patch("streamlit.sidebar")
     @patch("streamlit.selectbox", return_value="TestSource")
@@ -127,7 +127,7 @@ class TestUploadMdfFileUploader(unittest.TestCase):
 class TestUploadMdfParseSummary(unittest.TestCase):
     """C-5: Parse upload and display summary table."""
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("src.services.upload_service.UploadService.parse_upload")
     @patch("streamlit.session_state", {"user_role": "editor"})
     @patch("streamlit.header")
@@ -165,7 +165,7 @@ class TestUploadMdfParseSummary(unittest.TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["lx"], "word1")
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("src.services.upload_service.UploadService.parse_upload")
     @patch("streamlit.session_state", {"user_role": "editor"})
     @patch("streamlit.header")
@@ -196,7 +196,7 @@ class TestUploadMdfParseSummary(unittest.TestCase):
         mock_error.assert_called()
         self.assertIn("No valid", mock_error.call_args[0][0])
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.session_state", {"user_role": "admin"})
     @patch("streamlit.header")
     @patch("streamlit.selectbox", return_value="TestSource")
@@ -236,7 +236,7 @@ class TestUploadMdfParseSummary(unittest.TestCase):
 class TestStageAndMatch(unittest.TestCase):
     """C-6: Stage & Match button calls stage_entries then suggest_matches."""
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("src.services.upload_service.UploadService.suggest_matches")
     @patch("src.services.upload_service.UploadService.stage_entries")
     @patch("src.services.upload_service.UploadService.parse_upload")
@@ -306,7 +306,7 @@ class TestStageAndMatch(unittest.TestCase):
         mock_suggest.assert_called_once()
         self.assertEqual(mock_suggest.call_args[0][0], "batch-uuid-1234")
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("src.services.upload_service.UploadService.parse_upload")
     @patch("src.services.upload_service.UploadService.list_pending_batches")
     @patch("streamlit.session_state", {"user_role": "editor", "user_email": "test@example.com"})
@@ -346,7 +346,7 @@ class TestPendingBatchSelector(unittest.TestCase):
     """C-6a: Pending upload batches shown inline on main upload view."""
 
     @patch("src.services.identity_service.IdentityService.get_github_username", return_value="testuser")
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("src.services.upload_service.UploadService.list_pending_batches")
     @patch("streamlit.session_state", {"user_role": "editor", "user_email": "test@example.com"})
     @patch("streamlit.header")
@@ -409,7 +409,7 @@ class TestPendingBatchSelector(unittest.TestCase):
             # 14:52:00 = 14*3600 + 52*60 = 50400 + 3120 = 53520
             self.assertEqual(mock_download_btn.call_args[1]['file_name'], "pending_Natick_testuser_2026-02-08_53520.txt")
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("src.services.upload_service.UploadService.list_pending_batches")
     @patch("streamlit.session_state", {"user_role": "editor", "user_email": "test@example.com"})
     @patch("streamlit.header")
@@ -435,7 +435,7 @@ class TestPendingBatchSelector(unittest.TestCase):
 class TestReMatchButton(unittest.TestCase):
     """C-6b: Re-Match button calls rematch_batch (now in dedicated review view)."""
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("src.services.upload_service.UploadService.rematch_batch")
     @patch("streamlit.session_state", {"user_role": "editor", "user_email": "test@example.com",
                                         "review_batch_id": "abc-123",

--- a/tests/frontend/test_upload_review_d1.py
+++ b/tests/frontend/test_upload_review_d1.py
@@ -90,7 +90,7 @@ class TestReviewTableRendering(unittest.TestCase):
         st.session_state["review_page_size"] = 1
         st.session_state["review_filter_status"] = "All Records"
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.rerun")
     def test_empty_batch_redirects_to_upload(self, mock_rerun, mock_get_session):
         """When batch is empty, clear review_batch_id and rerun to upload view."""
@@ -110,7 +110,7 @@ class TestReviewTableRendering(unittest.TestCase):
         self.assertIsNotNone(flash)
         self.assertEqual(flash[0], "success")
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -161,7 +161,7 @@ class TestReviewTableRendering(unittest.TestCase):
         md_calls = [str(c) for c in mock_md.call_args_list]
         self.assertTrue(any("Page **1**" in c for c in md_calls))
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -222,7 +222,7 @@ class TestBulkApprovalButtons(unittest.TestCase):
         st.session_state["review_page_size"] = 1
         st.session_state["review_filter_status"] = "All Records"
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button")
     @patch("streamlit.columns")
@@ -270,7 +270,7 @@ class TestBulkApprovalButtons(unittest.TestCase):
         btn_labels = [c[0][0] for c in mock_button.call_args_list]
         self.assertIn("Approve All as New Records", btn_labels)
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button")
     @patch("streamlit.columns")
@@ -328,7 +328,7 @@ class TestComparisonView(unittest.TestCase):
         st.session_state["review_page_size"] = 1
         st.session_state["review_filter_status"] = "All Records"
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -378,7 +378,7 @@ class TestComparisonView(unittest.TestCase):
         render_calls = [str(c) for c in mock_render.call_args_list]
         self.assertTrue(any("fire" in c for c in render_calls))
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -435,7 +435,7 @@ class TestPerRecordApplyNow(unittest.TestCase):
         st.session_state["review_page_size"] = 1
         st.session_state["review_filter_status"] = "All Records"
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button")
     @patch("streamlit.columns")
@@ -486,7 +486,7 @@ class TestPerRecordApplyNow(unittest.TestCase):
         self.assertTrue(len(apply_calls) > 0)
         self.assertTrue(apply_calls[0][1].get("disabled", False))
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button")
     @patch("streamlit.columns")
@@ -547,7 +547,7 @@ class TestPagination(unittest.TestCase):
         st.session_state["review_page_size"] = 1
         st.session_state["review_filter_status"] = "All Records"
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -594,7 +594,7 @@ class TestPagination(unittest.TestCase):
         md_calls = [str(c) for c in mock_md.call_args_list]
         self.assertTrue(any("Page **1**" in c for c in md_calls))
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -647,7 +647,7 @@ class TestStageAndMatchDisable(unittest.TestCase):
 
     @patch("src.services.upload_service.UploadService.list_pending_batches", return_value=[])
     @patch("src.services.upload_service.UploadService.parse_upload")
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.session_state", {"user_role": "editor", "user_email": "test@test.com",
                                         "upload_staged_file_id": "already-staged-id"})
     @patch("streamlit.title")
@@ -703,7 +703,7 @@ class TestManualMatchOverride(unittest.TestCase):
         st.session_state["review_page_size"] = 1
         st.session_state["review_filter_status"] = "All Records"
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -754,7 +754,7 @@ class TestManualMatchOverride(unittest.TestCase):
                           if len(c[0]) > 0 and "Change match" in str(c[0][0])]
         self.assertTrue(len(expander_calls) > 0)
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -820,7 +820,7 @@ class TestManualMatchOverride(unittest.TestCase):
                         if len(c[0]) > 0 and c[0][0] == "Select record"]
         self.assertTrue(len(select_calls) > 0)
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button")
     @patch("streamlit.columns")
@@ -884,7 +884,7 @@ class TestManualMatchOverride(unittest.TestCase):
 
         mock_confirm.assert_called_once_with(7, 42)
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.subheader")
     @patch("streamlit.button", return_value=False)
     @patch("streamlit.columns")
@@ -946,7 +946,7 @@ class TestReviewFiltering(unittest.TestCase):
         st.session_state["review_page_size"] = 10
         st.session_state["review_filter_status"] = "All Records"
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.sidebar")
     @patch("streamlit.markdown")
     @patch("streamlit.container")
@@ -998,7 +998,7 @@ class TestReviewFiltering(unittest.TestCase):
         lx_calls_base = [c for c in _md.call_args_list if "base" in str(c[0][0])]
         self.assertEqual(len(lx_calls_base), 0)
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.sidebar")
     @patch("streamlit.markdown")
     @patch("streamlit.container")
@@ -1061,7 +1061,7 @@ class TestReviewFiltering(unittest.TestCase):
                 break
         self.assertTrue(page_info_found, f"Pagination info not found in markdown calls. MD calls: {md_texts}")
 
-    @patch("src.database.get_session")
+    @patch("src.database.connection.get_session")
     @patch("streamlit.sidebar")
     @patch("streamlit.selectbox")
     @patch("streamlit.rerun")

--- a/tests/services/test_linguistic_service.py
+++ b/tests/services/test_linguistic_service.py
@@ -10,7 +10,8 @@ from sqlalchemy.orm import sessionmaker
 from src.database.base import Base
 from src.database.models.core import Language, Record, RecordLanguage, Source
 from src.database.models.identity import User
-from src.database.models.workflow import EditHistory
+from src.database.models.search import GlossSearchEntry, HeadwordSearchEntry, SearchEntry
+from src.database.models.workflow import EditHistory, MatchupQueue
 from src.services.linguistic_service import LinguisticService
 from src.services.statistics_service import StatisticsService
 
@@ -77,7 +78,10 @@ class TestLinguisticService(unittest.TestCase):
         with self.engine.connect() as conn:
             conn.execute(
                 text(
-                    "TRUNCATE edit_history, records, record_languages, users, languages, sources RESTART IDENTITY CASCADE;"
+                    "TRUNCATE matchup_queue, edit_history, "
+                    "search_entries, headword_search_entries, gloss_search_entries, "
+                    "records, record_languages, users, languages, sources "
+                    "RESTART IDENTITY CASCADE;"
                 )
             )
             conn.commit()
@@ -448,3 +452,124 @@ class TestLinguisticService(unittest.TestCase):
             recent = StatisticsService.get_recent_activity()
             self.assertEqual(len(recent), 1)
             self.assertEqual(recent[0]["lx"], "apple")
+
+    def test_hard_delete_record_with_search_entries(self):
+        record = Record(
+            lx="nup", hm=1, ps="v", ge="die", source_id=self.source_id, mdf_data="\\lx nup\n\\va nut\n\\ge die"
+        )
+        self.session.add(record)
+        self.session.commit()
+
+        se = SearchEntry(record_id=record.id, term="nup", normalized_term="nup", entry_type="lx")
+        hse_lx = HeadwordSearchEntry(record_id=record.id, term="nup", normalized_term="nup", entry_type="lx")
+        hse_va = HeadwordSearchEntry(record_id=record.id, term="nut", normalized_term="nut", entry_type="va")
+        gse = GlossSearchEntry(record_id=record.id, term="die", normalized_term="die")
+        self.session.add_all([se, hse_lx, hse_va, gse])
+        self.session.commit()
+
+        self.assertEqual(self.session.query(SearchEntry).filter_by(record_id=record.id).count(), 1)
+        self.assertEqual(self.session.query(HeadwordSearchEntry).filter_by(record_id=record.id).count(), 2)
+        self.assertEqual(self.session.query(GlossSearchEntry).filter_by(record_id=record.id).count(), 1)
+
+        with self._patch_session():
+            result = LinguisticService.hard_delete_record(record.id)
+
+        self.assertTrue(result)
+        self.session.expire_all()
+        self.assertIsNone(self.session.query(Record).filter_by(id=record.id).first())
+        self.assertEqual(self.session.query(SearchEntry).filter_by(record_id=record.id).count(), 0)
+        self.assertEqual(self.session.query(HeadwordSearchEntry).filter_by(record_id=record.id).count(), 0)
+        self.assertEqual(self.session.query(GlossSearchEntry).filter_by(record_id=record.id).count(), 0)
+
+    def test_hard_delete_record_with_edit_history(self):
+        record = Record(lx="histdel", source_id=self.source_id, mdf_data="\\lx histdel")
+        self.session.add(record)
+        self.session.commit()
+
+        h1 = EditHistory(
+            record_id=record.id,
+            user_email="editor@example.com",
+            version=1,
+            change_summary="Creation",
+            current_data="\\lx histdel",
+        )
+        h2 = EditHistory(
+            record_id=record.id,
+            user_email="editor@example.com",
+            version=2,
+            change_summary="Update",
+            current_data="\\lx histdel\n\\ge meaning",
+        )
+        self.session.add_all([h1, h2])
+        self.session.commit()
+
+        self.assertEqual(self.session.query(EditHistory).filter_by(record_id=record.id).count(), 2)
+
+        with self._patch_session():
+            result = LinguisticService.hard_delete_record(record.id)
+
+        self.assertTrue(result)
+        self.session.expire_all()
+        self.assertIsNone(self.session.query(Record).filter_by(id=record.id).first())
+        self.assertEqual(self.session.query(EditHistory).filter_by(record_id=record.id).count(), 0)
+
+    def test_hard_delete_record_cleans_headword_and_gloss(self):
+        record = Record(
+            lx="wôpan",
+            hm=1,
+            ps="n",
+            ge="light",
+            source_id=self.source_id,
+            mdf_data="\\lx wôpan\n\\va wôpanâk\n\\ge light",
+        )
+        self.session.add(record)
+        self.session.commit()
+
+        hse_lx = HeadwordSearchEntry(record_id=record.id, term="wôpan", normalized_term="wopan", entry_type="lx")
+        hse_va = HeadwordSearchEntry(record_id=record.id, term="wôpanâk", normalized_term="wopanak", entry_type="va")
+        gse = GlossSearchEntry(record_id=record.id, term="light", normalized_term="light")
+        self.session.add_all([hse_lx, hse_va, gse])
+        self.session.commit()
+
+        self.assertEqual(self.session.query(HeadwordSearchEntry).filter_by(record_id=record.id).count(), 2)
+        self.assertEqual(self.session.query(GlossSearchEntry).filter_by(record_id=record.id).count(), 1)
+
+        with self._patch_session():
+            result = LinguisticService.hard_delete_record(record.id)
+
+        self.assertTrue(result)
+        self.session.expire_all()
+        self.assertIsNone(self.session.query(Record).filter_by(id=record.id).first())
+        self.assertEqual(self.session.query(HeadwordSearchEntry).filter_by(record_id=record.id).count(), 0)
+        self.assertEqual(self.session.query(GlossSearchEntry).filter_by(record_id=record.id).count(), 0)
+
+    def test_hard_delete_record_nonexistent_returns_false(self):
+        with self._patch_session():
+            result = LinguisticService.hard_delete_record(99999)
+        self.assertFalse(result)
+
+    def test_hard_delete_record_nullifies_matchup_suggestion(self):
+        record1 = Record(lx="suggested", source_id=self.source_id, mdf_data="\\lx suggested")
+        record2 = Record(lx="to_delete", source_id=self.source_id, mdf_data="\\lx to_delete")
+        self.session.add_all([record1, record2])
+        self.session.commit()
+
+        queue_entry = MatchupQueue(
+            lx="word",
+            mdf_data="\\lx word",
+            suggested_record_id=record2.id,
+            batch_id="test-batch",
+            status="pending",
+        )
+        self.session.add(queue_entry)
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.hard_delete_record(record2.id)
+
+        self.assertTrue(result)
+        self.session.expire_all()
+        self.assertIsNone(self.session.query(Record).filter_by(id=record2.id).first())
+        updated_queue = self.session.query(MatchupQueue).filter_by(id=queue_entry.id).first()
+        self.assertIsNotNone(updated_queue)
+        self.assertIsNone(updated_queue.suggested_record_id)


### PR DESCRIPTION
**Summary:**

Fixes all remaining broken test mock paths after #758's re-export removal and adds comprehensive unit tests for `hard_delete_record` with search entry cleanup verification.

**Outcome:** All 34 `@patch` mock decorators in frontend tests now use the correct `src.database.connection.get_session` path. Hard-delete function is verified to properly clean all three search tables (SearchEntry, HeadwordSearchEntry, GlossSearchEntry) before deleting records.

Fixes #698
Fixes #758
Fixes #761