### PR TITLE
[PLAN] #830 Phase 4: Spec-Creation/Brainstorming Evidence Artifacts + Chat Output Format Gate

### DIFF
--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -75,8 +75,53 @@ brainstorming (mandatory)
 - Approval gate checks for spec existence AFTER exploration
 - Exploration does NOT require approval (exploration phase)
 
+## Adversarial Verification: Authorization Claims
+
+When this skill detects "approved" or "go" signals in user input or issue comments, it MUST verify against actual GitHub state rather than trusting the claims at face value. This extends the `065-verification-honesty.md` principle to authorization detection during exploration.
+
+### Verification Table
+
+| Claim | Verification Action | Tool Call | Problem Class |
+|-------|-------------------|-----------|---------------|
+| "approved" found in issue comments | Verify the comment author is a developer (not bot/agent); verify the comment scope matches the current issue; verify the comment is not superseded by a revision | `github_issue_read(method=get_comments)` → filter by `author_association` | CONFLICTING |
+| "go" signal detected for a spec | Verify the spec actually exists and has `needs-approval` label removed OR an explicit authorization comment | `github_issue_read(method=get_labels)` + `github_issue_read(method=get_comments)` | VERIFICATION-GAP |
+| Spec claimed as "already approved" | Verify approval comment exists and spec has not been revised since that comment | `github_issue_read(method=get_comments)` → find authorization comment, compare timestamps with spec revision | CONFLICTING |
+| Spec claimed as "already a GitHub Issue" | Verify the issue actually exists with proper `[SPEC]` prefix | `github_issue_read(method=get, issue_number=N)` → check title prefix | MISSING-ELEMENT |
+
+### Evidence Artifacts
+
+Every authorization claim verification MUST produce an evidence artifact — a tool call result demonstrating the verification was performed.
+
+**Evidence format:**
+
+```
+Check: [what was verified]
+Tool: [tool call and parameters]
+Result: [actual state found]
+Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
+Action: [auto-fix|conditional|flag-for-review]
+```
+
+### Finding Classification
+
+Findings from authorization verification follow the three-tier model:
+
+| Classification | When | Action |
+|----------------|------|--------|
+| auto-fix | Safe mechanical correction (stale reference, wrong issue number) | Apply fix, note in evidence |
+| conditional | Requires scope/safety check (authorization from wrong person, wrong issue) | Verify scope, then proceed if safe |
+| flag-for-review | Requires domain judgment (conflicting authorization, ambiguous approval) | Report in findings, HALT for human review |
+
+### Enforcement
+
+**When authentication verification fails, do NOT proceed to spec-creation.** Instead:
+- CONFLICTING findings → HALT and report the conflict
+- VERIFICATION-GAP findings → Complete verification before proceeding
+- MISSING-ELEMENT findings → Create the missing artifact first
+
 ## Cross-References
 
 - Related skills: `approval-gate` (authorization), `spec-creation` (spec structuring and writing), `github-issue-creation` (spec-as-issue creation), `writing-plans` (plan creation)
-- Related guidelines: `140-planning-spec-creation.md` (spec workflow), `045-open-questions.md` (Q&A protocol)
+- Related guidelines: `140-planning-spec-creation.md` (spec workflow), `045-open-questions.md` (Q&A protocol), `065-verification-honesty.md` (evidence artifacts)
+- Related subtask: `spec-auditor --task ground-truth` (adversarial metadata verification model)
 - Source: Adapted from [obra/superpowers brainstorming](https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md)

--- a/.opencode/skills/brainstorming/tasks/enforcement.md
+++ b/.opencode/skills/brainstorming/tasks/enforcement.md
@@ -66,3 +66,45 @@ Before creating a spec, investigation MUST be complete. This is a hard gate, not
 | Modify production code | NO | Requires approved spec |
 | Modify production data | NO | Requires approved spec |
 | Run code against production DB | NO | Requires explicit user authorization |
