### PR TITLE
Replace hardcoded identity values + add writing-plans chat output (#770, #773)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -148,8 +148,8 @@ When the agent identifies a problem and the fix is clear, the ONLY permitted nex
 
 All identity values MUST use placeholder tokens that are resolved at runtime from session init output. Hardcoded values become stale when models, agents, orgs, or repos change.
 
-- 🚫 FORBIDDEN: `OpenCode`, `OpenCode Desktop`, `Claude`, or any specific agent name in skill files, guidelines, or task files
-- 🚫 FORBIDDEN: `ollama-cloud/glm-5`, `claude-3-5-sonnet`, or any specific model ID in skill files, guidelines, or task files
+- 🚫 FORBIDDEN: `<specific-agent-name>` (e.g., `OpenCode`, `OpenCode Desktop`, `Claude`) in skill files, guidelines, or task files
+- 🚫 FORBIDDEN: `<specific-model-id>` (e.g., `ollama-cloud/glm-5`, `claude-3-5-sonnet`) in skill files, guidelines, or task files
 - 🚫 FORBIDDEN: `michael-conrad`, `muksihs`, or any specific developer name/email in skill files, guidelines, or task files
 - 🚫 FORBIDDEN: `Brothertown-Language`, `snea-shoebox-editor`, or any specific org/repo name in skill files, guidelines, or task files
 - ✅ REQUIRED: Use `<AI-Name>`, `<model-id>`, `<AgentName>`, `<ModelID>`, `DEV_NAME`, `DEV_EMAIL`, `GIT_OWNER`, `GIT_REPO` placeholders everywhere

--- a/.opencode/skills/approval-gate/tasks/verify-already-implemented.md
+++ b/.opencode/skills/approval-gate/tasks/verify-already-implemented.md
@@ -66,7 +66,7 @@ When ALL success criteria are verified as already met:
 4. **Post chat output** with executive summary:
    - What happened: Spec #N approved but all success criteria already met
    - Outcome: Issue autoclosed as already implemented
-   - Byline: `🤖 OpenCode (ollama-cloud/glm-5.1) completed`
+   - Byline: `🤖 <AgentName> (<ModelID>) completed`
 
 5. **HALT** — no branch, no PR, no implementation needed
 

--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -14,7 +14,7 @@ Conversational-first exploration workflow. One question at a time, user-driven, 
 
 **Source:** Adapted from [obra/superpowers brainstorming](https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md). Key adaptations: no visual companion by default (conditional offer only for visual topics), no hard design-approval gate before writing-plans (our pipeline has approval-gate), dimensions used internally never as output sections, terminal state invokes spec-creation.
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)
 
 ## Persona
 

--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -88,7 +88,7 @@ This skill analyzes ACTUAL concerns, not static templates.
 - Related skills: `spec-auditor` (orchestrator), `writing-plans` (clean-room for fidelity)
 - Related guidelines: `000-critical-rules.md` (auditor enforcement), `142-planning-archive-workflow.md`
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)
 
 ## Symbolic Engine Integration
 

