### PR TITLE
[PLAN] #830 Phase 2: approval-gate Adversarial Verification

### DIFF
--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -154,16 +154,57 @@ This skill is a **heavy skill** — its task files contain significant detail th
 
 **Sub-agent context parameters:** Pass issue number, `WORKTREE_PATH`, `GIT_OWNER`, `GIT_REPO` from session init. When `WORKTREE_PATH` is set, sub-agents MUST receive it and use it as the base directory for all file operations and git commands.
 
+## Adversarial Verification Requirements
+
+Every task in this skill that reads a metadata claim (label, comment, STATUS marker, sub-issue state, authorization history) MUST verify that claim against actual state before trusting it for workflow decisions. This extends the `065-verification-honesty.md` principle from code verification to metadata verification.
+
+### Verification Table
+
+| Metadata Claim | Verification Action | Tool Call | Problem Class |
+|----------------|-------------------|-----------|---------------|
+| `needs-approval` label present | Check issue comments for explicit authorization ("approved"/"go") from a developer | `github_issue_read(method=get_comments)` | MISSING-ELEMENT |
+| `needs-approval` label absent | Verify no pending authorization is needed (issue state is actually authorized) | `github_issue_read(method=get_labels)` | STRUCTURE-VIOLATION |
+| Authorization comment exists | Verify author is a developer (not bot/agent); verify scope matches current issue; verify comment is not superseded by revision | `github_issue_read(method=get_comments)` → filter by author association | CONFLICTING |
+| STATUS marker value | Compare STATUS against actual content maturity per ground-truth classification | `github_issue_read(method=get)` → parse body content | STRUCTURE-VIOLATION |
+| Authorization currency | Verify spec has not been revised after most recent authorization comment | `github_issue_read(method=get_comments)` → compare revision timestamps | STRUCTURE-VIOLATION |
+| Sub-issue state (open/closed) | Verify sub-issue state via GitHub API, not from cached or claimed state | `github_issue_read(method=get, issue_number=N)` → check `state` field | VERIFICATION-GAP |
+| Fix spec existence | Verify fix spec sub-issue exists and has correct labels/STATUS for its maturity | `github_issue_read(method=get_sub_issues)` → verify each child | MISSING-TRACEABILITY |
+
+### Evidence Artifacts
+
+Every adversarial verification check MUST produce an evidence artifact — a tool call result that demonstrates the verification was performed. Assertions without tool call evidence are verification honesty violations per `065-verification-honesty.md`.
+
+**Evidence format:**
+
+```
+Check: [what was verified]
+Tool: [tool call and parameters]
+Result: [actual state found]
+Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
+Action: [auto-fix|conditional|flag-for-review]
+```
+
+### Finding Classification
+
+Findings from adversarial verification follow the same three-tier model as `spec-auditor` ground-truth:
+
+| Classification | When | Action |
+|----------------|------|--------|
+| auto-fix | Safe, mechanical corrections (stale label, mismatched STATUS) | Apply fix, note in evidence |
+| conditional | Requires scope/safety check before applying (authorization claim vs actual) | Verify scope, then apply if safe |
+| flag-for-review | Requires domain judgment (conflicting authorization, ambiguous state) | Report in findings, do not apply |
+
 ## Cross-References
 
 - Related skills: `git-workflow` (branch operations, cleanup), `pr-creation-workflow` (PR timing), `issue-review` (authorization status)
-- Related guidelines: `010-approval-gate.md`, `000-critical-rules.md`
+- Related guidelines: `010-approval-gate.md`, `000-critical-rules.md`, `065-verification-honesty.md`
 - Related skill tasks: `approval-gate --task verify-sub-issues` (sub-issue verification), `git-workflow --task cleanup` (post-merge closure)
