### PR TITLE
Implement spec→plan→sub-issue hierarchy

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -204,24 +204,25 @@ Chat output order (mandatory): 1) Executive summary, 2) URL (if exists), 3) AI b
 
 **MANDATORY: Read issue comments and respond publicly. See `github-comments` skill → "Responding to User Comments (MANDATORY)".**
 
-## Critical Violation: Sub-issue Structure Bypass — Multi-task Specs
+## Critical Violation: Sub-issue Structure Bypass — Multi-task Plans
 
-**⚠️ Implementing a multi-task spec without sub-issues is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Implementing a multi-task plan without sub-issues is a CRITICAL GUIDELINE VIOLATION.**
 
 - 🚫 FORBIDDEN: Implementing phases without sub-issue structure; assuming markdown checkboxes = tracking; creating step-level sub-issues
-- ✅ REQUIRED: Sub-issues at PHASE level; each linked via `github_sub_issue_write method=add`; single-task specs exempt; auto-create as pre-implementation setup
+- ✅ REQUIRED: Sub-issues at PHASE level under the plan (not the spec); each linked via `github_sub_issue_write method=add`; single-task plans exempt; auto-create as pre-implementation setup
+- ✅ REQUIRED: Plan is the parent of implementation sub-issues; spec references plan via body linked reference, NOT GitHub sub-issue link
 
 **See `github-sub-issues` skill for complete workflow including single-task exemption, auto-create workflow, and database ID requirement.**
 
-## Critical Violation: Stopping After Single Phase in Multi-Task Spec
+## Critical Violation: Stopping After Single Phase in Multi-Task Plan
 
-**⚠️ Halting after completing a single phase of a multi-task spec is a CRITICAL GUIDELINE VIOLATION.** Authorization cascades to ALL sub-issues. Complete ALL phases, report ONCE, HALT ONCE.
+**⚠️ Halting after completing a single phase of a multi-task plan is a CRITICAL GUIDELINE VIOLATION.** Plan approval cascades authorization to ALL sub-issues under the plan. Complete ALL phases, report ONCE, HALT ONCE.
 
-**See `approval-gate` skill → "Multi-Task Spec Authorization" for complete cascade workflow and enforcement matrix.**
+**See `approval-gate` skill → "Multi-Task Plan Authorization" for complete cascade workflow and enforcement matrix.**
 
 ## Critical Violation: Sub-issue Closure Timing — ZERO TOLERANCE
 
-**⚠️ Closing sub-issues before PR merge is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Closing sub-issues before PR merge is a CRITICAL GUIDELINE VIOLATION.** Sub-issues are children of the plan, not the spec.
 
 🚫 FORBIDDEN: Closing sub-issues after implementation but before PR merge; closing without verifying PR merge via GitHub API
 
@@ -295,7 +296,7 @@ Trigger words: "audit this spec", "review this issue", "revisit this task", "che
 
 ## Critical Violation: Bug Reports Without Fix Spec
 
-**⚠️ Bug reports must have a fix spec sub-issue before closure is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Bug reports must have a fix spec sub-issue before closure is a CRITICAL GUIDELINE VIOLATION.** Fix specs follow the plan-bridge hierarchy: spec → plan → sub-issues.
 
 - 🚫 FORBIDDEN: Closing a bug report without a linked fix spec sub-issue; treating bug reports as complete without fix spec
 - ✅ REQUIRED: Use `issue-review --task analyze-and-spec` to create fix spec sub-issues for bug reports; verify fix spec exists via `approval-gate --task verify-fix-spec` before closure
@@ -313,10 +314,10 @@ Trigger words: "audit this spec", "review this issue", "revisit this task", "che
 
 ## Critical Violation: Conflating Issue References with Authorization Cascade
 
-**⚠️ Treating issue references as sub-issue relationships that trigger authorization cascade is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Treating issue references as sub-issue relationships that trigger authorization cascade is a CRITICAL GUIDELINE VIOLATION.** In the plan-bridge hierarchy, the spec references the plan via body text (linked reference), NOT via GitHub sub-issue link. Only plan → sub-issue links trigger cascade.
 
-- 🚫 FORBIDDEN: Cascading authorization based on mentions in body/comments; assuming `#NNN` creates authorization links
-- ✅ REQUIRED: Only formal sub-issue links via `github_sub_issue_write` trigger cascade; verify with `github_issue_read(method=get_sub_issues)`
+- 🚫 FORBIDDEN: Cascading authorization based on mentions in body/comments; assuming `#NNN` creates authorization links; treating spec's body reference to a plan as a sub-issue link
+- ✅ REQUIRED: Only formal sub-issue links via `github_sub_issue_write` trigger cascade; verify with `github_issue_read(method=get_sub_issues)` on the **plan**, not the spec
 
 **See `approval-gate` skill → "Reference ≠ Authorization Cascade" for the complete verification procedure.**
 
@@ -333,7 +334,7 @@ Trigger words: "audit this spec", "review this issue", "revisit this task", "che
 
 ## Critical Violation: Closing Issues Before PR Merge
 
-**⚠️ Closing issues BEFORE the PR is merged is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Closing issues BEFORE the PR is merged is a CRITICAL GUIDELINE VIOLATION.** In the plan-bridge hierarchy, close sub-issues under the plan first, then the plan, then the spec.
 
 🚫 FORBIDDEN: Closing after implementation; closing when PR created but not merged; closing parents while children open; closing without "merge confirmed"
 
@@ -345,7 +346,7 @@ Trigger words: "audit this spec", "review this issue", "revisit this task", "che
 
 ## Critical Violation: Parent/Child Issue Closure
 
-**⚠️ Closing a parent issue while child issues remain open is a CRITICAL GUIDELINE VIOLATION.** Only close the child corresponding to the merged PR. Parent stays open until ALL children are closed.
+**⚠️ Closing a parent issue while child issues remain open is a CRITICAL GUIDELINE VIOLATION.** Only close the child corresponding to the merged PR. Parent stays open until ALL children are closed. In the plan-bridge hierarchy, the plan (not the spec) is the parent of implementation sub-issues.
 
 **See `git-workflow` skill `--task cleanup` for the complete parent/child closure workflow.**
 

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -3,7 +3,8 @@
 > **See `approval-gate` skill for complete procedural workflow including:**
 >
 > - Spec + authorization requirements
-> - Sub-issue verification gate
+> - Plan approval gate
+> - Sub-issue verification gate (under plan)
 > - Single-task exemption
 > - Re-evaluation checklist
 > - Bug report response
@@ -17,6 +18,7 @@
 | Requirement | Rule |
 | -- | -- |
 | **Spec before code** | NO code/guideline changes WITHOUT approved spec |
+| **Plan before implementation** | NO implementation WITHOUT approved plan (spec approval → plan creation, plan approval → implementation) |
 | **Authorization required** | NO implementation WITHOUT explicit `"approved"` or `"go"` |
 | **Explicit auth overrides label** | When user says `approved`/`go`, proceed REGARDLESS of `needs-approval` label |
 | **Branch first** | Create feature branch BEFORE any file modification |
@@ -52,8 +54,8 @@ The `needs-approval` label is a **tracking tool**, not a permanent gate. Its pur
 - **Session-bound**: New session = new authorization required (no carryover from previous sessions)
 - **Single-use**: Authorization for current phase/task only within that issue
 - **External input invalidates**: Bug reports require re-authorization
-- **Revision ≠ implementation**: Spec updates don't authorize code changes
-- **Reference ≠ authorization cascade**: Issue mentions in body/comments do NOT cascade authorization
+- **Revision ≠ implementation**: Spec updates don't authorize code changes; spec revision revokes linked plan approvals
+- **Reference ≠ authorization cascade**: Issue mentions in body/comments do NOT cascade authorization; spec references plan via body text, not sub-issue link
 - **Confirmation ≠ authorization**: Confirming an observation does NOT authorize implementation
 
 **🚫 CRITICAL: Old authorizations do NOT apply:**
@@ -62,15 +64,17 @@ The `needs-approval` label is a **tracking tool**, not a permanent gate. Its pur
 - Previous session authorization → NOT VALID for new issue/spec
 - Authorization is ZERO-BASED — every task needs NEW authorization
 
-### Multi-Task Spec Authorization (CRITICAL)
+### Multi-Task Plan Authorization (CRITICAL)
 
-**When parent issue has sub-issues:** authorization cascades to ALL sub-issues.
+**When a plan has sub-issues:** plan approval cascades authorization to ALL sub-issues under the plan.
 
-**See `approval-gate` skill → "Multi-Task Spec Authorization" for the complete authorization cascade workflow and enforcement matrix.**
+**See `approval-gate` skill → "Multi-Task Plan Authorization" for the complete authorization cascade workflow and enforcement matrix.**
+
+The plan-bridge hierarchy: Spec → (body linked reference) → Plan → Sub-issues. Sub-issues are children of the plan, NOT the spec.
 
 Key rules:
 
-- 🚫 DO NOT halt after each phase of multi-task spec
+- 🚫 DO NOT halt after each phase of multi-task plan
 - 🚫 DO NOT ask for re-authorization between phases
 - 🚫 DO NOT treat sub-issues as separate authorization units
 - ✅ Complete ALL phases, then report ONCE and HALT ONCE
@@ -95,7 +99,7 @@ Key rules:
 
 ### Revision Revokes Approval (MANDATORY)
 