+
+## Adversarial Verification of Process Flags (MANDATORY)
+
+**🚫 CRITICAL: STATUS markers and process-completion flags MUST be verified against actual state, not trusted from claims in issue comments or chat. This extends `065-verification-honesty.md` to brainstorming process flags.**
+
+### Verification Table
+
+| Process Flag | Verification Action | Tool Call | Problem Class |
+|-------------|-------------------|-----------|---------------|
+| "Exploration complete" | Verify all investigation checklist items have evidence artifacts (not just assertions) | Check that tool-call artifacts exist for each of the 6 checklist items | VERIFICATION-GAP |
+| "Code inspection done" | Verify actual tool calls were made for call paths, imports, dead code, formats, layers, alternatives | `srclight_get_callers`, `srclight_get_symbol`, etc. — confirm in artifacts | MISSING-ELEMENT |
+| "Problem understood" | Verify a clear problem statement exists in the spec or exploration notes | `github_issue_read(method=get, issue_number=N)` → check body for problem section | STRUCTURE-VIOLATION |
+| "Alternatives considered" | Verify at least 2 approaches were documented for significant decisions | `github_issue_read(method=get, issue_number=N)` → check for approach comparison | MISSING-ELEMENT |
+| "Risks identified" | Verify risk assessment with mitigation is documented | `github_issue_read(method=get, issue_number=N)` → check for risk section | MISSING-ELEMENT |
+| "User approved design" | Verify approval comment exists from a developer (not bot/agent) on the issue | `github_issue_read(method=get_comments)` → filter by author_association | CONFLICTING |
+| "STATUS marker value" | Compare claimed STATUS against actual issue content maturity | `github_issue_read(method=get)` → parse STATUS from body | STRUCTURE-VIOLATION |
+
+### Evidence Artifacts
+
+Every process-flag verification MUST produce an evidence artifact — a tool call result demonstrating the verification was performed. Assertions without artifacts are VERIFICATION-GAP findings.
+
+**Evidence format:**
+
+```
+Check: [what was verified]
+Tool: [tool call and parameters]
+Result: [actual state found]
+Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
+Action: [auto-fix|conditional|flag-for-review]
+```
+
+### Classification on Failure
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Checklist items claimed without tool-call evidence | VERIFICATION-GAP | conditional | Complete the tool calls before proceeding |
+| Problem statement missing from issue | STRUCTURE-VIOLATION | auto-fix | Add problem statement to issue body |
+| No alternatives documented for significant decision | MISSING-ELEMENT | conditional | Document alternatives before proceeding |
+| Approval from non-developer (bot/agent) | CONFLICTING | flag-for-review | HALT — requires real developer authorization |
+| STATUS marker claims maturity but content is incomplete | STRUCTURE-VIOLATION | auto-fix | Update STATUS to reflect actual maturity |
+
+**These verifications are MANDATORY before transitioning out of brainstorming. Skipping them is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/skills/brainstorming/tasks/explore.md
+++ b/.opencode/skills/brainstorming/tasks/explore.md
@@ -2,6 +2,53 @@
 
 Full conversational exploration workflow for requirements gathering before spec creation.
 