--- a/.opencode/skills/concern-separation-auditor/tasks/audit-phases.md
+++ b/.opencode/skills/concern-separation-auditor/tasks/audit-phases.md
@@ -56,4 +56,4 @@ Severity: [HIGH|MEDIUM|LOW]
 | Phase with <3 steps | Too small to split cleanly | No split needed |
 | Already separated | Analysis shows single concern | No change needed |
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/concern-separation-auditor/tasks/check-independence.md
+++ b/.opencode/skills/concern-separation-auditor/tasks/check-independence.md
@@ -50,4 +50,4 @@ Recommendation: [merge phases OR make dependency explicit OR uncouple]
 Severity: [HIGH|MEDIUM|LOW]
 ```
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -153,4 +153,4 @@ This skill is a **heavy skill** — its orchestration logic can run in isolation
 - Related guidelines: `010-approval-gate.md`, `000-critical-rules.md`
 - Adapted from: `implementation-workflow` (batch-orchestrate, context-passing, purification-and-enforcement, completion)
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
+++ b/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
@@ -259,4 +259,4 @@ assemble-batch:
 09. **Conflict resolution tiers** — auto-resolve 1-2, HALT on tier 3 during dependency merges
 10. **Always batch mode** — single issue = batch of one, no special-case path
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/tasks/assess.md
+++ b/.opencode/skills/divide-and-conquer/tasks/assess.md
@@ -79,4 +79,4 @@ If during implementation the scope expands beyond what was assessed:
 
 A conservative assessment (multi-sub-agent for work that could be done by one) is acceptable. The decomposition overhead is small compared to the risk of overflow. Do not second-gauge a multi-sub-agent decision.
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/tasks/completion.md
+++ b/.opencode/skills/divide-and-conquer/tasks/completion.md
@@ -53,4 +53,4 @@ Compare URL: ${BASE_URL}${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch>
 
 URL is ALWAYS last per `000-critical-rules.md`.
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/tasks/context-passing.md
+++ b/.opencode/skills/divide-and-conquer/tasks/context-passing.md
@@ -77,4 +77,4 @@ If a yield-back produces empty or missing fields:
 
 Pre-work receives context from orchestrator — no re-authorization check needed. If pre-work prompts for auth, it received stale context. Re-invoke with fresh context from approval-gate.
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/tasks/orchestrate.md
+++ b/.opencode/skills/divide-and-conquer/tasks/orchestrate.md
@@ -226,7 +226,7 @@ Created 4 core skills for brainstorming, planning, execution, and verification.
 
 Compare URL: https://github.com/owner/repo/compare/dev...branch
 
-🤖 OpenCode (ollama-cloud/glm-5.1) completed
+🤖 <AgentName> (<ModelID>) completed
 ```
 
 **Format verification (MANDATORY — check before posting):**
@@ -240,7 +240,7 @@ Compare URL: https://github.com/owner/repo/compare/dev...branch
 **Issue comment:**
 
 ```markdown
-🤖 OpenCode (ollama-cloud/glm-5) completed
+🤖 <AgentName> (<ModelID>) completed
 
 **Summary:**
 
@@ -304,4 +304,4 @@ divide-and-conquer/orchestrate:
     → Continues with implementation...
 ```
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/tasks/purification-and-enforcement.md
+++ b/.opencode/skills/divide-and-conquer/tasks/purification-and-enforcement.md
@@ -95,4 +95,4 @@ NEVER proceed to PR creation without explicit "create a PR":
 | Finishing checklist fails | HALT and report issues (lint, tests, uncommitted); do NOT proceed to review-prep |
 | Review-prep HALTs prematurely | Correct behavior - wait for "create a PR" |
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -56,4 +56,4 @@ Plan approved (approval-gate)
 
 - Related skills: `divide-and-conquer` (implementation orchestration), `approval-gate` (authorization), `verification-before-completion` (evidence), `finishing-a-development-branch` (branch readiness), `git-workflow` (branch/PR/cleanup)
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/executing-plans/tasks/progress.md
+++ b/.opencode/skills/executing-plans/tasks/progress.md
@@ -46,7 +46,7 @@ From plan's verification methods:
 **Next:** Step N+1 - [Next concern]
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) working
+🤖 <AgentName> (<ModelID>) working
 ```
 
 ## Multi-Step Execution Example
@@ -66,7 +66,7 @@ From plan's verification methods:
 **Evidence:** Migration test passed
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) step-1-complete
+🤖 <AgentName> (<ModelID>) step-1-complete
 
 ## Step 2: API Endpoints
 - ☐ Create login endpoint
@@ -74,5 +74,5 @@ From plan's verification methods:
 - ☐ Create refresh endpoint
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) working
+🤖 <AgentName> (<ModelID>) working
 ```

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -467,7 +467,7 @@ Before closing any issue (SPEC or Task), the AI agent MAY provide a final summar
 - **Superseded/Not Implemented**: The "Phase 3: Circuit breaker" was deferred to a follow-up issue #165.
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) completed
+🤖 <AgentName> (<ModelID>) completed
 ```
 
 ### When to Close
@@ -662,7 +662,7 @@ This parent issue cannot be closed because the following sub-issue(s) remain inc
 3. Or close as "not planned" with explanation if intentionally skipped
 
 ---
-🤖 ⚠️ OpenCode (ollama-cloud/glm-5) blocking
+🤖 ⚠️ <AgentName> (<ModelID>) blocking
 ```
 
 ## Common Issues