-**Any modification to a spec or task document MUST immediately revoke approval.**
+**Any modification to a spec or plan document MUST immediately revoke approval.** Spec revision revokes approval of any linked plan (referenced via body text). Plan revision revokes implementation authorization for its sub-issues.
 
 **See `approval-gate` skill for revision status transition rules, mandatory actions, and exemption categories.**
 
@@ -105,6 +109,15 @@ Exempt from approval revocation:
 
 - STATUS marker updates (`☐ → ☑`, `1.1 → 1.2`)
 - Bug report additions (separate from spec content changes)
+
+### Re-implementation Workflow
+
+When a spec is revised after a linked plan was already approved:
+
+1. Spec revision revokes the linked plan's approval
+2. The old plan is closed with a comment referencing the spec revision
+3. A new plan is created under the same spec (using `writing-plans` skill)
+4. The new plan requires fresh approval before implementation proceeds
 
 ### Label Handling
 
@@ -167,24 +180,52 @@ Key rules:
 | -- | -- |
 | `000-critical-rules.md` | Critical violations and auditor enforcement |
 | `020-go-prohibitions.md` | GO command restrictions |
-| `github-sub-issues` skill | Sub-issue creation and verification |
+| `140-planning-spec-creation.md` | Spec creation and plan-bridge hierarchy |
+| `github-sub-issues` skill | Sub-issue creation and verification (under plan) |
 | `git-workflow` skill `cleanup` task | Post-merge closure workflow |
 | `pr-creation-workflow` skill | PR creation timing |
+| `writing-plans` skill | Plan creation from approved spec |
+| `executing-plans` skill | Plan execution after plan approval |
 
 ```yaml+symbolic
 schema_version: "1.0"
-last_updated: "2026-04-12T12:00:00Z"
+last_updated: "2026-04-13T12:00:00Z"
 rules:
   - id: approval-gate-001
     title: "No implementation without authorization"
     conditions:
       all:
-        - "has_approved_spec == false"
+        - "has_approved_plan == false"
     actions:
       - HALT
     conflicts_with: []
     requires: []
     triggers: []
+    source: "010-approval-gate.md §Tier0"
+
+  - id: approval-gate-001a
+    title: "Spec approval authorizes plan creation, not implementation"
+    conditions:
+      all:
+        - "has_approved_spec == true"
+        - "has_approved_plan == false"
+    actions:
+      - INVOKE(writing-plans)
+    conflicts_with: []
+    requires: [approval-gate-001]
+    triggers: [writing-plans]
+    source: "010-approval-gate.md §Tier0"
+
+  - id: approval-gate-001b
+    title: "Plan approval authorizes implementation"
+    conditions:
+      all:
+        - "has_approved_plan == true"
+    actions:
+      - INVOKE(executing-plans)
+    conflicts_with: []
+    requires: [approval-gate-001a]
+    triggers: [executing-plans]
     source: "010-approval-gate.md §Tier0"
 
   - id: approval-gate-002
@@ -237,19 +278,54 @@ rules:
     triggers: []
     source: "010-approval-gate.md §Mandatory Requirements"
 
+  - id: approval-gate-006
+    title: "Spec revision revokes linked plan approvals"
+    conditions:
+      all:
+        - "spec_revised == true"
+        - "has_linked_plan == true"
+    actions:
+      - REVOKE(plan_approval)
+      - INVOKE(re-implementation-workflow)
+    conflicts_with: []
+    requires: []
+    triggers: [writing-plans]
+    source: "010-approval-gate.md §Revision Revokes Approval"
+
+  - id: approval-gate-007
+    title: "Sub-issues are under plan, not spec"
+    conditions:
+      all:
+        - "spec_has_sub_issues == true"
+        - "plan_has_sub_issues == false"
+    actions:
+      - RESTRUCTURE(move sub-issues to plan)
+    conflicts_with: []
+    requires: []
+    triggers: [github-sub-issues]
+    source: "010-approval-gate.md §Multi-Task Plan Authorization"
+
 state_machines:
   - id: approval-lifecycle
-    states: [draft, approved, implementing, pr_created, merged, closed]
+    states: [draft, spec_approved, plan_created, plan_approved, implementing, pr_created, merged, closed]
     start_state: draft
     transitions:
       - from: draft
-        to: approved
-        guard: "user_authorizes == true"
+        to: spec_approved
+        guard: "user_authorizes_spec == true"
+        action: INVOKE(writing-plans)
+      - from: spec_approved
+        to: plan_created
+        guard: "plan_exists == true"
         action: PROCEED
-      - from: approved
+      - from: plan_created
+        to: plan_approved
+        guard: "user_authorizes_plan == true"
+        action: INVOKE(executing-plans)
+      - from: plan_approved
         to: implementing
-        guard: "spec_exists == true"
-        action: INVOKE(approval-gate, then divide-and-conquer)
+        guard: "plan_approved == true"
+        action: INVOKE(divide-and-conquer)
       - from: implementing
         to: pr_created
         guard: "implementation_complete == true"
@@ -260,6 +336,6 @@ state_machines:
         action: PROCEED
       - from: merged
         to: closed
-        guard: "all_sub_issues_closed == true"
+        guard: "all_plan_sub_issues_closed == true"
         action: PROCEED
 ```

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -95,15 +95,16 @@ This rule applies universally to:
 
 ______________________________________________________________________
 
-## 5. Multi-task Spec Without Sub-issues — CRITICAL VIOLATION
+## 5. Multi-task Plan Without Sub-issues — CRITICAL VIOLATION
 
-**⚠️ Implementing a multi-task spec without sub-issues is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Implementing a multi-task plan without sub-issues is a CRITICAL GUIDELINE VIOLATION.** Sub-issues are children of the plan, not the spec.
 
 ### 🚫 ABSOLUTE PROHIBITION
 
-- **NEVER implement a multi-task spec without verified sub-issue structure**
-- **NEVER proceed **to implementation** when `get_sub_issues` returns empty array for multi-task specs **without auto-creating sub-issues first****
+- **NEVER implement a multi-task plan without verified sub-issue structure**
+- **NEVER proceed **to implementation** when `get_sub_issues` on the plan returns empty array for multi-task plans **without auto-creating sub-issues first****
 - **NEVER assume markdown checkboxes = task tracking**
+- **NEVER create sub-issues under the spec** — sub-issues belong to the plan
 
 ### ✅ MANDATORY
 
@@ -111,15 +112,15 @@ ______________________________________________________________________
 
 Key points:
 
-- Sub-issues at PHASE level, not step level
-- Single-task specs are exempt from sub-issue requirement
-- All multi-task specs MUST have sub-issues before implementation begins
-- Auto-creating sub-issues for an approved multi-task spec is a pre-implementation setup step covered by the parent's authorization. No separate authorization is required.
+- Sub-issues at PHASE level under the plan, not step level
+- Single-task plans are exempt from sub-issue requirement
+- All multi-task plans MUST have sub-issues before implementation begins
+- Auto-creating sub-issues for an approved multi-task plan is a pre-implementation setup step covered by the plan's authorization. No separate authorization is required.
 - After auto-creating sub-issues, the agent proceeds with implementation immediately (no re-authorization needed).
 
 ```yaml+symbolic
 schema_version: "1.0"
-last_updated: "2026-04-12T12:00:00Z"
+last_updated: "2026-04-13T12:00:00Z"
 rules:
   - id: go-prohibitions-001
     title: "Agent must never write GO as standalone token"
@@ -185,11 +186,11 @@ rules:
     source: "020-go-prohibitions.md §1 NEVER DO"
 
   - id: go-prohibitions-006
-    title: "Multi-task spec requires sub-issues"
+    title: "Multi-task plan requires sub-issues under plan"
     conditions:
       all:
-        - "spec_has_phases == true"
-        - "sub_issues_count == 0"
+        - "plan_has_phases == true"
+        - "plan_sub_issues_count == 0"
     actions:
       - HALT
     conflicts_with: []

--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -2,24 +2,34 @@
 
 ## Spec-Driven Development Workflow
 
-AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach:
+AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach with the **Plan-Bridge Hierarchy**:
 
 1. **Specify Phase**: Define **What & Why**. Kick off with a high-level vision (product brief), then expand it into a detailed specification focusing on user journeys, experiences, and success criteria.
-2. **Plan Phase**: Define **How**. Draft the technical plan (architecture, technical stack, and constraints).
-3. **Tasks Phase**: Break the plan into **small, reviewable chunks** (tasks) that can be implemented and tested in isolation.
+2. **Plan Phase** (Bridge): Define **How**. Create a plan issue (`[PLAN]` prefix, `plan` label) that references the spec via body linked reference. The plan bridges spec → tasks. **Spec approval authorizes plan creation; plan approval authorizes implementation.**
+3. **Tasks Phase**: Break the plan into **small, reviewable chunks** (sub-issues under the plan, not the spec) that can be implemented and tested in isolation.
 4. **Implement Phase**: **Execute** tasks and **verify** results.
+
+**Two-Gate Model:**
+- **Gate 1 — Spec Approval → Plan Creation**: Spec approval authorizes creating the plan issue. The spec references the plan via body text (linked reference, e.g., `Related Plan: #NNN`), NOT via GitHub sub-issue link.
+- **Gate 2 — Plan Approval → Implementation**: Plan approval authorizes implementation. Authorization cascades from the plan to all its sub-issues.
+
+**Plan-Bridge Hierarchy:** Spec → (body linked reference) → Plan → Sub-issues
 
 **CRITICAL**: Investigation and Planning phases are AUTO-COMPLETED before the spec is created. The spec file ONLY contains implementation and verification phases.
 
 **INVESTIGATION CHECKPOINT**: Before creating a spec, the agent MUST verify investigation is complete. See `142-planning-archive-workflow.md` for investigation completion criteria and permissible test activities.
 
