### PR TITLE
[PLAN] #830 Phase 3: git-workflow Live Verification

### DIFF
--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -104,6 +104,47 @@ This skill is a **heavy skill** — its task files contain significant detail th
 
 **⚠️ Worktree pass-through is MANDATORY:** When spawning sub-agents from a worktree context, `WORKTREE_PATH` MUST be included in the dispatch prompt. Sub-agents that perform git operations without `WORKTREE_PATH` will silently modify the main repo — this is a CRITICAL GUIDELINE VIOLATION (see #741).
 
+## Live Verification Requirements
+
+**🚫 CRITICAL: Every git-workflow task MUST verify actual git/GitHub state via tool calls before acting on claims. Do NOT trust cached values, assumed branch names, or claimed merge status without direct evidence.**
+
+### Verification Matrix
+
+| Verification Point | Tool Call | Expected Evidence | Applies To |
+| -- | -- | -- | -- |
+| **Branch state** | `git branch --show-current` | Current branch name matches expected | pre-work, implementation, rebase-pending |
+| **Working tree cleanliness** | `git status --porcelain` | Empty output (no uncommitted changes) | review-prep, pr-creation |
+| **Worktree location** | `git rev-parse --show-toplevel` | Returns worktree path (not main repo) | pre-work, implementation |
+| **Commit/push state** | `git log dev..HEAD --oneline` | At least one commit ahead of dev | review-prep, pr-creation |
+| **Tracking branch** | `git branch -vv` | `[origin/<branch>]` tracking exists | review-prep |
+| **Unpushed commits** | `git diff @{u} HEAD` | Empty diff (all commits pushed) | review-prep |
+| **PR merge status** | `github_pull_request_read(method=get)` | `merged_at` is not None | cleanup |
+| **Sub-issue closure** | `github_issue_read(method=get_sub_issues)` | All sub-issues state=closed | cleanup |
+| **File existence** | `git status --porcelain` | No uncommitted files (all committed) | pr-creation, implementation |
+| **Staged state** | `git diff --staged` | Expected changes are staged | commit-prep, pr-creation |
+| **Unstaged changes** | `git diff` | Empty (no unstaged changes) | pr-creation |
+| **Worktree environment** | `echo $WORKTREE_PATH` | Non-empty path matching worktree dir | pre-work, implementation |
+| **Stash state** | `git stash list` | Expected number of stashes (usually 0) | cleanup |
+
+### Adversarial Verification Principles
+
+1. **No cached trust:** Re-verify git state before every state-modifying operation (commit, push, squash, rebase)
+2. **Evidence required:** Each verification point MUST produce a tool-call artifact — assertions without evidence are VERIFICATION-GAP findings
+3. **Contradiction detection:** If actual state contradicts expected state, classify as a finding before proceeding
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Branch name doesn't match expected | STRUCTURE-VIOLATION | auto-fix | Report actual branch, verify worktree context |
+| Working tree dirty when should be clean | VERIFICATION-GAP | conditional | Commit or stash before proceeding |
+| `merged_at` is None (no merge) | CONFLICTING | flag-for-review | HALT — do not close issues |
+| Tracking branch missing | MISSING-ELEMENT | auto-fix | Push with `-u` to establish tracking |
+| Unpushed commits detected | VERIFICATION-GAP | conditional | Push before generating compare URL |
+| WORKTREE_PATH empty/not set | STRUCTURE-VIOLATION | auto-fix | HALT — fatal error, cannot proceed safely |
+| Staged changes differ from expected | CONFLICTING | flag-for-review | Verify staging matches intent before commit |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Investigate closure reason, may need reopen |
+
 ## Cross-References
 
 - Related skills: `approval-gate` (authorization), `pr-creation-workflow` (PR timing), `changelog-generator` (changelog generation), `conflict-resolution` (conflict classification during rebase/merge)

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -665,6 +665,68 @@ This parent issue cannot be closed because the following sub-issue(s) remain inc
 🤖 ⚠️ <AgentName> (<ModelID>) blocking
 ```
 
+## Live Verification (MANDATORY)
+
+**🚫 CRITICAL: Each verification point requires a tool call for evidence. Assertions without tool-call artifacts are VERIFICATION-GAP findings. Closing issues without verified merge evidence is a CRITICAL GUIDELINE VIOLATION.**
+
+### PR Merge Verification
+
+| Check | Tool Call | Expected Result | On Failure |
+| -- | -- | -- | -- |
+| PR merge status | `github_pull_request_read(method=get, ...)` | `merged_at` is not None | CONFLICTING → HALT, do not close issues |
+| Merged by | `github_pull_request_read(method=get, ...)` | `merged_by` populated | VERIFICATION-GAP → investigate |
+| Branch merged into dev | `git branch --merged dev` | Feature branch listed | VERIFICATION-GAP → may need manual merge |
+| Dev has merge commit | `git log --oneline -5 dev` | Merge commit visible | MISSING-ELEMENT → sync dev first |
+| Sub-issues closed | `github_issue_read(method=get_sub_issues, ...)` | All sub-issues state=closed | VERIFICATION-GAP → close remaining or investigate |
+
+### Verification Procedure
+
+**In Step 2 (Verify PR Merge), mandatory evidence collection:**
+
+```python
+# PR merge verification — MANDATORY, NOT OPTIONAL
+pr = github_pull_request_read(method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=N)
+
+# Evidence artifacts:
+# EVIDENCE: merged_at = pr.get("merged_at")  # Must be non-None
+# EVIDENCE: merged_by = pr.get("merged_by")   # Should be populated
+# EVIDENCE: state = pr.get("state")            # "closed" for merged PRs
+
+if pr.get("merged_at") is None:
+    # CONFLICTING finding — HALT
+    # Do NOT close issues, do NOT delete branches
+    pass
+```
+
+**In Step 5.5/6 (Issue Closure), verify sub-issues:**
+
+```python
+# Sub-issue closure verification
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=parent)
+
+# Evidence artifacts:
+# EVIDENCE: sub_issue_count = len(sub_issues)
+# EVIDENCE: open_issues = [s for s in sub_issues if s["state"] == "open"]
+
+if open_issues:
+    # VERIFICATION-GAP finding — investigate each open sub-issue
+    # Do NOT close parent until all children resolved
+    pass
+```
+
+### Finding Classification
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| `merged_at` is None | CONFLICTING | flag-for-review | HALT — PR not merged, cannot close issues |
+| `merged_by` is None but `merged_at` set | VERIFICATION-GAP | conditional | Investigate — may be bot merge, proceed with caution |
+| Branch not in `--merged dev` list | VERIFICATION-GAP | conditional | Sync dev with `git pull origin dev`, recheck |
+| Merge commit not in dev log | MISSING-ELEMENT | conditional | `git pull origin dev` then recheck |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Investigate closure reason, may need reopen |
+| Sub-issue still open after merge | VERIFICATION-GAP | conditional | Wait for platform auto-close, or manually close after verifying |
+
+**PR merge verification via API is MANDATORY. Trusting local git state alone is a CRITICAL GUIDELINE VIOLATION. Local `git pull` or fast-forward checks are NOT sufficient — they cannot distinguish between "merged via PR" and "locally merged without review."**
+
 ## Common Issues
 
 | Issue | Resolution |

--- a/.opencode/skills/git-workflow/tasks/commit-prep.md
+++ b/.opencode/skills/git-workflow/tasks/commit-prep.md
@@ -155,6 +155,46 @@ Commits occur during the PR creation workflow, not as a separate step:
 - This repository is an application/CI repo — **commit `uv.lock`**
 - If `pyproject.toml` changed, ensure `uv.lock` is staged
 
+## Live Verification (MANDATORY)
+
+**🚫 CRITICAL: Each verification point requires a tool call for evidence. Committing without verified staged state is a CRITICAL GUIDELINE VIOLATION.**
+
+### Staged State Verification
+
+| Check | Tool Call | Expected Result | On Failure |
+| -- | -- | -- | -- |
+| Staged diff matches intent | `git diff --staged` | Shows exactly what should be committed | CONFLICTING → re-stage |
+| No unintended unstaged changes | `git diff` | Empty or only expected changes | VERIFICATION-GAP → review and stage |
+| On correct branch | `git branch --show-current` | Feature branch (not `main`/`dev`) | STRUCTURE-VIOLATION → HALT |
+| Worktree location | `git rev-parse --show-toplevel` | Worktree path | STRUCTURE-VIOLATION → HALT |
+| Status shows expected files | `git status --porcelain` | Only intended files shown | VERIFICATION-GAP → review |
+
+### Verification Procedure
+
+**Between Step 1 (Discovery) and Step 2 (Summarize Changes), verify staged state:**
+
+```
+1. git diff --staged → EVIDENCE: <staged changes diff>
+2. git diff → EVIDENCE: <unstaged changes or "(empty)">
+3. git branch --show-current → EVIDENCE: <feature-branch-name>
+4. git rev-parse --show-toplevel → EVIDENCE: <worktree-path>
+5. git status --porcelain → EVIDENCE: <file status list>
+```
+
+**Compare `git diff --staged` output against the intended commit scope. If staged changes include files NOT intended for this commit, re-stage selectively.**
+
+### Finding Classification
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Staged files not matching intent | CONFLICTING | flag-for-review | Selective `git add` to correct staging |
+| Unstaged changes present | VERIFICATION-GAP | conditional | Review — may need `git add` or `.gitignore` |
+| On `main` or `dev` | STRUCTURE-VIOLATION | auto-fix | HALT — must be on feature branch in worktree |
+| Wrong toplevel path | STRUCTURE-VIOLATION | auto-fix | HALT — not in worktree context |
+| Locked/deleted files in status | VERIFICATION-GAP | flag-for-review | Investigate — may need `git rm` or recovery |
+
+**These verifications are MANDATORY before committing. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Why This Task Is Separate from PR Creation
 
 - User needs to review commit message BEFORE creation

--- a/.opencode/skills/git-workflow/tasks/implementation.md
+++ b/.opencode/skills/git-workflow/tasks/implementation.md
@@ -97,6 +97,48 @@ When `WORKTREE_PATH` is set, ALL file operation tool calls (`read`, `edit`, `wri
 - Related skills: `approval-gate` (authorization scope)
 - Related tasks: `pr-creation` (push and PR)
 
