### PR TITLE
[PLAN] #830 Phase 5: Remaining Skills Cross-Reference Verification

### DIFF
--- a/.opencode/skills/changelog-generator/SKILL.md
+++ b/.opencode/skills/changelog-generator/SKILL.md
@@ -191,6 +191,39 @@ If the output does NOT match `WORKTREE_PATH`, HALT and report: "Worktree mismatc
 
 If `WORKTREE_PATH` is NOT set, operate normally from the project root.
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `git-workflow` in Cross-References section | File exists at `.opencode/skills/git-workflow/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `since-last-release` | File exists at `.opencode/skills/changelog-generator/tasks/since-last-release.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `date-range` | File exists at `.opencode/skills/changelog-generator/tasks/date-range.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `backfill` | File exists at `.opencode/skills/changelog-generator/tasks/backfill.md` | MISSING-TRACEABILITY if missing |
+| `git-workflow` commit/branch workflow behavior | Matches actual SKILL.md: branch management and commit workflow | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
+## Cross-References
+
+- Related skills: `git-workflow` (branch management, commit workflow)
+- Related guidelines: `000-critical-rules.md` (no vibe coding, scope autonomy)
+
 ## Tips
 
 - Run from your git repository root

--- a/.opencode/skills/coherence-auditor/SKILL.md
+++ b/.opencode/skills/coherence-auditor/SKILL.md
@@ -91,9 +91,45 @@ After creating audit log:
 
 **Why:** Fresh-start AI agents cannot access `./tmp/` from previous sessions. GitHub Issue comments ARE preserved.
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `git-workflow` in Cross-References section | File exists at `.opencode/skills/git-workflow/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `guideline-auditor` in Cross-References section | File exists at `.opencode/skills/guideline-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `skill-creator` (implied by extraction workflow) | File exists at `.opencode/skills/skill-creator/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `sync-guidelines` (implied by sync workflow) | File exists at `.opencode/skills/sync-guidelines/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `extract-scan` | File exists at `.opencode/skills/coherence-auditor/tasks/extract-scan.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `extract-analyze` | File exists at `.opencode/skills/coherence-auditor/tasks/extract-analyze.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `maintenance-detect` | File exists at `.opencode/skills/coherence-auditor/tasks/maintenance-detect.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `maintenance-verify` | File exists at `.opencode/skills/coherence-auditor/tasks/maintenance-verify.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `create-report` | File exists at `.opencode/skills/coherence-auditor/tasks/create-report.md` | MISSING-TRACEABILITY if missing |
+| `git-workflow` PR behavior | Matches actual SKILL.md: PR creation and branch management | CONFLICTING if mismatched |
+| `guideline-auditor` quality verification behavior | Matches actual SKILL.md: guideline quality auditing | CONFLICTING if mismatched |
+| `skill-creator` creation workflow behavior | Matches actual SKILL.md: TDD skill creation, validation | CONFLICTING if mismatched |
+| `sync-guidelines` cross-repo sync behavior | Matches actual SKILL.md: issue-based sync, classification | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
-- Related skills: `git-workflow` (PR with changes), `guideline-auditor` (verify guideline quality)
+- Related skills: `git-workflow` (PR with changes), `guideline-auditor` (verify guideline quality), `skill-creator` (TDD skill creation for extraction candidates), `sync-guidelines` (cross-repo synchronization)
 
 ## Symbolic Engine Integration
 

--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -82,6 +82,37 @@ This skill analyzes ACTUAL concerns, not static templates.
 | Standalone skill | Subtask within orchestrator |
 | `--interactive` mode for human review | Always report-only |
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `spec-auditor` in Cross-References (orchestrated by) | File exists at `.opencode/skills/spec-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `writing-plans` in Cross-References section | File exists at `.opencode/skills/writing-plans/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `programming-principles` in Cross-References section | File exists at `.opencode/skills/programming-principles/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `audit-phases` | File exists at `.opencode/skills/concern-separation-auditor/tasks/audit-phases.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `check-independence` | File exists at `.opencode/skills/concern-separation-auditor/tasks/check-independence.md` | MISSING-TRACEABILITY if missing |
+| `spec-auditor` orchestration behavior | Matches actual SKILL.md: `concerns` subtask delegates to this skill | CONFLICTING if mismatched |
+| `writing-plans` clean-room behavior | Matches actual SKILL.md: `clean-room` task for fidelity generation | CONFLICTING if mismatched |
+| `programming-principles` principle definitions | Matches actual SKILL.md: SoC and Blast Radius principles defined there | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
 - Orchestrated by: `spec-auditor` (via `concerns` subtask)

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -72,8 +72,44 @@ Plan approved (approval-gate)
 
 **Progress is tracked against the plan issue.** The plan references the spec via body text (linked reference), not via GitHub sub-issue link.
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `divide-and-conquer` in Cross-References and Dispatch Order | File exists at `.opencode/skills/divide-and-conquer/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `approval-gate` in Cross-References and Dispatch Order | File exists at `.opencode/skills/approval-gate/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `verification-before-completion` in Cross-References and Dispatch Order | File exists at `.opencode/skills/verification-before-completion/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `finishing-a-development-branch` in Cross-References and Dispatch Order | File exists at `.opencode/skills/finishing-a-development-branch/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `git-workflow` in Cross-References and Dispatch Order | File exists at `.opencode/skills/git-workflow/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `writing-plans` in Received Context | File exists at `.opencode/skills/writing-plans/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `start` | File exists at `.opencode/skills/executing-plans/tasks/start.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `step` | File exists at `.opencode/skills/executing-plans/tasks/step.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `progress` | File exists at `.opencode/skills/executing-plans/tasks/progress.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `verify` | File exists at `.opencode/skills/executing-plans/tasks/verify.md` | MISSING-TRACEABILITY if missing |
+| `divide-and-conquer` dispatch behavior | Matches actual SKILL.md: `assemble-batch` task handles implementation | CONFLICTING if mismatched |
+| `approval-gate` dispatch behavior | Matches actual SKILL.md: `verify-authorization` dispatches to `executing-plans` | CONFLICTING if mismatched |
+| `verification-before-completion` redirect | Matches actual SKILL.md: `verify` task exists and redirects | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
-- Related skills: `divide-and-conquer` (implementation orchestration), `approval-gate` (authorization), `verification-before-completion` (evidence), `finishing-a-development-branch` (branch readiness), `git-workflow` (branch/PR/cleanup)
+- Related skills: `divide-and-conquer` (implementation orchestration), `approval-gate` (authorization), `verification-before-completion` (evidence), `finishing-a-development-branch` (branch readiness), `git-workflow` (branch/PR/cleanup), `writing-plans` (plan creation)
 
 Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/github-sub-issues/SKILL.md