+- Related subtask: `spec-auditor --task ground-truth` (adversarial metadata verification model)
 - Label state machine: `141-planning-status-tracking.md §10` (label add/remove actions for this skill)
 
 ```yaml+symbolic
 schema_version: "1.0"
-last_updated: "2026-04-12T12:00:00Z"
+  last_updated: "2026-04-14T12:00:00Z"
 rules:
   - id: approval-gate-skill-001
     title: "Pre-implementation authorization verification"

--- a/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
@@ -546,3 +546,62 @@ Issues have a merge-time conflict risk when:
 - Proceed immediately to `assemble-batch` after presenting the plan
 - Auto-detect partially-implemented issues (no developer input needed)
 - HALT for developer review only for unresolvable conflicts and different-intent stale assumptions
+
+## Adversarial Interdependency Verification
+
+**Before trusting spec-claimed dependencies, verify them against actual codebase state.** Specs may claim "Issue A must precede Issue B" based on assumed file overlap that doesn't exist, or miss dependencies that do exist.
+
+### Verify File Overlap Claims Against Actual Code
+
+```
+For each spec claiming file overlap with another spec:
+  - Extract file paths mentioned in each spec body
+  - Use srclight_get_dependents or srclight_get_callers to verify actual import/call chains
+  - If spec claims "A modifies X which B needs" but srclight shows no dependency → VERIFICATION-GAP
+  - If srclight shows dependency not mentioned in either spec → MISSING-ELEMENT
+```
+
+**Evidence artifact:** `srclight_get_dependents` and `srclight_get_callers` results for symbols mentioned in specs.
+
+### Verify Must-Precede Claims
+
+```
+For each must-precede relationship claimed in specs:
+  - Check if A actually creates/modifies symbols that B uses
+  - srclight_get_callers(symbol_name="<symbol_from_A>", project="<project>")
+  - If callers include code from B's scope → dependency verified
+  - If callers do NOT include code from B's scope → VERIFICATION-GAP (may not actually need serialization)
+```
+
+**Evidence artifact:** Caller graph results showing whether the claimed dependency exists in actual code.
+
+### Verify Independence Claims
+
+```
+For each pair of issues claimed as "independent":
+  - Use srclight_get_dependents(symbol_name="<key_symbol>", project="<project>", transitive=True)
+  - If transitive dependents include code from the other issue's scope → NOT independent
+  - Downgrade from "parallel-safe" to "conflict-risk" or "must-precede"
+```
+
+**Evidence artifact:** Transitive dependency graph showing whether claimed independence holds.
+
+### Verify Code References Exist
+
+```
+For each file path or symbol mentioned in any spec:
+  - File paths: verify with glob or read that the file exists
+  - Symbol names: verify with srclight_get_signature that the symbol exists
+  - If file/symbol does not exist → VERIFICATION-GAP (flag-for-review: planned but not yet implemented, or typo)
+```
+
+**Evidence artifact:** Search/glob results confirming existence or absence of referenced code.
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| File overlap claimed but no actual dependency | VERIFICATION-GAP | flag-for-review | Re-classify as independent unless other evidence |
+| Dependency exists but not mentioned in specs | MISSING-ELEMENT | conditional | Add to dependency graph, adjust execution order |
+| Independence claimed but transitive dependency exists | CONFLICTING | conditional | Downgrade to conflict-risk or must-precede |
+| Code reference to non-existent file/symbol | VERIFICATION-GAP | flag-for-review | Developer must confirm: planned or typo |

--- a/.opencode/skills/approval-gate/tasks/verify-already-implemented.md
+++ b/.opencode/skills/approval-gate/tasks/verify-already-implemented.md
@@ -125,6 +125,67 @@ Per `000-critical-rules.md` → "Skipping PR for Documentation/Guideline Changes
 
 Autoclose bypasses the PR workflow because no branch, commits, or PR are needed — the work is already done.
 
+## Adversarial Verification: Implementation State
+
+**Before claiming a spec is "already implemented," verify against actual codebase and git state — not claimed state, not cached results, not visual inspection.**
+
+### Verify Success Criteria Against Live Code
+
+```
+For each success criterion:
+  - Use actual tool calls: read, grep, srclight_search_symbols, srclight_get_signature
+  - Read the relevant file(s) directly — do NOT rely on memory of previous reads
+  - If criterion references specific file paths → verify files exist with glob
+  - If criterion references specific functions/classes → verify with srclight_get_signature
+  - If criterion references specific content → verify with grep or read
+  - Record: tool used, file path, line reference, summary of evidence
+```
+
+**Evidence artifact:** Tool call results (read, grep, srclight) for each criterion — NOT just "PASS/FAIL" assertions.
+
+### Verify Implementation Source
+
+```
+When claiming implementation exists:
+  - Check git log for commits referencing the issue number
+  git log --oneline --grep="#N" origin/dev
+  
+  - If commits found → verify they are merged to dev:
+    git branch --contains <commit-sha> | grep dev
+  
+  - If PR references found → verify PR merge via GitHub API:
+    github_pull_request_read(method=get, pullNumber=M)
+    → confirm merged == true AND state == "closed"
+  
+  - Do NOT trust "looks implemented" from file reads alone
+  - Do NOT trust cached PR merge status from previous sessions
+```
+
+**Evidence artifact:** Git log output and/or `github_pull_request_read` response confirming merge status.
+
+### Verify No Stale Implementation Claims
+
+```
+If success criteria reference specific code structure:
+  - Verify that code structure is CURRENT, not from a previous version
+  - If a file was modified after the "already implemented" check → re-verify
+  - Use srclight_recent_changes to check if relevant files changed recently
+  - If files changed since implementation → VERIFICATION-GAP (re-verify all criteria)
+```
+
+**Evidence artifact:** Recent changes output showing file modification dates relative to implementation.
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| Criterion cannot be verified | VERIFICATION-GAP | flag-for-review | Developer must confirm manually |
+| Implementation exists but not merged | VERIFICATION-GAP | flag-for-review | Cannot autoclose — PR must merge first |
+| Implementation claim from stale session | STRUCTURE-VIOLATION | conditional | Re-verify all criteria with fresh tool calls |
+| Code changed since implementation | VERIFICATION-GAP | flag-for-review | Re-verify affected criteria |
+| PR claimed merged but API says open | CONFLICTING | flag-for-review | Do NOT autoclose — verify merge manually |
+| File/symbol referenced in criterion does not exist | MISSING-TRACEABILITY | flag-for-review | Criterion may be inapplicable or spec may be stale |
+
 ## Context Required
 
 - Preceded by: `verify-authorization`, `verify-codebase`, `verify-blockers`

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -125,9 +125,79 @@ If a spec is revised (status changed to `REVISED - NEEDS APPROVAL`):
 - **Multi-task plan with missing sub-issues:** `verify-sub-issues` gate fails → HALT, no dispatch
 - **Batch approval:** Each plan in batch gets its own dispatch cycle after batch state is established
 
+### Step 2.5: Adversarial Verification — Verify Authorization Against Actual State
+
+**🚫 CRITICAL: Before trusting any authorization claim, verify it against actual GitHub state. Do NOT rely on cached values, assumed labels, or claimed authorization without direct evidence.**
+
+#### 2.5.1 Verify Author Identity
+
+```
+comments = github_issue_read(method="get_comments", issue_number=N)
+
+For each comment claiming "approved", "go", or "approved: X.Y":
+  - Verify comment author is a developer (not bot/agent)
+  - Check author_association: "MEMBER", "OWNER", or "COLLABORATOR" = human developer
+  - Check author_association: "FIRST_TIME_CONTRIBUTOR", "NONE" = not authorized
+  - Bot/agent comments (login contains "[bot]") are NOT authorization
+```
+
+**Evidence artifact:** `github_issue_read(method=get_comments)` response showing author details for the authorization comment.
+
+#### 2.5.2 Verify Authorization Scope
+
+```
+For each valid authorization comment found:
+  - Does the comment scope match the current issue number?
+  - "approved #N" where N ≠ current issue → NOT scoped to this issue
+  - "approved" without issue number → scoped to the issue where it appears
+  - "go" without issue number → scoped to the issue where it appears
+```
+
+**Evidence artifact:** Comment text and issue number showing scope match or mismatch.
+
+#### 2.5.3 Verify Authorization Currency
+
+```
+comments = github_issue_read(method="get_comments", issue_number=N)
+
+For each authorization comment:
+  - Compare comment timestamp against spec revision history
+  - If spec body was edited AFTER the authorization comment → authorization may be stale
+  - Check for "REVISED - NEEDS APPROVAL" in spec body → authorization is revoked
+  - If authorization comment is the most recent relevant comment → current
+```
+
+**Evidence artifact:** Comparison of authorization comment timestamp vs spec update timestamp.
+
+#### 2.5.4 Verify Sub-Issue State
+
+```
+For plan issues (detected in Step 5):
+  sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
+  
+  For each sub-issue:
+    - Verify state matches claimed state (open/closed) via API
+    - Do NOT trust cached or previously-read sub-issue state
+    - If sub-issue state is "closed" but no merged PR → VERIFICATION-GAP (flag-for-review)
+```
+
+**Evidence artifact:** `github_issue_read(method=get_sub_issues)` response showing actual state of each sub-issue.
+
+#### Finding Classification for Authorization Verification
+
+| Finding | Problem Class | Classification | Action |
+|---------|---------------|----------------|--------|
+| Authorization from bot/agent | CONFLICTING | flag-for-review | Reject as authorization source |
+| Authorization scoped to different issue | CONFLICTING | flag-for-review | Reject — not scoped to current issue |
+| Authorization superseded by revision | STRUCTURE-VIOLATION | auto-fix | Mark authorization as stale, require re-approval |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Report — may be premature closure |
+| `needs-approval` label stale (auth exists) | MISSING-ELEMENT | conditional | Remove label after verifying auth scope |
+| STATUS marker mismatched to content | STRUCTURE-VIOLATION | auto-fix | Update STATUS to reflect actual maturity |
+
 ## Context Required
 
 - Related tasks: `verify-sub-issues`, `verify-codebase`
 - Auto-dispatch targets: `writing-plans` (spec approval), `executing-plans` (plan approval)
 - Dispatch context for plan approval: pass `plan_issue=#N` and `spec_issue=#M` (extracted from plan body)
 - Label state machine: `141-planning-status-tracking.md §10` (remove `needs-approval`, add `in-progress` on approval)
