### PR TITLE
[PLAN] #849 Phase 1: Gitignore Credential Hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,14 @@ tmp/
 # Secrets and sensitive files
 .env
 .env.*
+id_rsa
+id_ed25519
+id_ecdsa
+id_dsa
+service-account.json
 .streamlit/*
 !.streamlit/config.toml
+.streamlit/secrets.toml.production
 *.key
 *.pem
 *.p12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/840-credential-leakage
+
+- **Gitignore Credential Hardening** (#840) - Expanded `.gitignore` with 6 new credential file patterns (SSH keys, production secrets, service accounts) and added 16 parameterized tests verifying all credential patterns are gitignored.
+
 ### spec/814-plan-bleed-ambiguous
 
 - **PLAN-BLEED-AMBIGUOUS Problem Class** (#814) - Added the PLAN-BLEED-AMBIGUOUS problem class to spec-auditor, completing the spec/plan boundary enforcement plan. Ambiguous content that could be either requirement or implementation detail is now flagged for domain judgment instead of being auto-fixed or missed.

--- a/tests/test_credential_guard.py
+++ b/tests/test_credential_guard.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+
+import pytest
+
+
+def _git_check_ignore(filepath: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", filepath],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+class TestGitignoreCredentialCoverage:
+    CREDENTIAL_FILENAMES = [
+        ".env",
+        ".env.local",
+        ".env.production",
+        "secrets.toml",
+        "secrets.toml.production",
+        ".streamlit/secrets.toml",
+        ".streamlit/secrets.toml.production",
+        "service-account.json",
+        "credentials.json",
+        "gcloud-credentials.json",
+        "id_rsa",
+        "id_ed25519",
+        "server.key",
+        "server.pem",
+        "client.p12",
+        "backup-credentials.yaml",
+    ]
+
+    @pytest.mark.parametrize("filepath", CREDENTIAL_FILENAMES)
+    def test_credential_file_is_gitignored(self, filepath: str):
+        assert _git_check_ignore(filepath), f"{filepath} is NOT matched by .gitignore"


### PR DESCRIPTION
**Summary:**

Expanded `.gitignore` credential coverage with 6 new patterns (SSH private keys, production Streamlit secrets, service account files) and added 16 parameterized tests verifying all credential file patterns are gitignored.

**Outcome:** SSH keys, production secrets, and service account files are now blocked from accidental git tracking, preventing credential leakage.

Fixes #850