+++ b/.opencode/skills/github-sub-issues/SKILL.md
@@ -83,8 +83,40 @@ Before implementing ANY subtask: get parent STATUS, extract authorized subtask, 
 - Treating sub-issue creation as a separate implementation phase
 - Implementing a phase that exists only as text in plan issue body
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `git-workflow` in Cross-References section | File exists at `.opencode/skills/git-workflow/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `approval-gate` in Cross-References section | File exists at `.opencode/skills/approval-gate/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `writing-plans` in auto-dispatch chain | File exists at `.opencode/skills/writing-plans/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `create-sub-issue` | File exists at `.opencode/skills/github-sub-issues/tasks/create-sub-issue.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `link-sub-issue` | File exists at `.opencode/skills/github-sub-issues/tasks/link-sub-issue.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `track-hierarchy` | File exists at `.opencode/skills/github-sub-issues/tasks/track-hierarchy.md` | MISSING-TRACEABILITY if missing |
+| `approval-gate` authorization cascade behavior | Matches actual SKILL.md: plan approval cascades to sub-issues | CONFLICTING if mismatched |
+| `git-workflow` cleanup behavior | Matches actual SKILL.md: `cleanup` task handles post-merge closure | CONFLICTING if mismatched |
+| `writing-plans` auto-dispatch | Matches actual SKILL.md: `create` task creates plan then dispatches to github-sub-issues | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
-- Related skills: `git-workflow` (before starting implementation), `approval-gate` (pre-implementation check)
+- Related skills: `git-workflow` (before starting implementation), `approval-gate` (pre-implementation check), `writing-plans` (auto-dispatch chain: writing-plans → github-sub-issues)
 - Related guidelines: `010-approval-gate.md`, `000-critical-rules.md`
 - Issue format: See `143-planning-spec-templates.md` for spec structure and `144-planning-spec-examples.md` for examples

--- a/.opencode/skills/issue-review/SKILL.md
+++ b/.opencode/skills/issue-review/SKILL.md
@@ -150,6 +150,43 @@ When invoked, this skill requires the following guidelines to be loaded on-deman
 
 - **Load guideline:** `.opencode/guidelines/067-context-completeness.md` — Required before reading issue comments (mandatory per context completeness rule)
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `spec-auditor` in Cross-References and Audit Path | File exists at `.opencode/skills/spec-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `approval-gate` in Cross-References and gather task | File exists at `.opencode/skills/approval-gate/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `github-comments` in Cross-References section | File exists at `.opencode/skills/github-comments/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `systematic-debugging` in Cross-References section | File exists at `.opencode/skills/systematic-debugging/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `github-issue-creation` in Cross-References section | File exists at `.opencode/skills/github-issue-creation/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `programming-principles` in Cross-References section | File exists at `.opencode/skills/programming-principles/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `gather` | File exists at `.opencode/skills/issue-review/tasks/gather.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `triage` | File exists at `.opencode/skills/issue-review/tasks/triage.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `audit` | File exists at `.opencode/skills/issue-review/tasks/audit.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `qa` | File exists at `.opencode/skills/issue-review/tasks/qa.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `analyze-and-spec` | File exists at `.opencode/skills/issue-review/tasks/analyze-and-spec.md` | MISSING-TRACEABILITY if missing |
+| `spec-auditor` audit delegation behavior | Matches actual SKILL.md: `audit` task delegates to spec-auditor with triage hints | CONFLICTING if mismatched |
+| `approval-gate` authorization check behavior | Matches actual SKILL.md: `verify-authorization` task for authorization status | CONFLICTING if mismatched |
+| `github-comments` comment posting behavior | Matches actual SKILL.md: comment format and routing rules | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
 - `spec-auditor`: Called by `audit` task for spec quality checks

--- a/.opencode/skills/plan-fidelity-auditor/SKILL.md
+++ b/.opencode/skills/plan-fidelity-auditor/SKILL.md
@@ -116,6 +116,39 @@ Only substantive differences after semantic matching are reported.
 | Flag-only for substantive changes | Recommends brainstorming for significant gaps |
 | Mandatory audit chain entry | Subtask within orchestrator |
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `spec-auditor` in Cross-References (orchestrated by) | File exists at `.opencode/skills/spec-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `writing-plans` in Cross-References section | File exists at `.opencode/skills/writing-plans/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `brainstorming` in Cross-References section | File exists at `.opencode/skills/brainstorming/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `programming-principles` in Cross-References section | File exists at `.opencode/skills/programming-principles/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `audit` | File exists at `.opencode/skills/plan-fidelity-auditor/tasks/audit.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `compare` | File exists at `.opencode/skills/plan-fidelity-auditor/tasks/compare.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `report` | File exists at `.opencode/skills/plan-fidelity-auditor/tasks/report.md` | MISSING-TRACEABILITY if missing |
+| `spec-auditor` orchestration behavior | Matches actual SKILL.md: `fidelity` subtask delegates to this skill | CONFLICTING if mismatched |
+| `writing-plans` clean-room invocation | Matches actual SKILL.md: `clean-room` task exists for generating plans | CONFLICTING if mismatched |
+| `brainstorming` recommendation behavior | Matches actual SKILL.md: exploration skill for deeper analysis | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
 - Orchestrated by: `spec-auditor` (via `fidelity` subtask)

--- a/.opencode/skills/receiving-code-review/SKILL.md
+++ b/.opencode/skills/receiving-code-review/SKILL.md
@@ -65,9 +65,39 @@ PR review received → receiving-code-review (address) → push changes → (rev
 - Push additional commits (do NOT squash review fixes)
 - PR is updated automatically on push
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `github-comments` (implied by PR comment responses) | File exists at `.opencode/skills/github-comments/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `requesting-code-review` in Cross-References section | File exists at `.opencode/skills/requesting-code-review/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `git-workflow` in Cross-References section | File exists at `.opencode/skills/git-workflow/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `address` | File exists at `.opencode/skills/receiving-code-review/tasks/address.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `respond` | File exists at `.opencode/skills/receiving-code-review/tasks/respond.md` | MISSING-TRACEABILITY if missing |
+| `git-workflow` branch management behavior | Matches actual SKILL.md: push additional commits, no squash of review fixes | CONFLICTING if mismatched |
+| `requesting-code-review` review request behavior | Matches actual SKILL.md: `prepare` and `request` tasks | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
-- Related skills: `requesting-code-review` (requesting review), `git-workflow` (branch management)
+- Related skills: `requesting-code-review` (requesting review), `git-workflow` (branch management), `github-comments` (PR comment format and routing)
 - Related guidelines: `050-scope-autonomy.md` (no scope creep), `060-tool-usage.md` (commands)
 
 ## Platform Compatibility

--- a/.opencode/skills/requesting-code-review/SKILL.md
+++ b/.opencode/skills/requesting-code-review/SKILL.md
@@ -58,9 +58,41 @@ finishing-a-development-branch → PR created by user → requesting-code-review
 - PR creation requires explicit "create a PR" instruction
 - This skill does NOT create PRs — only prepares them for review
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `github-comments` (implied by review request PR comments) | File exists at `.opencode/skills/github-comments/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `receiving-code-review` in Cross-References section | File exists at `.opencode/skills/receiving-code-review/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `git-workflow` in Cross-References section | File exists at `.opencode/skills/git-workflow/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `pr-creation-workflow` in Cross-References section | File exists at `.opencode/skills/pr-creation-workflow/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `finishing-a-development-branch` in Dispatch Order | File exists at `.opencode/skills/finishing-a-development-branch/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `prepare` | File exists at `.opencode/skills/requesting-code-review/tasks/prepare.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `request` | File exists at `.opencode/skills/requesting-code-review/tasks/request.md` | MISSING-TRACEABILITY if missing |
+| `receiving-code-review` behavior | Matches actual SKILL.md: `address` and `respond` tasks for review feedback | CONFLICTING if mismatched |
+| `git-workflow` PR creation behavior | Matches actual SKILL.md: `pr-creation` task | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
-- Related skills: `receiving-code-review` (responding to review), `git-workflow` (PR creation), `pr-creation-workflow` (PR timing)
+- Related skills: `receiving-code-review` (responding to review), `git-workflow` (PR creation), `pr-creation-workflow` (PR timing), `github-comments` (PR comment format)
 - Related guidelines: `080-code-standards.md` (AI attribution), `060-tool-usage.md` (commands)
 
 ## Platform Compatibility

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -195,6 +195,34 @@ GPU/CPU billing is flat-rate per inference, not per word. There is no economic i
 5. Validate skill structure with `quick_validate.py`
 6. Package with `package_skill.py`
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `coherence-auditor` in Cross-References section | File exists at `.opencode/skills/coherence-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `init` | File exists at `.opencode/skills/skill-creator/tasks/init.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `package` | File exists at `.opencode/skills/skill-creator/tasks/package.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `validate` | File exists at `.opencode/skills/skill-creator/tasks/validate.md` | MISSING-TRACEABILITY if missing |
+| `coherence-auditor` maintenance behavior | Matches actual SKILL.md: drift detection and verification for skills | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
 | External Source | Content Adapted |