+**SPEC REVISION**: When a spec is revised, all linked plan approvals are revoked. The old plan is closed and a new plan must be created and approved. See `010-approval-gate.md` §"Revision Revokes Approval" and §"Re-implementation Workflow".
+
 ______________________________________________________________________
 
-## Terminology: Spec vs. Guideline Files
+## Terminology: Spec vs. Plan vs. Guideline Files
 
 - **"Create a new spec"** = Create a GitHub Issue with `[SPEC]` prefix (Mandatory when GitHub MCP available)
+- **"Create a plan"** = Create a GitHub Issue with `[PLAN]` prefix and `plan` label, referencing the spec via body linked reference
 - **"Create a guideline file"** = Create/modify files in `.opencode/guidelines/` (Implementation task)
 - **SPEC = GitHub Issue** — Specs are planning/tracking artifacts, not file system artifacts
+- **PLAN = GitHub Issue** — Plans are separate issues that bridge specs to implementation sub-issues; sub-issues are children of the plan, not the spec
 
 ______________________________________________________________________
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -51,10 +51,11 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 ## Operating Protocol
 
 1. **Mandatory invocation (no decision point):** The agent MUST invoke approval-gate when it encounters `approved`/`go`, authorization questions, or implementation start. Never prompt for invocation — just invoke the skill.
-2. **Pre-Implementation Verification:** Verify spec exists as GitHub Issue, verify authorization, verify sub-issues (multi-task), check for blockers.
-3. **Implementation Scope:** Authorization grants ONLY the specified phase/task. HALT after completing authorized work.
-4. **Multi-task cascade:** When parent has sub-issues, authorization cascades to ALL sub-issues. Complete ALL phases, report ONCE, HALT ONCE.
-5. **Auto-dispatch after verification:** When all verification gates pass, auto-dispatch to the next skill in the chain. See Dispatch Order below.
+2. **Two-gate authorization model:** Spec approval → plan creation. Plan approval → implementation. Each gate requires explicit authorization.
+3. **Pre-Implementation Verification:** Verify spec or plan exists as GitHub Issue, verify authorization, verify sub-issues under plan (multi-task), check for blockers.
+4. **Multi-task cascade:** When plan has sub-issues, authorization cascades from plan to ALL sub-issues. Complete ALL phases, report ONCE, HALT ONCE.
+5. **Spec revision revocation:** If a spec is revised (status changed to REVISED - NEEDS APPROVAL), find linked plan issues by searching for `[PLAN]` issues referencing the spec number in their body and mark them for audit. Revision of a spec revokes approval on its linked plan.
+6. **Auto-dispatch after verification:** When all verification gates pass, auto-dispatch to the next skill in the chain. See Dispatch Order below.
 
 ## Dispatch Order
 
@@ -63,15 +64,16 @@ After `verify-authorization` completes successfully (all gates pass), the skill 
 ```
 Spec approved
   → verify-authorization (all gates pass)
+  → writing-plans --task create (auto-dispatched to create plan issue)
+
+Plan approved
+  → verify-authorization (all gates pass)
+  → sub-issue verification (if multi-phase)
   → pre-implementation-analysis (expand sub-issues, classify, build flat item list)
   → divide-and-conquer/assemble-batch (dispatch sub-agents, squash-merge into batch branch)
   → verification-before-completion
   → finishing-a-development-branch
   → git-workflow/review-prep
-
-Plan approved
-  → verify-authorization (all gates pass)
-  → executing-plans --task start (auto-dispatched)
 
 Already implemented
   → verify-authorization (all gates pass)
@@ -79,23 +81,24 @@ Already implemented
   → Auto-close (no dispatch)
 ```
 
-**Unified path:** Every approval — single issue or batch — follows the same flow: `verify-authorization` → `pre-implementation-analysis` → `assemble-batch`. Single issue = batch of one sub-agent. No forked paths.
+**Spec approval dispatches to plan creation, NOT implementation.** The plan then requires its own approval before implementation begins.
 
 **Dispatch context detection:**
 - Spec approval: Issue title contains `[SPEC` or has `spec` label
-- Plan approval: Issue is a sub-issue of a spec (plan relationship)
+- Plan approval: Issue has `plan` label or `[PLAN]` prefix in title
 - See `verify-authorization.md` Step 5 for full procedure
 
-**Circular dispatch prevention:** Plan approval dispatches to `executing-plans`, NOT back to `writing-plans`. Spec approval dispatches to `writing-plans`, which creates a plan. The plan then requires its own approval before dispatching to `executing-plans`.
+**Circular dispatch prevention:** Spec approval dispatches to `writing-plans`, which creates a plan. Plan approval dispatches to `executing-plans`. The plan requires its own approval before `executing-plans` can run.
 
 ## Authorization Requirements
 
 | Requirement | Description |
 |-------------|-------------|
-| **Spec exists as GitHub Issue** | No local fallback — GitHub Issues only |
+| **Spec or Plan exists as GitHub Issue** | No local fallback — GitHub Issues only |
+| **Two-gate authorization** | Spec approval → plan creation; Plan approval → implementation |
 | **Explicit authorization** | User says `approved`, `go`, or `approved: N.M` — OVERRIDES `needs-approval` label |
-| **Open questions resolved** | No unresolved items in spec |
-| **Sub-issues verified** | Multi-task specs require phase-level sub-issues |
+| **Open questions resolved** | No unresolved items in spec or plan |
+| **Sub-issues verified under plan** | Multi-task plans require phase-level sub-issues |
 | **Fix spec for bug reports** | Bug reports must have a fix spec sub-issue before closure (per `000-critical-rules.md`) |
 | **Implementation includes** | All file modifications that alter behavior: source code, skill files, guideline files, config files, test files, TypeScript plugins |
 
@@ -176,16 +179,16 @@ rules:
     source: "approval-gate/SKILL.md §Authorization Requirements"
 
   - id: approval-gate-skill-002
-    title: "Multi-task cascade: authorization extends to all sub-issues"
+    title: "Multi-task cascade: authorization extends from plan to all sub-issues"
     conditions:
       all:
-        - "parent_has_sub_issues == true"
+        - "plan_has_sub_issues == true"
         - "user_authorized == true"
     actions:
       - PROCEED
     conflicts_with: []
     requires: [approval-gate-002]
-    triggers: [divide-and-conquer]
+    triggers: [divide-and-conquer, executing-plans]
     source: "approval-gate/SKILL.md §Multi-task cascade"
 
   - id: approval-gate-skill-003

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -89,32 +89,45 @@ After all verification gates pass, determine the approval context and auto-dispa
 
 | Approval Context | How to Detect | Auto-Dispatch Target |
 |------------------|---------------|----------------------|
-| **Spec approval** | Issue title contains `[SPEC` or has `spec` label; no existing plan sub-issue | `writing-plans --task create` |
-| **Plan approval** | Issue is a plan (linked from a spec via sub-issue relationship) | `executing-plans --task start` |
+| **Spec approval** | Issue title contains `[SPEC` or has `spec` label | `writing-plans --task create` |
+| **Plan approval** | Issue has `plan` label or `[PLAN]` prefix in title | `executing-plans --task start` |
 | **Already implemented** | `verify-already-implemented` returns positive | No dispatch — auto-close instead |
 
 #### Auto-Dispatch Procedure
 
 1. Determine approval context (spec vs plan) by checking:
    - Issue title format: `[SPEC` prefix = spec approval
-   - Sub-issue relationships: if this issue is a sub-issue of a spec, it is a plan approval
+   - Issue title format: `[PLAN]` prefix = plan approval
    - Labels: presence of `spec` or `plan` labels
+   - Plan detection is via `plan` label or `[PLAN]` prefix in title (NOT via sub-issue relationship to spec)
 2. **If spec approval:** Invoke `writing-plans --task create` with context:
    - `spec_issue=#N` (the approved spec issue number)
    - `GIT_OWNER`, `GIT_REPO`, `WORKTREE_PATH` from session
-3. **If plan approval:** Invoke `executing-plans --task start` (existing behavior, no change)
+3. **If plan approval:** Invoke `executing-plans --task start` with context:
+   - `plan_issue=#N` (the approved plan issue number)
+   - `spec_issue=#M` (extracted from plan body — the spec reference)
+   - `GIT_OWNER`, `GIT_REPO`, `WORKTREE_PATH` from session
 4. **Chat output:** Clearly indicate the transition:
    - Spec approval: "Verification passed → Creating implementation plan"
    - Plan approval: "Verification passed → Starting implementation"
 
+#### Spec Revision Revocation Detection
+
+If a spec is revised (status changed to `REVISED - NEEDS APPROVAL`):
+
+1. Search for `[PLAN]` issues that reference the spec number in their body
+2. Mark found plans for audit (their authorization is revoked by the spec revision)
+3. Report affected plans in chat output
+
 #### Auto-Dispatch Edge Cases
 
 - **Spec already has a plan:** `writing-plans --task create` handles this (skips or updates per its existing logic)
-- **Multi-task spec with missing sub-issues:** `verify-sub-issues` gate fails → HALT, no dispatch
-- **Batch approval:** Each spec in batch gets its own dispatch cycle after batch state is established
+- **Multi-task plan with missing sub-issues:** `verify-sub-issues` gate fails → HALT, no dispatch
+- **Batch approval:** Each plan in batch gets its own dispatch cycle after batch state is established
 
 ## Context Required
 
 - Related tasks: `verify-sub-issues`, `verify-codebase`
 - Auto-dispatch targets: `writing-plans` (spec approval), `executing-plans` (plan approval)