+## Live Verification (MANDATORY)
+
+**🚫 CRITICAL: Verify git state via tool calls before each commit during implementation. Assertions without tool-call artifacts are VERIFICATION-GAP findings.**
+
+### Pre-Commit Verification
+
+| Check | Tool Call | Expected Result | On Failure |
+| -- | -- | -- | -- |
+| On correct branch | `git branch --show-current` | Feature branch (not `main`/`dev`) | STRUCTURE-VIOLATION → HALT |
+| Worktree location | `git rev-parse --show-toplevel` | Worktree path | STRUCTURE-VIOLATION → HALT |
+| Changes to commit | `git status --porcelain` | Expected modified files listed | MISSING-ELEMENT → no changes found |
+| Staged state matches intent | `git diff --staged` | Intended changes visible | VERIFICATION-GAP → re-stage |
+
+### Verification Procedure
+
+**Before each implementation commit, run:**
+
+```
+1. git branch --show-current → EVIDENCE: <feature-branch-name>
+2. git rev-parse --show-toplevel → EVIDENCE: <worktree-path>
+3. git status --porcelain → EVIDENCE: <modified files or "(empty)">
+4. git diff --staged → EVIDENCE: <staged changes or "(empty)">
+```
+
+**After each implementation commit, verify:**
+
+```
+1. git log --oneline -1 → EVIDENCE: commit hash and message visible
+2. git status --porcelain → EVIDENCE: "(empty)" if all committed
+```
+
+### Finding Classification
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| On `main` or `dev` | CONFLICTING | flag-for-review | HALT — must be in worktree on feature branch |
+| Wrong toplevel path | STRUCTURE-VIOLATION | auto-fix | HALT — not in worktree, re-invoke pre-work |
+| No changes to commit | MISSING-ELEMENT | conditional | Verify changes were saved — may need `git add` |
+| Staged changes don't match intent | VERIFICATION-GAP | conditional | Review diff, adjust staging |
+
+**These verifications are MANDATORY before each commit. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## When to Commit During Implementation
 
 Commit when:

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -953,6 +953,46 @@ User says "pr merged" → Agent invokes /skill git-workflow → Agent EXECUTES c
 3. Push and create PR with `hotfix` label (targeting `dev`)
 4. Request expedited review
 
