### PR TITLE
[SPEC] Replace template enforcement with intent-driven prose guidelines

### DIFF
--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -94,34 +94,23 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## 1.1. Engineering Requirements for Specs
+## 1.1. Spec Content Requirements
 
-**Every specification MUST include thorough requirements analysis.**
+**Every specification MUST cover these content areas.** The format is up to the agent — a simple spec may cover several areas in a single paragraph, while a complex spec may use separate sections.
 
-### Full Requirements Analysis Required
+### Content Coverage Questions
 
-Before any implementation, every spec must document:
-
-| Requirement | Description |
-| -- | -- |
-| **Problem Statement** | What is the problem? Why does it need solving? |
-| **Context** | Background, stakeholders, affected systems |
-| **Constraints** | Technical, resource, time, compatibility constraints |
-| **Assumptions** | What are we assuming that may not be true? |
-| **Success Criteria** | Testable, measurable criteria for completion |
-| **Edge Cases** | Boundary conditions and corner cases identified |
-| **Dependencies** | External systems, libraries, other teams affected |
-| **Integrations** | How does this integrate with existing code? |
-| **Risk Assessment** | What could go wrong? Mitigation strategies? |
-
-### Design Phase Required
-
-**No direct-to-implementation.** Before coding:
-
-1. **Explore codebase** for existing patterns and reusable components
-2. **Document design decisions** in the spec
-3. **Consider alternatives** and their tradeoffs
-4. **Get approval on approach** before starting implementation
+| Question | Why It Matters |
+|----------|---------------|
+| Does the spec clearly state the problem it solves and why? | Without this, the reader doesn't know what they're solving or whether the solution addresses the right thing |
+| Does the spec provide enough context for someone with no prior knowledge? | Agents lack memory context; the spec must be self-contained |
+| Does the spec identify what constraints and assumptions apply? | Constraints shape the solution space; assumptions may be wrong and need verification |
+| Does the spec define testable success criteria? | Binary pass/fail criteria are the only reliable way to verify completion |
+| Does the spec address edge cases and risks? | Unhandled edge cases become production bugs |
+| Does the spec explain why the chosen approach was selected? | Without rationale, the implementer might make different assumptions |
+| Does the spec identify affected files with stable anchors? | File paths and function names (not line numbers) enable targeted implementation |
+| Does the spec reference related issues with context? | Cross-references prevent duplicate work and ensure consistency |
+| Does the spec define what is explicitly out of scope? | Non-requirements prevent scope creep |
 
 ### Anti-Patterns in Specifications
 
@@ -134,6 +123,16 @@ Before any implementation, every spec must document:
 - No risk assessment
 - Skipping design phase
 - Proceeding without approval
+
+### Simple vs Complex Specs
+
+**Simple specs** (bug fixes, one-file changes, obvious solutions) may address all required content areas in a few paragraphs. A minimal spec can be as short as:
+
+> Problem → Context → Fix approach → Success criteria → Edge cases
+
+**Complex specs** (multi-file changes, cross-cutting concerns, architectural decisions) typically use separate sections for each content area. The `brainstorming` skill and `spec-creation` skill tasks provide prompts for thinking through each area.
+
+**The key principle: every content area must be addressed, but agents choose the format that matches the spec's complexity.**
 
 ______________________________________________________________________
 
@@ -177,46 +176,17 @@ A different AI agent (or the same agent after a context reset) may pick up this 
    - What alternatives were considered?
    - What constraints drove the decision?
 
-### Fresh-Start Context Checklist
+### Context Coverage Checklist
 
-Before submitting any spec, verify ALL of the following:
+Before submitting any spec, verify these self-containment questions:
 