+- Dispatch context for plan approval: pass `plan_issue=#N` and `spec_issue=#M` (extracted from plan body)
 - Label state machine: `141-planning-status-tracking.md §10` (remove `needs-approval`, add `in-progress` on approval)

--- a/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
@@ -2,19 +2,19 @@
 
 ## Purpose
 
-Verify sub-issue structure and STATUS gate for multi-task specs before implementation.
+Verify sub-issue structure and STATUS gate for multi-task plans before implementation. Sub-issues are verified under the plan issue, not the spec issue.
 
 ## Entry Criteria
 
-- Spec exists as GitHub Issue
+- Plan exists as GitHub Issue (with `plan` label or `[PLAN]` prefix)
 - Authorization received for specific subtask (e.g., "approved: 1.2")
 - Subtask number provided or extracted from authorization
-- Authorization received for parent spec (covers sub-issue creation)
+- Authorization received for plan (covers sub-issue creation)
 
 ## Exit Criteria
 
-- Sub-issues verified present (multi-task) OR exemption confirmed (single-task)
-- STATUS in parent matches requested subtask number
+- Sub-issues verified present under plan (multi-task) OR exemption confirmed (single-task/single-phase)
+- STATUS in plan matches requested subtask number
 - Auto-create performed if needed
 
 ## Procedure
@@ -22,33 +22,33 @@ Verify sub-issue structure and STATUS gate for multi-task specs before implement
 ### Step 1: Check for Sub-issues
 
 ```python
-sub_issues = github_issue_read(method="get_sub_issues", issue_number=parent_issue)
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=plan_issue)
 ```
 
-### Step 2: Determine Spec Type
+### Step 2: Determine Plan Type
 
-**Single-task spec (EXEMPT from sub-issues):**
-- Exactly ONE implementation task
+**Single-phase plan (EXEMPT from sub-issues):**
+- Exactly ONE implementation phase
 - No decomposition into phases needed
 - Can be implemented as atomic unit
 
-**Multi-task spec (REQUIRES sub-issues):**
+**Multi-task plan (REQUIRES sub-issues):**
 - Multiple phases (Phase 1, Phase 2, ...)
 - Multiple implementation tasks
 - Requires sequential work streams
 
 ### Step 3: Verify STATUS Gate (CRITICAL)
 
-**For multi-task specs with sub-issues:**
+**For multi-task plans with sub-issues:**
 
 1. Extract subtask number from authorization:
    - "approved: 1.2" → subtask 1.2
    - "approved: X.Y" → subtask X.Y
    - "approved" (no number) → check STATUS for current phase
 
-2. Get parent issue STATUS:
+2. Get plan issue STATUS:
    ```python
-   parent = github_issue_read(method="get", issue_number=parent_issue)
+   plan = github_issue_read(method="get", issue_number=plan_issue)
    # Parse STATUS from body
    # STATUS format: "STATUS: X.Y" or "STATUS: completed"
    # If STATUS not found, default to first subtask (1.1)
@@ -85,24 +85,24 @@ sub_issues = github_issue_read(method="get_sub_issues", issue_number=parent_issu
 
 If empty AND multi-task:
 
-**No separate authorization required.** Parent approval covers sub-issue creation as a setup step.
+**No separate authorization required.** Plan approval covers sub-issue creation as a setup step.
 
 ```python
-# For each PHASE in spec:
+# For each PHASE in plan:
 issue = github_issue_write(
     method="create",
-    title=f"[Task: #{parent}] {phase_description}",
-    body=f"Parent: #{parent}\nSubtask: {phase_number}\n\n## Purpose\n\n{phase_objective}\n\n## Procedure\n\n{phase_steps}",
+    title=f"[Task: #{plan_issue}] {phase_description}",
+    body=f"Plan: #{plan_issue}\nSubtask: {phase_number}\n\n## Purpose\n\n{phase_objective}\n\n## Procedure\n\n{phase_steps}",
     labels=["enhancement", "architecture"]
 )
 github_sub_issue_write(
     method="add",
-    issue_number=parent,
+    issue_number=plan_issue,
     sub_issue_id=issue["id"]
 )
 ```
 
-Auto-creating sub-issues for an approved multi-task spec does NOT require separate authorization. The parent's authorization covers this setup step.
+Auto-creating sub-issues for an approved multi-task plan does NOT require separate authorization. The plan's authorization covers this setup step.
 
 ### Step 5: Post Comment
 
@@ -110,13 +110,13 @@ Auto-creating sub-issues for an approved multi-task spec does NOT require separa
 
 ## Auto-Create Authorization
 
-**Auto-creating sub-issues for an approved multi-task spec does NOT require separate authorization.** The parent's authorization covers this setup step.
+**Auto-creating sub-issues for an approved multi-task plan does NOT require separate authorization.** The plan's authorization covers this setup step.
 
 | Action | Requires Separate Auth? | Why |
 |--------|------------------------|-----|
-| Auto-creating sub-issues | ❌ NO | Tracking/setup action, covered by parent authorization |
-| Linking sub-issues to parent | ❌ NO | Part of sub-issue creation workflow |
-| Proceeding to implementation after auto-creation | ❌ NO | Parent authorization continues to implementation |
+| Auto-creating sub-issues | ❌ NO | Tracking/setup action, covered by plan authorization |
+| Linking sub-issues to plan | ❌ NO | Part of sub-issue creation workflow |
+| Proceeding to implementation after auto-creation | ❌ NO | Plan authorization continues to implementation |
 
 ## STATUS Gate Rules
 
@@ -127,7 +127,7 @@ Auto-creating sub-issues for an approved multi-task spec does NOT require separa
 | STATUS is "completed" | ⛔ HALT - spec already complete |
 | STATUS not found + "approved" | ✅ PROCEED - default to first subtask (1.1), report decision |
 | STATUS not found + "approved: X.Y" | ✅ PROCEED - use specified X.Y, report decision |
-| Single-task spec (no STATUS) | ✅ PROCEED - no gate needed |
+| Single-phase plan (no STATUS) | ✅ PROCEED - no gate needed |
 | Subtask not in sub-issues list | ⛔ HALT - report available subtasks |
 
 ## Mandatory Reporting (No Silent Halts)
@@ -163,13 +163,13 @@ Auto-creating sub-issues for an approved multi-task spec does NOT require separa
 | Issue | Resolution |
 |-------|------------|
 | STATUS mismatch | POST report: "STATUS mismatch: authorized for X.Y but STATUS is Z.W. Please update STATUS or authorize correct subtask." |
-| STATUS not found | Default to first subtask (1.1), POST report: "STATUS not found. Defaulting to first subtask (1.1). Add 'STATUS: X.Y' to parent issue for tracking." |
+| STATUS not found | Default to first subtask (1.1), POST report: "STATUS not found. Defaulting to first subtask (1.1). Add 'STATUS: X.Y' to plan issue for tracking." |
 | Sub-issue not linked | Auto-create and link, POST report: "Created N sub-issues for phase tracking." |
-| Single-task spec with STATUS | Ignore STATUS, proceed, POST report: "Single-task spec, ignoring STATUS field." |
+| Single-phase plan with STATUS | Ignore STATUS, proceed, POST report: "Single-phase plan, ignoring STATUS field." |
 | Subtask not in list | HALT, POST report: "Subtask X.Y not found. Available subtasks: [list]. Please authorize a valid subtask." |
-| Parent issue missing STATUS field | Default to first subtask (1.1), proceed, report to chat |
+| Plan issue missing STATUS field | Default to first subtask (1.1), proceed, report to chat |
 
 ## Context Required
 
 - Related tasks: `verify-authorization`, `verify-codebase`
-- Label state machine: `141-planning-status-tracking.md §10` (label transitions when creating sub-issues)
+- Label state machine: `141-planning-status-tracking.md §10` (label transitions when creating sub-issues under plan)

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -92,6 +92,7 @@ When the orchestrator dispatches a sub-agent, it MUST pass:
 issue: <number>
 branch: "spec/<short-name>"
 spec: "<full spec body or relevant section>"
+plan_issue: <number or empty>
 authorization: "User approved #<N> on <date>"
 depth: <current decomposition depth, starting at 0>
 max_depth: <DIVIDE_AND_CONQUER_MAX_DEPTH or 3>
@@ -109,7 +110,7 @@ env_vars:
   DEV_EMAIL: "<from-session>"
 ```
 
-**Invariants:** `WORKTREE_PATH` is MANDATORY — no exceptions. If empty: FATAL ERROR → HALT.
+**Invariants:** `WORKTREE_PATH` is MANDATORY — no exceptions. If empty: FATAL ERROR → HALT. `plan_issue` is set when dispatched from plan approval flow.
 
 ## Sub-agent Result Contract
 
@@ -120,6 +121,7 @@ status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
 files_changed: ["<path>"]
 summary: "<what was implemented and key decisions>"
 concerns: "<only if DONE_WITH_CONCERNS>"
+plan_issue: <number or empty>
 verification_passed: true | false
 compare_url: "<compare URL from review-prep, or empty string>"
 exec_summary: "<1-2 sentence executive summary for chat output, or empty string>"

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -10,11 +10,25 @@ compatibility: opencode
 
 ## Overview
 