+## Live Verification (MANDATORY)
+
+**🚫 CRITICAL: Each verification point requires a tool call for evidence. Assertions without tool-call artifacts are VERIFICATION-GAP findings. Creating a PR without verified state is a CRITICAL GUIDELINE VIOLATION.**
+
+### All Changes Committed Verification
+
+| Check | Tool Call | Expected Result | On Failure |
+| -- | -- | -- | -- |
+| Working tree clean | `git status --porcelain` | Empty output | VERIFICATION-GAP → commit or stash first |
+| Staged changes match intent | `git diff --staged` | Shows expected staged changes only | CONFLICTING → re-stage correctly |
+| No unstaged changes | `git diff` | Empty diff | VERIFICATION-GAP → stage remaining changes |
+| Commits ahead of dev | `git log origin/dev..HEAD --oneline` | Expected commit(s) listed | MISSING-ELEMENT → squash may have failed |
+| Branch tracking | `git branch -vv` | `[origin/<branch>]` present | MISSING-ELEMENT → push with `-u` |
+| Worktree path correct | `git rev-parse --show-toplevel` | Worktree path (not main repo) | STRUCTURE-VIOLATION → HALT |
+
+### Verification Procedure
+
+**Between Step 3 (Squash) and Step 4 (Push), run these verifications:**
+
+```
+1. git status --porcelain → EVIDENCE: "(empty)" for clean tree
+2. git diff --staged → EVIDENCE: shows only intended squash commit diff
+3. git diff → EVIDENCE: "(empty)" for no unstaged changes
+4. git log origin/dev..HEAD --oneline → EVIDENCE: single commit for single-issue branch
+5. git branch -vv → EVIDENCE: tracking branch shown
+6. git rev-parse --show-toplevel → EVIDENCE: worktree path
+```
+
+### Finding Classification
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Uncommitted files | VERIFICATION-GAP | conditional | Commit before squash/push |
+| Staged diff shows wrong changes | CONFLICTING | flag-for-review | Verify squash targets correct files |
+| Unstaged changes remaining | VERIFICATION-GAP | auto-fix | `git add -A` and re-commit |
+| No commits ahead of dev | MISSING-ELEMENT | flag-for-review | Branch may be empty diff — investigate |
+| Wrong toplevel path | STRUCTURE-VIOLATION | auto-fix | HALT — not in worktree, wrong context |
+
+**These verifications are MANDATORY. Skipping them before PR creation is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Recovery from Accidental Protected Branch Commit
 
 If you somehow committed to `main`, `master`, or `dev` locally (hooks not installed):

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -309,6 +309,43 @@ If found, report collision and HALT — do not reuse another branch's worktree.
 3. Push and create PR with `hotfix` label
 4. Request expedited review
 