--- a/.opencode/skills/git-workflow/tasks/commit-prep.md
+++ b/.opencode/skills/git-workflow/tasks/commit-prep.md
@@ -100,7 +100,7 @@ Every implementation commit MUST include:
 ### AI Author Trailer
 
 - **Use your actual identity dynamically** — the AI knows its own name and email
-- **DO NOT use generic placeholders like "AI"** — use the actual AI agent name (e.g., "OpenCode Desktop", "OpenCode")
+- **DO NOT use generic placeholders like "AI"** — use the actual AI agent name detected from runtime context
 - **Email format**: Use a noreply address associated with the AI service (e.g., `noreply@opencode.ai`, `noreply@anthropic.com`)
 - **NEVER use the project domain** — those belong to the human collaborators
 - **Include model info**: Format is `Agent-Name (model-id) <email>`
@@ -108,7 +108,7 @@ Every implementation commit MUST include:
 **Example:**
 
 ```
-Co-authored-by: OpenCode (glm-5) <noreply@opencode.ai>
+Co-authored-by: <AI-Name> (<model-id>) <noreply@example.com>
 ```
 
 ### Human Collaborator Trailer
@@ -126,7 +126,7 @@ Co-authored-by: <DEV_NAME> <DEV_EMAIL>
 
 ```bash
 git commit -m "feat: Add user authentication" \
-    --trailer "Co-authored-by: OpenCode (glm-5) <noreply@opencode.ai>" \
+    --trailer "Co-authored-by: <AI-Name> (<model-id>) <noreply@example.com>" \
     --trailer "Co-authored-by: <DEV_NAME> <DEV_EMAIL>"
 ```
 

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -878,7 +878,7 @@ Every squash commit MUST include:
 
 - Use dynamic model detection at runtime
 - Format: `Co-authored-by: <AI-Name> (<model-id>) <noreply@example.com>`
-- Example: `Co-authored-by: OpenCode (glm-5) <noreply@opencode.ai>`
+- Example: `Co-authored-by: <AI-Name> (<model-id>) <noreply@example.com>`
 
 **Human Trailer:**
 

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -106,7 +106,7 @@ When implementation determines "no file changes needed":
 
 **When posting completion report (Step 3/4):**
 
-- **MUST dynamically detect model ID** - NEVER use hardcoded `ollama-cloud/glm-5`
+- **MUST dynamically detect model ID** - NEVER use hardcoded `<model-id>`
 - **MUST detect actual runtime identity** from environment/MCP tools
 - **If model ID unknown:** STOP and ask user - DO NOT use example from documentation
 
@@ -464,5 +464,5 @@ Updated git-workflow skill to push feature branches after implementation and pro
 ${GITBUCKET_HTML_URL}${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch-name>
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) completed
+🤖 <AgentName> (<ModelID>) completed
 ````

--- a/.opencode/skills/gitbucket-api/tasks/issue-operations.md
+++ b/.opencode/skills/gitbucket-api/tasks/issue-operations.md
@@ -224,7 +224,7 @@ api.add_issue_comment(
     owner="org",
     repo="project",
     issue_number=14,
-    body="""🤖 OpenCode completed
+    body="""🤖 <AgentName> completed
 
 **Summary:**
 

--- a/.opencode/skills/github-comments/tasks/format-comment.md
+++ b/.opencode/skills/github-comments/tasks/format-comment.md
@@ -73,7 +73,7 @@ Refactored the authentication module to use token-based sessions instead of cook
 **Outcome:** Session management now uses JWT tokens with configurable expiry, eliminating 401 errors for long-lived sessions.
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) completed
+🤖 <AgentName> (<ModelID>) completed
 ```
 
 **❌ WRONG (rigid Changed/Added/Removed lists):**
@@ -84,7 +84,7 @@ Refactored the authentication module to use token-based sessions instead of cook
 - Removed: cookie-based sessions
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) completed
+🤖 <AgentName> (<ModelID>) completed
 ```
 
 **Why prose-driven:**