-Plan execution skill that dispatches to `divide-and-conquer/assemble-batch` for implementation. This skill is a thin dispatch layer — all implementation logic flows through the unified batch workflow.
+Plan execution skill that dispatches to `divide-and-conquer/assemble-batch` for implementation. This skill is a thin dispatch layer — all implementation logic flows through the unified batch workflow. It receives plan context from `approval-gate` after plan approval.
 
 **Every approval follows one path:** `executing-plans` → `divide-and-conquer/assemble-batch` → batch branch → pr-creation → one PR.
 
 **There is no single-issue bypass.** Single issue = batch of one = one sub-agent.
+
+## Received Context
+
+When dispatched from `approval-gate` after plan approval, the following context is available:
+
+```yaml
+plan_issue: <number>
+spec_issue: <number, extracted from plan body>
+GIT_OWNER: "<from-session>"
+GIT_REPO: "<from-session>"
+WORKTREE_PATH: "<worktree path>"
+```
+
+**Verification:** If `plan_issue` is not present in the dispatch context, HALT — this skill requires plan context to track progress against the correct issue.
 
 ## Tasks
 
@@ -35,11 +49,15 @@ Plan execution skill that dispatches to `divide-and-conquer/assemble-batch` for 
 
 ## Operating Protocol
 
-1. **Dispatch to divide-and-conquer:** The `start` task invokes `divide-and-conquer --task assemble-batch` which handles all implementation — single issue or batch — through the unified workflow.
+1. **Verify plan context:** Before dispatching, confirm `plan_issue` is present in received context. If missing, HALT and report.
 
-2. **No direct implementation:** This skill does not implement directly. It dispatches.
+2. **Dispatch to divide-and-conquer:** The `start` task invokes `divide-and-conquer --task assemble-batch` which handles all implementation — single issue or batch — through the unified workflow. Pass `plan_issue` in the dispatch context.
 
-3. **Single issue = batch of one:** There is no separate path for single issues. The `assemble-batch` task handles single-issue dispatch as the default code path.
+3. **No direct implementation:** This skill does not implement directly. It dispatches.
+
+4. **Single issue = batch of one:** There is no separate path for single issues. The `assemble-batch` task handles single-issue dispatch as the default code path.
+
+5. **Progress reports against plan:** All progress tracking references the plan issue (not the spec issue). The plan is the implementation tracking artifact; the spec is the requirements artifact.
 
 ## Dispatch Order
 
@@ -51,6 +69,8 @@ Plan approved (approval-gate)
   → finishing-a-development-branch
   → git-workflow/review-prep
 ```
+
+**Progress is tracked against the plan issue.** The plan references the spec via body text (linked reference), not via GitHub sub-issue link.
 
 ## Cross-References
 

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -10,7 +10,7 @@ compatibility: opencode
 
 ## Overview
 
-Branch completion workflow that ensures a feature branch is fully ready for PR creation. Verifies all changes are committed, tested, pushed, and reviewed before the developer creates a PR. Adapted from the \<UPSTREAM_ORG>/\<UPSTREAM_REPO> workflow.
+Branch completion workflow that ensures a feature branch is fully ready for PR creation. Verifies all changes are committed, tested, pushed, and reviewed before the developer creates a PR. Implementation tracks against plan sub-issues, not spec sub-issues. Adapted from the \<UPSTREAM_ORG>/\<UPSTREAM_REPO> workflow.
 
 **Source Attribution:** This skill is adapted from \<UPSTREAM_ORG>/\<UPSTREAM_REPO> workflow (branch: newsrx).
 
@@ -59,6 +59,10 @@ When invoked, this skill requires the following guidelines to be loaded on-deman
 ```
 executing-plans → verification-before-completion → finishing-a-development-branch → review-prep → (PR creation by user)
 ```
+
+### Plan Hierarchy Context
+
+Implementation tracks against **plan sub-issues**, not spec sub-issues. The hierarchy is: Spec → (linked reference in body) → Plan → Sub-issues. When verifying branch completion, reference the plan issue for tracking status and the spec issue for requirements.
 
 ### Git-Workflow Integration
 

--- a/.opencode/skills/github-issue-creation/SKILL.md
+++ b/.opencode/skills/github-issue-creation/SKILL.md
@@ -22,8 +22,8 @@ You are an Issue Creation Enforcer. Your focus is ensuring all GitHub issue crea
 |------|---------|-------|
 | `pre-creation` | Validate before creating issue (conflicts, superseded, supersede check) | ~240 |
 | `creation` | Create issue with proper title, labels, byline | ~200 |
-| `post-creation` | Invoke auditors, create sub-issues for multi-task specs | ~180 |
-| `single-task-check` | Determine if spec needs sub-issues or is single-task | ~160 |
+| `post-creation` | Invoke auditors, trigger plan creation for multi-task specs | ~180 |
+| `single-task-check` | Determine if spec needs a plan issue (multi-task) or is single-task | ~160 |
 | `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~200 |
 
 ## Invocation
@@ -46,9 +46,9 @@ You are an Issue Creation Enforcer. Your focus is ensuring all GitHub issue crea
 
 2. **Workflow sequence:**
    - Phase 1: `pre-creation` → Validate spec, check for conflicts/superseded
-   - Phase 2: `single-task-check` → Determine if spec needs sub-issues
+   - Phase 2: `single-task-check` → Determine if spec needs a plan issue
    - Phase 3: `creation` → Create issue with labels and byline
-   - Phase 4: `post-creation` → Invoke auditors, create sub-issues if multi-task
+   - Phase 4: `post-creation` → Invoke auditors, trigger plan creation via writing-plans if multi-task
 
 ## What This Skill Does
 
@@ -67,10 +67,10 @@ You are an Issue Creation Enforcer. Your focus is ensuring all GitHub issue crea
 ### Single-Task vs Multi-Task Detection
 
 **Determines:**
-- Single-task spec (one implementation task, no sub-issues needed)
-- Multi-task spec (multiple phases, requires sub-issues)
+- Single-task spec (one implementation task, plan optional per agent intelligence)
+- Multi-task spec (multiple phases, requires plan issue)
 
-**Auto-creates sub-issues** for multi-task specs via `github-sub-issues` skill.
+**Triggers plan creation** for multi-task specs via `writing-plans` skill. Plan creation handles sub-issue creation under the plan.
 
 ### Creation Time Enforcement
 
@@ -91,7 +91,7 @@ You are an Issue Creation Enforcer. Your focus is ensuring all GitHub issue crea
 | `spec-auditor` | Orchestrate spec quality audit (subtasks: fresh-start, structure, content-quality, traceability, fidelity, concerns, operational) | Run BEFORE approval |
 | `approval-gate` | Enforce authorization | Run AFTER issue created |
 | `github-comments` | Byline format | Use for substantive comments only |
-| `github-sub-issues` | Sub-issue creation | Invoke for multi-task specs |
+| `writing-plans` | Plan issue creation | Invoke for multi-task specs after creation |
 
 ## When to Invoke
 
@@ -110,6 +110,7 @@ You are an Issue Creation Enforcer. Your focus is ensuring all GitHub issue crea
 - Create sub-issues for single-task specs
 - Skip auditor invocation for multi-task specs
 - Create issues with conflicting/overlapping objectives
+- Create sub-issues directly under spec (sub-issues go under plan)
 
 ### ✅ ALWAYS DO
 
@@ -118,15 +119,18 @@ You are an Issue Creation Enforcer. Your focus is ensuring all GitHub issue crea
 - Add creation byline in issue body footer
 - Invoke auditors before approval
 - Check for superseding/conflicting issues
+- For multi-task specs, invoke `writing-plans` for plan creation (not `github-sub-issues` directly)
 
 ## Task Dependencies
 
 ```
 pre-creation → single-task-check → creation → post-creation
-                                           ↓
-                                    (if multi-task)
-                                           ↓
-                                     github-sub-issues skill
+                                            ↓
+                                     (if multi-task)
+                                            ↓
+                                      writing-plans skill
+                                            ↓
+                                      plan issue (with sub-issues under plan)
 ```
 
 ## Enforcement
@@ -165,4 +169,4 @@ If GitHub MCP is unavailable:
 
 - Related skills: `spec-auditor`, `approval-gate`, `github-comments`, `github-sub-issues`
 - Related guidelines: `010-approval-gate.md`, `000-critical-rules.md`
-- Related skill tasks: `github-sub-issues --task create-sub-issue` (multi-task sub-issue creation), `git-workflow --task cleanup` (post-merge closure)
+- Related skill tasks: `writing-plans --task create` (plan creation for multi-task specs), `git-workflow --task cleanup` (post-merge closure)

--- a/.opencode/skills/github-issue-creation/tasks/post-creation.md
+++ b/.opencode/skills/github-issue-creation/tasks/post-creation.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Invoke auditors and create sub-issues after issue creation, ensuring spec quality before approval.
+Invoke auditors and trigger plan creation for multi-task specs after issue creation, ensuring spec quality before approval.
 
 ## Operating Protocol
 
@@ -18,7 +18,7 @@ Invoke auditors and create sub-issues after issue creation, ensuring spec qualit
 ## Exit Criteria
 
 - Auditors invoked (spec-auditor orchestrator — determines subtasks automatically)
-- Sub-issues created (if multi-task)
+- Plan creation triggered (if multi-task) via writing-plans skill
 - Issue ready for approval workflow
 
 ## Procedure