@@ -202,3 +230,5 @@ GPU/CPU billing is flat-rate per inference, not per word. There is no economic i
 | [obra/superpowers `writing-skills`](https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md) | TDD methodology, CSO, rationalization resistance, anti-patterns |
 | [obra/superpowers `testing-skills-with-subagents`](https://github.com/obra/superpowers/blob/main/skills/writing-skills/testing-skills-with-subagents.md) | Pressure scenario testing methodology |
 | [obra/superpowers `persuasion-principles`](https://github.com/obra/superpowers/blob/main/skills/writing-skills/persuasion-principles.md) | Persuasion principles for skill design |
+
+Related skills: `coherence-auditor` (drift detection and verification for new/updated skills)

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -370,6 +370,53 @@ This skill is a **heavy skill** — quality audits with all subtasks consume sig
 
 **Sub-agent context parameters:** Pass issue number, `WORKTREE_PATH`, `GIT_OWNER`, `GIT_REPO` from session init. When `WORKTREE_PATH` is set, sub-agents MUST receive it and use it as the base directory for all file operations and git commands.
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `brainstorming` in Cross-References section | File exists at `.opencode/skills/brainstorming/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `spec-creation` in Cross-References section | File exists at `.opencode/skills/spec-creation/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `writing-plans` in Cross-References section | File exists at `.opencode/skills/writing-plans/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `issue-review` in Cross-References section | File exists at `.opencode/skills/issue-review/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `programming-principles` in Cross-References section | File exists at `.opencode/skills/programming-principles/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `plan-fidelity-auditor` in delegated-from | File exists at `.opencode/skills/plan-fidelity-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `concern-separation-auditor` in delegated-from | File exists at `.opencode/skills/concern-separation-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `fresh-start` | File exists at `.opencode/skills/spec-auditor/tasks/fresh-start.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `structure` | File exists at `.opencode/skills/spec-auditor/tasks/structure.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `content-quality` | File exists at `.opencode/skills/spec-auditor/tasks/content-quality.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `traceability` | File exists at `.opencode/skills/spec-auditor/tasks/traceability.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `operational` | File exists at `.opencode/skills/spec-auditor/tasks/operational.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `fidelity` | File exists at `.opencode/skills/spec-auditor/tasks/fidelity.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `concerns` | File exists at `.opencode/skills/spec-auditor/tasks/concerns.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `operational-flow` | File exists at `.opencode/skills/spec-auditor/tasks/operational-flow.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `determinism` | File exists at `.opencode/skills/spec-auditor/tasks/determinism.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `error-recovery` | File exists at `.opencode/skills/spec-auditor/tasks/error-recovery.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `principles` | File exists at `.opencode/skills/spec-auditor/tasks/principles.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `ground-truth` | File exists at `.opencode/skills/spec-auditor/tasks/ground-truth.md` | MISSING-TRACEABILITY if missing |
+| Described behavior of `issue-review` | Matches actual SKILL.md: `audit` task delegates to spec-auditor | CONFLICTING if mismatched |
+| Described behavior of `writing-plans` | Matches actual SKILL.md: `clean-room` task generates plans | CONFLICTING if mismatched |
+| Described behavior of `programming-principles` | Matches actual SKILL.md: defines engineering principles | CONFLICTING if mismatched |
+| `brainstorming` invocation in Invocation section | Skill has corresponding invocation entry | MISSING-TRACEABILITY if missing |
+| `spec-creation` invocation context | Skill describes creation-time discipline for traceability | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
 - Related skills: `brainstorming` (exploration), `spec-creation` (creation-time discipline for traceability and operational requirements), `writing-plans` (clean-room generation for fidelity subtask), `issue-review` (delegates to spec-auditor via audit task), `programming-principles` (authoritative principle definitions for principles subtask — this subtask checks compliance, that skill defines the principles)

--- a/.opencode/skills/sync-guidelines/SKILL.md
+++ b/.opencode/skills/sync-guidelines/SKILL.md
@@ -106,7 +106,38 @@ last_sync:
 3. Human reviews and merges in target repository
 4. Update sync state after successful sync
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `git-workflow` in Cross-References section | File exists at `.opencode/skills/git-workflow/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `coherence-auditor` (implied by sync consistency checking) | File exists at `.opencode/skills/coherence-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `classify` | File exists at `.opencode/skills/sync-guidelines/tasks/classify.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `sync-push` | File exists at `.opencode/skills/sync-guidelines/tasks/sync-push.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `sync-pull` | File exists at `.opencode/skills/sync-guidelines/tasks/sync-pull.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `issue-format` | File exists at `.opencode/skills/sync-guidelines/tasks/issue-format.md` | MISSING-TRACEABILITY if missing |
+| `git-workflow` branch management behavior | Matches actual SKILL.md: branch, commit, PR workflow | CONFLICTING if mismatched |
+| `coherence-auditor` drift detection behavior | Matches actual SKILL.md: detects guideline-skill drift | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
-- Related skills: `git-workflow` (branch management, commit workflow)
+- Related skills: `git-workflow` (branch management, commit workflow), `coherence-auditor` (drift detection and verification after sync)
 - Related guidelines: `000-critical-rules.md` (no vibe coding, scope autonomy)

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -143,7 +143,43 @@ The spec itself is NOT modified during re-implementation. The plan is the mutabl
 - Plan approved but missing TDD steps → REJECT plan
 - Plan approved and complete → PROCEED to implementation
 
+## Cross-Reference Verification (MANDATORY)
+
+**🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**
+
+| Reference | Verification | Finding Class |
+| -- | -- | -- |
+| `brainstorming` in Cross-References section | File exists at `.opencode/skills/brainstorming/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `approval-gate` in Cross-References and Auto-Dispatch Entry | File exists at `.opencode/skills/approval-gate/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `executing-plans` in Cross-References section | File exists at `.opencode/skills/executing-plans/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `spec-auditor` in Cross-References section | File exists at `.opencode/skills/spec-auditor/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `github-sub-issues` in Cross-References and Auto-Dispatch Entry | File exists at `.opencode/skills/github-sub-issues/SKILL.md` | MISSING-TRACEABILITY if missing |
+| `spec-creation` in Cross-References section | File exists at `.opencode/skills/spec-creation/SKILL.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `create` | File exists at `.opencode/skills/writing-plans/tasks/create.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `validate` | File exists at `.opencode/skills/writing-plans/tasks/validate.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `retroactive` | File exists at `.opencode/skills/writing-plans/tasks/retroactive.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `clean-room` | File exists at `.opencode/skills/writing-plans/tasks/clean-room.md` | MISSING-TRACEABILITY if missing |
+| `approval-gate` auto-dispatch behavior | Matches actual SKILL.md: `verify-authorization` dispatches to `writing-plans` | CONFLICTING if mismatched |
+| `github-sub-issues` dispatch behavior | Matches actual SKILL.md: `create-sub-issue` task for sub-issue linking | CONFLICTING if mismatched |
+| `spec-auditor` clean-room invocation | Matches actual SKILL.md: `fidelity` subtask invokes `writing-plans --task clean-room` | CONFLICTING if mismatched |
+
+**Verification Procedure:**
+
+Before invoking any cross-referenced skill:
+1. `ls .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: file exists or MISSING-TRACEABILITY
+2. `grep -c "<task-name>" .opencode/skills/<skill-name>/SKILL.md` → EVIDENCE: task referenced or MISSING-TRACEABILITY
+3. Compare described behavior with actual content → EVIDENCE: match or CONFLICTING
+
+**Classification on failure:**
+
+| Failure | Problem Class | Classification | Action |
+| -- | -- | -- | -- |
+| Referenced skill file missing | MISSING-TRACEABILITY | flag-for-review | Cannot verify cross-reference |
+| Referenced task file missing | MISSING-TRACEABILITY | flag-for-review | Task may have been renamed |
+| Described behavior mismatches | CONFLICTING | flag-for-review | Cross-reference may be stale |
+| Invocation mismatch | CONFLICTING | flag-for-review | Skill may have been updated |
+
 ## Cross-References
 
-- Related skills: `brainstorming` (pre-spec), `approval-gate` (authorization), `executing-plans` (implementation), `spec-auditor` (fidelity subtask uses clean-room), `github-sub-issues` (sub-issue creation under plan)
+- Related skills: `brainstorming` (pre-spec), `approval-gate` (authorization), `executing-plans` (implementation), `spec-auditor` (fidelity subtask uses clean-room), `github-sub-issues` (sub-issue creation under plan), `spec-creation` (spec creation discipline)
 - Source: adapted from [obra/superpowers `writing-plans`](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md)

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -64,16 +64,35 @@ Create an implementation plan from an approved spec.
 
 9. **Report plan creation in chat (MANDATORY):**
 
-   Produce chat output in the mandatory format per `000-critical-rules.md`:
+    Produce chat output in the mandatory format per `000-critical-rules.md`:
 
-    1. **Executive summary**: 1-2 sentences describing what plan was created and for which spec
-    2. **URL**: The plan issue URL (e.g., `https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/<N>`)
-    3. **AI byline**: `🤖 <AgentName> (<ModelID>)` — ALWAYS LAST
+     1. **Executive summary**: 1-2 sentences describing what plan was created and for which spec
+     2. **URL**: The plan issue URL (e.g., `https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/<N>`)
+     3. **AI byline**: `🤖 <AgentName> (<ModelID>)` — ALWAYS LAST
 
-    Example:
+     Example:
 
-    Created implementation plan for #771 (branch stacking prerequisite). 7 tasks across 6 files (3 skills + 3 guidelines).
-    https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/772
-    🤖 <AgentName> (<ModelID>)
+     Created implementation plan for #771 (branch stacking prerequisite). 7 tasks across 6 files (3 skills + 3 guidelines).
+     https://github.com/<GIT_OWNER>/<GIT_REPO>/issues/772
+     🤖 <AgentName> (<ModelID>)
 
-    Sub-issues are linked under the plan issue, NOT under the spec.
+     Sub-issues are linked under the plan issue, NOT under the spec.
+
+10. **Cross-reference verification (MANDATORY before plan creation):**
+
+    Before creating the plan issue, verify that all referenced skills exist and their described behaviors match actual skill content:
+
+    ```bash
+    # Verify approval-gate dispatch chain
+    ls .opencode/skills/approval-gate/SKILL.md && grep -c "verify-authorization" .opencode/skills/approval-gate/SKILL.md
+    # Verify github-sub-issues task
+    ls .opencode/skills/github-sub-issues/SKILL.md && grep -c "create-sub-issue" .opencode/skills/github-sub-issues/SKILL.md
+    # Verify spec-creation exists
+    ls .opencode/skills/spec-creation/SKILL.md
+    # Verify brainstorming exists
+    ls .opencode/skills/brainstorming/SKILL.md
+    # Verify spec-auditor clean-room invocation
+    ls .opencode/skills/spec-auditor/SKILL.md && grep -c "clean-room\|fidelity" .opencode/skills/spec-auditor/SKILL.md
+    ```
+
+    If any verification fails: flag as MISSING-TRACEABILITY or CONFLICTING and note in plan creation output.


### PR DESCRIPTION
**Summary:**

Adds adversarial cross-reference verification sections to 13 remaining skill files and writing-plans/tasks/create.md, ensuring every skill cross-reference is verified against actual file existence and content before invocation.

**Outcome:** All skills across the suite now require evidence-based cross-reference verification, completing the ground-truth verification coverage from #830.

Fixes #835