-| Element | Required Content |
-| -- | -- |
-| **Problem Statement** | What is broken/needed and WHY (with context) |
-| **Affected Files** | List of files with function/section anchors and snippets |
-| **Related Issues** | Links + summaries + relevance explanation |
-| **Context** | Background on affected systems, prior decisions |
-| **Constraints** | Technical, resource, time, compatibility limits |
-| **Assumptions** | What we're assuming that may not be true |
-| **Success Criteria** | Testable, measurable completion criteria |
-| **Edge Cases** | Identified boundary conditions |
-| **Dependencies** | External systems, libraries, affected teams |
-| **Risk Assessment** | What could go wrong and mitigations |
-| **Decision Rationale** | Why this approach was chosen |
-
-### Example: Bad vs Good Spec Context
-
-**❌ BAD (assumes memory context):**
-
-> Fix the bug in the authentication module as discussed.
-
-**✅ GOOD (self-contained):**
-
-> **Problem:** The OAuth2 token refresh fails when the refresh token expires (issue #123).
->
-> **Location:** `src/auth/oauth_client.py` in `refresh_token()` function:
->
-> ```python
-> def refresh_token(self):
->     # BUG: Does not handle expired refresh_token
->     response = self._request_token(...)
->     # Raises TokenExpiredError instead of re-authenticating
-> ```
->
-> **Context:** Users reported being logged out after 7 days (token expiry). Related to #100 (persistent sessions).
->
-> **Decision:** Re-authenticate using stored credentials rather than failing.
+| Question | Why It Matters |
+|----------|---------------|
+| Does the spec describe the problem with full context, not just "as discussed"? | A fresh agent has no memory of earlier conversation |
+| Does the spec include file paths with stable anchors (not line numbers)? | Line numbers break on every edit |
+| Does the spec include code snippets for key changes (<20 lines)? | Code context prevents misunderstandings |
+| Does the spec include URLs and summaries for all related issues? | Bare links without context are useless |
+| Does the spec document decision rationale? | Without it, implementers may choose different approaches |
 
 ______________________________________________________________________
 
@@ -234,4 +204,4 @@ This ensures consistent workflow and prevents context fragmentation.
 
 ______________________________________________________________________
 
-*Source: Content migrated from `040-plan-delivery.md`*
+*Source: Content migrated from `040-plan-delivery.md`, restructured per spec #821*

--- a/.opencode/guidelines/141-planning-status-tracking.md
+++ b/.opencode/guidelines/141-planning-status-tracking.md
@@ -4,7 +4,9 @@
 
 ### STATUS Field Format
 
-Every spec file MUST have a **STATUS** header at the top of the file:
+Every spec file SHOULD have a **STATUS** indicator at the top. The format varies by spec complexity:
+
+**For multi-phase specs (recommended format):**
 
 ```markdown
 # Spec: [Feature Name]
@@ -18,20 +20,37 @@ CREATED: 2026-03-24
 ...
 ```
 
-**⚠️ CRITICAL: Phase names MUST describe specific concerns, NOT generic activities.**
+**For simple single-task specs (acceptable format):**
 
-- ✅ Good: "Database Schema Setup", "API Endpoint Integration", "Error Handling Layer"
-- ❌ Bad: "Implementation", "Testing", "Development", "Build"
+```markdown
+# Spec: [Bug Description]
 
-#### Status Values
+STATUS: in progress
+
+---
+
+## Fix Approach
+...
+```
+
+**STATUS values:**
 
 | Format | Meaning |
 | -- | -- |
 | `1` | Phase 1, no specific step tracked |
 | `1.2` | Phase 1, step 2 (currently active) |
 | `2.1-3` | Phase 2, steps 1-3 in progress |
+| `in progress` | Simple spec — currently being worked on |
+| `complete` | Simple spec — all work done |
 | `completed` | All phases done, ready for archive |
 | `1.1 (REVISED - NEEDS APPROVAL)` | Spec was modified, awaiting fresh approval |
+
+**Advisory note:** `STATUS: phase.step` format is recommended for multi-phase specs. For simple bug fixes or single-task specs, a brief status note like `in progress` or `complete` is acceptable without phase.step numbering.
+
+**⚠️ CRITICAL: Phase names MUST describe specific concerns, NOT generic activities.**
+
+- ✅ Good: "Database Schema Setup", "API Endpoint Integration", "Error Handling Layer"
+- ❌ Bad: "Implementation", "Testing", "Development", "Build"
 
 #### Revision Status Format
 
@@ -64,6 +83,8 @@ STATUS: 1.1 (REVISED - NEEDS APPROVAL)
 | `↻` | In progress | Currently working — **MARK DURING WORK** |
 | `☑` | Complete | Task done and verified |
 | `☒` | Blocked | Issue found, cannot proceed |
+
+Status markers (`☐`/`↻`/`☑`/`☒`) are recommended for tracking step completion. Any clear progress indicator works — the intent is visibility, not a specific format.
 
 **CRITICAL**: Update to `↻` (in progress) **during** implementation, not just after completion.
 
@@ -262,4 +283,4 @@ Skills that change issue state MUST consult this section (`§10`) before adding 
 
 ______________________________________________________________________
 
-*Source: Content migrated from `040-plan-delivery.md`*
+*Source: Content migrated from `040-plan-delivery.md`, updated per spec #821*

--- a/.opencode/guidelines/143-planning-spec-templates.md
+++ b/.opencode/guidelines/143-planning-spec-templates.md
@@ -1,454 +1,147 @@
 # Planning: Spec Templates
 
-## Spec Creation Checklist
+## Intent, Not Templates
 
-Before creating or submitting any spec, bug report, or issue, verify ALL required elements are present.
+**These examples illustrate possibilities, not mandatory formats.** Agents should adapt structure to match the spec's complexity and domain.
 
-### Mandatory Elements Checklist
+A simple bug fix needs only a few sentences of problem, context, and criteria. A multi-phase feature benefits from more structure. The goal is always: can a fresh agent pick up this spec and implement it correctly without additional context?
 
-Use this checklist for every spec:
+## Content Coverage Checklist
 
-```markdown
-## Fresh-Start Context Checklist
+Before creating any spec, bug report, or issue, verify these intent questions are answered. The *format* of the answers is up to the agent — the *content* must be present:
 
-- [ ] **Problem Statement** — What is broken/needed and WHY (with context)
-- [ ] **Affected Files** — List of files with anchors (function/section) and code snippets
-- [ ] **Related Issues** — Links + summaries + relevance explanation
-- [ ] **Context** — Background on affected systems, prior decisions
-- [ ] **Constraints** — Technical, resource, time, compatibility limits
-- [ ] **Assumptions** — What we're assuming that may not be true
-- [ ] **Success Criteria** — Testable, measurable completion criteria
-- [ ] **Edge Cases** — Identified boundary conditions
-- [ ] **Dependencies** — External systems, libraries, affected teams
-- [ ] **Risk Assessment** — What could go wrong and mitigations
-- [ ] **Decision Rationale** — Why this approach was chosen (if applicable)
-```
+| Question | Intent |
+|----------|--------|
+| Does the spec describe what problem it solves and why? | Problem statement — what's broken or needed, with context |
+| Does the spec explain the background and affected systems? | Context — who is affected, what triggered this, what's the current state |
+| Does the spec define testable completion criteria? | Success criteria — binary pass/fail conditions for each requirement |
+| Does the spec address what could go wrong? | Edge cases and risk — boundary conditions, failure modes |
+| Does the spec explain why this approach was chosen? | Decision rationale — alternatives considered and reasons for rejection |
+| Does the spec list constraints and assumptions? | Technical, resource, time, and compatibility limits |
+| Does the spec reference related issues with context? | Related issues — links with summaries and relevance (not bare links) |
+| Does the spec identify affected files with anchors? | Affected files — file paths with function names or section headers, not line numbers |
+| Does the spec provide enough context for a fresh agent? | Self-containment — no "as discussed above" or "see previous comment" |
 
-### Self-Containment Rules
+**Simple specs may address several questions in a single paragraph. Complex specs may need separate sections for each. The format adapts to complexity.**
 
-Verify the spec is self-contained:
+## Self-Containment Rules
 
-```markdown
-## Self-Containment Verification
+These are content quality rules, not structural requirements:
 
-- [ ] NO "as discussed above" — all context stated inline
-- [ ] NO "see previous comment" — information restated
-- [ ] NO "as mentioned in chat" — decisions documented
-- [ ] File paths use STABLE ANCHORS — function names `process_data()` or section headers `"Section Name"`
-- [ ] ⚠️ AVOID line numbers `file.py:42` — they break on every edit
-- [ ] Code snippets included for short sections (<20 lines)
-- [ ] Issue links include URLs and summaries
-```
+- NO "as discussed above" — all context stated inline
+- NO "see previous comment" — information restated
+- NO "as mentioned in chat" — decisions documented
+- File paths use STABLE ANCHORS — function names `process_data()` or section headers `"Section Name"`
+- AVOID line numbers `file.py:42` — they break on every edit
+- Code snippets included for short sections (<20 lines)
+- Issue links include URLs and summaries
 
 ______________________________________________________________________
 
-## Spec Template (Feature)
-
-Use this template for new feature specifications.
-
-```markdown
-# Spec: [Feature Name]
-
-STATUS: 1.1
-CREATED: YYYY-MM-DD
-
----
-
-## Objective
-
-[What does this feature accomplish? Why is it needed?]
-
----
-
-## Problem Statement
-
-[What problem does this solve? What pain point does it address? Include context about who is affected and why this matters now.]
-
----
-
-## Context
-
-**Background:**
-[Relevant history, prior decisions, current state]
-
-**Affected Systems:**
-[Which components, modules, or services are affected]
-
-**Stakeholders:**
-[Who cares about this change? Developers, users, other teams]
-
----
-
-## Constraints
-
-| Constraint Type | Details |
-|-----------------|---------|
-| Technical | [e.g., must work with Python 3.10+] |
-| Resource | [e.g., no additional dependencies] |
-| Time | [e.g., needed by Q2] |
-| Compatibility | [e.g., cannot break existing API] |
-
----
-
-## Assumptions
-
-1. [Assumption 1 - what we're assuming that may not be true]
-2. [Assumption 2]
-3. [Assumption 3]
-
----
-
-## Affected Files
-
-| File | Anchor | Description | Code Snippet |
-|------|--------|-------------|--------------|
-| `path/to/file.py` | `function_name()` or `"Section Name"` | [What this section does] | [Short snippet] |
-
----
-
-## Related Issues
-
-| Issue | Summary | Relevance |
-|-------|---------|-----------|
-| [#123](https://github.com/owner/repo/issues/123) | [Brief summary] | [Why it matters to this spec] |
-
----
-
-## Success Criteria
-
-1. ✅ [Testable criterion 1]
-2. ✅ [Testable criterion 2]
-3. ✅ [Testable criterion 3]
-
----
-
-## Edge Cases
-
-1. **[Edge case 1]:** [Description and handling]
-2. **[Edge case 2]:** [Description and handling]
-
----
-
-## Dependencies
-
-| Dependency | Type | Impact |
-|------------|------|--------|
-| [Library/Service] | [Internal/External] | [What happens if unavailable] |
-
----
-
-## Risk Assessment
-
-| Risk | Probability | Impact | Mitigation |
-|------|-------------|--------|------------|
-| [What could go wrong] | [Low/Medium/High] | [Low/Medium/High] | [How we handle it] |
-
----
-
-## Decision Rationale
-
-**Decision:** [What approach was chosen]
-
-**Why:** [Why this approach over alternatives]
-
-**Alternatives Considered:**
-1. [Alternative 1] — Rejected because [reason]
-2. [Alternative 2] — Rejected because [reason]
-
----
-
-## Phase 1: [Concern Name] (Gated)
-
-### Steps
-
-**SPEC PHASE STEPS describe WHAT to deliver, not HOW to implement.**
-
-| ✅ What-Level (Spec) | ❌ How-Level (Plan) |
-|-----------------------|----------------------|
-| "Add user validation endpoint" | "Create validate_user() in auth.py" |
-| "Ensure emails are unique" | "ALTER TABLE users ADD UNIQUE(email)" |
-| "Processing completes within 2s" | "Use asyncio with connection pool" |
-
-1. ☐ [First task for this concern]
-2. ☐ [Second task for this concern]
-3. ☐ [Third task for this concern]
-
----
-
-## Phase 2: [Next Concern] (Gated)
-
-### Steps
-
-1. ☐ [First task for this concern]
-2. ☐ [Second task for this concern]
-
----
-
-## Phase 3: [Verification Concern] (Auto-progress)
-
-### Steps
-
-1. ☐ Run automated tests
-2. ☐ Verify edge cases
-
----
-
-## Phase 4: [Review Concern] (Gated)
-
-### Steps
-
-1. ☐ Human review of changes
-2. ☐ Approve or request revisions
-
----
-
-
-
-**⚠️ CRITICAL: Phase names MUST describe specific concerns, NOT generic activities.**
-- ✅ Good: "Database Schema Setup", "API Endpoint Integration", "Error Handling Layer"
-- ❌ Bad: "Implementation", "Testing", "Development", "Build"
-```
+## Example Variants: Feature Spec
+
+### Minimal Feature Spec (simple change, single file)
+
+> **Objective:** Add `retry_count` parameter to `fetch_data()` in `src/api/client.py` so callers can control retry behavior.
+>
+> **Problem:** Currently `fetch_data()` retries indefinitely on transient failures, causing timeout cascades in production.
+>
+> **Success Criteria:**
+> 1. ✅ `fetch_data(retry_count=3)` retries exactly 3 times then raises
+> 2. ✅ Default behavior unchanged (current retries for backward compatibility)
+> 3. ✅ Existing tests pass
+>
+> **Edge Cases:** retry_count=0 means no retries (fail immediately).
+
+This minimal spec works because the change is small and self-explanatory. Separate sections for context, dependencies, and risk aren't needed — they're obvious.
+
+### Standard Feature Spec (moderate change, multiple files)
+
+> **Objective:** Add Redis caching layer for frequently accessed article metadata.
+>
+> **Problem:** Article metadata API calls average 150ms response time, causing slow page loads. 85% cache hit potential identified.
+>
+> **Context:** Current queries hit PostgreSQL directly. Most queries target the same ~1000 recently-published articles. Article metadata changes infrequently. Redis already deployed per infra team.
+>
+> **Fix Approach:** Redis as cache layer with 1-hour TTL. Fallback to DB when Redis unavailable.
+>
+> **Affected Files:**
+> | File | Anchor | Changes |
+> |------|--------|---------|
+> | `src/api/articles.py` | `get_article_metadata()` | Add cache check before DB query |
+> | `src/cache/__init__.py` | new file | Redis client wrapper |
+> | `src/config.py` | "Configuration" section | Add Redis connection config |
+>
+> **Constraints:** Must not exceed 512MB Redis memory. Must handle Redis unavailable gracefully.
+>
+> **Success Criteria:**
+> 1. ✅ API response time <20ms for cached queries
+> 2. ✅ Cache hit rate >80%
+> 3. ✅ Graceful fallback when Redis unavailable
+> 4. ✅ Cache invalidation on article update
+>
+> **Edge Cases:** Redis unavailable → fallback to DB (log warning). Cache full → LRU eviction. Article updated → invalidate entry.
+>
+> **Risk Assessment:** Redis memory limit (Low prob, High impact → monitor). Cache invalidation bugs (Med prob, Med impact → test update flows).
+
+This standard spec adds context, affected files, constraints, and risk because the change touches multiple files and has infrastructure dependencies.
+
+### Comprehensive Feature Spec (large change, cross-cutting)
+
+See the full example in `144-planning-spec-examples.md` for comprehensive specs with phased implementation, full risk assessment, and detailed decision rationale. Comprehensive specs use all the structure they need — phases, affected files with code snippets, extended risk assessment, dependencies table, and decision rationale with alternatives.
 
 ______________________________________________________________________
 
-## Spec Template (Bug Fix)
+## Example Variants: Bug Fix Spec
 
-Use this template for bug fix specifications.
+### Minimal Bug Fix Spec (obvious fix, one line change)
 
-````markdown
-# Spec: [Bug Description]
+> **Problem:** `process_data()` crashes when input list is empty, raising `IndexError` at `src/core/processor.py:42`.
+>
+> **Fix:** Add empty list guard before accessing `data[0]`.
+>
+> **Success Criteria:**
+> 1. ✅ Empty list input returns empty result (no crash)
+> 2. ✅ Non-empty list input behavior unchanged
 
-STATUS: 1.1
-CREATED: YYYY-MM-DD
+### Standard Bug Fix Spec (needs investigation context)
 
----
-
-## Objective
-
-[What does this bug fix accomplish?]
-
----
-
-## Problem Statement
-
-**Symptom:** [What is the observed incorrect behavior?]
-
-**Expected Behavior:** [What should happen instead?]
-
-**Impact:** [Who is affected and how severely?]
-
----
-
-## Context
-
-**Where the bug occurs:**
-[Which component, module, or user flow]
-
-**When the bug occurs:**
-[What conditions trigger the bug]
-
-**Discovery:**
-[How was the bug found? User report, automated test, etc.]
-
----
-
-## Root Cause Analysis
-
-**Investigation:**
-[What was discovered during analysis]
-
-**Cause:**
-[What is the underlying cause]
-
-**Evidence:**
-[Code snippets, logs, or other evidence]
-
-```python
-# Relevant code at path/to/file.py in `function_name()` or "Section Name"
-def broken_function():
-    # BUG: Off-by-one error in loop
-    for i in range(len(items)):  # Should be range(len(items) - 1)
-        process(items[i])
-````
+> **Problem:** OAuth2 refresh_token fails on expiry, causing unexpected logout for ~15% of users who don't log in for more than 7 days.
+>
+> **Expected Behavior:** Automatically re-authenticate using stored credentials when refresh token expires.
+>
+> **Root Cause:** `refresh_token()` in `src/auth/oauth_client.py` catches `TokenExpiredError` but re-raises instead of calling `authenticate()`.
+>
+> **Fix Approach:** Catch `TokenExpiredError` and call `authenticate()` with stored credentials.
+>
+> **Side Effects:** None — existing refresh logic unchanged for valid tokens.
+>
+> **Success Criteria:**
+> 1. ✅ Users with expired refresh tokens auto-re-authenticated
+> 2. ✅ Auth failures surface appropriate error messages
+> 3. ✅ No credentials logged or exposed
+> 4. ✅ Existing refresh logic unchanged for valid tokens
+>
+> **Edge Cases:** Credentials no longer valid → prompt re-login. Network failure → propagate error. Rate limiting → backoff and retry.
+>
+> **Related Issues:** #100 (persistent sessions), #150 (token rotation)
 
 ______________________________________________________________________
 
-## Affected Files
+## Example Variants: Guideline Update Spec
 
-| File | Anchor | Description |
-| -- | -- | -- |
-| `path/to/file.py` | `function_name()` or `"Section Name"` | [Function with bug] |
+### Minimal Guideline Update (small rule change)
 
-______________________________________________________________________
+> **Problem:** Current guidelines don't address when to use `--no-verify` with git commands.
+>
+> **Proposed Change:** Add rule to `000-critical-rules.md` prohibiting `--no-verify` unless explicitly authorized.
+>
+> **Success Criteria:** Guidelines load correctly. Search finds new content.
 
-## Related Issues
+### Standard Guideline Update (philosophy or process change)
 
-| Issue | Summary | Relevance |
-| -- | -- | -- |
-| [#123](https://github.com/owner/repo/issues/123) | [Related bug or feature] | [Connection to this fix] |
-
-______________________________________________________________________
-
-## Fix Approach
-
-**Solution:** [What change will fix the bug]
-
-**Why this approach:** [Why this is the minimal correct fix]
-
-**Side effects:** [What else might be affected]
+See `144-planning-spec-examples.md` for a standard guideline update example with problem statement, context, proposed change, decision rationale, and verification steps.
 
 ______________________________________________________________________
 
-## Success Criteria
-
-1. ✅ Bug is fixed and test passes
-2. ✅ No regression in existing tests
-3. ✅ Edge case handling verified
-
-______________________________________________________________________
-
-## Edge Cases
-
-1. **[Edge case 1]:** [How the fix handles it]
-2. **[Edge case 2]:** [How the fix handles it]
-
-______________________________________________________________________
-
-## Phase 1: [Bug Fix Concern] (Gated)
-
-### Steps
-
-1. ☐ Implement fix for [bug description]
-2. ☐ Add test case for [specific scenario]
-3. ☐ Run full test suite to verify no regression
-
-______________________________________________________________________
-
-## Phase 2: [Verification Concern] (Auto-progress)
-
-### Steps
-
-1. ☐ Verify original bug scenario passes
-2. ☐ Verify edge cases pass
-3. ☐ Verify no regression in related tests
-
-______________________________________________________________________
-
-## Phase 3: [Review Concern] (Gated)
-
-### Steps
-
-1. ☐ Code review
-2. ☐ Approve or request revisions
-
-______________________________________________________________________
-
-**⚠️ CRITICAL: Phase names MUST describe specific concerns, NOT generic activities.**
-
-- ✅ Good: "Database Schema Fix", "Authentication Logic Fix", "Error Handling Update"
-- ❌ Bad: "Implementation", "Testing", "Bug Fix", "Development"
-
-````
-
----
-
-## Spec Template (Guideline Update)
-
-Use this template for changes to `.opencode/guidelines/`.
-
-```markdown
-# Spec: Guidelines: [Topic]
-
-STATUS: 1.1
-CREATED: YYYY-MM-DD
-
----
-
-## Objective
-
-[What guideline change is being made? Why?]
-
----
-
-## Problem Statement
-
-**Current State:** [What do the guidelines currently say or not say?]
-
-**Issue:** [What problem does this cause? Why is the current state insufficient?]
-
-**Impact:** [Who is affected? What mistakes happen without this guidance?]
-
----
-
-## Context
-
-**Background:**
-[Why is this guideline needed now? What triggered this change?]
-
-**Stakeholders:**
-[Which agents/developers need this guidance]
-
----
-
-## Proposed Change
-
-**File(s) to modify:**
-- `.opencode/guidelines/planning/00-spec-creation.md`
-
-**Change summary:**
-[What sections are being added or modified]
-
----
-
-## Decision Rationale
-
-**Why this approach:**
-[Why this specific change over alternatives]
-
-**Alternatives considered:**
-1. [Alternative 1] — Rejected because [reason]
-2. [Alternative 2] — Rejected because [reason]
-
----
-
-## Success Criteria
-
-1. ✅ Guideline documentation updated
-2. ✅ Changes load correctly in `.opencode/tools/guidelines`
-3. ✅ All files pass linting
-
----
-
-## Phase 1: [Guideline Module Update] (Gated)
-
-### Steps
-
-1. ☐ [Update guideline file]
-2. ☐ [Verify with .opencode/tools tools]
-
----
-
-## Phase 2: Guideline Verification (Auto-progress)
-
-### Steps
-
-1. ☐ Verify guidelines load correctly
-2. ☐ Verify search finds new content
-
----
-
-## Phase 3: Human Approval (Gated)
-
-### Steps
-
-1. ☐ Human review of changes
-2. ☐ Approve or request revisions
-
----
-
-
-````
-
-______________________________________________________________________
-
-*Source: Created to support fresh-start context requirements*
+*Source: Migrated from rigid templates to intent-driven prose per spec #821*

--- a/.opencode/guidelines/144-planning-spec-examples.md
+++ b/.opencode/guidelines/144-planning-spec-examples.md
@@ -1,386 +1,170 @@
 # Planning: Spec Examples
 
-## Good vs Bad Spec Context
+## Examples of Different Valid Structures
 
-This document provides examples of good and bad spec context to illustrate the fresh-start requirements.
+This document provides examples of different valid structures for specs at various complexity levels. There is no single "correct" format — the right structure depends on the spec's complexity, domain, and audience.
 
-______________________________________________________________________
+**Key principle:** A spec that covers all required content areas (problem, context, success criteria) is valid regardless of its section headers. A spec with the "correct" headers but missing content is invalid.
 
-## Example 1: Bug Report
-
-### ❌ BAD Bug Report (Assumes Memory Context)
-
-> **Title:** Fix authentication bug as discussed
->
-> **Description:** Fix the bug in auth where users get logged out. See previous comments for details.
->
-> **Steps:** Implement the fix we talked about.
-
-This is BAD because:
-
-- No context about WHAT bug
-- No WHERE (which file, which function)
-- No WHY (what causes the bug)
-- No HOW to fix (no approach documented)
-- References "previous comments" instead of restating
+The examples below show how the same content area can be covered at different levels of detail and with different organizational choices.
 
 ______________________________________________________________________
 
-### ✅ GOOD Bug Report (Self-Contained)
+## Example 1: Bug Report — Different Complexity Levels
 
-> **Title:** OAuth2 refresh_token fails on expiry, causing unexpected logout
+### Minimal Bug Report (one-line fix, obvious cause)
+
+> **Problem:** `process_data()` crashes on empty input, raising `IndexError` at `src/core/processor.py:42`.
 >
-> **Problem:** Users are unexpectedly logged out after 7 days when their OAuth2 refresh token expires. The current implementation does not handle the `TokenExpiredError` and instead propagates the exception, terminating the user session.
+> **Fix:** Add empty list guard.
 >
-> **Location:** `refresh_token()` in `src/auth/oauth_client.py`:
+> **Success Criteria:** ✅ Empty input returns empty result. ✅ Non-empty input unchanged.
+
+**Why this works:** The problem, fix, and criteria are obvious. No separate context section needed — it's self-evident. The one-line description is sufficient because any agent can understand the issue from the problem statement alone.
+
+### Standard Bug Report (needs investigation context)
+
+> **Problem:** OAuth2 refresh_token fails on expiry, causing unexpected logout for ~15% of users who don't log in for more than 7 days.
 >
-> ```python
-> def refresh_token(self):
->     # BUG: Does not handle expired refresh_token
->     response = self._request_token(self._refresh_token)
->     # Raises TokenExpiredError instead of re-authenticating
->     return response
-> ```
+> **Expected Behavior:** Automatically re-authenticate using stored credentials when refresh token expires.
 >
-> **Root Cause:** When `refresh_token` is called with an expired token, the API returns `TokenExpiredError`. The current code catches this error but simply re-raises it, instead of attempting to re-authenticate using stored credentials.
+> **Root Cause:** `refresh_token()` in `src/auth/oauth_client.py` catches `TokenExpiredError` but re-raises instead of calling `authenticate()`.
 >
-> **Expected Behavior:** When refresh token expires, automatically re-authenticate using stored credentials (username/password in secure storage) and return a valid token.
+> **Fix Approach:** Catch `TokenExpiredError` and call `authenticate()` with stored credentials.
 >
-> **Context:** This affects ~15% of users who don't log in for more than 7 days. Related to #100 (persistent sessions) and #150 (token rotation strategy).
->
-> **Decision:** Implement re-authentication flow by catching `TokenExpiredError` and calling `authenticate()` with stored credentials.
->
-> **Constraints:**
->
-> - Must not break existing token refresh logic
-> - Must work with the new credential storage added in #100
-> - Must not expose credentials in logs
->
-> **Edge Cases:**
->
-> - Credentials no longer valid → prompt user to re-login
-> - Network failure during re-auth → propagate error
-> - Rate limiting on auth API → backoff and retry
->
-> **Related Issues:**
->
-> | Issue | Summary | Relevance |
-> | -- | -- | -- |
-> | [#100](https://github.com/owner/repo/issues/100) | Persistent sessions | Credential storage implementation |
-> | [#150](https://github.com/owner/repo/issues/150) | Token rotation | Future improvement for longer sessions |
+> **Side Effects:** None — existing refresh logic unchanged for valid tokens.
 >
 > **Success Criteria:**
->
-> 1. ✅ Users with expired refresh tokens are automatically re-authenticated
-> 2. ✅ Re-authentication failures surface appropriate error messages
+> 1. ✅ Users with expired refresh tokens auto-re-authenticated
+> 2. ✅ Auth failures surface appropriate error messages
 > 3. ✅ No credentials logged or exposed
 > 4. ✅ Existing refresh logic unchanged for valid tokens
+>
+> **Edge Cases:** Credentials no longer valid → prompt re-login. Network failure → propagate error. Rate limiting → backoff and retry.
+>
+> **Related Issues:** #100 (persistent sessions), #150 (token rotation)
 
-This is GOOD because:
+**Why this works:** The problem affects real users, has a non-obvious root cause, and has multiple edge cases. The standard format provides enough structure for an agent to implement correctly without additional context. A fresh agent can pick this up and know exactly what to do.
 
-- ✅ Problem clearly stated with symptom and impact
-- ✅ Exact file/line location provided
-- ✅ Code snippet included
-- ✅ Root cause analysis
-- ✅ Expected behavior specified
-- ✅ Context with related issues linked and explained
-- ✅ Decision rationale documented
-- ✅ Constraints listed
-- ✅ Edge cases identified
-- ✅ Success criteria testable
+### Comprehensive Bug Report (cross-cutting, multi-system)
+
+For bugs that involve multiple systems, affect production users significantly, or have complex deployment considerations, use the full spec structure with context section, affected files table, root cause analysis with evidence, detailed edge cases, risk assessment, and phased implementation. The extra structure serves the complexity.
 
 ______________________________________________________________________
 
-## Example 2: Feature Specification
+## Example 2: Feature Specification — Different Complexity Levels
 
-### ❌ BAD Feature Spec (Assumes Memory Context)
+### Minimal Feature Spec (single-function addition)
 
-> **Title:** Add caching as discussed in yesterday's meeting
+> **Objective:** Add `retry_count` parameter to `fetch_data()` in `src/api/client.py` so callers can control retry behavior.
 >
-> **Description:** Implement caching for the API. We decided on Redis.
+> **Problem:** Currently `fetch_data()` retries indefinitely on transient failures, causing timeout cascades.
 >
-> **Steps:** Add caching layer, update API handlers, add tests.
+> **Success Criteria:**
+> 1. ✅ `fetch_count(retry_count=3)` retries exactly 3 times then raises
+> 2. ✅ Default behavior unchanged
+> 3. ✅ Existing tests pass
+>
+> **Edge Cases:** retry_count=0 means no retries (fail immediately).
 
-This is BAD because:
+**Why this works:** The change is small, localized, and self-explanatory. A single paragraph covers the essential content areas. No need for affected files tables, risk assessments, or phased implementation — those would add noise, not value.
 
-- References "yesterday's meeting" without restating decisions
-- No context for WHY caching is needed
-- No details on WHAT to cache
-- No alternatives considered documented
-- No success criteria
-- No constraints or edge cases
+### Standard Feature Spec (multi-file change with dependencies)
 
-______________________________________________________________________
-
-### ✅ GOOD Feature Spec (Self-Contained)
-
-> **Title:** Add Redis caching layer for frequently accessed article metadata
+> **Objective:** Add Redis caching layer for frequently accessed article metadata.
 >
-> **Problem Statement:** Article metadata API calls average 150ms response time, causing slow page loads for article lists. Users report poor experience on mobile devices with slower connections.
+> **Problem:** Article metadata API calls average 150ms response time, causing slow page loads. 85% cache hit potential identified.
 >
-> **Objective:** Reduce API response time from 150ms average to \<20ms for article metadata queries by implementing a Redis caching layer.
+> **Context:** Current queries hit PostgreSQL directly. Most queries target the same ~1000 recently-published articles. Article metadata changes infrequently. Redis already deployed per infra team.
 >
-> **Context:**
->
-> - Current article metadata queries hit PostgreSQL directly
-> - Most queries are for the same ~1000 recently-published articles
-> - Article metadata changes infrequently (title, author, publication date)
-> - Previous analysis showed 85% cache hit potential
->
-> **Decision:** Use Redis as cache layer with 1-hour TTL for article metadata.
->
-> **Why Redis over Alternatives:**
->
-> | Option | Pros | Cons | Decision |
-> | -- | -- | -- | -- |
-> | Redis | Fast, supports TTL, already in infra | Memory-based | ✅ CHOSEN |
-> | Memcached | Simple, fast | No built-in TTL management | ❌ More config needed |
-> | In-process | No network overhead | Lost on restart | ❌ Not suitable for HA |
+> **Fix Approach:** Redis as cache layer with 1-hour TTL. Fallback to DB when Redis unavailable.
 >
 > **Affected Files:**
->
 > | File | Anchor | Changes |
-> | -- | -- | -- |
-> | `src/api/articles.py` | `get_article_metadata()` function | Add cache layer |
-> | `src/cache/__init__.py` | new file | New Redis client wrapper |
+> |------|--------|---------|
+> | `src/api/articles.py` | `get_article_metadata()` | Add cache check before DB query |
+> | `src/cache/__init__.py` | new file | Redis client wrapper |
 > | `src/config.py` | "Configuration" section | Add Redis connection config |
 >
-> **Code Context:**
-> Current `get_article_metadata()` in `src/api/articles.py`:
->
-> ```python
-> def get_article_metadata(article_id: str) -> dict:
->     """Fetch article metadata from database."""
->     # TO BE MODIFIED: Add cache check before DB query
->     result = db.query("SELECT * FROM articles WHERE id = ?", article_id)
->     return result
-> ```
->
-> **Constraints:**
->
-> - Must not exceed 512MB Redis memory allocation
-> - Cache invalidation required on article updates
-> - Must handle Redis unavailable gracefully (fallback to DB)
-> - TTL of 1 hour (3600 seconds)
->
-> **Assumptions:**
->
-> - Redis server already deployed (per infra team confirmation)
-> - Article metadata structure stable (no schema changes planned)
+> **Constraints:** Must not exceed 512MB Redis memory. Must handle Redis unavailable gracefully.
 >
 > **Success Criteria:**
->
-> 1. ✅ API response time \<20ms for cached article queries
+> 1. ✅ API response time <20ms for cached queries
 > 2. ✅ Cache hit rate >80%
 > 3. ✅ Graceful fallback when Redis unavailable
-> 4. ✅ Cache invalidation on article update works
+> 4. ✅ Cache invalidation on article update
 >
-> **Edge Cases:**
+> **Edge Cases:** Redis unavailable → fallback to DB. Cache full → LRU eviction. Article updated → invalidate entry.
 >
-> - Redis unavailable → Fallback to DB query (log warning)
-> - Article updated → Invalidate cache entry
-> - Cache full → Redis LRU eviction handles automatically
->
-> **Dependencies:**
->
-> - Redis server (already deployed: `redis.internal:6379`)
-> - `redis-py` library (add to requirements)
->
-> **Risk Assessment:**
->
-> | Risk | Probability | Impact | Mitigation |
-> | -- | -- | -- | -- |
-> | Redis memory limit exceeded | Low | High | Monitor usage, set TTL |
-> | Cache invalidation bugs | Medium | Medium | Tests for update flows |
-> | Increased complexity | Medium | Low | Clear abstraction layer |
->
-> **Related Issues:**
->
-> | Issue | Summary | Relevance |
-> | -- | -- | -- |
-> | [#50](https://github.com/owner/repo/issues/50) | Performance audit | Original performance report |
-> | [#200](https://github.com/owner/repo/pull/200) | Redis infra setup | Infrastructure PR |
+> **Risk Assessment:** Redis memory limit (Low prob, High impact). Cache invalidation bugs (Med prob, Med impact).
 
-This is GOOD because:
+**Why this works:** The change touches multiple files and has infrastructure dependencies. The standard format provides affected files, constraints, and risk assessment. Without these, an implementer might miss the Redis unavailable edge case or the memory constraint.
 
-- ✅ Problem statement with measurable impact
-- ✅ Context explaining current state and why change is needed
-- ✅ Decision documented with alternatives considered
-- ✅ Affected files with function/section anchors (NOT line numbers)
-- ✅ Code snippets included
-- ✅ Constraints and assumptions listed
-- ✅ Success criteria are testable and measurable
-- ✅ Edge cases identified with handling
-- ✅ Dependencies documented
-- ✅ Risk assessment with mitigations
-- ✅ Related issues with context on why they matter
+### Comprehensive Feature Spec (large, cross-cutting change)
+
+For features that span multiple systems, require phased deployment, or have significant risk, use the full structure with phased implementation, extended risk assessment with blast radius analysis, detailed decision rationale with alternatives, and dependencies table. The comprehensive format serves the complexity.
 
 ______________________________________________________________________
 
-## Example 3: Guideline Update
+## Example 3: Guideline Update — Different Complexity Levels
 
-### ❌ BAD Guideline Update
+### Minimal Guideline Update (adding a rule)
 
-> **Title:** Update guidelines
+> **Problem:** Guidelines don't address when to use `--no-verify` with git commands.
 >
-> **Description:** Add the rule we talked about for specs.
+> **Proposed Change:** Add prohibition to `000-critical-rules.md`.
+>
+> **Success Criteria:** Guidelines load correctly. Search finds new content.
 
-This is BAD because:
+**Why this works:** Small change, obvious impact, no architectural implications.
 
-- No context on WHAT rule
-- No WHY the rule is needed
-- No WHERE to add it
-- No decision rationale
+### Standard Guideline Update (philosophy or process change)
 
-______________________________________________________________________
-
-### ✅ GOOD Guideline Update
-
-> **Title:** Guidelines: Add fresh-start context requirements for all specs
+> **Problem:** Spec templates enforce rigid structure that causes agents to fill in sections mechanically rather than reasoning about what content each spec needs.
 >
-> **Problem Statement:** Specs often assume context from prior conversations. When a new AI agent picks up a spec (or the same agent after context reset), critical information is missing, leading to incorrect implementations or repeated questions.
+> **Current State:** `143-planning-spec-templates.md` presents complete templates as "use this template" and `spec-creation/tasks/write.md` provides a 12-section mandatory list that agents treat as required regardless of spec complexity.
 >
-> **Current State:** Guidelines in the "Mandatory Elements Checklist" section of `144-planning-spec-templates.md` describe requirements analysis but don't mandate self-containment for agent context-loss scenarios.
+> **Proposed Change:** Replace rigid templates with intent-driven prose guidelines and varied examples at different complexity levels.
 >
-> **Proposed Change:** Add new section 1.2 "Fresh-Start Context Requirements" mandating that all specs include full context inline, with no reliance on "see above" or "as discussed" references.
->
-> **Why This Change:**
->
-> 1. AI agents have no persistent memory between sessions
-> 2. Different agents may work on the same spec at different times
-> 3. Context loss leads to implementation errors
-> 4. Self-contained specs reduce back-and-forth questions
->
-> **Decision Rationale:**
->
-> - Considered adding to `000-critical-rules.md` — rejected because this is a process improvement, not a zero-tolerance violation
-> - Considered separate file — rejected because spec creation workflow should be in one place
-> - Chosen: Add to `00-spec-creation.md` as section 1.2, after engineering requirements
+> **Decision Rationale:** Templates trigger mechanical filling. Intent descriptions let agents reason about what structure serves each specific spec. The existing prose-driven skills (brainstorming, plan-fidelity-auditor) demonstrate this approach works.
 >
 > **Success Criteria:**
->
-> 1. ✅ New section added
-> 2. ✅ Checklist template created
-> 3. ✅ Bad/Good examples documented
-> 4. ✅ Guidelines load correctly
+> 1. ✅ No mandatory templates remain
+> 2. ✅ Examples show different valid structures for different complexity levels
+> 3. ✅ Verification uses content-coverage questions, not section header checks
 
-This is GOOD because:
-
-- ✅ Clear problem statement
-- ✅ Current state with file references
-- ✅ Proposed change described
-- ✅ Decision rationale with alternatives
-- ✅ Success criteria listed
+**Why this works:** The change has philosophical implications across multiple files. The standard format provides current state, proposed change, and decision rationale. A fresh agent can understand both what and why.
 
 ______________________________________________________________________
 
-## Quick Reference: Fresh-Start Checklist
+## Self-Containment Principles
 
-Before finalizing any spec, verify:
+Regardless of spec format (minimal, standard, or comprehensive), these principles apply to ALL specs:
 
-| Element | Include This |
-| -- | -- |
-| **Problem** | What and WHY (with context) |
-| **Location** | File path + function/section anchors + snippets |
-| **References** | Issue URL + summary + relevance |
-| **Context** | Background, history, affected systems |
-| **Constraints** | Technical, time, resource limits |
-| **Assumptions** | What might not be true |
-| **Criteria** | Testable success conditions |
-| **Edges** | Boundary conditions |
-| **Deps** | External systems/libraries |
-| **Risks** | What could go wrong |
+| Principle | Why |
+|-----------|-----|
+| No "as discussed above" | A fresh agent has no memory of earlier conversation |
+| Stable anchors, not line numbers | Line numbers break on every edit |
+| Code snippets for key changes | Prevents misunderstandings about what code does |
+| Related issues include summaries | Bare links without context are useless |
+| Decision rationale documented | Without it, implementers may choose different approaches |
 
-**Golden Rule:** If a new agent with no memory context cannot implement the spec correctly from the spec alone, the spec is incomplete.
+**Golden Rule:** If a new agent with no memory context cannot implement the spec correctly from the spec alone, the spec is incomplete — regardless of how well it follows any template.
 
 ______________________________________________________________________
 
-## Example 4: Sub-issue Structure (Multi-task Spec)
+## Sub-issue Structure (Multi-task Spec)
 
-### ✅ GOOD Multi-task Spec with Sub-issues
+When a spec has multiple phases/tasks, each phase SHOULD be tracked as a separate sub-issue.
 
-When a spec has multiple phases/tasks, each phase MUST be tracked as a separate sub-issue.
+**Parent Issue:** Contains the full spec with all phases.
 
-**Parent Issue:**
+**Sub-issues CREATED:** One per phase, with descriptive titles referencing the parent.
 
-> **Title:** [SPEC] Add user authentication
->
-> **STATUS:** 1.1
->
-> **Objective:** Implement user authentication with OAuth2 and session management.
->
-> **Phases:**
->
-> 1. Phase 1: Database schema (user tables, indexes)
-> 2. Phase 2: API endpoints (login, logout, refresh)
-> 3. Phase 3: UI components (login form, session handling)
->
-> **Implementation details in body...**
+**Single-task exemption:** When a spec has exactly one task, no sub-issues are required.
 
-**Sub-issues CREATED:**
-
-- `#101: [Task: #100] Create database schema for user authentication`
-- `#102: [Task: #100] Implement authentication API endpoints`
-- `#103: [Task: #100] Build user login UI components`
-
-**Why this works:**
-
-- Each phase is trackable as its own issue
-- Progress visible in GitHub's sub-issue view
-- Agents can verify which phase to implement
-- Clear parent-child hierarchy
-
-### ✅ GOOD Single-task Spec (No Sub-issues Needed)
-
-When a spec has ONE task, no sub-issues are required.
-
-**The Issue:**
-
-> **Title:** [SPEC] Fix typo in README
->
-> **STATUS:** 1.1
->
-> **Problem:** README contains " instalation" (missing 'l')
->
-> **Solution:** Fix the typo in the installation section
->
-> **Success Criteria:** Typo corrected
-
-**No sub-issues needed because:**
-
-- ✅ Exactly ONE implementation task
-- ✅ No decomposition needed
-- ✅ Single unit of work
-- ✅ Can be implemented directly
-
-### Sub-issue Auto-create
-
-**See `github-sub-issues` skill for the complete auto-create workflow, single-task exemption, database ID requirement, and phase-level structure.**
+**See `github-sub-issues` skill for the complete auto-create workflow and phase-level structure.**
 
 ______________________________________________________________________
 
-## Example 5: Issue-First Strategy (No Local Fallback)
-
-### ❌ BAD: Local Plan Files When GitHub Available
-
-> **Title:** [SPEC] Add rate limiting
->
-> **Notes:** Created plan file `plans/SPEC-rate-limiting.md` because GitHub MCP was unavailable.
-
-This is BAD because:
-
-- Local files fragment tracking
-- No centralized visibility
-- Manual sync required
-- History is not preserved in GitHub
-- Different agents can't see the plan
-
-### ✅ GOOD: GitHub Issues as Sole Mechanism
-
-When GitHub MCP tools are available, GitHub Issues are the ONLY authoritative source.
-
-**See `github-issue-creation` skill for the complete issue creation workflow, `github-sub-issues` skill for sub-issue creation, and the GitHub MCP Required — No Fallback policy.**
-
-______________________________________________________________________
-
-*Source: Created to illustrate fresh-start context requirements*
+*Source: Reframed from template compliance to varied valid structures per spec #821*

--- a/.opencode/skills/github-issue-creation/tasks/pre-creation.md
+++ b/.opencode/skills/github-issue-creation/tasks/pre-creation.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Validate spec before creating GitHub Issue to prevent conflicts, superseded issues, and missing essential sections.
+Validate spec before creating GitHub Issue to prevent conflicts, superseded issues, and missing essential content.
 
 ## Operating Protocol
 
@@ -17,7 +17,7 @@ Validate spec before creating GitHub Issue to prevent conflicts, superseded issu
 ## Exit Criteria
 
 - Spec validated (no conflicts, no superseded issues)
-- All essential sections present
+- Essential content coverage confirmed
 - Ready to create issue
 
 ## Procedure
@@ -52,20 +52,28 @@ For each open spec issue:
 1. HALT
 2. Suggest updating or closing stale spec first
 
-### Step 3: Validate Spec Completeness
+### Step 3: Validate Spec Content Coverage
 
-**Ensure essential sections are present:**
+**Ensure essential content is present, regardless of section header names.**
 
-| Section | Required |
-|---------|----------|
-| Problem Statement | ✅ YES |
-| Context | ✅ YES |
-| Success Criteria | ✅ YES |
-| Decision Rationale | (for complex specs) |
+The check is content-coverage, not structural conformity. A spec that covers all required concerns under different section names passes. A spec with the exact "correct" headers but missing content fails.
 
-**If missing sections:**
+| Content Area | What to Check |
+|-------------|---------------|
+| Problem description | Does the spec describe what problem it solves and why it matters? |
+| Context | Does the spec provide enough background for a fresh agent to understand? |
+| Success criteria | Does the spec include testable, binary pass/fail completion criteria? |
+
+**Content coverage check examples:**
+
+- A spec with "Background", "The Issue", "How We Know It Works" passes ✅ (covers problem, context, criteria)
+- A spec with "Problem Statement", "Context", "Success Criteria" passes ✅ (covers problem, context, criteria)
+- A spec with "Problem Statement" header but empty content fails ❌ (missing actual content)
+- A spec with no problem description but a detailed implementation plan fails ❌ (what problem is it solving?)
+
+**If content coverage is missing:**
 1. HALT
-2. Report missing sections
+2. Report missing content areas (not missing headers, missing *content*)
 3. Do NOT proceed with creation
 
 ### Step 4: Report Validation Result
@@ -85,7 +93,7 @@ For each open spec issue:
 |-------|------------|
 | Superseding issue found | HALT, report conflict, suggest closing superseded spec |
 | Conflicting objectives | HALT, suggest reconciling or splitting scopes |
-| Missing sections | HALT, require spec update before creation |
+| Missing content coverage | HALT, require spec update before creation |
 | Stale open spec detected | HALT, suggest updating or closing stale spec |
 
 ## Safety Checks
@@ -94,22 +102,30 @@ Before proceeding, verify ALL:
 
 - No superseding issues exist
 - No conflicting specs exist
-- All essential sections present
+- Essential content coverage is present (problem, context, success criteria)
 - Spec is not stale
 
 **If ANY check fails → HALT and report.**
 
-## Example: Superseding Issue Detection
+## Example: Content Coverage Check
 
-**New Spec:** "[SPEC] Add rate limiting"
+**New Spec:** "Add rate limiting to API endpoints"
 
-**Check:** Query open issues
-- Found: Issue #50 "[SPEC-FIX] Rate limiting for API endpoints"
+**Check:** Content coverage
+- Problem described? Yes — "API calls average 150ms, causing slow page loads"
+- Context provided? Yes — "Current queries hit DB directly, 85% cache hit potential"
+- Success criteria testable? Yes — "API response <20ms for cached queries, >80% cache hit rate"
 
-**Result:** HALT. Issue #50 supersedes this spec. Suggest:
-1. Review #50 to see if it covers the requirement
-2. Close new spec if superseded
-3. Update #50 if scope needs expansion
+**Result:** PASS. Content coverage is sufficient regardless of section headers.
+
+**New Spec:** "Improve the API"
+
+**Check:** Content coverage
+- Problem described? No — "improve" is vague, no measurable problem stated
+- Context provided? No — no background on what's wrong
+- Success criteria testable? No — "better API" is not testable
+
+**Result:** FAIL. Missing content coverage, not missing headers.
 
 ## Context Required
 

--- a/.opencode/skills/spec-auditor/tasks/concerns.md
+++ b/.opencode/skills/spec-auditor/tasks/concerns.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Analyze spec phase structure for concern separation quality — deployment independence, risk profile, and blast radius. All findings are reported, NOT auto-applied.
+Analyze spec phase structure for concern separation quality — deployment independence, risk profile, and blast radius. All findings are reported for agent review, NOT auto-applied.
 
 **Delegated from:** concern-separation-auditor (v1). Now a subtask within spec-auditor.
 
@@ -44,26 +44,22 @@ Subtask: concerns
 Finding: [BOILERPLATE-TITLE|CONCERN_MIXING|DEPENDENCY_REVERSAL|HIGH_RISK_GROUPING] - [summary]
 Location: [phase/step where issue found]
 Context: [why concern separation matters for this spec]
-Classification: [auto-fix|conditional|flag-for-review]
-Fix Action: [what was done OR "flagged for review — [reason]"]
+Classification: flag-for-review
+Fix Action: flagged for review — [reason]
 Severity: [HIGH|MEDIUM|LOW]
 ```
 
-## Auto-Fix Classification
+## Why Flag-for-Review (Not Auto-Fix)
 
-| Problem Class | Classification | Fix Action |
-|---------------|---------------|------------|
-| BOILERPLATE-TITLE | auto-fix | Rename phase to describe specific concern |
-| CONCERN_MIXING | auto-fix | Split mixed-concern phase into separate phases per concern |
-| DEPENDENCY_REVERSAL | auto-fix | Reorder phases to match dependency order |
-| HIGH_RISK_GROUPING | auto-fix | Separate high-risk steps into their own phase or flag at top of phase |
+Concern-splitting and phase-renaming require context judgment that the auditor lacks:
 
-## Why Auto-Fix Is Safe for These Findings
+- A BOILERPLATE-TITLE rename might be wrong for the specific spec. The spec author may have chosen a simple name intentionally for a simple change.
+- A concern split might break an intentionally grouped phase. Some phases group related concerns that are deployed together.
+- The agent has full context about the spec's complexity, domain, and deployment requirements. The auditor doesn't.
 
-- BOILERPLATE-TITLE: Generic names are always suboptimal; specific concern names are always better
-- CONCERN_MIXING: Mixed-concern phases create deployment risk; splitting is always correct
-- DEPENDENCY_REVERSAL: Wrong order is objectively wrong; reordering is always correct
-- HIGH_RISK_GROUPING: Separating risk profiles is always safer
+All findings are reported for agent review. The agent decides whether to apply changes based on their understanding of the spec's domain.
+
+This aligns with the v2 design philosophy from `concern-separation-auditor/SKILL.md`: findings are presented, not imposed.
 
 ## When to Run
 

--- a/.opencode/skills/spec-auditor/tasks/structure.md
+++ b/.opencode/skills/spec-auditor/tasks/structure.md
@@ -2,10 +2,10 @@
 
 ## Purpose
 
-Check that a document follows the required structural format. For specs, this means STATUS headers, phase/step numbering, and status markers. For non-spec documents, structure checks are adapted to be less strict.
+Check that a document has clear progress tracking, creation context, and consistent structure. For specs, this means verifying that content is findable, trackable, and organized. For non-spec document types, structure checks are adapted to be less strict.
 
 **Note for non-spec document types:** STATUS/phase/step markers and approval tracking are relaxed differently per type:
-- **Plan:** Has STATUS markers and phases but no approval tracking — check STATUS and phases, skip approval markers
+- **Plan:** Has phases but no approval tracking — check phases, skip approval markers
 - **Process Flow:** Has sequential steps but no STATUS headers — check step numbering and I/O contracts, skip STATUS/phase checks
 - **Runbook/SOP:** Has sequential steps and possibly a prerequisites section — check step numbering and section presence, skip STATUS/phase checks
 - **Checklist:** Has checkbox items — check checkbox format, skip STATUS/phase/step checks
@@ -13,55 +13,48 @@ Check that a document follows the required structural format. For specs, this me
 
 ## Checks
 
-| Check | Problem Class | Description |
-|-------|---------------|-------------|
-| STATUS header | STRUCTURE-VIOLATION | Is `STATUS: phase.step` present? |
-| CREATED date | MISSING-ELEMENT | Is `CREATED: YYYY-MM-DD` present? |
-| Phase numbering | STRUCTURE-VIOLATION | Are phases numbered 1, 2, 3...? |
-| Step numbering | STRUCTURE-VIOLATION | Are steps numbered within each phase? |
-| Status markers | STRUCTURE-VIOLATION | Are `☐`/`↻`/`☑`/`☒` used correctly? |
-| Phase names | MISSING-ELEMENT | Do phase names describe specific concerns, not generic activities? |
+This subtask verifies content quality and completeness, not structural conformity to a specific template.
+
+| Check | Problem Class | Description | Classification |
+|-------|---------------|-------------|----------------|
+| Trackability | CONTENT-COVERAGE | Is there a way to track progress? (Any format: STATUS phase.step, simple status note, inline progress markers) | flag-for-review |
+| Creation context | CONTENT-COVERAGE | Is there creation context (date, author, or STATUS marker)? | flag-for-review |
+| Consistent structure | CONTENT-COVERAGE | Does the spec use consistent structure throughout? (Sections, phases, or steps are organized logically, not randomly scattered) | flag-for-review |
+| Concern-named phases | MISSING-ELEMENT | Do phase names describe specific concerns, not generic activities? ("Database Schema Setup", not "Implementation") | flag-for-review |
+
+**Advisory guidelines (not mandatory):**
+- STATUS with `phase.step` format (e.g., `STATUS: 1.2`) is recommended for multi-phase specs but not required
+- CREATED date is recommended but not mandatory
+- Phase/step numbering is recommended for multi-phase specs, optional for simple specs
+- Status markers (`☐`/`↻`/`☑`/`☒`) are recommended but any clear progress indicator works
 
 ## Procedure
 
 1. Read the spec issue via GitHub MCP
-2. Check for STATUS header at the top
-3. Check for CREATED date
-4. Check that phases are numbered sequentially
-5. Check that steps are numbered within each phase
-6. Check that status markers are present on each step
-7. Verify phase names describe specific concerns (not "Implementation", "Testing", "Build")
-
-## Phase Name Quality
-
-| Pattern | Status | Reason |
-|---------|--------|--------|
-| Single-word activity | BOILERPLATE-TITLE flag | No concern boundary specified |
-| "Testing" alone | BOILERPLATE-TITLE flag | Generic activity |
-| "Testing Infrastructure" | ACCEPTABLE | Specific concern |
-| "Database Schema Setup" | GOOD | Specific concern |
-| "Implementation" | BOILERPLATE-TITLE flag | Generic activity |
-
-**Note:** BOILERPLATE-TITLE findings are auto-fixed — the subtask renames generic phase names to describe specific concerns.
+2. Check that progress is trackable (any clear method)
+3. Check that creation context exists (date, author, or status marker)
+4. Check that structure is consistent (not randomly organized)
+5. Check that phase names describe specific concerns (if phases exist)
 
 ## Report Format
 
 ```
 Subtask: structure
-Finding: [STRUCTURE-VIOLATION|MISSING-ELEMENT] - [summary]
+Finding: [CONTENT-COVERAGE|MISSING-ELEMENT] - [summary]
 Location: [section of spec]
-Context: [why structure matters for this spec]
-Classification: [auto-fix|conditional|flag-for-review]
-Fix Action: [what was done OR "flagged for review — [reason]"]
+Context: [why content quality matters for this spec]
+Classification: flag-for-review
+Fix Action: flagged for review — [reason]
 Severity: [HIGH|MEDIUM|LOW]
 ```
 
-## Auto-Fix Classification
+## Why Flag-for-Review (Not Auto-Fix)
 
-| Problem Class | Classification | Fix Action |
-|---------------|---------------|------------|
-| STRUCTURE-VIOLATION | auto-fix | Fix STATUS headers, numbering, markers |
-| MISSING-ELEMENT (CREATED date) | auto-fix | Add `CREATED: YYYY-MM-DD` |
-| MISSING-ELEMENT (phase names) | auto-fix | Rename boilerplate phase names to describe specific concerns |
+Structure choices are context-dependent:
+- A simple bug fix doesn't need `STATUS: 1.2` — `in progress` or `complete` is sufficient
+- A spec with phases named "Setup" and "Verification" might be fine for a small change
+- The agent has full context about the spec's complexity; the auditor doesn't
+
+All structure findings are reported for agent review. The agent decides whether to apply changes.
 
 Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-creation/tasks/decompose.md
+++ b/.opencode/skills/spec-creation/tasks/decompose.md
@@ -56,19 +56,15 @@ For each unit:
 - What happens when it fails? (error propagation, fallback behavior, recovery)
 - How is failure detected? (logging, metrics, alerts)
 
-## Output Format
+## Content Coverage
 
-```
-## Problem Decomposition
+Does the decomposition define clear units with:
+- A single purpose for each unit?
+- Defined interfaces (what goes in, what comes out)?
+- Known invariants that must hold?
+- Failure modes (how it fails, what happens)?
 
-### Unit: <name>
-- Purpose: <one-sentence description>
-- Interface: <API contract, data schema>
-- Inputs: <what comes in>
-- Outputs: <what goes out>
-- Invariants: <what must always be true>
-- Failure modes: <how it fails, what happens>
-```
+**Any format that communicates these concerns clearly is acceptable** — structured per-unit sections, tables, prose descriptions, or diagrams. The agent chooses the format that best serves the spec's complexity.
 
 ## Context Required
 

--- a/.opencode/skills/spec-creation/tasks/requirements.md
+++ b/.opencode/skills/spec-creation/tasks/requirements.md
@@ -34,13 +34,12 @@ Requirements implied but not stated:
 
 ### Step 3: Build Constraints & Assumptions Ledger
 
-| Category | Items | Source |
-|----------|-------|--------|
-| Technical constraints | Platform, language, framework restrictions | Investigation |
-| Resource constraints | Time, personnel, infrastructure limits | User input |
-| Assumptions | Things taken as true without verification | Inference |
-| Dependencies | External systems, libraries, APIs required | Investigation |
-| Non-requirements | What is explicitly NOT in scope | User input + scoping |
+Document constraints and assumptions in any format that clearly communicates:
+- **Technical constraints** — platform, language, framework restrictions and their source (investigation findings or user input)
+- **Resource constraints** — time, personnel, infrastructure limits and their source
+- **Assumptions** — things taken as true without verification, with how to confirm each
+- **Dependencies** — external systems, libraries, APIs required and what happens if unavailable
+- **Non-requirements** — what is explicitly out of scope and why
 
 ### Step 4: Document Non-Requirements
 
@@ -49,27 +48,16 @@ Explicitly list what is NOT in scope:
 - Capabilities implied but excluded
 - Edge cases that are out of scope
 
-## Output Format
+## Content Coverage
 
-```
-## Requirements Extraction
+Does the requirements analysis cover:
+- Explicit requirements from the user?
+- Implicit requirements inferred from context?
+- Constraints (technical, resource, compatibility)?
+- Assumptions (and how to verify them)?
+- Non-requirements (what's explicitly out of scope)?
 
-### Explicit Requirements
-1. [R1] <requirement>
-2. [R2] <requirement>
-
-### Implicit Requirements
-1. [IR1] <requirement> (inferred from: <source>)
-
-### Constraints
-- <constraint> (source: <investigation or user>)
-
-### Assumptions
-- <assumption> (verification: <how to confirm>)
-
-### Non-Requirements (Out of Scope)
-- <exclusion> (reason: <why>)
-```
+**Any format that covers these concerns is acceptable** — tables, prose lists, bullet points, or structured sections. The agent chooses the format that best communicates the requirements for this specific spec.
 
 ## Context Required
 

--- a/.opencode/skills/spec-creation/tasks/risk.md
+++ b/.opencode/skills/spec-creation/tasks/risk.md
@@ -20,9 +20,11 @@ Analyze risk, blast radius, failure propagation, and operational requirements (l
 
 ### Step 1: Risk Assessment
 
-For each component/change:
-| Risk | Severity | Probability | Mitigation |
-|------|----------|-------------|------------|
+For each component/change, assess:
+- What risks exist (technical, integration, data, security)
+- Severity of each risk (low/medium/high/critical)
+- Probability of each risk occurring
+- Mitigation strategy for each risk
 
 ### Step 2: Blast Radius Analysis
 
@@ -47,26 +49,15 @@ Document operational needs:
 - **Deployment:** Rollout strategy, blue/green, canary, feature flags
 - **Data migration:** Schema changes, data transformation, rollback
 
-## Output Format
+## Content Coverage
 
-```
-## Risk Assessment
+Does the risk assessment cover:
+- Severity and probability for each risk?
+- Blast radius for high-risk components (what breaks, how far it spreads, rollback strategy)?
+- Failure propagation paths?
+- Operational requirements (logging, metrics, alerts, deployment)?
 
-| Risk | Severity | Probability | Mitigation |
-|------|----------|-------------|------------|
-
-### Blast Radius: <high-risk component>
-- Failure impact: <what breaks>
-- Propagation: <how far it spreads>
-- Rollback: <recovery strategy>
-
-## Operational Requirements
-- Logging: <requirements>
-- Metrics: <requirements>
-- Alerts: <requirements>
-- Deployment: <requirements>
-- Data migration: <requirements>
-```
+**Any format that communicates these concerns effectively is acceptable.** Formal risk tables with severity/probability matrices work well for complex specs. Prose descriptions work well for simple specs with few risks. The agent chooses the format that best serves the spec.
 
 ## Context Required
 

--- a/.opencode/skills/spec-creation/tasks/traceability.md
+++ b/.opencode/skills/spec-creation/tasks/traceability.md
@@ -18,13 +18,12 @@ Map every requirement to spec section, test, and implementation step. Ensure not
 
 ## Procedure
 
-### Step 1: Build Traceability Matrix
+### Step 1: Build Traceability
 
-Map each requirement ID to:
-
-| Requirement | Spec Section | Test Scenario | Implementation Step |
-|-------------|-------------|---------------|---------------------|
-| [R1] | Section X | Test case Y | Step Z |
+Map each requirement to:
+- Which spec section covers it
+- What test scenario validates it
+- Which implementation step implements it
 
 ### Step 2: Verify Bidirectional Coverage
 
@@ -40,19 +39,14 @@ Map each requirement ID to:
 - Requirements without test scenarios (untestable)
 - Requirements without implementation steps (orphan)
 
-## Output Format
+## Content Coverage
 
-```
-## Traceability Matrix
+Can each requirement be traced to a spec section, test scenario, and implementation step? Does the traceability provide bidirectional coverage?
 
-| Req ID | Spec Section | Test | Implementation |
-|--------|-------------|------|----------------|
-| [R1]   | §2.1        | T1   | Step 3         |
-| [R2]   | §2.2        | T2   | Step 4         |
+- **Forward traceability:** Every requirement → spec section and test
+- **Backward traceability:** Every spec section → requirement
 
-### Gaps
-- <any missing mappings>
-```
+**Any format that provides this coverage is acceptable.** A formal traceability matrix table works well for complex specs. A prose list or inline references work well for simple specs. The agent chooses the format that best serves the spec.
 
 ## Context Required
 

--- a/.opencode/skills/spec-creation/tasks/write.md
+++ b/.opencode/skills/spec-creation/tasks/write.md
@@ -21,13 +21,15 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
 ### Step 1: Assemble Spec
 
-Combine outputs from prerequisite tasks into a structured spec:
-- Overview and goals (from requirements)
-- Non-goals (from non-requirements)
-- Architecture and interfaces (from decompose)
-- Success criteria (acceptance criteria with binary pass/fail)
-- Edge cases and error handling (from risk)
-- Traceability references (from traceability)
+Combine outputs from prerequisite tasks into a coherent spec. The spec should address the following content areas — the agent decides which sections to use and how to organize them:
+
+- **Objectives and goals** — What this spec achieves
+- **Constraints and scope** — What's in and out of scope
+- **Success criteria** — Testable, binary pass/fail conditions
+- **Risk and edge cases** — What could go wrong and boundary conditions
+- **Implementation approach** — For the reader's understanding, not prescribing HOW (see Step 4.5)
+
+Skip areas that don't apply to simple specs; add areas that do. The spec should be self-contained and clear, regardless of structure.
 
 ### Step 2: Eliminate Ambiguity (Principle #4)
 
@@ -48,22 +50,13 @@ For each feature/requirement:
 
 ### Step 4: Structure the Deliverable (Principle #10)
 
-Spec sections (adapt to spec complexity):
+**Content coverage matters more than section structure.** The agent chooses the optimal structure for the spec's complexity:
 
-1. **Overview** — Problem statement and context
-2. **Goals** — What this spec achieves
-3. **Non-Goals** — What is explicitly out of scope
-4. **Success Criteria** — Testable, binary pass/fail
-5. **Architecture** — Components, interfaces, data flow
-6. **Interfaces** — API contracts, data schemas, boundaries
-7. **Data Models** — Schemas, migrations, constraints
-8. **Edge Cases** — Error handling, failure modes, limits
-9. **Acceptance Criteria** — Per-feature binary tests
-10. **Risk Assessment** — High-risk areas, mitigation
-11. **Operational Requirements** — Logging, metrics, deployment
-12. **Rollout Plan** — Deployment strategy, rollback
+- **Simple specs** (bug fixes, one-file changes): May use a minimal format — Problem, Context, Fix, Criteria, Edge Cases — all in flowing prose without section headers
+- **Standard specs** (multi-file changes): May use typical sections — Objective, Problem, Context, Fix Approach, Success Criteria, Edge Cases
+- **Complex specs** (cross-cutting, multi-phase): May use full structure — Objective, Problem, Context, Affected Files, Fix Approach, Success Criteria, Edge Cases, Dependencies, Risk, Decision Rationale, Phases
 
-Skip sections that don't apply (e.g., no data models for a guideline-only change).
+**Any format that covers the required content areas is acceptable.** The agent decides the structure that best serves the specific spec.
 
 ### Step 4.5: Spec/Plan Boundary Check
 
@@ -96,7 +89,7 @@ Fix any issues inline. No need to re-review — just fix and move on.
 
 Invoke `github-issue-creation` skill to persist the spec as a GitHub Issue:
 
-1. Invoke `github-issue-creation --task pre-creation` to validate (check for conflicts, superseded issues, missing sections)
+1. Invoke `github-issue-creation --task pre-creation` to validate (check for conflicts, superseded issues, content coverage)
 2. If validation fails → HALT and report. Fix issues and re-validate.
 3. If validation passes → invoke `github-issue-creation --task single-task-check` to determine sub-issue needs
 4. Invoke `github-issue-creation --task creation` to create the GitHub Issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/821-template-enforcement
+
+- **Intent-Driven Spec Guidelines** (#821) - Replaced rigid structural templates across 12 guideline and skill files with intent-driven prose guidelines. Auditors now flag issues for review instead of auto-fixing, and spec creation uses content coverage prompts instead of mandatory section checklists.
+
 ### spec/592-submodule-release
 
 - **Submodule Release Coordination** (#592) - Implemented automanaged submodule lifecycle: session-start sync with missing dev auto-creation, automated commit/push in review-prep, SHA validation scripts (validate-submodule-refs.sh, enhanced validate-release-tags.sh with --semver/--branch), PR dependency chain enforcement, automated dev→main release promotion, and cross-platform (GitHub + GitBucket) tag verification.


### PR DESCRIPTION
**Summary:**

Replaced rigid structural template enforcement across 12 guideline and skill files with intent-driven prose guidelines that leverage AI reasoning instead of forcing template-filling mode. Auditors now flag issues for review rather than auto-fixing them.

**Outcome:** Developers and agents can write specs in natural prose with flexible structure, while auditors provide meaningful feedback instead of mechanically enforcing template compliance.

Fixes #821
Fixes #822
Fixes #823
Fixes #824
Fixes #825
Fixes #826