+- Adversarial verification model: `spec-auditor --task ground-truth` (finding classification and evidence artifacts)

--- a/.opencode/skills/approval-gate/tasks/verify-blockers.md
+++ b/.opencode/skills/approval-gate/tasks/verify-blockers.md
@@ -56,6 +56,83 @@ For each dependency listed in spec:
 | Conflicting spec | HALT and identify conflict |
 | Missing dependency | HALT and ask about alternatives |
 
+## Adversarial Verification: Blocker State
+
+**Before trusting any blocker claim (issue exists, issue is open, issue is blocking), verify against actual GitHub API state.** Do NOT rely on cached issue state, comment claims, or assumed blocker relationships.
+
+### Verify Blocker Issues Exist and Are Actually Blocking
+
+```
+For each identified blocker issue:
+  blocker = github_issue_read(method="get", issue_number=blocker_number)
+  
+  - Verify issue exists (404 → MISSING-TRACEABILITY: blocker reference is stale)
+  - Verify issue state matches claimed state:
+    - If claimed "open" but actually "closed" → VERIFICATION-GAP (blocker resolved)
+    - If claimed "closed" but actually "open" → CONFLICTING (blocker still active)
+  - Verify issue is genuinely blocking:
+    - If blocker has a merged PR that resolves it → blocker is resolved
+    - If blocker title/content doesn't relate to current issue → VERIFICATION-GAP
+```
+
+**Evidence artifact:** `github_issue_read(method=get)` for each blocker showing actual state, title, and labels.
+
+### Verify Superseding Issues Against Actual State
+
+```
+For each potential superseding issue:
+  issue = github_issue_read(method="get", issue_number=N)
+  comments = github_issue_read(method="get_comments", issue_number=N)
+  
+  - Verify issue is still open and active (closed → not superseding)
+  - Verify issue scope actually covers current spec (read body, compare scope)
+  - Do NOT trust "supercedes" label or claim without body verification
+  - If claimed superseding but scope is narrower than current spec → CONFLICTING
+```
+
+**Evidence artifact:** Issue body comparison between claimed superseder and current spec.
+
+### Verify Dependency Availability
+
+```
+For each dependency listed in spec:
+  - If dependency is a package/library → verify with srclight or import check
+  - If dependency is another issue → verify via github_issue_read(method=get)
+    - Is it open? Closed? Does it have a merged PR?
+  - If dependency is a code symbol → verify with srclight_get_signature
+    - Does the symbol exist? Is it in the expected module?
+```
+
+**Evidence artifact:** Tool call results confirming dependency existence and availability.
+
+### Verify needs-approval Label Against Actual Auth State
+
+```
+issue = github_issue_read(method="get", issue_number=N)
+comments = github_issue_read(method="get_comments", issue_number=N)
+
+has_label = "needs-approval" in [l["name"] for l in issue["labels"]]
+has_auth = any comment from developer (MEMBER/OWNER/COLLABORATOR) saying "approved"/"go"
+
+- has_label AND has_auth → STRUCTURE-VIOLATION (auto-fix: label is stale, remove it)
+- no label AND no auth → VERIFICATION-GAP (may need label added)
+- has_label AND no auth → Correct state, proceed to HALT
+- no label AND has_auth → Correct state, proceed with implementation
+```
+
+**Evidence artifact:** Label list and comment search results showing actual auth state.
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| Blocker issue 404 | MISSING-TRACEABILITY | flag-for-review | Developer must resolve stale reference |
+| Blocker claimed open but actually closed | VERIFICATION-GAP | auto-fix | Remove blocker, proceed |
+| Blocker claimed closed but actually open | CONFLICTING | flag-for-review | Developer must confirm blocker status |
+| Superseding issue scope narrower than claimed | CONFLICTING | flag-for-review | Developer must judge supersession |
+| Dependency symbol/file does not exist | VERIFICATION-GAP | flag-for-review | Developer must confirm: planned or typo |
+| needs-approval label stale | STRUCTURE-VIOLATION | auto-fix | Remove label (explicit auth overrides) |
+
 ## Context Required
 
 - Related tasks: `verify-authorization`, `verify-open-questions`

