### PR TITLE
Batch implementation: 4 remaining issues (Apr 13, batch 2)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -127,6 +127,41 @@ Feature branches target `dev`. Compare URLs: `compare/dev...<branch-name>`. Only
 
 **See `080-code-standards.md` for complete attribution requirements (file types, formats, exceptions).**
 
+## Critical Violation: Offer-to-Edit Bypass — Offering to Modify Files Without Spec
+
+**⚠️ Offering to modify files without a spec is a CRITICAL GUIDELINE VIOLATION.**
+
+When the agent identifies a problem and the fix is clear, the ONLY permitted next action is creating a spec or reporting the finding. Never offer to edit, update, modify, or fix a file directly.
+
+| Pattern | Correct Action |
+|---------|---------------|
+| "Want me to update X?" | Create a spec for the update, HALT |
+| "Shall I fix this?" | Create a bug report or fix spec, HALT |
+| "I can change X to Y" | Create a spec for the change, HALT |
+| "Ready to implement?" | Create a spec first, then HALT |
+
+**Why this matters:** The offer-to-edit pattern is a rationalization bypass. The agent reasons: "I'm not *doing* the edit, I'm just *offering* — so I'm not violating the rule." But the offer normalizes direct edits and creates social pressure to authorize without a spec. The spec-first workflow exists precisely to prevent this.
+
+## Critical Violation: Hardcoded Identity Values in Skills and Guidelines
+
+**⚠️ Hardcoding agent names, model IDs, developer names, developer emails, org names, repo names, or platform names in skill files, guideline files, task files, or any AI agent configuration is a CRITICAL GUIDELINE VIOLATION.**
+
+All identity values MUST use placeholder tokens that are resolved at runtime from session init output. Hardcoded values become stale when models, agents, orgs, or repos change.
+
+- 🚫 FORBIDDEN: `OpenCode`, `OpenCode Desktop`, `Claude`, or any specific agent name in skill files, guidelines, or task files
+- 🚫 FORBIDDEN: `ollama-cloud/glm-5`, `claude-3-5-sonnet`, or any specific model ID in skill files, guidelines, or task files
+- 🚫 FORBIDDEN: `michael-conrad`, `muksihs`, or any specific developer name/email in skill files, guidelines, or task files
+- 🚫 FORBIDDEN: `Brothertown-Language`, `snea-shoebox-editor`, or any specific org/repo name in skill files, guidelines, or task files
+- ✅ REQUIRED: Use `<AI-Name>`, `<model-id>`, `<AgentName>`, `<ModelID>`, `DEV_NAME`, `DEV_EMAIL`, `GIT_OWNER`, `GIT_REPO` placeholders everywhere
+- ✅ REQUIRED: Skill-creator MUST validate that no hardcoded identity values appear in generated skill files
+- ✅ REQUIRED: Spec-auditor MUST flag hardcoded identity values as STRUCTURE-VIOLATION auto-fix findings
+
+**Applies to:** SKILL.md files, task/*.md files, guideline files, agent configuration files, code comments that serve as templates or examples.
+
+**Exempt from placeholders (concrete values are OK):** Python source code runtime strings, test fixtures, historical changelog entries, repository URLs in examples that use `<GIT_OWNER>/<GIT_REPO>` pattern.
+
+**See `080-code-standards.md` for the complete placeholder reference and `skill-creator/SKILL.md` for the validation gate.**
+
 ## Critical Violation: Missing Progress Reports
 
 **⚠️ Failing to report progress in chat after implementation is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -384,6 +384,15 @@ No feature creep: implement ONLY what is in the approved spec. No unapproved wor
 
 **See per-skill `tasks/completion.md` files and `.opencode/skills/completion-core/completion-core.md` for the shared completion operations.**
 
+## Critical Violation: Silent Agent Termination
+
+**⚠️ Agents that produce no output before stopping are a CRITICAL GUIDELINE VIOLATION.** If the agent halts, it MUST produce a status message explaining what was completed, what was attempted, and why the halt occurred.
+
+- 🚫 FORBIDDEN: Producing zero output before stopping; silently failing without error message; context overflow without reporting the overflow; tool failure without reporting the failure; ending a session with no summary of work done
+- ✅ REQUIRED: Every HALT MUST be preceded by a status message; every failure MUST be reported with the specific error; every context overflow MUST be reported with the specific cause; every completed task MUST produce an executive summary
+
+**See `020-go-prohibitions.md` for the complete halt requirements and `finishing-a-development-branch` skill for completion guarantees.**
+
 ## Critical Violation: Skipping Interdependency Analysis for Batch Approvals
 
 **⚠️ Processing multiple approved issues without interdependency analysis is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -162,6 +162,32 @@ All identity values MUST use placeholder tokens that are resolved at runtime fro
 
 **See `080-code-standards.md` for the complete placeholder reference and `skill-creator/SKILL.md` for the validation gate.**
 
+## Critical Violation: Implementation Without Spec — Expanding the Definition
+
+**⚠️ "Implementation" includes more than writing source code.** The spec-first rule applies to ALL file modifications that alter behavior, configuration, or enforcement.
+
+The following are ALL implementation actions that require an approved spec:
+
+| Action | Requires Spec? | Why |
+|--------|---------------|-----|
+| Writing Python code | ✅ Yes | Classic implementation |
+| Editing skill files (SKILL.md, task/*.md) | ✅ Yes | Alters agent enforcement behavior |
+| Editing guideline files | ✅ Yes | Alters agent constraints |
+| Editing configuration (pyproject.toml, .pre-commit-config.yaml) | ✅ Yes | Alters build/test behavior |
+| Editing TypeScript plugins (session-enforcement.ts) | ✅ Yes | Alters runtime enforcement |
+| Editing test files | ✅ Yes | Alters test suite behavior |
+| Creating new files of any type | ✅ Yes | Adds new behavior or content |
+| Fixing a typo in documentation | ❌ No | No behavioral change |
+| Formatting code (ruff format) | ❌ No | No behavioral change |
+
+**🚫 FORBIDDEN patterns (all require spec):**
+- "It's just a skill file" → Skill files alter agent enforcement. Spec required.
+- "It's just a guideline" → Guidelines alter agent constraints. Spec required.
+- "It's just a config change" → Config changes alter behavior. Spec required.
+- "It's a small fix" → Size doesn't matter. If it changes behavior, spec required.
+
+**See `010-approval-gate.md` for the complete authorization workflow.**
+
 ## Critical Violation: Missing Progress Reports
 
 **⚠️ Failing to report progress in chat after implementation is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -45,6 +45,7 @@
 
 - **Verify actual codebase state before acting.** When a GO names a specific phase, verify the actual codebase state of that phase's deliverables before taking any action — regardless of plan markers.
 - **SILENTLY HALT after a verified-complete phase.** If verification confirms a named phase is already fully and correctly implemented, report the verified findings and HALT without prompting.
+- **Every halt MUST produce a status message.** If the agent stops, it MUST output what was completed, what was attempted, and why it stopped. Zero output before stopping is a critical violation.
 
 ## 2. Iterative Feedback & Plan Revision
 

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -33,6 +33,7 @@
 - **Questions are NOT authorization.** "Should I do X?" and "Would you like me to X?" are questions seeking permission, not receiving it. Never act on a question — wait for explicit authorization.
 - **SILENTLY HALT after every task/report.** Factual reporting is permitted, but it must NEVER be followed by a prompt for next steps.
 - **Never name the next phase or action in a halt message.** Halt messages must be factual statements about what was completed — never forward-looking references to what comes next.
+- **No "offer to edit" patterns.** The agent MUST NOT offer to edit, update, modify, or fix a file directly. Instead, create a spec or bug report. Patterns like "Want me to update X?", "Shall I fix this?", "I can change X to Y" are PROHIBITED — they bypass the spec-first workflow.
 - **Never self-answer a solicitation.** Pose no questions that you then answer yourself to bypass authorization.
 
 ### ⚠️ ASK FIRST

--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -194,7 +194,7 @@ Co-authored with AI: <AI-Name> (<model-id>)
 **Example:**
 
 ```
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)
 ```
 
 ### Repository Creation
@@ -206,8 +206,8 @@ When creating a new repository, the README MUST include:
 
 This repository was created with assistance from AI:
 
-- **AI Agent**: OpenCode
-- **Model**: ollama-cloud/glm-5
+- **AI Agent**: <AI-Name>
+- **Model**: <model-id>
 - **Date**: YYYY-MM-DD
 ```
 
@@ -220,7 +220,7 @@ Every Python file with original AI-authored code MUST include attribution in the
 ```python
 """Module description.
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)
 """
 ```
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -97,6 +97,7 @@ Already implemented
 | **Open questions resolved** | No unresolved items in spec |
 | **Sub-issues verified** | Multi-task specs require phase-level sub-issues |
 | **Fix spec for bug reports** | Bug reports must have a fix spec sub-issue before closure (per `000-critical-rules.md`) |
+| **Implementation includes** | All file modifications that alter behavior: source code, skill files, guideline files, config files, test files, TypeScript plugins |
 
 ## Fix Spec Verification for Bug Reports
 

--- a/.opencode/skills/approval-gate/tasks/completion.md
+++ b/.opencode/skills/approval-gate/tasks/completion.md
@@ -24,6 +24,15 @@ Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
 
 Before adding or removing labels in completion, consult `141-planning-status-tracking.md §10` for the complete label transition matrix and the GitHub `labels` parameter warning (replaces all labels, not additive).
 
+## Completion Guarantee
+
+**MANDATORY:** Regardless of authorization outcome (approved, rejected, blocked, error), produce a status message containing:
+1. Authorization decision (approved/rejected/blocked)
+2. Issue number and branch (if applicable)
+3. What happens next (workflow forward, HALT, or error)
+
+This is the completion guarantee: NO authorization check ends without a status message.
+
 ## Report Phase
 
 Generate executive summary in chat:

--- a/.opencode/skills/approval-gate/tasks/verify-qa-mode.md
+++ b/.opencode/skills/approval-gate/tasks/verify-qa-mode.md
@@ -40,6 +40,7 @@ Check if user instruction contains implementation-related keywords:
 - Refactor, refactor X, clean up X
 - Optimize, optimize X, improve X
 - Want me to, shall I, I can change, I can update, I can fix, I can modify
+- Edit the skill, update the guideline, fix the skill file, update the guideline file, modify SKILL.md
 
 **Offer-to-Edit Patterns (ALSO require gate):**
 Phrases that offer to make changes without going through the spec workflow:

--- a/.opencode/skills/approval-gate/tasks/verify-qa-mode.md
+++ b/.opencode/skills/approval-gate/tasks/verify-qa-mode.md
@@ -39,6 +39,15 @@ Check if user instruction contains implementation-related keywords:
 - Remove, remove X, delete X
 - Refactor, refactor X, clean up X
 - Optimize, optimize X, improve X
+- Want me to, shall I, I can change, I can update, I can fix, I can modify
+
+**Offer-to-Edit Patterns (ALSO require gate):**
+Phrases that offer to make changes without going through the spec workflow:
+- "Want me to update X?" → Redirect to spec creation, HALT
+- "Shall I fix this?" → Redirect to bug report or fix spec, HALT
+- "I can change X to Y" → Redirect to spec creation, HALT
+- "Ready to implement?" → Redirect to spec creation, HALT
+- "I'll just update this" → Redirect to spec creation, HALT
 
 **Spec/Planning Keywords (skip gate):**
 - Create a spec, create an issue, create a bug report

--- a/.opencode/skills/finishing-a-development-branch/tasks/completion.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/completion.md
@@ -25,6 +25,16 @@ Reference `.opencode/skills/completion-core/completion-core.md` for steps 3-6:
 3. Post status comment on issue (with idempotency check)
 4. Report executive summary in chat (always runs)
 
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, failure, error, early termination), produce a status message containing:
+1. What was completed
+2. What was attempted
+3. Why the halt occurred (if not explicit completion)
+4. Current branch state (if applicable)
+
+This is the completion guarantee: NO workflow ends without a status message. The completion task is idempotent and safe to invoke multiple times.
+
 ## Report Phase
 
 Generate executive summary in chat:

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -131,6 +131,40 @@ The `validate` task (`quick_validate.py`) SHOULD check for:
 
 **Rationale:** Sub-agents that don't receive worktree context silently modify the main repo instead of the feature branch. This is a context window safety issue (see #741).
 
+## Placeholder Enforcement Requirement (MANDATORY)
+
+**All new and updated skills MUST NOT contain hardcoded identity values.** This is a mandatory quality gate for the `validate` task.
+
+### Required in every skill that:
+
+1. **References AI agents** — MUST use `<AI-Name>` and `<model-id>` placeholders, never specific names like `OpenCode` or `Claude`
+2. **References developers** — MUST use `DEV_NAME` and `DEV_EMAIL` from session init, never specific names like `michael-conrad`
+3. **References organizations/repos** — MUST use `GIT_OWNER` and `GIT_REPO` from session init, never specific names like `Brothertown-Language`
+4. **Contains bylines or attribution** — MUST use `<AI-Name> (<model-id>)` format, never specific agent/model combinations
+
+### Validation Gate
+
+The `validate` task (`quick_validate.py`) SHOULD check for and flag:
+- Specific agent names (`OpenCode`, `Claude`, `GPT-4`, etc.) in SKILL.md or task files
+- Specific model IDs (`ollama-cloud/glm-5`, `claude-3-5-sonnet`, etc.) in SKILL.md or task files
+- Specific developer names or emails in SKILL.md or task files
+- Specific org/repo names in SKILL.md or task files (except in examples using the `<GIT_OWNER>/<GIT_REPO>` pattern)
+- Specific platform URLs in SKILL.md or task files (except in examples using session init variable references)
+
+### Placeholder Reference
+
+| Value Type | Placeholder | Source |
+|-----------|-------------|--------|
+| AI agent name | `<AI-Name>` or `<AgentName>` | System prompt identity detection |
+| AI model ID | `<model-id>` or `<ModelID>` | System prompt identity detection |
+| Developer name | `DEV_NAME` | Session init |
+| Developer email | `DEV_EMAIL` | Session init |
+| Organization | `GIT_OWNER` | Session init |
+| Repository | `GIT_REPO` | Session init |
+| Platform | `GIT_PLATFORM` | Session init |
+| GitHub URL | `GITHUB_HTML_URL` | Session init |
+| GitBucket URL | `GITBUCKET_HTML_URL` | Session init |
+
 ## Session Init Variable Alignment Requirement
 
 Skills and guidelines reference session-init variables by exact name (e.g., `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`). These names MUST match the `KEY: value` output of `.opencode/tools/session-init` exactly 1:1.

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-auditor
-description: Use when auditing a spec for quality, structure, or completeness. Triggers on: audit spec, review spec, spec quality, validate spec, check spec, audit issue, revisit spec.
+description: Use when auditing a spec for quality, structure, or completeness. Triggers on: audit spec, review spec, spec quality, validate spec, check spec, audit issue, revisit spec, audit plan, audit runbook, audit SOP, audit checklist, audit document, content-aware audit.
 type: discipline-enforcing
 license: MIT
 compatibility: opencode
@@ -10,15 +10,17 @@ compatibility: opencode
 
 ## Overview
 
-Single audit orchestrator entry point for spec quality. Determines which subtasks to run based on the issue's nature, runs the minimal baseline always, and applies auto-fixes for safe findings while flagging ambiguous findings for review.
+Content-aware audit orchestrator that accepts any document type. Determines document type automatically (or via manual override), selects appropriate subtasks, runs the minimal baseline always, and applies auto-fixes for safe findings while flagging ambiguous findings for review.
 
 **Core v2 shift:** Spec-auditor is now the orchestrator. Plan-fidelity-auditor and concern-separation-auditor are no longer invoked directly — their logic lives as subtasks (`fidelity` and `concerns`) within spec-auditor.
 
 **v3 shift:** Spec-auditor now uses an auto-fix model with three-tier classification instead of the previous report-only approach. Safe findings are fixed directly; ambiguous findings are flagged for developer review.
 
+**v4 shift:** Spec-auditor now supports content-aware auditing. Input can come from issues, files, or URLs. Document type is autodetected and subtask selection is tailored per type. Three new operational subtasks (`operational-flow`, `determinism`, `error-recovery`) support process flows, runbooks, and SOPs.
+
 ## Persona
 
-You are a Spec Quality Orchestrator. Your focus is determining what to audit, running the appropriate subtasks, auto-fixing safe findings, flagging ambiguous findings for review, and presenting an executive summary of all actions taken.
+You are a Content-Aware Audit Orchestrator. Your focus is determining document type, selecting appropriate subtasks, auto-fixing safe findings, flagging ambiguous findings for review, and presenting an executive summary of all actions taken.
 
 ## Tasks
 
@@ -31,46 +33,102 @@ You are a Spec Quality Orchestrator. Your focus is determining what to audit, ru
 | `operational` | Logging, metrics, deployment completeness | ~300 |
 | `fidelity` | Clean-room plan comparison | ~600 |
 | `concerns` | Phase structure, deployment independence | ~400 |
+| `operational-flow` | Process flow / runbook operational checks | ~400 |
+| `determinism` | Deterministic behavior and state dependency checks | ~300 |
+| `error-recovery` | Runbook error recovery and rollback checks | ~350 |
 
 ## Invocation
 
-- `/skill spec-auditor --issue N` — Full audit (determine subtasks automatically)
+- `/skill spec-auditor --issue N` — Full audit of a GitHub Issue (determine subtasks automatically)
+- `/skill spec-auditor --file path` — Full audit of a local file (determine subtasks automatically)
+- `/skill spec-auditor --url URL` — Full audit of a URL (determine subtasks automatically)
 - `/skill spec-auditor --issue N --task fresh-start` — Self-containment checks only
 - `/skill spec-auditor --issue N --task structure` — Structure checks only
 - `/skill spec-auditor --issue N --task fidelity` — Clean-room comparison only
 - `/skill spec-auditor --issue N --task concerns` — Phase structure checks only
+- `/skill spec-auditor --file path --type plan` — Audit with manual type override
+- `/skill spec-auditor --url URL --type runbook` — Audit with manual type override
 - `/skill spec-auditor` — Overview only
+
+One of `--issue`, `--file`, or `--url` is mandatory (except for overview mode). Use `--type` to override autodetected document type. Use `--task` to run a single subtask.
 
 ## Operating Protocol
 
-1. **Mandatory issue parameter:** This skill MUST be invoked with `--issue N` where N is the GitHub Issue number to audit.
+1. **Mandatory input parameter:** This skill MUST be invoked with one of `--issue N`, `--file path`, or `--url URL` (except overview mode). The content source determines how to read the document.
 
-2. **Subtask determination:** When invoked without `--task`, the agent determines which subtasks to run:
-   - **Baseline (always runs):** `fresh-start`, `structure`, `fidelity`
-   - **Conditional (agent decides based on issue nature):** `content-quality`, `traceability`, `operational`, `concerns`
+2. **Document type autodetection:** When invoked without `--type`, the agent detects the document type from content signals:
 
-3. **Conditional subtask selection guidance:**
+   **Signal table:**
 
-| Issue Type | Typically Relevant Subtasks |
-|------------|---------------------------|
-| Simple bug fix | Baseline only |
-| Feature with phases | Baseline + `concerns` |
-| Infrastructure change | Baseline + `operational` + `concerns` |
-| Complex multi-phase spec | All subtasks |
-| Spec with external dependencies | Baseline + `traceability` + `operational` |
-| Single-task spec (no phases) | Baseline (skip `concerns`) |
+   | Signal | Type Suggested | Weight |
+   |--------|---------------|--------|
+   | `STATUS:` header with phase.step format | Spec | 3 |
+   | Phase/step numbering (`1.1`, `1.2`, `2.1`) | Spec | 2 |
+   | Success criteria section | Spec | 2 |
+   | `STATUS:` header without approval tracking | Plan | 2 |
+   | Milestone/deliverable structure | Plan | 2 |
+   | Sequential numbered steps (imperative mood) | Process Flow | 3 |
+   | Step result feeds next step input | Process Flow | 2 |
+   | "Runbook" or "SOP" in title or header | Runbook/SOP | 3 |
+   | Prerequisites section | Runbook/SOP | 1 |
+   | Error recovery / rollback sections | Runbook/SOP | 2 |
+   | Checkbox list (`- [ ]`, `- [x]`) | Checklist | 3 |
+   | Flat list of items without phases | Checklist | 2 |
+   | Reference table, API documentation | Reference Doc | 3 |
+   | No phases, no steps, no criteria | Reference Doc | 1 |
+
+   **Scoring algorithm:**
+   - Sum weights for each type from matching signals
+   - Highest total score wins
+   - Ties: prefer more specific type (Spec > Plan > Process Flow > Runbook/SOP > Checklist > Reference Doc)
+
+   **Confidence levels:**
+
+   | Confidence | Condition | Action |
+   |------------|-----------|--------|
+   | High | Single type score ≥ 5 AND ≥ 3 points above runner-up | Proceed with detected type |
+   | Medium | Single type score ≥ 5 AND 1–2 points above runner-up | Proceed but note medium confidence in summary |
+   | Low | Two or more types within 2 points, or top score 3–4 | Flag for user to confirm type before auditing |
+   | None | Empty or unparseable content | Error out — cannot audit |
+
+   **Manual override:** `--type <type>` bypasses autodetection. Valid types: `spec`, `plan`, `process-flow`, `runbook`, `checklist`, `reference-doc`.
+
+3. **Subtask determination:** When invoked without `--task`, the agent determines which subtasks to run based on document type:
+
+   | Document Type | Baseline Subtasks | Conditional Subtasks |
+   |---------------|-------------------|---------------------|
+   | Spec | `fresh-start`, `structure`, `fidelity` | `content-quality`, `traceability`, `operational`, `concerns` |
+   | Plan | `fresh-start`, `structure` | `content-quality`, `concerns` |
+   | Process Flow | `fresh-start`, `structure` (adapted) | `operational-flow`, `determinism` |
+   | Runbook/SOP | `fresh-start`, `structure` (adapted) | `operational-flow`, `determinism`, `error-recovery` |
+   | Checklist | `fresh-start`, `structure` (adapted) | — |
+   | Reference Doc | `fresh-start` | — |
+
+   **Conditional subtask selection guidance (Spec-type only):**
+
+   | Issue Type | Typically Relevant Subtasks |
+   |------------|---------------------------|
+   | Simple bug fix | Baseline only |
+   | Feature with phases | Baseline + `concerns` |
+   | Infrastructure change | Baseline + `operational` + `concerns` |
+   | Complex multi-phase spec | All subtasks |
+   | Spec with external dependencies | Baseline + `traceability` + `operational` |
+   | Single-task spec (no phases) | Baseline (skip `concerns`) |
 
 4. **All findings are classified and acted on per the auto-fix model.** Safe findings are fixed directly; ambiguous findings are flagged for developer review.
 
 5. **After all subtasks complete, produce a chat executive summary** per the `Chat Executive Summary` section below.
 
-## Minimal Baseline (Always Runs)
+## Minimal Baseline (Varies by Document Type)
 
-| Subtask | What It Checks | Why Always |
-|---------|----------------|------------|
-| `fresh-start` | Self-containment of spec content | Every spec must be understandable without prior context |
-| `structure` | STATUS headers, phase/step numbering, markers | Every spec needs proper structure |
-| `fidelity` | Clean-room plan comparison | Every spec should faithfully address its problem |
+| Document Type | Baseline Subtasks | Why These |
+|---------------|-------------------|-----------|
+| Spec | `fresh-start`, `structure`, `fidelity` | Every spec must be self-contained, properly structured, and faithful to its problem |
+| Plan | `fresh-start`, `structure` | Plans need self-containment and structure; `fidelity` applies only to specs |
+| Process Flow | `fresh-start`, `structure` (adapted) | Flows need self-containment and adapted structure checks |
+| Runbook/SOP | `fresh-start`, `structure` (adapted) | Runbooks need self-containment and adapted structure checks |
+| Checklist | `fresh-start`, `structure` (adapted) | Checklists need self-containment and adapted structure checks |
+| Reference Doc | `fresh-start` | Reference docs only need self-containment checks |
 
 ## Auto-Fix Model (CRITICAL)
 
@@ -98,6 +156,9 @@ This is a v3 core principle. Previous versions (v2) were report-only — finding
 | FRESH-START-VIOLATION | Inline context, replace "see above" with actual content | Self-containment is always correct; removes ambiguity |
 | DEPENDENCY-INCOMPLETE | Add specific integration points | Precision is always better than vagueness |
 | APPROACH_DIFFERENCE | Add missing approach or clarify difference | Fidelity to the clean-room plan is always desirable |
+| OPERATIONAL-FLOW-GAP | Add placeholder for missing error recovery, I/O contract, or rollback step | Placeholder doesn't change semantics; developer fills in |
+| DETERMINISM-VIOLATION | Add explicit environment assumptions and state dependency notes | Explicitness is always correct; removes ambiguity |
+| ERROR-RECOVERY-GAP | Add prerequisites, scope, escalation, and version stub sections | Standard boilerplate for runbooks; developer fills in |
 
 **Conditional findings:**
 
@@ -141,13 +202,16 @@ The orchestrator delegates to these subtasks:
 
 ```
 spec-auditor (orchestrator)
-├── fresh-start.md    — Self-containment checks
-├── structure.md       — STATUS, numbering, markers
-├── content-quality.md — Reasoning, ambiguity, conflicts, scope
-├── traceability.md    — Orphan requirements/features (NEW)
-├── operational.md    — Logging, metrics, deployment (NEW)
-├── fidelity.md       — Clean-room plan comparison (delegated from plan-fidelity-auditor)
-└── concerns.md       — Phase structure, independence (delegated from concern-separation-auditor)
+├── fresh-start.md         — Self-containment checks
+├── structure.md            — STATUS, numbering, markers (adapted for non-spec types)
+├── content-quality.md      — Reasoning, ambiguity, conflicts, scope
+├── traceability.md         — Orphan requirements/features
+├── operational.md           — Logging, metrics, deployment
+├── fidelity.md             — Clean-room plan comparison (delegated from plan-fidelity-auditor)
+├── concerns.md             — Phase structure, independence (delegated from concern-separation-auditor)
+├── operational-flow.md     — Process flow / runbook operational checks (NEW)
+├── determinism.md          — Deterministic behavior and state dependency checks (NEW)
+└── error-recovery.md       — Runbook error recovery and rollback checks (NEW)
 ```
 
 Each subtask is loaded via `--task` and produces findings in the report format above.
@@ -173,6 +237,9 @@ Existing classes remain, plus two new ones:
 | DEPENDENCY-INCOMPLETE | Missing integration points |
 | **MISSING-TRACEABILITY** | Requirements/features without trace links (NEW) |
 | **OPERATIONAL-REQUIREMENTS-INCOMPLETE** | Missing logging/metrics/deployment (NEW) |
+| **OPERATIONAL-FLOW-GAP** | Missing error recovery, I/O contracts, idempotency, or rollback in process flows |
+| **DETERMINISM-VIOLATION** | Hidden non-determinism, unstated environment assumptions, undocumented state dependencies |
+| **ERROR-RECOVERY-GAP** | Missing prerequisites, scope, escalation contacts, versioning, or validation gates in runbooks |
 
 ## Audit Findings Handling
 
@@ -202,7 +269,10 @@ After the audit session completes, findings are acted on per the auto-fix model:
 
 **Format:**
 ```
-## Spec Audit: #N — [spec title]
+## Content Audit: [source identifier] — [document title]
+
+**Document Type:** [Spec|Plan|Process Flow|Runbook/SOP|Checklist|Reference Doc] (confidence: [High|Medium|Low])
+**Source:** [--issue N|--file path|--url URL]
 
 **Changes Made:**
 - [subtask] [problem-class]: [what was fixed] (auto-fix)
@@ -213,14 +283,14 @@ After the audit session completes, findings are acted on per the auto-fix model:
 - [subtask] [problem-class]: [summary] — [reason not acted on] (flag-for-review)
 - (or "None" if all findings were auto-fixed or conditionally fixed)
 
-**Issue:** [URL of the audited issue]
+**Issue:** [URL of the audited issue, if applicable]
 ```
 
 **Rules:**
 - Executive summary goes to chat ONLY, not GitHub comments
 - Changes Made lists ALL auto-fix and conditional fix actions in summary form
 - Findings Not Acted On lists ALL flag-for-review findings with the specific reason they weren't auto-fixed
-- If audit finds zero issues, output: `## Spec Audit: #N — [spec title] — No findings. Issue: [URL]`
+- If audit finds zero issues, output: `## Content Audit: [source] — [title] — No findings. Type: [type] (confidence: [level]). Issue: [URL if applicable]`
 - Issue URL is constructed from session init values (`GIT_OWNER`, `GIT_REPO`)
 
 ## Mandatory Invocation
@@ -229,21 +299,26 @@ After the audit session completes, findings are acted on per the auto-fix model:
 
 When creating a GitHub Issue `[SPEC]`, the AI agent MUST:
 1. Create the spec issue with all required content
-2. Invoke `/skill spec-auditor --issue N` (orchestrator determines subtasks)
+2. Invoke `/skill spec-auditor --issue N` (orchestrator determines type and subtasks)
 3. Auto-fix findings are applied directly; flag-for-review findings remain in executive summary for developer action
 4. Add `needs-approval` label
 5. Post "ready for review" comment ONLY if substantive spec changes were made during step 3 (auto-fixes of structure/boilerplate are non-substantive)
+
+When auditing a plan, runbook, process flow, checklist, or reference document, use `--file path` or `--url URL` as appropriate.
 
 **Skipping the orchestrator is a CRITICAL GUIDELINE VIOLATION.**
 
 ## Scope Boundaries
 
-- Read-only analysis of GitHub Issue `[SPEC]` specs, plus auto-fix of safe findings
-- Edits limited to spec content via GitHub Issue updates (auto-fixes applied directly)
+- Read-only analysis of GitHub Issues, local files, or URLs, plus auto-fix of safe findings
+- Edits limited to spec content via GitHub Issue updates (auto-fixes applied directly); file/URL sources are read-only
 - Flag-for-review findings reported in executive summary but NOT applied
 - No changes to project source code, scripts, or notebooks
 - No new specs, expansions, or "improvements" beyond what findings require
 - Must use GitHub MCP tools for all issue operations
+- Document type autodetection uses signal scoring; Low confidence requires user confirmation before proceeding
+- None confidence (empty/unparseable content) produces an error — cannot audit
+- **Backward compatibility:** `--issue N` produces identical results to previous behavior
 - **Worktree awareness check:** Skills that perform git operations, read/write files, or dispatch sub-agents MUST include a "Worktree Mode" section and pass `WORKTREE_PATH` in sub-agent dispatch contexts. Missing worktree awareness is a medium-severity finding.
 
 ## Sub-Agent Spawning
@@ -268,20 +343,23 @@ This skill is a **heavy skill** — quality audits with all subtasks consume sig
 
 ## Key Differences from v1
 
-| v1 (Fixed Chain) | v2 (Orchestrator) | v3 (Auto-Fix Orchestrator) |
-|------------------|-------------------|---------------------------|
-| Three separate auditor skills | Single orchestrator with subtasks | Single orchestrator with subtasks |
-| All auditors always run | Agent decides conditional subtasks | Agent decides conditional subtasks |
-| Baseline runs every time | Baseline always runs (fresh-start, structure, fidelity) | Baseline always runs (fresh-start, structure, fidelity) |
-| Auto-fixes applied automatically | Findings reported, agent decides | Three-tier classification: auto-fix, conditional, flag-for-review |
-| No traceability check | `traceability` subtask (NEW) | `traceability` subtask |
-| No operational requirements check | `operational` subtask (NEW) | `operational` subtask |
-| plan-fidelity-auditor invoked directly | `fidelity` subtask delegated | `fidelity` subtask delegated |
-| concern-separation-auditor invoked directly | `concerns` subtask delegated | `concerns` subtask delegated |
-| No executive summary | No executive summary | Chat executive summary mandatory |
-| Report format: Recommendation field | Report format: Recommendation field | Report format: Classification + Fix Action fields |
+| v1 (Fixed Chain) | v2 (Orchestrator) | v3 (Auto-Fix Orchestrator) | v4 (Content-Aware) |
+|------------------|-------------------|---------------------------|-------------------|
+| Three separate auditor skills | Single orchestrator with subtasks | Single orchestrator with subtasks | Single orchestrator with subtasks |
+| All auditors always run | Agent decides conditional subtasks | Agent decides conditional subtasks | Agent decides conditional subtasks per document type |
+| Baseline runs every time | Baseline always runs (fresh-start, structure, fidelity) | Baseline always runs (fresh-start, structure, fidelity) | Baseline varies by document type |
+| Auto-fixes applied automatically | Findings reported, agent decides | Three-tier classification: auto-fix, conditional, flag-for-review | Three-tier classification (unchanged) |
+| No traceability check | `traceability` subtask (NEW) | `traceability` subtask | `traceability` subtask |
+| No operational requirements check | `operational` subtask (NEW) | `operational` subtask | `operational` subtask |
+| plan-fidelity-auditor invoked directly | `fidelity` subtask delegated | `fidelity` subtask delegated | `fidelity` subtask delegated |
+| concern-separation-auditor invoked directly | `concerns` subtask delegated | `concerns` subtask delegated | `concerns` subtask delegated |
+| No executive summary | No executive summary | Chat executive summary mandatory | Chat executive summary mandatory, includes document type |
+| Report format: Recommendation field | Report format: Recommendation field | Report format: Classification + Fix Action fields | Report format: Classification + Fix Action fields |
+| Issue-only input | Issue-only input | Issue-only input | `--issue`, `--file`, `--url` input |
+| No type detection | No type detection | No type detection | Signal-based autodetection + `--type` override |
+| Spec-only auditing | Spec-only auditing | Spec-only auditing | Multi-type: spec, plan, process-flow, runbook, checklist, reference-doc |
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)
 
 ## Symbolic Engine Integration
 

--- a/.opencode/skills/spec-auditor/tasks/concerns.md
+++ b/.opencode/skills/spec-auditor/tasks/concerns.md
@@ -76,4 +76,4 @@ Severity: [HIGH|MEDIUM|LOW]
 - Single-task specs (no phases to analyze)
 - Simple bug fixes with one phase
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/content-quality.md
+++ b/.opencode/skills/spec-auditor/tasks/content-quality.md
@@ -66,4 +66,4 @@ Severity: [HIGH|MEDIUM|LOW]
 | SUPERSEDED-CLOSURE-VIOLATION | flag-for-review | May reference valid future work |
 | ARCHITECTURAL-REASONING-GAP | flag-for-review | Requires understanding design tradeoffs |
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/determinism.md
+++ b/.opencode/skills/spec-auditor/tasks/determinism.md
@@ -1,0 +1,51 @@
+# Task: determinism
+
+## Purpose
+
+Check process flow, runbook, and SOP documents for deterministic behavior: same inputs produce same outputs, no hidden non-determinism, environment assumptions are explicit, and state dependencies are documented.
+
+**Applicable document types:** Process Flow, Runbook/SOP
+
+## Checks
+
+| Check | Problem Class | Description |
+|-------|---------------|-------------|
+| Input/output determinism | DETERMINISM-VIOLATION | Same inputs → same outputs for every step |
+| Hidden non-determinism | DETERMINISM-VIOLATION | No timestamps, random values, or external state used as decision inputs |
+| Environment assumptions | DETERMINISM-VIOLATION | Environment requirements stated explicitly (OS, versions, configs) |
+| State dependencies | DETERMINISM-VIOLATION | State dependencies between steps are documented |
+
+## Procedure
+
+1. Read the document from issue, file, or URL source
+2. Confirm document type is Process Flow or Runbook/SOP (skip otherwise)
+3. For each step:
+   - Verify that given the same inputs, the step produces the same outputs
+   - Check for use of `Date.now()`, `Math.random()`, external API responses, or current timestamps as decision inputs
+   - Verify environment requirements are stated (e.g., Python 3.12, Docker 24.x)
+4. For cross-step dependencies:
+   - Verify state that carries between steps is explicitly documented
+   - Verify no implicit state assumptions (e.g., "the file from step 2" must name the file)
+5. Create findings for each violation
+
+## Report Format
+
+```
+Subtask: determinism
+Finding: DETERMINISM-VIOLATION - [summary]
+Location: [step or section]
+Context: [why determinism matters for this document type]
+Classification: [auto-fix|conditional|flag-for-review]
+Fix Action: [what was done OR "flagged for review — [reason]"]
+Severity: [HIGH|MEDIUM|LOW]
+```
+
+## Auto-Fix Classification
+
+| Problem Class | Classification | Fix Action |
+|---------------|---------------|------------|
+| DETERMINISM-VIOLATION (missing environment assumptions) | auto-fix | Add placeholder "Environment: [specify required versions/configs]" |
+| DETERMINISM-VIOLATION (undocumented state dependency) | auto-fix | Add explicit state dependency note between steps |
+| DETERMINISM-VIOLATION (non-deterministic step) | flag-for-review | Non-determinism may be intentional; requires domain judgment |
+
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/error-recovery.md
+++ b/.opencode/skills/spec-auditor/tasks/error-recovery.md
@@ -1,0 +1,63 @@
+# Task: error-recovery
+
+## Purpose
+
+Check runbook and SOP documents for error recovery and rollback completeness: prerequisites, scope, contact/escalation, version/date, and validation gates.
+
+**Applicable document types:** Runbook/SOP
+
+## Checks
+
+| Check | Problem Class | Description |
+|-------|---------------|-------------|
+| Prerequisites | ERROR-RECOVERY-GAP | Tools, access, and credentials needed before starting are listed |
+| Scope | ERROR-RECOVERY-GAP | What this runbook covers and what it doesn't is stated |
+| Contact/escalation | ERROR-RECOVERY-GAP | Who to call when things go wrong is documented |
+| Version/date | ERROR-RECOVERY-GAP | When this was last validated is recorded |
+| Validation gate | ERROR-RECOVERY-GAP | How to confirm the procedure succeeded is specified |
+
+## Procedure
+
+1. Read the document from issue, file, or URL source
+2. Confirm document type is Runbook/SOP (skip otherwise)
+3. Check for prerequisites section:
+   - Required tools and their versions
+   - Required access levels or credentials
+   - Required environment state (e.g., "database must be backed up")
+4. Check for scope definition:
+   - What this runbook covers
+   - What it does NOT cover (out of scope)
+5. Check for contact/escalation:
+   - Primary contact for questions
+   - Escalation path for failures outside runbook scope
+6. Check for version/date:
+   - Last validation date
+   - Version number if applicable
+7. Check for validation gate at end:
+   - How to verify the procedure succeeded
+   - What "success" looks like (specific, measurable criteria)
+8. Create findings for each missing element
+
+## Report Format
+
+```
+Subtask: error-recovery
+Finding: ERROR-RECOVERY-GAP - [summary]
+Location: [section or "absent from document"]
+Context: [why this matters for runbook reliability]
+Classification: [auto-fix|conditional|flag-for-review]
+Fix Action: [what was done OR "flagged for review — [reason]"]
+Severity: [HIGH|MEDIUM|LOW]
+```
+
+## Auto-Fix Classification
+
+| Problem Class | Classification | Fix Action |
+|---------------|---------------|------------|
+| ERROR-RECOVERY-GAP (missing prerequisites) | auto-fix | Add "## Prerequisites" stub with checklist template |
+| ERROR-RECOVERY-GAP (missing scope) | auto-fix | Add "## Scope" stub with "In scope" / "Out of scope" template |
+| ERROR-RECOVERY-GAP (missing escalation) | auto-fix | Add "## Escalation" stub with contact template |
+| ERROR-RECOVERY-GAP (missing version/date) | auto-fix | Add `Last Validated: [date]` header |
+| ERROR-RECOVERY-GAP (missing validation gate) | auto-fix | Add "## Validation" stub with success criteria template |
+
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/fidelity.md
+++ b/.opencode/skills/spec-auditor/tasks/fidelity.md
@@ -116,4 +116,4 @@ If clean-room generation fails:
 - Clean-room plan is a comparison artifact only
 - Must use GitHub MCP tools for issue operations
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/fresh-start.md
+++ b/.opencode/skills/spec-auditor/tasks/fresh-start.md
@@ -2,7 +2,15 @@
 
 ## Purpose
 
-Check that a spec is self-contained and understandable by an agent with no memory context. No "see above", no vague references, no assumptions about prior conversations.
+Check that a document is self-contained and understandable by an agent with no memory context. No "see above", no vague references, no assumptions about prior conversations.
+
+**Note for non-spec document types:** Self-containment checks focus on the document type's specific requirements:
+- **Spec:** Full self-containment — all context inline, no external references without summaries
+- **Plan:** Milestones and deliverables must be self-contained; cross-references to specs must include summaries
+- **Process Flow:** Each step's inputs and outputs must be explicitly stated; no assumed knowledge of tool locations or credentials
+- **Runbook/SOP:** Prerequisites, tools, and credentials must be listed; no assumed environment knowledge
+- **Checklist:** Items must be self-explanatory; no ambiguous shorthand
+- **Reference Doc:** Definitions and context must be included; cross-references must have summaries
 
 ## Checks
 
@@ -49,4 +57,4 @@ Per guidelines `045-open-questions.md` and `140-planning-spec-creation.md`:
 - File references must use stable anchors
 - Cross-references must include summaries
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/operational-flow.md
+++ b/.opencode/skills/spec-auditor/tasks/operational-flow.md
@@ -1,0 +1,55 @@
+# Task: operational-flow
+
+## Purpose
+
+Check process flow and runbook documents for operational completeness: error recovery paths, input/output contracts, idempotency, sequential correctness, pause/resume capability, and rollback paths.
+
+**Applicable document types:** Process Flow, Runbook/SOP
+
+## Checks
+
+| Check | Problem Class | Description |
+|-------|---------------|-------------|
+| Error recovery | OPERATIONAL-FLOW-GAP | Every step has a "what if this fails" path |
+| Input/output contracts | OPERATIONAL-FLOW-GAP | Each step's outputs feed the next step's inputs |
+| Idempotency | OPERATIONAL-FLOW-GAP | Can any step be safely re-run? |
+| Sequential correctness | OPERATIONAL-FLOW-GAP | Are steps in dependency order? |
+| Pause/resume | OPERATIONAL-FLOW-GAP | Can the operator stop and resume between steps? |
+| Rollback | OPERATIONAL-FLOW-GAP | Is there a rollback path from any step? |
+
+## Procedure
+
+1. Read the document from issue, file, or URL source
+2. Confirm document type is Process Flow or Runbook/SOP (skip otherwise)
+3. For each step in the document:
+   - Verify an error recovery path exists (what to do if this step fails)
+   - Verify inputs and outputs are explicitly stated
+   - Check if the step can be safely re-run if interrupted
+4. Verify global properties:
+   - Steps are in correct dependency order (no forward dependencies)
+   - Pause/resume points are identifiable
+   - Rollback paths exist from any step to a known-good state
+5. For each missing element, create a finding
+
+## Report Format
+
+```
+Subtask: operational-flow
+Finding: OPERATIONAL-FLOW-GAP - [summary]
+Location: [step or section]
+Context: [why this matters for operational correctness]
+Classification: [auto-fix|conditional|flag-for-review]
+Fix Action: [what was done OR "flagged for review — [reason]"]
+Severity: [HIGH|MEDIUM|LOW]
+```
+
+## Auto-Fix Classification
+
+| Problem Class | Classification | Fix Action |
+|---------------|---------------|------------|
+| OPERATIONAL-FLOW-GAP (missing error recovery) | auto-fix | Add placeholder "If this step fails: [describe recovery]" |
+| OPERATIONAL-FLOW-GAP (missing I/O contract) | auto-fix | Add placeholder "Inputs: [list] / Outputs: [list]" |
+| OPERATIONAL-FLOW-GAP (wrong order) | flag-for-review | Reordering steps requires understanding intent |
+| OPERATIONAL-FLOW-GAP (no rollback) | flag-for-review | Rollback design requires domain expertise |
+
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/operational.md
+++ b/.opencode/skills/spec-auditor/tasks/operational.md
@@ -66,4 +66,4 @@ Creation-time operational requirements are enforced by the `spec-creation` skill
 
 **Finding pattern:** `MISSING-OPERATIONAL` — Spec lacks creation-time operational requirements. Was `spec-creation --task risk` used?
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/structure.md
+++ b/.opencode/skills/spec-auditor/tasks/structure.md
@@ -2,7 +2,14 @@
 
 ## Purpose
 
-Check that a spec follows the required structural format for STATUS headers, phase/step numbering, and status markers.
+Check that a document follows the required structural format. For specs, this means STATUS headers, phase/step numbering, and status markers. For non-spec documents, structure checks are adapted to be less strict.
+
+**Note for non-spec document types:** STATUS/phase/step markers and approval tracking are relaxed differently per type:
+- **Plan:** Has STATUS markers and phases but no approval tracking — check STATUS and phases, skip approval markers
+- **Process Flow:** Has sequential steps but no STATUS headers — check step numbering and I/O contracts, skip STATUS/phase checks
+- **Runbook/SOP:** Has sequential steps and possibly a prerequisites section — check step numbering and section presence, skip STATUS/phase checks
+- **Checklist:** Has checkbox items — check checkbox format, skip STATUS/phase/step checks
+- **Reference Doc:** No structural format required — skip this subtask entirely (baseline uses fresh-start only)
 
 ## Checks
 
@@ -57,4 +64,4 @@ Severity: [HIGH|MEDIUM|LOW]
 | MISSING-ELEMENT (CREATED date) | auto-fix | Add `CREATED: YYYY-MM-DD` |
 | MISSING-ELEMENT (phase names) | auto-fix | Rename boilerplate phase names to describe specific concerns |
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/traceability.md
+++ b/.opencode/skills/spec-auditor/tasks/traceability.md
@@ -62,4 +62,4 @@ Creation-time traceability is enforced by the `spec-creation` skill's `traceabil
 
 **Finding pattern:** `MISSING-TRACEABILITY` — Spec lacks creation-time traceability. Was `spec-creation --task traceability` used?
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)


### PR DESCRIPTION
## Summary

Batch implementation of 4 remaining issues from the Apr 13 batch approval, plus the fix specs created for 3 bug reports.

## Outcome

- **#539** — Content-aware auditor with document type autodetection: added `--file`, `--url`, `--type` parameters, document type autodetection with confidence scoring, per-type subtask selection, and 3 new operational subtasks (`operational-flow`, `determinism`, `error-recovery`). All hardcoded bylines replaced with `<AI-Name> (<model-id>)` placeholders.
- **#750** — Offer-to-edit bypass prohibition: added critical violation to `000-critical-rules.md` and `020-go-prohibitions.md`, added offer-pattern detection to `approval-gate verify-qa-mode`, added placeholder enforcement requirement to `skill-creator/SKILL.md`, updated `080-code-standards.md` examples to use placeholders.
- **#672** — Implementation definition expansion: added critical violation to `000-critical-rules.md` explicitly listing skill files, guideline files, config files, test files, and TypeScript plugins as "implementation" requiring an approved spec. Added skill-editing keywords to `verify-qa-mode` and `approval-gate SKILL.md`.
- **#660** — Silent termination prohibition: added critical violation to `000-critical-rules.md` requiring status messages before any halt, added "every halt must produce a status message" rule to `020-go-prohibitions.md`, added completion guarantee steps to both `finishing-a-development-branch/tasks/completion.md` and `approval-gate/tasks/completion.md`.

## Fix Specs Created

- **#766** — Fix spec for #750 (offer-to-edit bypass)
- **#767** — Fix spec for #672 (skill compliance enforcement)
- **#768** — Fix spec for #660 (silent termination)

## Excluded

- **#592** — Brainstorm (STATUS 0.2), not implementable — needs design decisions first

Fixes #539
Fixes #750
Fixes #672
Fixes #660