### PR TITLE
Batch: Remove redundant session-init (#805) + Active spec/plan enforcement (#838)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -473,6 +473,20 @@ Structural decisions — single-task vs multi-task classification, phase decompo
 
 **See `approval-gate` skill → `verify-already-implemented` task → "Auto-Close Procedure" for the post-merge issue closure workflow. See `finishing-a-development-branch` skill → `checklist` task for issue-closure verification steps.**
 
+## Critical Violation: Silent Halt Without Prompt — No Spec/Plan Search Before Stopping
+
+**⚠️ Halting silently when no spec/plan exists for an implementation request — without first searching GitHub Issues for candidates and presenting them — is a CRITICAL GUIDELINE VIOLATION.**
+
+When an agent receives an implementation instruction but cannot find an associated spec or plan, it must actively search for existing candidates before halting. A silent halt with no search and no presentation of options is a process gap that treats missing documentation as the user's problem rather than an actionable finding.
+
+- 🚫 FORBIDDEN: Halting silently without searching GitHub Issues; presenting no candidates when implementation authorization lacks a matching spec/plan; offering only "create a new spec" without checking for existing specs first
+- ✅ REQUIRED: Search GitHub Issues for candidate specs/plans using label filters (`[SPEC]`, `[PLAN]`, `[SPEC-FIX]`) and keyword matching against the request target; present all candidates with URLs; offer create-or-select before halting; flag as FAILURE if no candidates found
+- ✅ REQUIRED: When no candidate exists, the agent MUST present the failure state ("No existing spec/plan found for [topic]") before offering to create one
+
+**Why this matters:** The current Q/A mode halt is passive — it stops work but doesn't help the user find existing tracking. Active search turns "no spec found" from a dead end into a decision point: "here are N existing issues that may match, which one (if any) did you mean?" This reduces duplicate spec creation and connects implementation requests to existing tracking.
+
+**See `020-go-prohibitions.md` §1 "NEVER DO" and "ALWAYS DO" for the search procedure, and `approval-gate` skill → `verify-qa-mode` task → Step 2.5 for the mandatory search step.**
+
 ______________________________________________________________________
 
 **Search guidelines:** Use `srclight_search_symbols` or `grep` to find relevant guidelines.

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -25,6 +25,7 @@
 | **Human-only merge** | Agents MUST NEVER merge PRs |
 | **MCP tools** | Use appropriate tools per five-tier hierarchy (see `mcp-tool-usage` skill) |
 | **Silent halt** | HALT after completion, after PR creation — no prompts |
+| **Search before halt** | When no spec/plan exists for an implementation request, search GitHub Issues for existing candidates (label filters: `[SPEC]`, `[PLAN]`, `[SPEC-FIX]`; keyword matching against request target), present candidates with URLs, offer create-or-select before halting — see `000-critical-rules.md` §Silent Halt Without Prompt |
 | **PR timing** | PRs require explicit `"create a PR"` instruction |
 | **Issue closure** | Close issues ONLY after PR merge confirmed |
 

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -36,6 +36,7 @@
 - **No "offer to edit" patterns.** The agent MUST NOT offer to edit, update, modify, or fix a file directly. Instead, create a spec or bug report. Patterns like "Want me to update X?", "Shall I fix this?", "I can change X to Y" are PROHIBITED — they bypass the spec-first workflow.
 - **Never self-answer a solicitation.** Pose no questions that you then answer yourself to bypass authorization.
 - **NEVER suggest parallel execution as a valid default approach.** Stacking is prerequisite; parallel is opportunistic. Agents must not present parallelism as an equally valid option.
+- **No silent halt without search+prompt.** When no spec/plan exists for an implementation request, the agent MUST NOT simply halt. It must search GitHub Issues for existing candidates, present them with URLs, and offer create-or-select before halting. A silent halt with no search and no candidate presentation is a critical violation — see `000-critical-rules.md` §Silent Halt Without Prompt.
 
 ### ⚠️ ASK FIRST
 
@@ -47,6 +48,12 @@
 - **Verify actual codebase state before acting.** When a GO names a specific phase, verify the actual codebase state of that phase's deliverables before taking any action — regardless of plan markers.
 - **SILENTLY HALT after a verified-complete phase.** If verification confirms a named phase is already fully and correctly implemented, report the verified findings and HALT without prompting.
 - **Every halt MUST produce a status message.** If the agent stops, it MUST output what was completed, what was attempted, and why it stopped. Zero output before stopping is a critical violation.
+- **Search issues before halting on missing spec/plan.** When an implementation request lacks a matching spec or plan:
+  1. Search GitHub Issues using label filters: `[SPEC]`, `[PLAN]`, `[SPEC-FIX]`
+  2. Search GitHub Issues using keyword matching against the request target
+  3. If candidates found: present all candidates with URLs, offer user a choice to select one or create a new spec
+  4. If no candidates found: present the failure state ("No existing spec/plan found for [topic]"), offer to create a new spec
+  5. Only after search+presentation: HALT, but the halt message now includes the search results
 
 ## 2. Iterative Feedback & Plan Revision
 
@@ -197,4 +204,21 @@ rules:
     requires: [approval-gate-001]
     triggers: [github-sub-issues]
     source: "020-go-prohibitions.md §5"
+
+  - id: go-prohibitions-007
+    title: "No silent halt without search+prompt for missing spec/plan"
+    conditions:
+      all:
+        - "implementation_requested == true"
+        - "matching_spec_exists == false"
+        - "matching_plan_exists == false"
+        - "search_performed == false"
+    actions:
+      - SEARCH(github_issues)
+      - PRESENT(candidates)
+      - HALT
+    conflicts_with: []
+    requires: [approval-gate-010]
+    triggers: [approval-gate, brainstorming]
+    source: "020-go-prohibitions.md §1 NEVER DO, ALWAYS DO"
 ```

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -28,6 +28,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | `verify-blockers` | Check for blocking issues/dependencies | ~320 |
 | `verify-open-questions` | Check for unresolved questions in spec | ~370 |
 | `verify-fix-spec` | For bug reports, verify fix spec sub-issue exists before closure | ~250 |
+| `search-prompt-fail` | Search GitHub Issues for existing spec/plan candidates before Q/A halt; present candidates or report failure | ~300 |
 | `pre-implementation-analysis` | Analyze interdependencies and expand sub-issues for all approved issues (single or batch), producing flat item list for assemble-batch | ~500 |
 | `post-implementation` | Push branch, generate compare URL, HALT | ~480 |
 | `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~150 |
@@ -41,6 +42,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 - `/skill approval-gate --task verify-blockers` - Check for blockers
 - `/skill approval-gate --task verify-open-questions` - Check for unresolved questions
 - `/skill approval-gate --task verify-fix-spec` - Verify fix spec exists for bug reports
+- `/skill approval-gate --task search-prompt-fail` - Search for existing spec/plan candidates before Q/A halt
 - `/skill approval-gate --task pre-implementation-analysis` - Analyze interdependencies and expand sub-issues for all approved issues, then yield to assemble-batch
 - `/skill approval-gate --task post-implementation` - After implementation done
 - `/skill approval-gate --task completion` - Invoke when workflow halts at any point
@@ -245,4 +247,20 @@ rules:
     requires: []
     triggers: [git-workflow]
     source: "approval-gate/SKILL.md §Post-Implementation Workflow"
+
+  - id: approval-gate-skill-004
+    title: "Search before Q/A halt when no spec/plan found"
+    conditions:
+      all:
+        - "implementation_requested == true"
+        - "matching_spec_exists == false"
+        - "matching_plan_exists == false"
+    actions:
+      - INVOKE(search-prompt-fail)
+      - PRESENT(candidates_or_failure)
+      - HALT
+    conflicts_with: []
+    requires: []
+    triggers: [approval-gate, brainstorming, spec-creation]
+    source: "approval-gate/SKILL.md §search-prompt-fail task"
 ```

--- a/.opencode/skills/approval-gate/tasks/verify-qa-mode.md
+++ b/.opencode/skills/approval-gate/tasks/verify-qa-mode.md
@@ -71,6 +71,24 @@ GATE 2: Is authorization documented (explicit "approved"/"go" comment)?
 GATE 3: Is current branch a feature branch (not main/dev/master)?
 ```
 
+### Step 2.5: Search for Existing Spec/Plan Candidates (MANDATORY before Q/A mode)
+
+**When ANY gate fails (no spec, no authorization, or wrong branch), the agent MUST search GitHub Issues for existing candidates before entering Q/A mode.** A silent halt without searching is a critical violation — see `000-critical-rules.md` §Silent Halt Without Prompt.
+
+**Search Procedure:**
+
+1. **Label search:** Search GitHub Issues with labels `[SPEC]`, `[PLAN]`, `[SPEC-FIX]` in the repository
+2. **Keyword search:** Search GitHub Issues using keywords from the implementation request (e.g., feature name, component, module, bug area)
+3. **Evaluate candidates:** For each result, assess relevance to the request target
+4. **Present candidates:** If candidates found, list them with:
+   - Issue number and title
+   - URL
+   - Brief relevance assessment (why it matches)
+5. **Offer create-or-select:** Present user with options: select an existing candidate OR create a new spec
+6. **Report failure if no candidates:** If search yields no relevant candidates, explicitly state "No existing spec/plan found for [topic]" before offering spec creation
+
+**This step is MANDATORY.** Skipping it and going straight to Q/A mode is a critical violation.
+
 ### Step 3: Evaluate Gate Results
 
 #### Scenario A: All Checks Pass → PROCEED
@@ -83,7 +101,7 @@ GATE 3: Is current branch a feature branch (not main/dev/master)?
 ACTION: Invoke git-workflow --task pre-work
 ```
 
-#### Scenario B: Any Check Fails → Q/A MODE
+#### Scenario B: Any Check Fails → SEARCH → Q/A MODE
 
 ```
 ❌ Gate failed
@@ -93,8 +111,10 @@ ENFORCEMENT:
 2. Do NOT create branch
 3. Do NOT write code
 4. Do NOT commit
-5. Switch to Q/A mode
-6. Ask single question: "What would you like me to do?"
+5. SEARCH GitHub Issues for existing candidates (Step 2.5)
+6. PRESENT candidates or failure state
+7. Switch to Q/A mode
+8. Offer create-or-select before halting
 ```
 
 ### Step 4: Q/A Mode Response Format
@@ -104,14 +124,21 @@ ENFORCEMENT:
 ```
 I see you'd like me to implement [X], but I need clarification first.
 
-[If no spec] There's no GitHub Issue tracking this work. 
+[If search found candidates:]
+I found the following existing specs/plans that may be relevant:
+1. #123 [SPEC] Feature X implementation — <URL>
+2. #456 [PLAN] Feature X rollout — <URL>
+
+Would you like me to work with one of these, or create a new spec?
+
+[If no spec] No existing spec/plan found for [X].
   Would you like me to create a spec first?
 
-[If on main/dev] I'm currently on the [main] branch. 
+[If on main/dev] I'm currently on the [main] branch.
   I need to create a feature branch first, but I need a spec/issue to associate it with.
 
 [If no authorization] This work hasn't been authorized yet.
-  Would you like to create a spec for review first?
+  Would you like to review the spec and authorize it?
 
 What would you like me to do?
 ```
@@ -142,12 +169,30 @@ What would you like me to do?
 **Agent Internal Check:**
 - Keyword: "Fix" = implementation
 - GitHub Issue? NO
-- Action: Q/A Mode
+- Action: Search before Q/A Mode
 
-**Agent Response:**
+**Agent Search:**
+- Label search: `[SPEC]`, `[PLAN]`, `[SPEC-FIX]` for "authentication" or "login"
+- Keyword search: "authentication bug", "login.py"
+
+**Agent Response (if candidates found):**
 ```
 I see you'd like me to fix an authentication bug, but there's no GitHub Issue 
 tracking this work.
+
+I found these existing issues that may be relevant:
+1. #42 [SPEC] Authentication flow improvements — https://github.com/owner/repo/issues/42
+2. #87 [SPEC-FIX] Login timeout bug — https://github.com/owner/repo/issues/87
+
+Would you like me to work with one of these, or create a new spec/bug report?
+
+What would you like me to do?
+```
+
+**Agent Response (if no candidates found):**
+```
+I see you'd like me to fix an authentication bug, but no existing spec/plan 
+was found for this topic.
 
 Would you like me to create a spec/bug report first?
 

--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -47,9 +47,10 @@ You are a Requirements Explorer. Your focus is understanding what the user wants
 
 6. **Visual companion conditional:** Offered only when topic involves visual decisions. Do NOT offer by default for this backend/Python project.
 
-7. **Terminal state is two-path:** Do NOT write the spec in brainstorming. Do NOT ask permission to implement. Instead:
+7. **Terminal state is three-path:**
    - **Path A (spec NOT yet a GitHub Issue):** Invoke `github-issue-creation` skill to create the spec as a GitHub Issue with `needs-approval` label → HALT for review.
    - **Path B (spec already a GitHub Issue AND approved):** Transition directly to `writing-plans` skill.
+   - **Path C (user declines spec/plan → FAILURE):** If the user declines both creating a new spec and selecting an existing candidate (from the search-prompt-fail workflow), this is a FAILURE state. Report: "Spec/Plan Required → Cannot proceed without a spec or plan to track this work." HALT.
 
 ## Key Principles
 
@@ -66,7 +67,8 @@ You are a Requirements Explorer. Your focus is understanding what the user wants
 ```
 brainstorming (mandatory)
   ├─ Path A: spec NOT yet GitHub Issue → github-issue-creation → HALT for review
-  └─ Path B: spec already GitHub Issue AND approved → writing-plans → executing-plans
+  ├─ Path B: spec already GitHub Issue AND approved → writing-plans → executing-plans
+  └─ Path C: user declines spec/plan → FAILURE: Spec/Plan Required → HALT
 ```
 
 ## Approval Gate Integration

--- a/.opencode/skills/gitbucket-api/tasks/mcp-operations.md
+++ b/.opencode/skills/gitbucket-api/tasks/mcp-operations.md
@@ -175,24 +175,6 @@ org = api.create_organization(
 )
 ```
 
-## Session Integration
-
-Get credentials from session init:
-
-```python
-from skills.gitbucket_api.tools import get_session_values, GitBucketAPI
-
-# Get all session values
-values = get_session_values()
-# {'GITBUCKET_URL': '...', 'GIT_OWNER': '...', ...}
-
-# GitBucket auto-detects from environment
-api = GitBucketAPI()  # Uses GITBUCKET_URL and GITBUCKET_TOKEN
-```
-
 ## Source Code
 
 - `tools/gitbucket_api.py` - Core client with all endpoints
-- `tools/auth.py` - Token & Basic auth
-- `tools/exceptions.py` - Exception hierarchy
-- `tools/session.py` - Session integration

--- a/.opencode/skills/gitbucket-api/tasks/session-integration.md
+++ b/.opencode/skills/gitbucket-api/tasks/session-integration.md
@@ -124,38 +124,6 @@ GITBUCKET_TOKEN=your-personal-access-token
 | Token | All operations | `GITBUCKET_TOKEN` | ✅ Working |
 | Basic | Admin endpoints | `GITBUCKET_USERNAME`, `GITBUCKET_PASSWORD` | ❌ Broken |
 
-## Platform Detection
-
-```python
-from skills.gitbucket_api.tools import is_gitbucket, is_github
-
-if is_gitbucket():
-    # Use GitBucket API
-    api = GitBucketAPI()
-    issue = api.create_issue(...)
-
-elif is_github():
-    # Use GitHub tools
-    issue = github_issue_write(...)
-```
-
-## Repository Context
-
-```python
-from skills.gitbucket_api.tools import get_repo_context
-
-context = get_repo_context()
-# {'GIT_OWNER': 'myorg', 'GIT_REPO': 'myrepo', 'GIT_PLATFORM': 'gitbucket'}
-
-# Use in API calls
-api = GitBucketAPI()
-issue = api.create_issue(
-    owner=context['GIT_OWNER'],
-    repo=context['GIT_REPO'],
-    title="Bug report"
-)
-```
-
 ## Error Handling
 
 ```python
@@ -196,13 +164,5 @@ except NotFoundError:
 
 1. **Use config file** - Create `secrets.toml` with `create_config_file()` for persistent credentials
 2. **Token auth ONLY** - Basic auth is broken in GitBucket, use token for all operations
-3. **Platform detection** - Check `is_gitbucket()` before GitBucket API calls
-4. **Error handling** - Catch specific exceptions (AuthenticationError, NotFoundError, etc.)
-5. **Cross-platform** - Config locations work on Linux, macOS, Windows
-
-## Source Code
-
-- `tools/auth.py` - Credential loading, platform-specific paths
-- `tools/session.py` - Session integration
-- `.opencode/tools/session-init` - Session init script
-
+3. **Error handling** - Catch specific exceptions (AuthenticationError, NotFoundError, etc.)
+4. **Cross-platform** - Config locations work on Linux, macOS, Windows

--- a/.opencode/skills/spec-creation/SKILL.md
+++ b/.opencode/skills/spec-creation/SKILL.md
@@ -53,6 +53,14 @@ You are a Spec Architect. Your focus is structuring investigation results into a
    - User provides investigation results and asks for a structured spec
    - DO NOT skip to write without completing applicable prerequisite tasks
 
+3. **Select-existing pathway (MANDATORY before writing new spec):** Before creating a new spec, the agent MUST check whether an existing spec/plan already covers the request. This pathway is especially relevant when arriving from the `search-prompt-fail` workflow (see `approval-gate` skill → `verify-qa-mode` task → Step 2.5).
+   - Search GitHub Issues using labels `[SPEC]`, `[PLAN]`, `[SPEC-FIX]` and keywords from the request
+   - If candidates found: present them to the user with URLs and relevance assessment
+   - If user selects an existing candidate: transition to that issue's workflow (e.g., `approval-gate` if already approved, `brainstorming` Path B if approved, `brainstorming` Path A if not yet a spec)
+   - If user declines all candidates: proceed with new spec creation (this skill's normal workflow)
+   - If no candidates found: proceed with new spec creation
+   - This check prevents duplicate spec creation and connects requests to existing tracking
+
 2. **Simplicity heuristic for task skipping:**
 
    | Spec Complexity | Tasks | Example |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,6 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 ## Boundaries (Critical)
 
 **✅ ALWAYS:**
-- Run session init script at session start
 - Create feature branch BEFORE any filesystem change
 - Wait for explicit authorization ("approved" or "go") before implementing
 - SILENTLY HALT after completing a task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/838-active-enforcement
+
+- **Active Spec/Plan Enforcement** (#838) - Added "Silent Halt Without Prompt" critical violation requiring agents to search GitHub Issues for existing spec/plan candidates before halting, present the results to the user, and flag as FAILURE if no spec/plan is created. Updated 7 files: 000-critical-rules.md, 010-approval-gate.md, 020-go-prohibitions.md, approval-gate SKILL.md, verify-qa-mode.md, brainstorming SKILL.md, and spec-creation SKILL.md.
+
+### spec/805-redundant-session-init
+
+- **Remove Redundant Session-Init Execution** (#805) - Removed redundant "Run session init script at session start" instruction from AGENTS.md (plugin already injects this) and cleaned stale references to deleted session.py, auth.py, and exceptions.py from gitbucket-api skill documentation.
+
 ### spec/840-credential-leakage
 
 - **Credential Leakage Prevention** (#840) - Added layered defense against credential leaks: gitignore hardening (16 patterns), conditional detect-secrets pre-commit hook (opt-in via `.secrets.baseline`), generalized session-init credential guard (`.env`, `.streamlit/secrets.toml`, `.streamlit/secrets.toml.production`), remediation documentation, and 25 integration tests across 4 test classes.


### PR DESCRIPTION
**Summary:**

Two approved specs implemented as a batch: removed redundant session-init execution from AGENTS.md and cleaned stale session.py references, and added active spec/plan enforcement requiring agents to search GitHub Issues before halting on missing specs/plans.

**Outcome:**

#805 agents no longer redundantly run session-init when the plugin already injects it; stale session.py references cleaned from gitbucket-api docs.
#838 agents must now search GitHub Issues for existing specs/plans before halting, present candidates to the user, and flag as FAILURE if no spec/plan is created — replacing silent halts with productive intervention.

## Batch Issues

Implements #805 — Remove redundant session-init execution and dead code
Implements #838 — Active spec/plan enforcement — prompt instead of silent halt

Fixes #805
Fixes #838
Fixes #844
Fixes #845
Fixes #846
Fixes #847
Fixes #848
Fixes #851
Fixes #853
Fixes #856
Fixes #858
Fixes #859
Fixes #860