@@ -26,38 +26,26 @@ Invoke auditors and create sub-issues after issue creation, ensuring spec qualit
 ### Step 1: Determine Single-Task vs Multi-Task
 
 **Use `single-task-check` task to determine:**
-- Single-task spec (ONE phase, no sub-issues needed)
-- Multi-task spec (multiple phases, requires sub-issues)
+- Single-task spec (ONE phase, plan optional per agent intelligence)
+- Multi-task spec (multiple phases, requires plan issue)
 
-### Step 2: Create Sub-Issues (Multi-Task Only)
+### Step 2: Trigger Plan Creation (Multi-Task Only)
 
 **If multi-task spec:**
 
+Invoke `writing-plans --task create` to create the plan issue. Plan creation handles:
+- Creating the `[PLAN]` issue with `plan` label
+- Adding a linked reference to the spec in the plan body
+- Creating sub-issues under the plan (via `github-sub-issues` skill)
+
+**Do NOT create sub-issues directly under the spec.** Sub-issues belong under the plan, not the spec.
+
 ```python
-# For each phase in spec:
-sub_issue = github_issue_write(
-    method="create",
-    owner=owner,
-    repo=repo,
-    title=f"[Task: #{parent_number}] {phase_title}",
-    body=phase_content,
-    labels=["needs-approval"]
-)
-
-# Link as sub-issue:
-github_sub_issue_write(
-    method="add",
-    owner=owner,
-    repo=repo,
-    issue_number=parent_number,
-    sub_issue_id=sub_issue["id"]  # Use DATABASE ID
-)
+# Post-creation triggers writing-plans:
+# writing-plans --task create
+#   → creates [PLAN] issue referencing spec #N in body
+#   → creates sub-issues under the plan
 ```
-
-**Phase-level sub-issues:**
-- One sub-issue per phase
-- NOT one per step
-- Use database ID (not issue number) for linking
 
 ### Step 3: Invoke Spec-Auditor Orchestrator
 
@@ -90,8 +78,8 @@ Previous workflow (DEPRECATED):
 ## Single-Task Exemption
 
 **If single-task:**
-- No sub-issues needed
-- Skip `github-sub-issues` skill invocation
+- Plan issue optional (per agent intelligence — agent may create one if it adds clarity)
+- No sub-issues needed under any plan
 - Proceed to auditor invocation
 
 ## Safety Checks
@@ -99,10 +87,10 @@ Previous workflow (DEPRECATED):
 Before proceeding, verify ALL:
 
 - Auditors invoked (spec-auditor orchestrator — determines subtasks automatically)
-- Sub-issues created (if multi-task)
+- Plan creation triggered (if multi-task)
 
 **If ANY check fails → HALT and report.**
 
 ## Context Required
 
-- Related tasks: `creation` (runs first), `single-task-check` (determination logic)
+- Related tasks: `creation` (runs first), `single-task-check` (determination logic), `writing-plans --task create` (plan creation for multi-task)

--- a/.opencode/skills/github-issue-creation/tasks/single-task-check.md
+++ b/.opencode/skills/github-issue-creation/tasks/single-task-check.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Determine if a spec is single-task (no sub-issues needed) or multi-task (requires phase-level sub-issues).
+Determine if a spec is single-task (plan optional) or multi-task (requires plan issue with phase-level sub-issues).
 
 ## Operating Protocol
 