+## Live Verification (MANDATORY)
+
+**🚫 CRITICAL: Each verification point requires a tool call for evidence. Assertions without tool-call artifacts are VERIFICATION-GAP findings.**
+
+### Branch State Verification
+
+| Check | Tool Call | Expected Result | On Failure |
+| -- | -- | -- | -- |
+| Current branch | `git branch --show-current` | Feature branch name (not `main`, `dev`) | STRUCTURE-VIOLATION → HALT |
+| Working tree clean | `git status --porcelain` | Empty output | VERIFICATION-GAP → stash or commit first |
+| Worktree location | `git rev-parse --show-toplevel` | Worktree path (not main repo path) | STRUCTURE-VIOLATION → HALT |
+| WORKTREE_PATH set | `echo $WORKTREE_PATH` (or equivalent) | Non-empty, matches worktree dir | STRUCTURE-VIOLATION → HALT (fatal) |
+| Dev base hash | `git rev-parse --short dev` | Valid 7-char SHA | MISSING-ELEMENT → sync dev first |
+
+### Verification Procedure
+
+**After Step 4 (Verify Worktree Environment), run these verifications and record evidence:**
+
+```
+1. git branch --show-current → EVIDENCE: <branch-name>
+2. git status --porcelain → EVIDENCE: <output or "(empty)">
+3. git rev-parse --show-toplevel → EVIDENCE: <path>
+4. WORKTREE_PATH → EVIDENCE: <path or "(empty)">
+```
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| On `main` or `dev` branch | CONFLICTING | flag-for-review | HALT — must create worktree first |
+| Dirty working tree in worktree | VERIFICATION-GAP | conditional | Stash or commit before implementation |
+| `rev-parse` returns main repo path | STRUCTURE-VIOLATION | auto-fix | Not in worktree — re-invoke using-git-worktrees |
+| WORKTREE_PATH empty | STRUCTURE-VIOLATION | auto-fix | FATAL — cannot safely do file operations |
+| dev hash stale | MISSING-ELEMENT | conditional | Re-run `git pull origin dev` |
+
+**These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Context Required
 
 - Related skills: `approval-gate` (authorization check), `using-git-worktrees` (worktree creation)