+## Evidence Artifact Requirement for Exploration Checklist (MANDATORY)
+
+**🚫 CRITICAL: Each item in the code inspection checklist (Step 0) and project context exploration (Step 1) MUST produce a tool-call artifact demonstrating the verification was performed. Assertions without tool-call evidence are VERIFICATION-GAP findings per `065-verification-honesty.md`.**
+
+### Checklist Evidence Requirements
+
+| Checklist Item | Verification Action | Tool Call | Problem Class |
+|----------------|-------------------|-----------|---------------|
+| 1. Trace call paths | Verify actual import/call relationships for the target code | `srclight_get_callers(symbol_name="target")` and `srclight_get_callees(symbol_name="target")` | VERIFICATION-GAP |
+| 2. Verify imports | Confirm actual import path matches assumed path | `srclight_get_symbol(name="module.symbol")` → check file location | VERIFICATION-GAP |
+| 3. Detect dead code | Verify referenced symbols are actually used | `srclight_get_dependents(symbol_name="symbol")` → check if non-empty | MISSING-ELEMENT |
+| 4. Verify format/protocol assumptions | Confirm data format, signature, or protocol matches assumption | `srclight_get_signature(name="function_name")` → compare with assumed | CONFLICTING |
+| 5. Confirm architectural layer | Verify the target code is in the correct layer | `srclight_search_symbols(query="target", kind="function")` → check file path | STRUCTURE-VIOLATION |
+| 6. Check for existing alternatives | Search for existing solutions to the stated problem | `srclight_search_symbols(query="feature description")` → check results | MISSING-ELEMENT |
+
+### Exploration Context Evidence (Step 1)
+
+| Context Item | Verification Action | Tool Call | Problem Class |
+|-------------|-------------------|-----------|---------------|
+| Recent commits | Verify claimed recent activity actually exists | `srclight_recent_changes(n=10)` → confirm commits | VERIFICATION-GAP |
+| Existing patterns | Verify referenced patterns exist in codebase | `srclight_search_symbols(query="pattern")` → confirm results | MISSING-ELEMENT |
+| Documentation files | Verify claimed documentation exists | `glob(pattern="docs/**/*.md")` → confirm file paths | MISSING-ELEMENT |
+| Configuration state | Verify project config matches assumptions | `read(filePath="pyproject.toml")` → confirm dependencies | CONFLICTING |
+
+### Evidence Format
+
+```
+Check: [what was verified]
+Tool: [tool call and parameters]
+Result: [actual state found]
+Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
+Action: [auto-fix|conditional|flag-for-review]
+```
+
+### Classification on Failure
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Call path assumption wrong | CONFLICTING | conditional | Re-map actual call path, update analysis |
+| Import path assumed but not found | VERIFICATION-GAP | conditional | Search alternates, verify actual path |
+| Dead code claimed as alive | MISSING-ELEMENT | auto-fix | Remove from affected-files list |
+| Data format assumption wrong | CONFLICTING | flag-for-review | HALT — design may be based on wrong format |
+| Architectural layer violation | STRUCTURE-VIOLATION | flag-for-review | HALT — redesign may be needed |
+| Alternative solution already exists | MISSING-ELEMENT | conditional | Evaluate existing solution, adjust scope |
+
+**These verifications are MANDATORY. Asserting "I checked" without tool-call artifacts is a VERIFICATION-GAP finding. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Process Flow
 
 <!-- Original dot digraph below is superseded by the yaml+symbolic state machine block at the end of this file. -->

--- a/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
@@ -46,12 +46,23 @@ Run the completion checklist to verify a branch is fully ready for PR creation.
 - [ ] Module docstrings present
 - [ ] No narration print statements
 
-### Chat Output Format
-- [ ] Executive summary present as first chat output element
-- [ ] Compare URL present before AI byline
-- [ ] AI byline in format `🤖 <AgentName> (<ModelID>) <status>` after URL
-- [ ] No URL before executive summary
-- [ ] No byline before URL
+### Chat Output Format (MANDATORY — Zero Tolerance)
+- [ ] Executive summary present as **first** chat output element (before any URL)
+- [ ] Outcome line present after summary
+- [ ] Compare URL present (after summary, before byline)
+- [ ] AI byline in format `🤖 <AgentName> (<ModelID>) <status>` appears **last** (after URL)
+- [ ] No URL before executive summary (CRITICAL VIOLATION if violated)
+- [ ] No byline before URL (CRITICAL VIOLATION if violated)
+
+**This format applies to EVERY halt point where implementation is reported complete:**
+- review-prep after implementation
+- Sub-agent result reports from divide-and-conquer dispatch
+- Phase boundary halts (merge gates between phases)
+- Approval-gate post-implementation reports
+
+**Evidence requirement:** Verify format by reviewing chat output before marking this checklist item complete. Assertions without reviewing the actual output are VERIFICATION-GAP findings.
+
+**Auto-fix on failure:** If any element is missing or misordered, fix the output before proceeding. Missing elements are MISSING-ELEMENT (auto-fix). Wrong ordering is STRUCTURE-VIOLATION (auto-fix).
 
 ### Ready for PR?
 - [ ] All checklist items pass

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -428,6 +428,74 @@ Compare URL: ${GITBUCKET_HTML_URL}${GIT_OWNER}/${GIT_REPO}/compare/dev...<branch
 
 **These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
 