--- a/.opencode/skills/approval-gate/tasks/verify-fix-spec.md
+++ b/.opencode/skills/approval-gate/tasks/verify-fix-spec.md
@@ -68,3 +68,66 @@ Examine sub-issues for:
 
 - `issue-review --task analyze-and-spec`: Creates fix spec for bug reports
 - `000-critical-rules.md`: Bug reports must have fix spec before closure
+- `065-verification-honesty.md`: Verification claims must be backed by tool call evidence
+- `spec-auditor --task ground-truth`: Adversarial verification model for metadata claims
+
+## Ground-Truth Verification
+
+**Before trusting any fix spec claim, verify it against actual GitHub state.** Do NOT rely on cached sub-issue lists, assumed labels, or claimed STATUS values.
+
+### Verify Fix Spec Exists (Not Just Claimed)
+
+```
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
+
+For each sub-issue returned:
+  - Verify it actually exists by reading it:
+    child = github_issue_read(method="get", issue_number=sub_issue_number)
+  - Verify it is a fix spec (not a related but non-fix issue):
+    - Title starts with "[SPEC] Fix:" OR
+    - Has "spec" label OR
+    - Body contains fix spec content
+  - If sub_issue_number returns 404 → MISSING-TRACEABILITY (flag-for-review)
+```
+
+**Evidence artifact:** `github_issue_read(method=get_sub_issues)` and `github_issue_read(method=get)` for each sub-issue.
+
+### Verify Fix Spec Labels and STATUS Match Maturity
+
+```
+For each verified fix spec sub-issue:
+  labels = github_issue_read(method=get_labels, issue_number=sub_issue_number)
+  body = github_issue_read(method=get, issue_number=sub_issue_number)
+  
+  - If has "needs-approval" label but content is DETAILED or COMPLETE → STRUCTURE-VIOLATION
+    (auto-fix: note label is stale, recommend removal after auth)
+  - If STATUS says BRAINSTORM/DRAFT but content is DETAILED/COMPLETE → STRUCTURE-VIOLATION
+    (auto-fix: update STATUS marker per ground-truth maturity classification)
+  - If STATUS says COMPLETE but content is BRAINSTORM/DRAFT → CONFLICTING
+    (flag-for-review: may indicate tracking intent, developer must judge)
+```
+
+**Evidence artifact:** Label list and body content for each fix spec sub-issue.
+
+### Verify Fix Spec Is Not Closed Prematurely
+
+```
+For each fix spec sub-issue:
+  child = github_issue_read(method=get, issue_number=sub_issue_number)
+  
+  - If child state is "closed" → verify a merged PR exists
+  - Search for PRs referencing the sub-issue number
+  - If closed with no merged PR → VERIFICATION-GAP (flag-for-review: premature closure)
+```
+
+**Evidence artifact:** Issue state response and PR search results.
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| Fix spec sub-issue 404 | MISSING-TRACEABILITY | flag-for-review | Developer must resolve missing issue |
+| Fix spec labels stale | STRUCTURE-VIOLATION | auto-fix | Note stale label, recommend removal |
+| STATUS mismatch (conservative) | STRUCTURE-VIOLATION | auto-fix | Update STATUS to match content |
+| STATUS mismatch (overstated) | CONFLICTING | flag-for-review | Developer must judge intent |
+| Premature closure | VERIFICATION-GAP | flag-for-review | Report — no merged PR found |