--- a/.opencode/skills/git-workflow/tasks/rebase-pending.md
+++ b/.opencode/skills/git-workflow/tasks/rebase-pending.md
@@ -232,6 +232,44 @@ Rebase Summary: All <count> pending PRs rebased onto updated dev.
 Continuing with cleanup for the merged PR...
 ```
 
+## Live Verification (MANDATORY)
+
+**🚫 CRITICAL: Each verification point requires a tool call for evidence. Assertions without tool-call artifacts are VERIFICATION-GAP findings. Rebasing without verified branch state is a CRITICAL GUIDELINE VIOLATION.**
+
+### Branch State Verification Before Rebase
+
+| Check | Tool Call | Expected Result | On Failure |
+| -- | -- | -- | -- |
+| On correct branch | `git branch --show-current` | PR branch name (not `main`/`dev`) | STRUCTURE-VIOLATION → HALT |
+| Worktree location | `git rev-parse --show-toplevel` | Worktree path (not main repo) | STRUCTURE-VIOLATION → HALT |
+| Working tree clean | `git status --porcelain` | Empty output | VERIFICATION-GAP → stash or commit first |
+| Dev is up to date | `git fetch origin && git log --oneline origin/dev -1` | Recent SHA, post-merge | MISSING-ELEMENT → re-fetch |
+
+### Verification Procedure
+
+**Before each rebase attempt (Step 2), verify branch state:**
+
+```
+1. git branch --show-current → EVIDENCE: <branch-name>
+2. git rev-parse --show-toplevel → EVIDENCE: <worktree-path-or-main-repo>
+3. git status --porcelain → EVIDENCE: "(empty)" for clean tree
+4. git fetch origin → EVIDENCE: fetch result
+5. git log --oneline origin/dev -1 → EVIDENCE: recent dev SHA
+```
+
+### Finding Classification
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| On wrong branch | CONFLICTING | flag-for-review | Switch to correct branch before rebase |
+| Not in worktree | STRUCTURE-VIOLATION | auto-fix | Create worktree or use existing one |
+| Dirty working tree | VERIFICATION-GAP | conditional | Stash changes before rebase (`git stash`) |
+| Dev SHA is stale | MISSING-ELEMENT | auto-fix | `git fetch origin` to update |
+| Rebase conflicts (Tier 1-2) | VERIFICATION-GAP | auto-fix | Auto-resolve, note in chat |
+| Rebase conflicts (Tier 3) | CONFLICTING | flag-for-review | HALT for developer review |
+
+**These verifications are MANDATORY before each rebase. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Edge Cases
 
 | Scenario | Action |

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -390,6 +390,44 @@ Compare URL: ${GITBUCKET_HTML_URL}${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch
 
 **Why:** Commit without push = empty compare URL. Push is mandatory after commit.
 
+## Live Verification (MANDATORY)
+
+**🚫 CRITICAL: Each verification point requires a tool call for evidence. Assertions without tool-call artifacts are VERIFICATION-GAP findings.**
+
+### Commit/Push State Verification
+
+| Check | Tool Call | Expected Result | On Failure |
+| -- | -- | -- | -- |
+| Working tree clean | `git status --porcelain` | Empty output | VERIFICATION-GAP → commit/stash first |
+| Commits ahead of dev | `git log dev..HEAD --oneline` | At least one commit listed | MISSING-ELEMENT → branch has no changes |
+| Tracking branch exists | `git branch -vv` | `[origin/<branch>]` shown | MISSING-ELEMENT → push with `-u` |
+| All commits pushed | `git diff @{u} HEAD` | Empty diff | VERIFICATION-GAP → push remaining commits |
+| Branch on correct base | `git merge-base HEAD origin/dev` | Dev-based ancestor SHA | STRUCTURE-VIOLATION → rebase on dev |
+
+### Verification Procedure
+
+**After Step 1.5 (Rebase on Current Dev) and before Step 2 (Verify Branch Is Pushed), run these verifications:**
+
+```
+1. git status --porcelain → EVIDENCE: <output or "(empty)">
+2. git log dev..HEAD --oneline → EVIDENCE: <commit list>
+3. git branch -vv → EVIDENCE: <tracking status>
+4. git diff @{u} HEAD → EVIDENCE: <output or "(empty)">
+5. git merge-base HEAD origin/dev → EVIDENCE: <SHA>
+```
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Uncommitted changes | VERIFICATION-GAP | conditional | Commit before pushing |
+| No commits ahead of dev | MISSING-ELEMENT | flag-for-review | Branch may have empty diff — investigate |
+| No tracking branch | MISSING-ELEMENT | auto-fix | Push with `git push -u origin <branch>` |
+| Unpushed commits | VERIFICATION-GAP | auto-fix | Push remaining commits immediately |
+| Wrong merge base | STRUCTURE-VIOLATION | conditional | Rebase on `origin/dev` before generating URL |
+
+**These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Context Required
 
 - Related skills: `pr-creation-workflow` (PR timing)


### PR DESCRIPTION
**Summary:**

Adds adversarial live verification requirements to all 8 git-workflow skill files, mandating tool-call evidence artifacts before state-modifying operations instead of trusting cached or claimed state.

**Outcome:** Git-workflow tasks now verify branch state, commit/push state, PR merge status, and file existence against live git/GitHub state before proceeding.

Fixes #833