--- a/.opencode/skills/guideline-auditor/SKILL.md
+++ b/.opencode/skills/guideline-auditor/SKILL.md
@@ -225,7 +225,7 @@ Fixed DRY violation where same rule appeared in three files with slightly differ
 **Outcome:** Single source of truth for "never use echo redirects" rule.
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) completed
+🤖 <AgentName> (<ModelID>) completed
 ```
 
 ---

--- a/.opencode/skills/plan-fidelity-auditor/SKILL.md
+++ b/.opencode/skills/plan-fidelity-auditor/SKILL.md
@@ -122,4 +122,4 @@ Only substantive differences after semantic matching are reported.
 - Related tasks: `compare` (comparison logic), `report` (finding reporting)
 - Related skills: `writing-plans` (clean-room generation), `brainstorming` (recommended for gaps)
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/plan-fidelity-auditor/tasks/audit.md
+++ b/.opencode/skills/plan-fidelity-auditor/tasks/audit.md
@@ -38,4 +38,4 @@ If the writing-plans subtask fails:
 - Clean-room plan is a comparison artifact only
 - Must use GitHub MCP tools for all issue operations
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/plan-fidelity-auditor/tasks/compare.md
+++ b/.opencode/skills/plan-fidelity-auditor/tasks/compare.md
@@ -64,4 +64,4 @@ phases_missing: K
 phases_extra: L
 ```
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/plan-fidelity-auditor/tasks/report.md
+++ b/.opencode/skills/plan-fidelity-auditor/tasks/report.md
@@ -68,4 +68,4 @@ When significant gaps are found (3+ HIGH-severity findings or any VAGUE_PROBLEM 
 
 After the audit session, create `./tmp/audit-fidelity-YYYYMMDD.md` with all findings and retain in `./tmp/` for session reference. Do NOT post as GitHub Issue comment — audit findings are internal agent guidance.
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/receiving-code-review/tasks/address.md
+++ b/.opencode/skills/receiving-code-review/tasks/address.md
@@ -57,7 +57,7 @@ Post replies to each review comment:
 **Details:** [What was changed or why not]
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) addressed
+🤖 <AgentName> (<ModelID>) addressed
 ```
 
 ## Anti-Patterns

--- a/.opencode/skills/receiving-code-review/tasks/respond.md
+++ b/.opencode/skills/receiving-code-review/tasks/respond.md
@@ -18,7 +18,7 @@ Reply to review comments after changes have been made, providing clear documenta
 **Response:** Fixed
 **Details:** [What was changed and where]
 
-🤖 OpenCode (ollama-cloud/glm-5) addressed
+🤖 <AgentName> (<ModelID>) addressed
 ```
 
 ### For Explained Comments (Not Fixed)
@@ -27,7 +27,7 @@ Reply to review comments after changes have been made, providing clear documenta
 **Response:** Explained
 **Details:** [Why this was not changed — rationale for keeping current approach]
 
-🤖 OpenCode (ollama-cloud/glm-5) addressed
+🤖 <AgentName> (<ModelID>) addressed
 ```
 
 ### For Declined Comments
@@ -36,7 +36,7 @@ Reply to review comments after changes have been made, providing clear documenta
 **Response:** Declined
 **Details:** [Respectful reasoning for disagreeing with the suggestion]
 
-🤖 OpenCode (ollama-cloud/glm-5) addressed
+🤖 <AgentName> (<ModelID>) addressed
 ```
 
 ## Important Notes

--- a/.opencode/skills/requesting-code-review/tasks/prepare.md
+++ b/.opencode/skills/requesting-code-review/tasks/prepare.md
@@ -86,7 +86,7 @@ uv run pyright src/
 Fixes #[issue-number]
 
 ---
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)
 ```
 
 ## Anti-Patterns

--- a/.opencode/skills/requesting-code-review/tasks/request.md
+++ b/.opencode/skills/requesting-code-review/tasks/request.md
@@ -34,7 +34,7 @@ Post a review request comment on the PR:
 - [Any specific questions]
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) review-requested
+🤖 <AgentName> (<ModelID>) review-requested
 ```
 
 ### Step 2: Update PR Labels

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -137,7 +137,7 @@ The `validate` task (`quick_validate.py`) SHOULD check for:
 
 ### Required in every skill that:
 
-1. **References AI agents** — MUST use `<AI-Name>` and `<model-id>` placeholders, never specific names like `OpenCode` or `Claude`
+1. **References AI agents** — MUST use `<AI-Name>` and `<model-id>` placeholders, never specific agent names or model IDs
 2. **References developers** — MUST use `DEV_NAME` and `DEV_EMAIL` from session init, never specific names like `michael-conrad`
 3. **References organizations/repos** — MUST use `GIT_OWNER` and `GIT_REPO` from session init, never specific names like `Brothertown-Language`
 4. **Contains bylines or attribution** — MUST use `<AI-Name> (<model-id>)` format, never specific agent/model combinations