+## Live Verification: Chat Output Format (MANDATORY)
+
+**🚫 CRITICAL: Skipping the mandatory output format is a CRITICAL GUIDELINE VIOLATION. Every halt point MUST produce this format.**
+
+### Output Format Verification
+
+After generating the compare URL (Step 3) and before HALT (Step 5), verify ALL elements are present in the chat output:
+
+| Check | Tool Call Evidence | Expected Result | On Failure |
+| -- | -- | -- | -- |
+| Executive summary present | Review chat output | First element is `**Summary:**` block | MISSING-ELEMENT → add before proceeding |
+| Outcome present | Review chat output | `**Outcome:**` line follows summary | MISSING-ELEMENT → add before proceeding |
+| Compare URL present | Review chat output | URL starts with `https://github.com/` or `${GITBUCKET_HTML_URL}` | MISSING-ELEMENT → generate URL before proceeding |
+| AI byline present | Review chat output | Ends with `🤖 <AgentName> (<ModelID>)` line | MISSING-ELEMENT → add before proceeding |
+| No URL before summary | Review chat output | URL appears AFTER summary, not before | STRUCTURE-VIOLATION → reorder output |
+| No byline before URL | Review chat output | Byline appears AFTER URL, not before | STRUCTURE-VIOLATION → reorder output |
+
+### Format Template (MANDATORY at EVERY halt point)
+
+**This format applies not just to review-prep, but to EVERY sub-agent completion and every HALT where implementation is done:**
+
+```
+**Summary:**
+
+<1-2 sentences describing impact and stakeholder value.>
+
+**Outcome:** <What changed for stakeholders>
+
+https://github.com/<GIT_OWNER>/<GIT_REPO>/compare/dev...<branch-name>
+
+🤖 <AgentName> (<ModelID>) <status>
+```
+
+### Applicability
+
+This format requirement applies to:
+
+1. **review-prep** — after implementation, before PR
+2. **Sub-agent result reports** — every sub-agent returning from divide-and-conquer dispatch
+3. **Phase boundary halts** — when a multi-phase plan requires a merge gate before the next phase
+4. **Approval-gate post-implementation** — when reporting implementation complete
+
+Any halt point where the agent reports completion MUST produce this format. Skipping it is a VERIFICATION-GAP finding equivalent to asserting "implementation complete" without evidence.
+
+### Verification Procedure
+
+**After Step 4 (Report Completion) and before Step 5 (HALT):**
+
+```
+1. Review chat output for "**Summary:**" → EVIDENCE: <found or missing>
+2. Review chat output for "**Outcome:**" → EVIDENCE: <found or missing>
+3. Review chat output for compare URL pattern → EVIDENCE: <found or missing>
+4. Review chat output for byline pattern → EVIDENCE: <found or missing>
+5. Verify ordering: summary → outcome → URL → byline → EVIDENCE: <correct or reordered>
+```
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Missing summary | MISSING-ELEMENT | auto-fix | Add summary before proceeding |
+| Missing outcome | MISSING-ELEMENT | auto-fix | Add outcome before proceeding |
+| Missing compare URL | MISSING-ELEMENT | auto-fix | Generate URL before proceeding |
+| Missing byline | MISSING-ELEMENT | auto-fix | Add byline before proceeding |
+| Wrong ordering | STRUCTURE-VIOLATION | auto-fix | Reorder to summary → outcome → URL → byline |
+
+**These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Context Required
 
 - Related skills: `pr-creation-workflow` (PR timing)