--- a/.opencode/skills/approval-gate/tasks/verify-open-questions.md
+++ b/.opencode/skills/approval-gate/tasks/verify-open-questions.md
@@ -41,6 +41,61 @@ If ANY open questions remain unresolved:
 | Some unresolved | HALT and post questions |
 | Answers unclear | Ask for clarification |
 
+## Adversarial Verification: Question Resolution State
+
+**Before trusting that open questions are unresolved, verify against ALL comments on the issue.** A question listed as "open" in the spec body may have been answered in a subsequent comment — without the spec body being updated.
+
+### Verify Open Questions Against All Comments
+
+```
+issue = github_issue_read(method="get", issue_number=N)
+comments = github_issue_read(method="get_comments", issue_number=N)
+
+For each open question found in spec body:
+  - Search ALL comments for answers or discussions resolving the question
+  - Look for developer (MEMBER/OWNER/COLLABORATOR) responses that answer the question
+  - If answer found in comments but not reflected in spec body → STRUCTURE-VIOLATION
+    (auto-fix: note that question is resolved in comments, recommend spec update)
+  - If no answer found in any comment → question is genuinely unresolved
+```
+
+**Evidence artifact:** `github_issue_read(method=get_comments)` search results showing whether answers exist for each open question.
+
+### Verify Question Is Genuinely a Blocker
+
+```
+For each unresolved open question:
+  - Is the question blocking implementation, or is it a design preference?
+  - If implementation can proceed regardless of the answer → NOT a blocker
+  - If the answer changes the implementation approach → IS a blocker
+  - Do NOT treat all open questions as implementation blockers
+```
+
+**Evidence artifact:** Analysis of each question showing whether it blocks implementation.
+
+### Verify No New Questions in Comments
+
+```
+comments = github_issue_read(method="get_comments", issue_number=N)
+
+- Check ALL comments for questions not listed in the spec's "Open Questions" section
+- Developer may have raised new questions in comments
+- If new questions found → MISSING-ELEMENT (conditional: add to open questions)
+```
+
+**Evidence artifact:** Comment scan results showing any unlisted questions.
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| Question resolved in comments but spec says open | STRUCTURE-VIOLATION | auto-fix | Note resolution, recommend spec update |
+| Question is non-blocking preference | VERIFICATION-GAP | auto-fix | Reclassify as non-blocking, proceed |
+| New questions in comments not in spec | MISSING-ELEMENT | conditional | Add to open questions if blocking |
+| Genuinely unresolved blocking question | — | — | Properly identified, HALT for answer |
+
 ## Context Required
 
 - Related tasks: `verify-authorization`, `verify-codebase`