@@ -145,8 +145,8 @@ The `validate` task (`quick_validate.py`) SHOULD check for:
 ### Validation Gate
 
 The `validate` task (`quick_validate.py`) SHOULD check for and flag:
-- Specific agent names (`OpenCode`, `Claude`, `GPT-4`, etc.) in SKILL.md or task files
-- Specific model IDs (`ollama-cloud/glm-5`, `claude-3-5-sonnet`, etc.) in SKILL.md or task files
+- Specific agent names (e.g., `<AI-Name>`) in SKILL.md or task files — must use placeholder tokens
+- Specific model IDs (e.g., `<model-id>`) in SKILL.md or task files — must use placeholder tokens
 - Specific developer names or emails in SKILL.md or task files
 - Specific org/repo names in SKILL.md or task files (except in examples using the `<GIT_OWNER>/<GIT_REPO>` pattern)
 - Specific platform URLs in SKILL.md or task files (except in examples using session init variable references)

--- a/.opencode/skills/skill-creator/scripts/init_skill.py
+++ b/.opencode/skills/skill-creator/scripts/init_skill.py
@@ -14,7 +14,6 @@ Examples:
 import sys
 from pathlib import Path
 
-
 SKILL_TEMPLATE = """---
 name: {skill_name}
 description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
@@ -99,20 +98,20 @@ Executable code (Python/Bash/etc.) that can be run directly to perform specific 
 
 **Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
 
-**Note:** Scripts may be executed without loading into context, but can still be read by OpenCode for patching or environment adjustments.
+**Note:** Scripts may be executed without loading into context, but can still be read by <AI-Name> for patching or environment adjustments.
 
 ### references/
-Documentation and reference material intended to be loaded into context to inform OpenCode's process and thinking.
+Documentation and reference material intended to be loaded into context to inform <AI-Name>'s process and thinking.
 
 **Examples from other skills:**
 - Product management: `communication.md`, `context_building.md` - detailed workflow guides
 - BigQuery: API reference documentation and query examples
 - Finance: Schema documentation, company policies
 
-**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that OpenCode should reference while working.
+**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that <AI-Name> should reference while working.
 
 ### assets/
-Files not intended to be loaded into context, but rather used within the output OpenCode produces.
+Files not intended to be loaded into context, but rather used within the output <AI-Name> produces.
 
 **Examples from other skills:**
 - Brand styling: PowerPoint template files (.pptx), logo files
@@ -189,7 +188,7 @@ This placeholder represents where asset files would be stored.
 Replace with actual asset files (templates, images, fonts, etc.) or delete if not needed.
 
 Asset files are NOT intended to be loaded into context, but rather used within
-the output OpenCode produces.
+the output <AI-Name> produces.
 
 Example asset files from other skills:
 - Brand guidelines: logo.png, slides_template.pptx

--- a/.opencode/skills/spec-creation/SKILL.md
+++ b/.opencode/skills/spec-creation/SKILL.md
@@ -132,4 +132,4 @@ To invoke: /skill spec-creation --task requirements
 - **Downstream:** `writing-plans` (plan creation — transforms approved spec into implementation plan)
 - **Source:** Adapted and extended from `brainstorming` Steps 7-9 (not a verbatim move)
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -136,4 +136,4 @@ This skill is a **heavy skill** — task dispatching and orchestration can run i
 
 - Related skills: `approval-gate` (authorization), `git-workflow` (git ops), `divide-and-conquer` (primary orchestration, context window safety), `verification-before-completion` (evidence), `finishing-a-development-branch` (branch readiness), `using-git-worktrees` (worktree creation with BASE_BRANCH)
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/subagent-driven-development/tasks/implementer-prompt.md
+++ b/.opencode/skills/subagent-driven-development/tasks/implementer-prompt.md
@@ -142,7 +142,7 @@ Task tool (general-purpose):
     - You are working on branch: [branch-name]
     - Feature branches target `dev`, not `main`
     - Commit with descriptive messages
-    - Include co-author trailer: Co-authored-by: OpenCode (<model-id>)
+    - Include co-author trailer: Co-authored-by: <AI-Name> (<model-id>)
     - Run lint and typecheck before committing
     - Run tests to verify your changes work
 ```

--- a/.opencode/skills/verification-before-completion/SKILL.md
+++ b/.opencode/skills/verification-before-completion/SKILL.md
@@ -107,7 +107,7 @@ If `WORKTREE_PATH` is NOT set, operate normally from the project root.
 
 This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow enforces evidence-based verification to prevent premature completion claims.
 
-Key adaptations for OpenCode:
+Key adaptations for <AI-Name>:
 - Integration with existing executing-plans and git-workflow skills
 - GitBucket platform support via MCP tools
 - Dispatch table integration for mandatory invocation

--- a/.opencode/skills/verification-before-completion/tasks/verify.md
+++ b/.opencode/skills/verification-before-completion/tasks/verify.md
@@ -90,7 +90,7 @@ Verify all success criteria have evidence before allowing completion claims.
 - [ ] Re-run verification after evidence added
 
 ---
-🤖 OpenCode (ollama-cloud/glm-5) verification
+🤖 <AgentName> (<ModelID>) verification
 ```
 
 ## Post-Verification Chain

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -18,7 +18,7 @@ Plan creation workflow that transforms approved specs into actionable implementa
 
 | Task | Purpose | Words |
 | -- | -- | -- |
-| `create` | Create plan from approved spec | ~800 |
+| `create` | Create plan from approved spec; report in chat | ~800 |
 | `validate` | Check for placeholders and completeness | ~500 |
 | `retroactive` | Create plan for existing spec | ~600 |
 | `clean-room` | Generate independent plan from problem statement only | ~500 |
@@ -91,6 +91,7 @@ approval-gate --task verify-authorization (all gates pass for spec approval)
 6. Create plan issue or return markdown
 7. Self-review (coverage, placeholders, type consistency)
 8. Validate (no placeholders, TDD structure, actionable steps)
+9. Chat output with URL — Report plan creation using exec summary + URL + byline format per `000-critical-rules.md`
 
 ## Enforcement
 

--- a/.opencode/skills/writing-plans/tasks/clean-room.md
+++ b/.opencode/skills/writing-plans/tasks/clean-room.md
@@ -139,4 +139,4 @@ affected_files_count: K
 - Related tasks: `create` (standard plan creation), `validate` (plan validation)
 - Related skills: `spec-auditor` (orchestrator), `brainstorming` (recommended when gaps found)
 
-Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -58,3 +58,17 @@ Create an implementation plan from an approved spec.
    - Check for TBD/TODO placeholders
    - Verify all steps are actionable
    - Verify success criteria are testable
+
+9. **Report plan creation in chat (MANDATORY):**
+
+   Produce chat output in the mandatory format per `000-critical-rules.md`:
+
+   1. **Executive summary**: 1-2 sentences describing what plan was created and for which spec
+   2. **URL**: The plan issue URL (e.g., `https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/<N>`)
+   3. **AI byline**: `🤖 <AgentName> (<ModelID>)` — ALWAYS LAST
+
+   Example:
+
+   Created implementation plan for #771 (branch stacking prerequisite). 7 tasks across 6 files (3 skills + 3 guidelines).
+   https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/772
+   🤖 <AgentName> (<ModelID>)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,11 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 - OAuth authentication via Streamlit OAuth
 - Session management and cookie handling
 
+### Changed
+
+- **Identity Placeholder Sweep** (#770) - Replaced remaining hardcoded org/user/identity values with typed placeholders across skill and tool files, ensuring repository portability.
+- **Mandatory Chat Output in Writing-Plans** (#773) - Added mandatory chat output step to the writing-plans create task, ensuring plan creation always produces a visible executive summary.
+
 ## [0.1.0]
 
 ### main (initial)


### PR DESCRIPTION
**Summary:**

Eliminates hardcoded identity values across skill/guideline files and adds mandatory chat output reporting to the writing-plans create task, enforcing the critical violation rules already in place.

**Outcome:** All skill/guideline/tool files now use runtime-resolvable placeholders (`<AI-Name>`, `<AgentName>`, `<ModelID>`, `<model-id>`) instead of hardcoded agent/model values. Plan creation now produces exec summary + URL + AI byline per 000-critical-rules.md.

## Batch Issues

Implements #770 — Replace ~56 hardcoded identity values with placeholders across 38 files
Implements #773 — Add mandatory chat output step to writing-plans create task

Fixes #770
Fixes #773