--- a/.opencode/skills/spec-creation/SKILL.md
+++ b/.opencode/skills/spec-creation/SKILL.md
@@ -134,6 +134,41 @@ The `requirements` task identifies explicit, implicit, and constraint requiremen
 To invoke: /skill spec-creation --task requirements
 ```
 
+## Evidence Artifact Requirements
+
+Every task in this skill that asserts a verification checkpoint (self-review, traceability, change control) MUST produce a tool-call artifact demonstrating the verification was performed. Assertions without tool-call evidence are verification honesty violations per `065-verification-honesty.md`.
+
+### Verification Table
+
+| Checkpoint | Verification Action | Tool Call | Problem Class |
+|------------|-------------------|-----------|---------------|
+| Self-review placeholder scan | Verify no "TBD", "TODO", incomplete sections remain in the spec body | `github_issue_read(method=get)` → search body for placeholder patterns | STRUCTURE-VIOLATION |
+| Self-review consistency | Cross-reference requirement IDs between sections; verify no contradictions | `github_issue_read(method=get)` → parse section anchors | CONFLICTING |
+| Traceability bidirectional | Verify every requirement maps to a section and every section maps to a requirement | `github_issue_read(method=get)` → check trace references | MISSING-TRACEABILITY |
+| Traceability target existence | Verify that referenced issues, specs, and code actually exist | `github_issue_read(method=get, issue_number=N)` for each referenced issue; `srclight_get_symbol(name=N)` for each referenced symbol | VERIFICATION-GAP |
+| Change-control STATUS exemption | Verify that STATUS markers claiming exemption (initial creation, non-substantive) actually qualify | `github_issue_read(method=get)` → check STATUS against revision history | CONFLICTING |
+| Spec created as Issue | Verify the spec exists as a GitHub Issue with `[SPEC]` prefix and `needs-approval` label | `github_issue_read(method=get)` → check title, `github_issue_read(method=get_labels)` → check label | MISSING-ELEMENT |
+
+### Evidence Format
+
+```
+Check: [what was verified]
+Tool: [tool call and parameters]
+Result: [actual state found]
+Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
+Action: [auto-fix|conditional|flag-for-review]
+```
+
+### Finding Classification
+
+Findings from evidence verification follow the three-tier model:
+
+| Classification | When | Action |
+|----------------|------|--------|
+| auto-fix | Safe, mechanical corrections (placeholder removal, reference fix) | Apply fix, note in evidence |
+| conditional | Requires scope/safety check before applying (traceability gap, STATUS claim) | Verify scope, then apply if safe |
+| flag-for-review | Requires domain judgment (contradictions, ambiguous STATUS exemption) | Report in findings, do not apply |
+
 ## Cross-References
 
 - **Calls:** `github-issue-creation` (spec persistence — `write` task invokes pre-creation → single-task-check → creation)
@@ -142,5 +177,7 @@ To invoke: /skill spec-creation --task requirements
 - **Parallel with:** `approval-gate` (authorization — waits for spec to be approved)
 - **Downstream:** `writing-plans` (plan creation — transforms approved spec into implementation plan)
 - **Source:** Adapted and extended from `brainstorming` Steps 7-9 (not a verbatim move)
+- **Guidelines:** `065-verification-honesty.md` (evidence artifacts)
+- **Related subtask:** `spec-auditor --task ground-truth` (adversarial metadata verification model)
 
 Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-creation/tasks/change-control.md
+++ b/.opencode/skills/spec-creation/tasks/change-control.md
@@ -46,6 +46,42 @@ After revision, the spec needs fresh authorization:
 - Do NOT proceed to implementation
 - Wait for explicit `approved` or `go`
 
+## Adversarial Verification of STATUS Exemption (MANDATORY)
+
+**🚫 CRITICAL: Every STATUS marker claiming exemption from change control MUST be verified against actual revision history. Unverified exemption claims are CONFLICTING findings per `065-verification-honesty.md`.**
+
+### Verification Procedure
+
+After Step 1 (Identify Changes) and Step 2 (Version the Spec), verify any STATUS exemption claims:
+
+| Exemption Claim | Verification Action | Tool Call | Problem Class |
+|----------------|-------------------|-----------|---------------|
+| "Initial spec creation" (no version increment) | Verify the spec has no prior versions — check Issue body for `STATUS: 1.0` or version history | `github_issue_read(method=get, issue_number=N)` → search body for `STATUS:` markers | CONFLICTING |
+| "Non-substantive change" (typos, cross-refs) | Verify the change is truly non-substantive — no scope, requirements, or success criteria changes | `github_issue_read(method=get, issue_number=N)` → compare current vs previous body content | CONFLICTING |
+| "STATUS marker update" (checkbox, phase number) | Verify the change is only a STATUS marker toggle — no content change | `github_issue_read(method=get, issue_number=N)` → diff body against comment history | STRUCTURE-VIOLATION |
+| "Bug report addition" (separate from spec content) | Verify the added content is a bug report section, not a spec content change | `github_issue_read(method=get, issue_number=N)` → check section added | VERIFICATION-GAP |
+
+### Evidence Format
+
+```
+Check: [what was verified]
+Tool: [tool call and parameters]
+Result: [actual state found]
+Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
+Action: [auto-fix|conditional|flag-for-review]
+```
+
+### Classification on Failure
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Claims "initial creation" but `STATUS: 1.0` exists | CONFLICTING | auto-fix | Increment version, apply change control |
+| Claims "non-substantive" but content changed | CONFLICTING | flag-for-review | HALT — requires domain review |
+| Claims "STATUS update" but content also changed | STRUCTURE-VIOLATION | auto-fix | Apply full change control to content change |
+| Claims "bug report" but adds spec requirements | VERIFICATION-GAP | conditional | Verify scope; if requirements changed, apply change control |
+
+**These verifications are MANDATORY for any STATUS exemption claim. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Exemptions
 
 - Initial spec creation (version 1.0): No change control needed

--- a/.opencode/skills/spec-creation/tasks/traceability.md
+++ b/.opencode/skills/spec-creation/tasks/traceability.md
@@ -48,6 +48,45 @@ Can each requirement be traced to a spec section, test scenario, and implementat
 
 **Any format that provides this coverage is acceptable.** A formal traceability matrix table works well for complex specs. A prose list or inline references work well for simple specs. The agent chooses the format that best serves the spec.
 
+## Adversarial Verification of Trace Targets (MANDATORY)
+
+**🚫 CRITICAL: Every trace target (referenced issue, spec, code symbol) MUST be verified to actually exist. Unverified trace references are MISSING-TRACEABILITY findings per `065-verification-honesty.md`.**
+
+### Verification Procedure
+
+After building traceability (Step 1-3), verify every referenced target:
+
+| Trace Target Type | Verification Action | Tool Call | Problem Class |
+|-------------------|-------------------|-----------|---------------|
+| Referenced GitHub Issue | Verify the issue exists and is accessible | `github_issue_read(method=get, issue_number=N)` → confirm `title` is not "404" | MISSING-TRACEABILITY |
+| Referenced spec (by issue number) | Verify the spec Issue exists with proper prefix and labels | `github_issue_read(method=get, issue_number=N)` → check title starts with `[SPEC]` | MISSING-TRACEABILITY |
+| Referenced code symbol | Verify the symbol exists in the current codebase | `srclight_get_symbol(name="symbol_name")` → confirm non-empty result | VERIFICATION-GAP |
+| Referenced file path | Verify the file exists at the claimed path | `glob(pattern="**/filepath")` → confirm match | VERIFICATION-GAP |
+| Bidirectional coverage | Verify every requirement maps to a section AND every section maps to a requirement | Cross-reference requirement list with section anchors | MISSING-TRACEABILITY |
+
+### Evidence Format
+
+```
+Check: [what was verified]
+Tool: [tool call and parameters]
+Result: [actual state found]
+Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
+Action: [auto-fix|conditional|flag-for-review]
+```
+
+### Classification on Failure
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced issue does not exist | MISSING-TRACEABILITY | auto-fix | Remove or replace the broken reference |
+| Referenced spec lacks [SPEC] prefix | MISSING-TRACEABILITY | conditional | Verify it IS a spec; add prefix or fix reference |
+| Referenced code symbol not found | VERIFICATION-GAP | conditional | May be renamed/removed; verify alternate names |
+| Referenced file path not found | VERIFICATION-GAP | conditional | May be reorganized; search for file |
+| Requirement with no section mapping | MISSING-TRACEABILITY | auto-fix | Add section mapping |
+| Section with no requirement mapping | STRUCTURE-VIOLATION | flag-for-review | Possible scope creep; report for domain review |
+
+**These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ## Context Required
 
 - Preceded by: `requirements`, optionally `decompose`

--- a/.opencode/skills/spec-creation/tasks/write.md
+++ b/.opencode/skills/spec-creation/tasks/write.md
@@ -85,6 +85,38 @@ After writing the spec, review with fresh eyes:
 
 Fix any issues inline. No need to re-review — just fix and move on.
 
+### Step 5.5: Evidence Artifact Verification (MANDATORY)
+
+**🚫 CRITICAL: Each self-review checkpoint MUST produce a tool-call artifact demonstrating the verification was performed. Assertions without tool-call evidence are VERIFICATION-GAP findings per `065-verification-honesty.md`.**
+
+| Checkpoint | Verification Action | Tool Call | Problem Class |
+|------------|-------------------|-----------|---------------|
+| No placeholders remain | Verify spec body contains no "TBD", "TODO", "FIXME", or incomplete section markers | `github_issue_read(method=get, issue_number=N)` → search body for `/TBD\|TODO\|FIXME/` | STRUCTURE-VIOLATION |
+| Internal consistency | Cross-reference requirement IDs between sections; verify no contradictions | `github_issue_read(method=get)` → parse section anchors vs referenced IDs | CONFLICTING |
+| Scope check evidence | Verify scope is appropriate for single plan or flagged for decomposition | `github_issue_read(method=get)` → count affected files, check for phase markers | VERIFICATION-GAP |
+| Ambiguity resolved | Verify no requirement can be interpreted two ways | `github_issue_read(method=get)` → scan for "should", "etc.", vague terms | STRUCTURE-VIOLATION |
+
+**Evidence format:**
+
+```
+Check: [what was verified]
+Tool: [tool call and parameters]
+Result: [actual state found]
+Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
+Action: [auto-fix|conditional|flag-for-review]
+```
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Placeholders found in spec body | STRUCTURE-VIOLATION | auto-fix | Replace with concrete content |
+| Contradictory requirements across sections | CONFLICTING | flag-for-review | Report, do not auto-resolve |
+| Scope too large for single plan | VERIFICATION-GAP | conditional | Flag decomposition, then apply if confirmed |
+| Vague/ambiguous terms present | STRUCTURE-VIOLATION | auto-fix | Replace with measurable terms |
+
+**These verifications are MANDATORY after self-review. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
+
 ### Step 6: Create GitHub Issue
 
 Invoke `github-issue-creation` skill to persist the spec as a GitHub Issue:


### PR DESCRIPTION
**Summary:**

Adds adversarial evidence artifact requirements to spec-creation and brainstorming skills, and closes a verification gap by enforcing mandatory chat output format (exec summary + outcome + compare URL + byline) at every halt point, not just review-prep.

**Outcome:** Phase boundary halts, sub-agent completions, and approval-gate reports now require the same evidence-based output format, catching the gap where implementation completions produced casual summaries instead of structured reports.

Fixes #834