@@ -17,7 +17,8 @@ Determine if a spec is single-task (no sub-issues needed) or multi-task (require
 ## Exit Criteria
 
 - Determination made: single-task or multi-task
-- If multi-task: phase list identified for sub-issue creation
+- If multi-task: phase list identified for plan creation
+- Plan need determination passed to post-creation
 
 ## Procedure
 
@@ -49,12 +50,13 @@ Determine if a spec is single-task (no sub-issues needed) or multi-task (require
 | **Distinct concerns** | Phases address different architectural concerns |
 | **Deployment independence** | Phases can be deployed separately |
 
-### Step 3: Determine Sub-Issue Strategy
+### Step 3: Determine Plan Strategy
 
 **If SINGLE-TASK:**
 
 ```
 Result: SINGLE-TASK
+Plan needed: Optional (per agent intelligence — create if it adds clarity)
 Sub-issues: None
 Next: Proceed to issue creation
 ```
@@ -63,12 +65,13 @@ Next: Proceed to issue creation
 
 ```
 Result: MULTI-TASK
+Plan needed: YES
 Phases:
   - Phase 1: [Title]
   - Phase 2: [Title]
   - ...
-Sub-issues needed: YES
-Next: Create sub-issues in post-creation
+Sub-issues under plan: YES
+Next: Create plan issue in post-creation via writing-plans
 ```
 
 ### Step 4: Report Determination
@@ -80,9 +83,9 @@ Next: Create sub-issues in post-creation
 
 - Type: {single-task|multi-task}
 - Phases: {count}
-- Sub-issues needed: {yes|no}
+- Plan needed: {yes|optional}
 
-{If multi-task, list phase titles for sub-issue creation}
+{If multi-task, list phase titles for plan creation}
 ```
 
 ## Edge Cases
@@ -116,7 +119,7 @@ Next: Create sub-issues in post-creation
 - Same concern (database schema)
 - Second is verification of first
 
-**Determination:** MULTI-TASK (verification is separate concern)
+**Determination:** MULTI-TASK (verification is separate concern) → plan needed
 
 ### Edge Case 3: Large Single Phase
 
@@ -133,7 +136,22 @@ Next: Create sub-issues in post-creation
 - All steps for ONE feature
 - No verification phase
 
-**Determination:** SINGLE-TASK
+**Determination:** SINGLE-TASK (plan optional)
+
+### Edge Case 4: Single-Phase Plan
+
+**Plan:**
+```
+## Phase 1: Update Skills (Gated)
+- Update approval-gate
+- Update divide-and-conquer
+```
+
+**Analysis:**
+- Single phase in plan
+- Multiple files but single concern
+
+**Determination:** Single-phase plan — no sub-issues needed under the plan
 
 ## Safety Checks
 
@@ -147,4 +165,4 @@ Before proceeding, verify ALL:
 
 ## Context Required
 
-- Related tasks: `pre-creation` (runs first), `creation` (uses determination)
+- Related tasks: `pre-creation` (runs first), `creation` (uses determination), `post-creation` (triggers writing-plans if multi-task)

--- a/.opencode/skills/github-sub-issues/SKILL.md
+++ b/.opencode/skills/github-sub-issues/SKILL.md
@@ -10,7 +10,9 @@ compatibility: opencode
 
 ## Overview
 
-Ensures multi-task specs have proper sub-issue structure before implementation begins. Sub-issues track phases as separate GitHub Issues linked to the parent, providing state tracking, progress visibility, and proper parent-child relationships.
+Ensures multi-task plans have proper sub-issue structure before implementation begins. Sub-issues track phases as separate GitHub Issues linked to the parent **plan** (not the spec), providing state tracking, progress visibility, and proper parent-child relationships.
+
+The hierarchy is: **Spec → (linked reference) → Plan → Sub-issues**. Sub-issues are children of the plan issue, NOT the spec.
 
 ## Tasks
 
@@ -29,41 +31,41 @@ Ensures multi-task specs have proper sub-issue structure before implementation b
 
 ## Single-Task Exemption
 
-Single-task issues do NOT require sub-issues. A spec is "single-task" if it has exactly ONE implementation task/phase with no decomposition needed. If single-task: proceed without sub-issue verification. If multi-task: sub-issues are MANDATORY.
+Single-task plans do NOT require sub-issues. A plan is "single-task" if it has exactly ONE implementation task/phase with no decomposition needed. If single-task: proceed without sub-issue verification. If multi-task: sub-issues are MANDATORY.
 
 ## Sub-Issue Verification Gate (MANDATORY Before Implementation)
 
-1. Call `github_issue_read method=get_sub_issues` on parent issue
-2. **If empty AND multi-task:** AUTO-CREATE sub-issues immediately, then proceed — no separate authorization needed
+1. Call `github_issue_read method=get_sub_issues` on the **plan** issue (not the spec)
+2. **If empty AND multi-task:** AUTO-CREATE sub-issues under the plan immediately, then proceed — no separate authorization needed
 3. **If sub-issues exist:** Verify phase being implemented is among them, proceed
 
-**Authorization for the parent spec covers sub-issue creation.** When `get_sub_issues` returns empty for an approved multi-task spec, auto-create and proceed.
+**Authorization for the parent plan covers sub-issue creation.** When `get_sub_issues` returns empty for an approved multi-task plan, auto-create and proceed.
 
 ## Phase-Level vs Step-Level
 
 Sub-issues = PHASES, not steps. Phases are approval units; steps are implementation details within phases.
 
 ```
-✅ CORRECT: Phase-level sub-issues
-SPEC #100: Feature Name
-├── Task #101: [Task: #100] Create database schema
-├── Task #102: [Task: #100] Implement API endpoints
-└── Task #103: [Task: #100] Build UI components
+✅ CORRECT: Phase-level sub-issues under plan
+PLAN #200: [PLAN] Feature Name
+├── Task #201: [Task: #200] Create database schema
+├── Task #202: [Task: #200] Implement API endpoints
+└── Task #203: [Task: #200] Build UI components
 
 ❌ WRONG: Step-level sub-issues (too granular)
-├── Task #101: Step 1.1 - Create table
-├── Task #102: Step 1.2 - Add index
+├── Task #201: Step 1.1 - Create table
+├── Task #202: Step 1.2 - Add index
 ```
 
 ## Title Format
 
-Format: `[Task: #<parent-number>] <descriptive-title>`
+Format: `[Task: #<plan-number>] <descriptive-title>`
 
-Titles MUST describe WHAT the task accomplishes, not just the phase type. "Phase 1 - Implementation" is PROHIBITED. "[Task: #100] Add OAuth2 authentication" is correct.
+Titles MUST describe WHAT the task accomplishes, not just the phase type. "Phase 1 - Implementation" is PROHIBITED. "[Task: #200] Add OAuth2 authentication" is correct.
 
 ## Context Efficiency (CRITICAL)
 
-API responses from `github_issue_write` and `github_sub_issue_write` contain full parent issue body (~8KB each). Creating + linking 8 sub-issues produces ~128KB of context — enough to block implementation.
+API responses from `github_issue_write` and `github_sub_issue_write` contain full plan issue body (~8KB each). Creating + linking 8 sub-issues produces ~128KB of context — enough to block implementation.
 
 **MANDATORY:** Extract ONLY issue number and database ID from API responses. Discard full response body immediately.
 
@@ -77,9 +79,9 @@ Before implementing ANY subtask: get parent STATUS, extract authorized subtask, 
 
 ## Prohibited Halts
 
-- Halting to ask "should I create sub-issues?" when parent spec is already approved
+- Halting to ask "should I create sub-issues?" when the plan is already approved
 - Treating sub-issue creation as a separate implementation phase
-- Implementing a phase that exists only as text in parent issue body
+- Implementing a phase that exists only as text in plan issue body
 
 ## Cross-References
 

--- a/.opencode/skills/github-sub-issues/tasks/create-sub-issue.md
+++ b/.opencode/skills/github-sub-issues/tasks/create-sub-issue.md
@@ -2,27 +2,27 @@
 
 ## Purpose
 
-Create a sub-issue for a parent spec issue at the phase level.
+Create a sub-issue for a parent plan issue at the phase level.
 
 ## Entry Criteria
 
-- Parent issue number identified
+- Plan issue number identified
 - Phase name/description provided
-- Spec has multiple phases (not single-task)
+- Plan has multiple phases (not single-task)
 
 ## Exit Criteria
 
 - Sub-issue created with proper title format
-- Sub-issue linked to parent via database ID
+- Sub-issue linked to plan via database ID
 
 ## Procedure
 
-### Step 1: Verify Parent is Multi-Task
+### Step 1: Verify Plan is Multi-Task
 
 ```python
-parent = github_issue_read(method="get", issue_number=N)
-# Check if spec has multiple phases
-phases = extract_phases(parent["body"])
+plan = github_issue_read(method="get", issue_number=M)
+# Check if plan has multiple phases
+phases = extract_phases(plan["body"])
 if len(phases) == 1:
     # Single-task exemption - no sub-issue needed
     return
@@ -31,7 +31,7 @@ if len(phases) == 1:
 ### Step 2: Check Existing Sub-Issues
 
 ```python
-sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=M)
 # If sub-issues exist for this phase, skip
 ```
 
@@ -42,15 +42,15 @@ sub_issue = github_issue_write(
     method="create",
     owner=GIT_OWNER,
     repo=GIT_REPO,
-    title=f"[Task: #{N}] {phase_description}",
-    body=f"**Parent Issue:** #{N}\n\n{phase_content}",
+    title=f"[Task: #{M}] {phase_description}",
+    body=f"**Parent Plan:** #{M}\n\n{phase_content}",
     labels=["task"]
 )
 ```
 
-**Title format:** `[Task: #PARENT] Phase Description`
+**Title format:** `[Task: #PLAN] Phase Description`
 
-### Step 4: Link to Parent
+### Step 4: Link to Plan
 
 **CRITICAL: Use database ID, not issue number.**
 
@@ -59,8 +59,8 @@ github_sub_issue_write(
     method="add",
     owner=GIT_OWNER,
     repo=GIT_REPO,
-    issue_number=N,           # Parent issue NUMBER
-    sub_issue_id=sub_issue["id"]  # Sub-issue DATABASE ID
+    issue_number=M,               # Plan issue NUMBER
+    sub_issue_id=sub_issue["id"]   # Sub-issue DATABASE ID
 )
 ```
 
@@ -70,7 +70,7 @@ github_sub_issue_write(
 
 | Issue | Resolution |
 |-------|------------|
-| Parent is single-task | Skip - no sub-issue needed |
+| Plan is single-task | Skip - no sub-issue needed |
 | Sub-issue already exists | Skip creation |
 | Database ID not found | Use response["id"] not response["number"] |
 | Link fails | Verify parent issue exists |
@@ -78,4 +78,5 @@ github_sub_issue_write(
 ## Context Required
 
 - Session values: GIT_OWNER, GIT_REPO
+- Parent context comes from the plan issue, not the spec
 - Related tasks: `link-sub-issue`, `track-hierarchy`

--- a/.opencode/skills/github-sub-issues/tasks/link-sub-issue.md
+++ b/.opencode/skills/github-sub-issues/tasks/link-sub-issue.md
@@ -2,18 +2,18 @@
 
 ## Purpose
 
-Link a sub-issue to its parent issue using database ID (not issue number).
+Link a sub-issue to its parent plan issue using database ID (not issue number).
 
 ## Entry Criteria
 
 - Sub-issue created
 - Sub-issue database ID available
-- Parent issue number identified
+- Plan issue number identified
 
 ## Exit Criteria
 
-- Sub-issue linked to parent via GitHub's sub-issue feature
-- Link visible in parent issue's task list
+- Sub-issue linked to plan via GitHub's sub-issue feature
+- Link visible in plan issue's task list
 
 ## Procedure
 
@@ -33,14 +33,14 @@ sub_issue = github_issue_read(method="get", issue_number=M)
 db_id = sub_issue["id"]
 ```
 
-### Step 2: Link to Parent
+### Step 2: Link to Plan
 
 ```python
 github_sub_issue_write(
     method="add",
     owner=GIT_OWNER,
     repo=GIT_REPO,
-    issue_number=N,           # Parent issue NUMBER (not ID)
+    issue_number=M,           # Plan issue NUMBER (not ID)
     sub_issue_id=db_id        # Sub-issue DATABASE ID (not number)
 )
 ```
@@ -48,7 +48,7 @@ github_sub_issue_write(
 ### Step 3: Verify Link
 
 ```python
-sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=M)
 # Verify sub_issue is now in the list
 ```
 
@@ -57,7 +57,7 @@ sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
 | Issue | Resolution |
 |-------|------------|
 | Used issue number instead of ID | Get .id field from issue response |
-| Link returns error | Verify parent and sub-issue both exist |
+| Link returns error | Verify plan and sub-issue both exist |
 | Sub-issue not appearing | Call get_sub_issues to verify link |
 
 ## Context Required

--- a/.opencode/skills/github-sub-issues/tasks/track-hierarchy.md
+++ b/.opencode/skills/github-sub-issues/tasks/track-hierarchy.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-Verify and maintain parent-child issue hierarchy for multi-task specs.
+Verify and maintain parent-child issue hierarchy for multi-task plans.
 
 ## Entry Criteria
 
-- Parent issue number identified
+- Plan issue number identified
 - Sub-issues created (or need creation)
 
 ## Exit Criteria
@@ -17,31 +17,31 @@ Verify and maintain parent-child issue hierarchy for multi-task specs.
 
 ## Procedure
 
-### Step 1: Get Parent Issue
+### Step 1: Get Plan Issue
 
 ```python
-parent = github_issue_read(method="get", issue_number=N)
-phases = extract_phases(parent["body"])
+plan = github_issue_read(method="get", issue_number=M)
+phases = extract_phases(plan["body"])
 ```
 
 ### Step 2: Get Sub-Issues
 
 ```python
-sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=M)
 ```
 
 ### Step 3: Build Hierarchy Tree
 
 ```markdown
-SPEC #N: [Title]
-├── Task #[M1]: Phase 1 - [Description]
-├── Task #[M2]: Phase 2 - [Description]
-└── Task #[M3]: Phase 3 - [Description]
+PLAN #M: [PLAN] Feature Name
+├── Task #P1: [Task: #M] Phase 1 - Description
+├── Task #P2: [Task: #M] Phase 2 - Description
+└── Task #P3: [Task: #M] Phase 3 - Description
 ```
 
 ### Step 4: Identify Gaps
 
-**For each phase in spec:**
+**For each phase in plan:**
 - Check if corresponding sub-issue exists
 - If missing: create via `create-sub-issue`
 

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -14,6 +14,25 @@ Plan creation workflow that transforms approved specs into actionable implementa
 
 **Source attribution:** TDD step granularity, no-placeholders rule, plan document header, file structure section, and self-review checklist adapted from [obra/superpowers `writing-plans`](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md).
 
+## Plan Issue Model
+
+Plans are separate GitHub Issues, not content appended to spec bodies. The hierarchy is:
+
+```
+Spec #N (approved)
+  → [PLAN] #M (linked reference via body text "Spec: #N")
+       ├── Task #P1: [Task: #M] Phase 1
+       ├── Task #P2: [Task: #M] Phase 2
+       └── Task #P3: [Task: #M] Phase 3
+```
+
+**Plan issue properties:**
+- Title prefix: `[PLAN]`
+- Labels: `plan` + `needs-approval`
+- Body contains spec reference as prose (e.g., `Spec: #784`)
+- Sub-issues are children of the plan, NOT the spec
+- The plan references the spec via body text (linked reference), not via GitHub sub-issue link
+
 ## Tasks
 
 | Task | Purpose | Words |
@@ -66,6 +85,7 @@ This skill can be invoked automatically by `approval-gate` after successful veri
 ```
 approval-gate --task verify-authorization (all gates pass for spec approval)
   → writing-plans --task create (auto-dispatched)
+    → github-sub-issues --task create-sub-issue (sub-issues under plan, not spec)
 ```
 
 **Auto-dispatch context passed from approval-gate:**
@@ -81,6 +101,28 @@ approval-gate --task verify-authorization (all gates pass for spec approval)
 
 **No circular dispatch:** `writing-plans` never dispatches back to `approval-gate`. After plan creation, the plan requires its own approval (user says "approved"), which triggers `approval-gate` → `executing-plans` (not `writing-plans`).
 
+## Spec Revision Revocation
+
+When the spec referenced by a plan is revised, all linked plans must be re-approved:
+
+1. **Find linked plans:** Search GitHub Issues with `plan` label for body text matching `Spec: #N` (where N is the revised spec number)
+2. **Re-apply `needs-approval` label** to each found plan
+3. **Add audit comment** on each plan: `Spec #N has been revised. Plan requires re-approval before implementation.`
+4. **HALT** — do not proceed with implementation from any plan linked to the revised spec until re-approved
+
+This replaces the previous model where plan content lived in the spec body and revision automatically invalidated it. With the plan-bridge model, revision affects the spec but plans are separate issues that must be explicitly re-reviewed.
+
+## Re-Implementation
+
+When a new plan is needed under the same spec (e.g., previous plan was rejected or superseded):
+
+1. **Create new `[PLAN]` issue** following standard plan creation procedure
+2. **Close old plan** with comment: `Superseded by #N` (where N is the new plan number)
+3. **Update old plan labels:** Remove `needs-approval`, add `wontfix` or close outright
+4. **Sub-issues of old plan** remain linked to the old plan (not the spec) — they are closed along with the old plan or re-created under the new plan as appropriate
+
+The spec itself is NOT modified during re-implementation. The plan is the mutable artifact; the spec is the stable reference.
+
 ## Operating Protocol
 
 1. Read approved spec from GitHub Issue
@@ -88,20 +130,20 @@ approval-gate --task verify-authorization (all gates pass for spec approval)
 3. Plan phase structure by judgment (prose-driven)
 4. Define tasks within each phase using TDD step structure
 5. Write plan document header (Goal, Architecture, Tech Stack)
-6. Create plan issue or return markdown
+6. Create `[PLAN]` GitHub Issue — title prefixed with `[PLAN]`, labels `plan`+`needs-approval`, body includes spec reference as prose (e.g., `Spec: #N`); then create sub-issues under the plan (not the spec) via `github-sub-issues` skill
 7. Self-review (coverage, placeholders, type consistency)
 8. Validate (no placeholders, TDD structure, actionable steps)
 9. Chat output with URL — Report plan creation using exec summary + URL + byline format per `000-critical-rules.md`
 
 ## Enforcement
 
-- No plan → CREATE plan (writing-plans skill)
-- Plan exists but unapproved → HALT, wait for approval
+- No plan → CREATE plan (writing-plans skill) as `[PLAN]` GitHub Issue
+- Plan exists but unapproved → HALT, wait for plan approval (not spec approval of plan content)
 - Plan approved but has placeholders → REJECT plan
 - Plan approved but missing TDD steps → REJECT plan
 - Plan approved and complete → PROCEED to implementation
 
 ## Cross-References
 
-- Related skills: `brainstorming` (pre-spec), `approval-gate` (authorization), `executing-plans` (implementation), `spec-auditor` (fidelity subtask uses clean-room)
+- Related skills: `brainstorming` (pre-spec), `approval-gate` (authorization), `executing-plans` (implementation), `spec-auditor` (fidelity subtask uses clean-room), `github-sub-issues` (sub-issue creation under plan)
 - Source: adapted from [obra/superpowers `writing-plans`](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md)

--- a/.opencode/skills/writing-plans/tasks/clean-room.md
+++ b/.opencode/skills/writing-plans/tasks/clean-room.md
@@ -28,7 +28,7 @@ Generate a clean-room implementation plan from a problem statement only, using p
 | -- | -- | -- |
 | Input source | Approved spec issue | Problem statement only (from temp file) |
 | References existing plan | May reference spec phases | **NEVER references existing plan** |
-| Creates GitHub issue | Yes | **No** — returned as markdown only |
+| Creates GitHub issue | Yes (`[PLAN]` prefixed issue) | **No** — returned as markdown only |
 | Requires approval | Yes (`needs-approval` label) | **No** — comparison artifact |
 | Skip approval gate | No | **Yes** — not an implementation plan |
 | Structure | Agent-chosen prose | Agent-chosen prose (no template) |

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -42,9 +42,12 @@ Create an implementation plan from an approved spec.
 
 6. **Create plan issue:**
 
-   - Title: `[PLAN] <Feature Name>`
-   - Body: Plan with header, file structure, phases with TDD tasks
-   - Link to parent spec (sub-issue)
+    - Title: `[PLAN] <Feature Name>`
+    - Labels: `plan` + `needs-approval`
+    - Body: Spec reference as prose (e.g., `Spec: #784`), then plan with header, file structure, phases with TDD tasks
+    - Do NOT link plan as sub-issue of spec — the plan references the spec via body text only
+
+    After plan issue is created, create sub-issues under the plan (not the spec) for each phase via `github-sub-issues --task create-sub-issue`.
 
 7. **Self-review:**
 
@@ -63,12 +66,14 @@ Create an implementation plan from an approved spec.
 
    Produce chat output in the mandatory format per `000-critical-rules.md`:
 
-   1. **Executive summary**: 1-2 sentences describing what plan was created and for which spec
-   2. **URL**: The plan issue URL (e.g., `https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/<N>`)
-   3. **AI byline**: `🤖 <AgentName> (<ModelID>)` — ALWAYS LAST
+    1. **Executive summary**: 1-2 sentences describing what plan was created and for which spec
+    2. **URL**: The plan issue URL (e.g., `https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/<N>`)
+    3. **AI byline**: `🤖 <AgentName> (<ModelID>)` — ALWAYS LAST
 
-   Example:
+    Example:
 
-   Created implementation plan for #771 (branch stacking prerequisite). 7 tasks across 6 files (3 skills + 3 guidelines).
-   https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/772
-   🤖 <AgentName> (<ModelID>)
+    Created implementation plan for #771 (branch stacking prerequisite). 7 tasks across 6 files (3 skills + 3 guidelines).
+    https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/772
+    🤖 <AgentName> (<ModelID>)
+
+    Sub-issues are linked under the plan issue, NOT under the spec.

--- a/.opencode/skills/writing-plans/tasks/retroactive.md
+++ b/.opencode/skills/writing-plans/tasks/retroactive.md
@@ -8,18 +8,20 @@ Create a plan for an existing spec that does not yet have one.
 
 1. **Query existing spec:**
 
-   - Get spec from GitHub Issue
-   - Check for linked plan (sub-issues)
+    - Get spec from GitHub Issue
+    - Search for linked plans (GitHub Issues with `plan` label and body text matching `Spec: #N`)
 
 2. **If no plan exists:**
 
-   - Create plan from spec using hybrid approach (phases + TDD steps)
-   - Include header, file structure, self-review
-   - Link as sub-issue
-   - HALT and wait for plan approval
+    - Create `[PLAN]` GitHub Issue with `plan` + `needs-approval` labels
+    - Include spec reference as prose in body (e.g., `Spec: #N`)
+    - Plan content uses hybrid approach (phases + TDD steps)
+    - Include header, file structure, self-review
+    - Create sub-issues under the plan (not the spec)
+    - HALT and wait for plan approval
 
 3. **If plan exists:**
 
-   - Validate plan (check for placeholders, TDD structure)
-   - If invalid → Report issues
-   - If valid → Proceed to implementation
+    - Validate plan (check for placeholders, TDD structure)
+    - If invalid → Report issues
+    - If valid → Proceed to implementation

--- a/.opencode/skills/writing-plans/tasks/validate.md
+++ b/.opencode/skills/writing-plans/tasks/validate.md
@@ -13,6 +13,9 @@ Check an existing plan for placeholders and completeness.
 5. **TDD structure** — Each task has failing test → implement → passing test steps
 6. **File structure** — All files are listed with responsibilities
 7. **Self-review evidence** — Agent has performed spec coverage, placeholder, and type consistency checks
+8. **Spec reference** — Plan body contains a spec reference (search for `Spec: #N` pattern)
+9. **Sub-issue parent** — If plan has sub-issues, they link to the plan (not the spec)
+10. **Plan label** — Plan issue has `plan` label
 
 ## No-Placeholders Rule
 


### PR DESCRIPTION
## Summary

Introduces plan issues as a first-class bridge between specs and implementation phases, establishing the spec→plan→sub-issue hierarchy with two distinct authorization gates.

## Outcome

- Plan issues created with `[PLAN]` prefix and `plan` label; sub-issues under the plan (not spec)
- Two authorization gates: spec approval → plan creation, plan approval → implementation
- Spec revision automatically revokes linked plan approvals
- Re-implementation creates new plan under same spec; old plans closed with reference
- 18 skill files and 4 guideline files updated consistently
- Single-phase plans optional per agent intelligence

Fixes #784
Fixes #785
Fixes #786
Fixes #787
Fixes #788
Fixes #789