### PR TITLE
Feature branch stacking prerequisite over parallel sub-agent execution (#771)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -402,6 +402,19 @@ No feature creep: implement ONLY what is in the approved spec. No unapproved wor
 - 🚫 FORBIDDEN: Processing issues one-by-one without analysis; assuming independence without checking; hiding analysis in reasoning
 - ✅ REQUIRED: Invoke `pre-implementation-analysis` for all approvals (single or batch); expand sub-issues; classify each issue; build dependency graph; present analysis in chat; execute in dependency order
 
+## Critical Violation: Treating Branch Stacking as Optional
+
+**⚠️ Bypassing stacking discipline without justification is a CRITICAL GUIDELINE VIOLATION. Stacking is a prerequisite for code correctness, not a preference.**
+
+- 🚫 FORBIDDEN: Treating stacking as a "default preference" that can be overridden for convenience
+- 🚫 FORBIDDEN: Interpreting "independent issues" as "must be parallel" — independence ≠ parallelism
+- 🚫 FORBIDDEN: Dispatching sub-agents in parallel when stacking is the appropriate approach
+- 🚫 FORBIDDEN: Choosing parallel execution because it "saves time" without verifying circumstances genuinely allow it
+- ✅ REQUIRED: Sequential branch stacking as the prerequisite execution model
+- ✅ REQUIRED: Explicit documented justification in batch state if parallel execution is chosen (opportunistic only)
+- ✅ REQUIRED: Stack branches via `git merge <prior-branch>` into dependent branches before implementation
+- ✅ REQUIRED: When in doubt, stack — parallel execution is never the starting assumption
+
 ______________________________________________________________________
 
 **Search guidelines:** Use `srclight_search_symbols` or `grep` to find relevant guidelines.

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -35,6 +35,7 @@
 - **Never name the next phase or action in a halt message.** Halt messages must be factual statements about what was completed — never forward-looking references to what comes next.
 - **No "offer to edit" patterns.** The agent MUST NOT offer to edit, update, modify, or fix a file directly. Instead, create a spec or bug report. Patterns like "Want me to update X?", "Shall I fix this?", "I can change X to Y" are PROHIBITED — they bypass the spec-first workflow.
 - **Never self-answer a solicitation.** Pose no questions that you then answer yourself to bypass authorization.
+- **NEVER suggest parallel execution as a valid default approach.** Stacking is prerequisite; parallel is opportunistic. Agents must not present parallelism as an equally valid option.
 
 ### ⚠️ ASK FIRST
 

--- a/.opencode/guidelines/115-branch-naming.md
+++ b/.opencode/guidelines/115-branch-naming.md
@@ -14,6 +14,23 @@
 - AI intelligence determines appropriate branch name
 - Developer can override AI-suggested names
 
+## Stacking Prerequisite
+
+**Feature branches are stacked sequentially as a prerequisite for code correctness.** This is not a preference or default — it is the required approach. Parallel execution is opportunistic and depends on circumstances genuinely allowing it.
+
+**Why stacking is prerequisite (not preference):**
+- Incremental merge conflict resolution — conflicts discovered one branch at a time, not all at once at PR time
+- Clear causal chain in git history — each branch builds on the prior
+- Hidden dependency detection — "independent" issues often share imports, fixtures, or configuration
+- Context window savings from stacking outweigh time savings from parallelism
+
+**When parallel execution MAY be opportunistic (requires documented justification):**
+- Genuinely independent hotfixes touching completely separate files
+- Time-critical production fixes where stacking delay is unacceptable
+- Developer has verified no shared files, imports, fixtures, or configuration
+
+**When in doubt, stack.**
+
 ## Three-Branch Architecture
 
 **Branch Model:**

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -59,7 +59,8 @@ Enforces context window safety by mandating pre-flight assessment before non-tri
 8. **Branch per issue** — each issue gets its own feature branch and worktree. No shared branches across issues.
 9. **Frozen branches** — once a prior branch is merged into a dependent, it is frozen (no rebase, amend, or force-push).
 10. **Verification gate remains mandatory** — sub-agents MUST run `verification-before-completion --task verify` and `finishing-a-development-branch --task checklist` before returning results. Orchestrator enforces this in dispatch context.
-11. **Completion guarantee** — idempotent completion on any halt. Invoke `--task completion` before halting regardless of outcome.
+11. **Stacking is a prerequisite, not a preference** — feature branches MUST be stacked sequentially (merge-based dependency resolution) as the prerequisite approach. Parallel sub-agent dispatch is OPPORTUNISTIC — it depends on circumstances genuinely allowing it (truly independent codepaths, no shared files, no hidden dependencies). When in doubt, stack.
+12. **Completion guarantee** — idempotent completion on any halt. Invoke `--task completion` before halting regardless of outcome.
 
 ## Overflow Signal Contract
 

--- a/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
+++ b/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
@@ -240,12 +240,11 @@ assemble-batch:
 - Resume from the first incomplete issue by checking which issue numbers appear in commit messages
 - Feature branches still contain the individual issue work for reference
 
-### Parallel-Safe Issues (No Dependencies)
+### Parallel-Safe Issues (No Dependencies) — Opportunistic Only
 
-- Independent issues still get their own branches and worktrees
-- They do NOT merge any prior branches (no dependency)
-- They are squash-merged into the batch branch in any order
-- Parallel-safe issues CAN be developed simultaneously in separate worktrees
+- Even independent issues SHOULD be stacked sequentially. Parallel execution is opportunistic — it depends on circumstances genuinely allowing it (no shared files, no logical coupling, no hidden dependencies).
+- "Independent" in a batch context means "no declared dependency," not "safe to run in parallel." Stacking catches hidden dependencies automatically.
+- If parallel execution is chosen for an independent issue, document the justification in the batch state file with explicit reasoning (why stacking was bypassed, what makes the issue genuinely independent).
 
 ## Mandatory Rules
 

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -34,12 +34,9 @@ Execute an approved implementation plan by dispatching fresh subagents per task,
 | Situation | Use |
 |-----------|-----|
 | Need two-stage review per task (spec + quality) | `subagent-driven-development` |
-| Plan with independent tasks, same session | `subagent-driven-development` |
-| Need fresh context per task | `subagent-driven-development` |
-| Standard implementation without per-task review | `divide-and-conquer` |
+| Standard implementation (stacking prerequisite) | `divide-and-conquer` (always stacked) |
 | Task risks context window overflow | `divide-and-conquer` |
-| Dependencies between tasks (must-precede) | `divide-and-conquer` (orchestrate) or `subagent-driven-development` with merge-based dependency resolution |
-| Any batch implementation | Either (use `divide-and-conquer` for simplicity, `subagent-driven-development` for review rigor) |
+| **Independent tasks that genuinely permit parallel work** | Either — but stacking is prerequisite, parallel is opportunistic |
 
 ## The Process
 
@@ -119,6 +116,8 @@ env_vars:
 ## Red Flags
 
 Never skip approval-gate, never skip reviews, never dispatch multiple implementation subagents in parallel, never accept "close enough" on spec compliance, never skip verification-before-completion, never skip review-prep before HALT, never create PR without explicit instruction.
+
+**Stacking prerequisite:** Feature branches MUST be stacked sequentially. Parallel dispatch is OPPORTUNISTIC and requires documented justification — it is never the default or preferred approach.
 
 ## Sub-Agent Spawning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 - **Batch Approval Implementation** (#756, #752, #728, #688, #680, #667, #533, #306, #662, #630, #683, #763, #762, #614, #470, #467) - 17 issues implemented in a single batch, including unified batch workflow, mandatory post-implementation invocation, auto-rebase pending PRs, bug analysis auto-spec, discussion-conclusion non-authorization patterns, label state machine cross-references, spec-auditor auto-fix model, branch-header changelog, identity placeholder cleanup, brainstorming terminal state, session enforcement discussion mode, ruff version sync, stale User import fix, byline format standardization, PR trigger check, and template-driven element removal.
 
+### spec/branch-stacking-prerequisite
+
+- **Branch Stacking Prerequisite** (#771) - Established that feature branch stacking is a prerequisite for code correctness, not a preference. Updated 6 documentation files to reframe parallel execution as opportunistic-only with documented justification required. Added critical violation entry for treating stacking as optional.
+
 ### Changed
 
 - **Unified Batch Workflow** (#756) - Renamed batch-approval-analysis to pre-implementation-analysis, removed IMPLEMENT_DIRECTLY dispatch path, and unified single/batch issue handling through divide-and-conquer assemble-batch.


### PR DESCRIPTION
## Summary

Updated 6 documentation files to establish that feature branch stacking is a prerequisite for code correctness (not merely a preference), and parallel execution is opportunistic-only requiring documented justification.

## Outcome

- `divide-and-conquer` SKILL.md: Added Operating Protocol rule #11 stating stacking is prerequisite
- `assemble-batch.md`: Reframed "Parallel-Safe Issues" section as opportunistic-only with justification requirement
- `000-critical-rules.md`: Added critical violation entry for treating branch stacking as optional
- `subagent-driven-development` SKILL.md: Updated when-to-use table and added stacking prerequisite red flag
- `115-branch-naming.md`: Added Stacking Prerequisite section with rationale and opportunistic exceptions
- `020-go-prohibitions.md`: Added prohibition against suggesting parallel execution as default approach

Fixes #771
Fixes #772