+- `065-verification-honesty.md`: Verification claims must be backed by tool call evidence
+- `spec-auditor --task ground-truth`: Adversarial verification model

--- a/.opencode/skills/approval-gate/tasks/verify-qa-mode.md
+++ b/.opencode/skills/approval-gate/tasks/verify-qa-mode.md
@@ -259,6 +259,66 @@ What would you like me to do?
   purpose: "Branch creation and git state"
 ```
 
+## Adversarial Verification: Spec-Less Detection
+
+**Before trusting the three-gate checks (GitHub Issue, authorization, feature branch), verify each gate against actual state — not assumptions or cached values.**
+
+### Verify Issue Exists and Contains Actual Spec Content
+
+```
+If user references an issue number:
+  issue = github_issue_read(method="get", issue_number=N)
+  body = issue["body"]
+  
+  - Verify issue actually exists (404 = no issue → Gate 1 FAILS)
+  - Verify body contains spec content (not empty or placeholder text)
+  - Check if body has STATUS marker — if so, compare against actual content maturity
+  - If STATUS says BRAINSTORM but content is DETAILED/COMPLETE → STRUCTURE-VIOLATION
+    (Gate still passes — issue exists — but NOTE the maturity mismatch)
+  - If body is empty or placeholder → Gate 1 FAILS (no real spec)
+```
+
+**Evidence artifact:** `github_issue_read(method=get)` response showing issue body content and STATUS marker.
+
+### Verify Authorization Against Actual Comment State
+
+```
+If user claims authorization exists:
+  comments = github_issue_read(method="get_comments", issue_number=N)
+  
+  - Search ALL comments for "approved", "go", "authorized"
+  - Verify author is a developer (author_association: MEMBER/OWNER/COLLABORATOR)
+  - Bot/agent "approved" comments are NOT valid authorization
+  - If no valid authorization comment found → Gate 2 FAILS
+  - If authorization comment found but spec was revised after → Gate 2 FAILS (stale auth)
+```
+
+**Evidence artifact:** `github_issue_read(method=get_comments)` response with author details for authorization claims.
+
+### Verify Branch State Against Actual Git State
+
+```
+current_branch = git branch --show-current
+git_status = git status
+
+- If claimed to be on feature branch but actually on main/dev → Gate 3 FAILS
+- If claimed to be clean but has uncommitted changes → VERIFICATION-GAP
+  (uncommitted changes may indicate prior unauthorized work)
+```
+
+**Evidence artifact:** `git branch --show-current` and `git status` output.
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| Issue 404 | MISSING-TRACEABILITY | flag-for-review | Developer must create or reference correct issue |
+| Issue body empty/placeholder | MISSING-ELEMENT | flag-for-review | Spec content must be created before implementation |
+| STATUS maturity mismatch | STRUCTURE-VIOLATION | auto-fix | Note mismatch, recommend STATUS update |
+| Authorization from bot/agent | CONFLICTING | flag-for-review | Reject as authorization, require human approval |
+| Authorization superseded by revision | STRUCTURE-VIOLATION | flag-for-review | Require re-authorization |
+| Unauthorized prior work detected | VERIFICATION-GAP | flag-for-review | Report — may need to `git checkout` to clean state |
+
 ## Edge Cases
 
 ### Edge Case 1: User Bypass Attempt

--- a/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
@@ -169,6 +169,69 @@ Auto-creating sub-issues for an approved multi-task plan does NOT require separa
 | Subtask not in list | HALT, POST report: "Subtask X.Y not found. Available subtasks: [list]. Please authorize a valid subtask." |
 | Plan issue missing STATUS field | Default to first subtask (1.1), proceed, report to chat |
 
+## Adversarial Verification: Sub-Issue State
+
+**Before trusting any sub-issue claim (existence, state, labels, STATUS), verify against actual GitHub API state.** Do NOT rely on cached sub-issue lists, previously-read state, or claimed closures.
+
+### Verify Sub-Issue Existence and State
+
+```
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=plan_issue)
+
+For each sub-issue returned:
+  child = github_issue_read(method="get", issue_number=sub_issue_number)
+  
+  - Verify child exists (404 = deleted sub-issue → MISSING-TRACEABILITY)
+  - Verify child.state matches claimed state (do NOT trust cache)
+  - If child.state == "closed" → verify merged PR exists before treating as complete
+    - Search for PRs referencing the sub-issue
+    - If closed but no merged PR → VERIFICATION-GAP (premature closure)
+  - Verify child.title matches the phase description (not reassigned to different work)
+```
+
+**Evidence artifact:** `github_issue_read(method=get)` for each sub-issue showing actual state, title, and labels.
+
+### Verify Sub-Issue Labels and STATUS
+
+```
+For each sub-issue:
+  labels = github_issue_read(method=get_labels, issue_number=sub_issue_number)
+  body = github_issue_read(method=get, issue_number=sub_issue_number)
+  
+  - If has "needs-approval" label but parent plan has explicit authorization → STRUCTURE-VIOLATION
+    (auto-fix: authorization cascades from plan, label should be removed)
+  - If STATUS marker in sub-issue body is mismatched to actual content maturity → STRUCTURE-VIOLATION
+    (auto-fix: update STATUS per ground-truth maturity classification)
+  - If STATUS says COMPLETE but sub-issue is open → CONFLICTING
+    (flag-for-review: may indicate tracking mismatch)
+```
+
+**Evidence artifact:** Label list and body content for each sub-issue.
+
+### Verify Sub-Issue Link Integrity
+
+```
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=plan_issue)
+parent_check = github_issue_read(method="get_sub_issues", issue_number=sub_issue_number)
+
+- Verify sub-issues are linked under the correct parent (plan, not spec)
+- If sub-issue is linked under spec instead of plan → STRUCTURE-VIOLATION
+  (auto-fix: re-link under plan, remove from spec)
+```
+
+**Evidence artifact:** Sub-issue list from plan showing correct parent-child relationships.
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| Sub-issue 404 | MISSING-TRACEABILITY | flag-for-review | Developer must resolve deleted sub-issue |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Report — may be premature closure |
+| Sub-issue needs-approval stale | STRUCTURE-VIOLATION | auto-fix | Remove label (auth cascades from plan) |
+| STATUS maturity mismatch | STRUCTURE-VIOLATION | auto-fix | Update STATUS to match content |
+| Sub-issue linked under spec (not plan) | STRUCTURE-VIOLATION | auto-fix | Re-link under correct parent |
+| Title reassigned to different work | CONFLICTING | flag-for-review | Developer must verify scope |
+
 ## Context Required
 
 - Related tasks: `verify-authorization`, `verify-codebase`


### PR DESCRIPTION
**Summary:**

Adds adversarial "Don't Trust — Verify" verification sections to all 9 approval-gate skill files, ensuring every label, comment, STATUS marker, and sub-issue trust point is verified against actual GitHub/git state before being trusted for workflow decisions.

**Outcome:** Approval-gate skills no longer trust cached or claimed state — every authorization check now requires evidence artifacts from live API calls or git commands.

Fixes #832