### PR TITLE
Implement #814: add PLAN-BLEED-AMBIGUOUS problem class to spec-auditor

### DIFF
--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -192,6 +192,7 @@ This is a v3 core principle. Previous versions (v2) were report-only — finding
 | BLAST_RADIUS_VIOLATION | Isolation scope depends on deployment architecture |
 | TESTABILITY_VIOLATION | Testability tradeoffs require understanding of project constraints |
 | PRINCIPLE_VIOLATION | Generic principle violation requires domain judgment |
+| PLAN-BLEED-AMBIGUOUS | Content could be requirement or implementation detail; requires domain judgment |
 
 **Reporting format (v3 — includes Classification and Fix Action):**
 ```
@@ -264,6 +265,7 @@ Existing classes remain, plus two new ones:
 | **TESTABILITY_VIOLATION** | Design that makes testing difficult without explicit tradeoff note |
 | **PRINCIPLE_VIOLATION** | Any of the 20 engineering principles violated without documented tradeoff note (fallback) |
 | **PLAN-BLEED** | Spec prescribing HOW instead of WHAT; implementation details belong in the plan |
+| **PLAN-BLEED-AMBIGUOUS** | Content that could be either a requirement or implementation detail; requires domain judgment |
 
 ## Audit Findings Handling
 

--- a/.opencode/skills/spec-auditor/tasks/content-quality.md
+++ b/.opencode/skills/spec-auditor/tasks/content-quality.md
@@ -17,6 +17,7 @@ Check architectural reasoning, ambiguity, conflicts, and scope creep in a spec.
 | Comment format | COMMENT-FORMAT-VIOLATION | Does the spec use executive summary format? |
 | Superseded closure | SUPERSEDED-CLOSURE-VIOLATION | Does closing language claim future action without execution? |
 | Plan bleed | PLAN-BLEED | Does the spec contain implementation details (code, DDL, algorithms) that belong in the plan? |
+| Plan bleed (ambiguous) | PLAN-BLEED-AMBIGUOUS | Could content be either a requirement or implementation detail? Requires domain judgment |
 
 ## Procedure
 
@@ -39,6 +40,7 @@ Check architectural reasoning, ambiguity, conflicts, and scope creep in a spec.
 | Step-by-step algorithms with imperative logic | Implementation procedure | Input/output contract |
 | File paths with "add", "modify", "create" language | File-level instructions | Affected files + anchors table |
 | Architecture decisions without "MUST" constraints | Design choices | Architecture requirements table |
+| Ambiguous content (could be requirement or implementation) | Could be either spec- or plan-level | Flag for domain judgment (PLAN-BLEED-AMBIGUOUS) |
 
 ## Nine Core Areas (Reference)
 
@@ -57,7 +59,7 @@ These are NOT mandatory sections — they're areas the agent should consider. A 
 
 ```
 Subtask: content-quality
-Finding: [ARCHITECTURAL-REASONING-GAP|AMBIGUOUS|CONFLICTING|SCOPE-CREEP-RISK|VERIFICATION-GAP|DEPENDENCY-INCOMPLETE|COMMENT-FORMAT-VIOLATION|SUPERSEDED-CLOSURE-VIOLATION|PLAN-BLEED] - [summary]
+Finding: [ARCHITECTURAL-REASONING-GAP|AMBIGUOUS|CONFLICTING|SCOPE-CREEP-RISK|VERIFICATION-GAP|DEPENDENCY-INCOMPLETE|COMMENT-FORMAT-VIOLATION|SUPERSEDED-CLOSURE-VIOLATION|PLAN-BLEED|PLAN-BLEED-AMBIGUOUS] - [summary]
 Location: [section of spec]
 Context: [why this matters for implementability]
 Classification: [auto-fix|conditional|flag-for-review]
@@ -78,5 +80,6 @@ Severity: [HIGH|MEDIUM|LOW]
 | SUPERSEDED-CLOSURE-VIOLATION | flag-for-review | May reference valid future work |
 | ARCHITECTURAL-REASONING-GAP | flag-for-review | Requires understanding design tradeoffs |
 | PLAN-BLEED | auto-fix | Replace code/DDL/algorithms with requirements tables; note moved content for plan |
+| PLAN-BLEED-AMBIGUOUS | flag-for-review | Content could be requirement or implementation detail; requires domain judgment |
 
 Co-authored with AI: <AI-Name> (<model-id>)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/814-plan-bleed-ambiguous
+
+- **PLAN-BLEED-AMBIGUOUS Problem Class** (#814) - Added the PLAN-BLEED-AMBIGUOUS problem class to spec-auditor, completing the spec/plan boundary enforcement plan. Ambiguous content that could be either requirement or implementation detail is now flagged for domain judgment instead of being auto-fixed or missed.
+
 ### spec/821-template-enforcement
 
 - **Intent-Driven Spec Guidelines** (#821) - Replaced rigid structural templates across 12 guideline and skill files with intent-driven prose guidelines. Auditors now flag issues for review instead of auto-fixing, and spec creation uses content coverage prompts instead of mandatory section checklists.


### PR DESCRIPTION
**Summary:**

Completes the spec/plan boundary enforcement plan by adding the PLAN-BLEED-AMBIGUOUS problem class to spec-auditor, so ambiguous content that could be either a requirement or implementation detail is flagged for domain judgment instead of being auto-fixed or missed.

**Outcome:** Auditors will now properly distinguish clear plan-bleed (auto-fixable) from ambiguous content (requires human judgment), preventing incorrect auto-fixes on specs where domain context is needed.

Fixes #814
Fixes #815
Fixes #816
Fixes #817