### PR TITLE
Schema/API Verification — Verify Before Claiming Knowledge (#839)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -46,6 +46,21 @@ When a main agent is operating in a worktree and dispatches a sub-agent, the sub
 - 🚫 FORBIDDEN: Using unverified APIs, guessed env vars, outdated patterns, or memory-based signatures
 - ✅ REQUIRED: Verify API signatures from official docs, confirm env vars from config, use `srclight_get_signature` for code signatures
 
+## Critical Violation: Schema/API/Code Verification — Claiming Knowledge Without Verification
+
+**⚠️ Asserting config schema compliance, API signatures, or code implementation details without verifying against live documentation or live source is a CRITICAL GUIDELINE VIOLATION.**
+
+**See `065-verification-honesty.md` → "Proactive Verification" section for the complete rule, evidence requirements, examples, and when proactive verification applies.**
+
+- 🚫 FORBIDDEN: Asserting config compliance without fetching and verifying the actual schema
+- 🚫 FORBIDDEN: Using API signatures from training data without verifying against live documentation or `srclight_get_signature`
+- 🚫 FORBIDDEN: Claiming code behavior without checking via `srclight_get_symbol`, `read`, or `srclight_get_signature`
+- 🚫 FORBIDDEN: Writing specs or code that reference schema fields, API parameters, or function signatures from memory
+- ✅ REQUIRED: Fetch and verify config schemas before asserting compliance
+- ✅ REQUIRED: Verify API signatures via `srclight_get_signature` or official documentation before using them
+- ✅ REQUIRED: Verify code implementation details via `srclight_get_symbol`, `read`, or `srclight_get_signature` before claiming behavior
+- ✅ REQUIRED: Tag any assertion that could not be verified as `(unverified)`
+
 ## Critical Violation: Verification Dishonesty — Reporting Memory as Verified
 
 **⚠️ Reporting unverified information as verified, or using memory recall instead of actual verification, is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/065-verification-honesty.md
+++ b/.opencode/guidelines/065-verification-honesty.md
@@ -148,3 +148,70 @@ There are NO exceptions to metadata verification:
 - **Cross-references are not self-certifying.** A `#N` reference does not mean the issue exists or matches. Verify via GitHub MCP.
 - **Code references are not self-certifying.** A file path in a spec does not mean the file exists. Verify via codebase tools.
 - **Authorization comments are not self-certifying.** An approval comment may predate a revision. Verify timestamps.
+
+## Proactive Verification
+
+The verification honesty principle extends beyond reactive verification (when instructed to check) to **proactive verification** — verifying BEFORE making claims, not just when told to verify.
+
+### Core Rule: Verify Before Claiming
+
+**🚫 CRITICAL VIOLATION: Asserting config schema compliance, API signatures, or code implementation details without verifying against live documentation or live source.**
+
+When an agent is about to make a structural claim — about config schemas, API signatures, function parameters, or code behavior — it MUST verify that claim against live documentation or live source before asserting it. Memory, training data, and "common knowledge" are NOT verification sources.
+
+### What Must Be Proactively Verified
+
+| Category | What to Verify | How to Verify |
+|----------|---------------|---------------|
+| Config schemas / JSON schemas | Field names, types, required vs optional, default values, nested structure | Fetch schema from canonical source; parse and verify against spec |
+| API signatures | Function names, parameter names, parameter order, return types, async/sync | `srclight_get_signature`, official docs, source code `read` |
+| Library methods | Method existence, parameter names, deprecation status, version compatibility | Official docs, `srclight_search_symbols`, changelog |
+| Code implementation details | Class hierarchy, function behavior, error handling, side effects | `srclight_get_symbol`, `srclight_get_type_hierarchy`, source code `read` |
+| Environment variables | Variable names, defaults, required vs optional | `.env.example`, config documentation, `read` tool |
+
+### Examples of Violations and Correct Behavior
+
+❌ **VIOLATION:** "The config accepts a `timeout` field" (asserted from training data without checking the actual schema)
+
+❌ **VIOLATION:** "The `create_shoebox` method takes `name` and `path` parameters" (from memory, not verified)
+
+❌ **VIOLATION:** "This function returns a `Shoebox` object" (assumed from context, not checked)
+
+✅ **CORRECT:** "The config accepts a `timeout` field — verified by reading `schemas/config.json`" (with tool call visible)
+
+✅ **CORRECT:** "The `create_shoebox` method takes `name` and `path` parameters — verified via `srclight_get_signature`" (with tool call visible)
+
+✅ **CORRECT:** "The `ShoeboxEditor.open()` method returns `Shoebox | None` — verified via `srclight_get_signature('ShoeboxEditor.open')`" (with tool call visible)
+
+✅ **CORRECT:** "The `timeout` field defaults to 30 seconds (unverified)" — tagged when verification is not yet available
+
+### When Proactive Verification Applies
+
+| Situation | Proactive Verification Required? |
+|-----------|----------------------------------|
+| Writing a spec that references config fields | ✅ Yes — verify fields exist in schema |
+| Writing a spec that references API endpoints | ✅ Yes — verify endpoints and parameters |
+| Writing a spec that references function signatures | ✅ Yes — verify via srclight or source |
+| Implementing code that calls an API | ✅ Yes — verify signature before calling |
+| Creating a config file | ✅ Yes — verify schema compliance |
+| Describing existing code behavior | ✅ Yes — verify via read or srclight |
+| General explanation or reasoning about approach | ❌ No — but tag unverified assertions |
+| Brainstorming alternatives | ❌ No — but tag assertions as speculative |
+
+### Unverified Assertion Tagging
+
+When proactive verification is not immediately feasible (e.g., external service unavailable, schema not yet published), the agent MUST tag unverified assertions:
+
+- Format: `(unverified)` after the assertion
+- Example: "The API accepts `page_size` as a query parameter (unverified)"
+- Limitations: No more than 3 unverified assertions per spec section before verification becomes mandatory
+
+### Relationship to Other Sections
+
+This Proactive Verification section extends the core Verification Honesty rule (verify when instructed) by adding a proactive duty (verify BEFORE claiming). It does NOT replace the reactive duty — both apply simultaneously:
+
+- **Reactive** (core rule): When instructed to check, verify, confirm — use tools
+- **Proactive** (this section): Before asserting schema/API/code claims — verify against live source
+- **Metadata** (previous section): Before trusting metadata claims — verify against actual state
+
+All three duties share the same evidence requirement: visible tool call or command output confirming the result.

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -30,6 +30,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | `verify-fix-spec` | For bug reports, verify fix spec sub-issue exists before closure | ~250 |
 | `search-prompt-fail` | Search GitHub Issues for existing spec/plan candidates before Q/A halt; present candidates or report failure | ~300 |
 | `pre-implementation-analysis` | Analyze interdependencies and expand sub-issues for all approved issues (single or batch), producing flat item list for assemble-batch | ~500 |
+| `verify-schema-api-knowledge` | Verify that the agent has performed live verification before making schema/API/code claims; gate before proceeding | ~350 |
 | `post-implementation` | Push branch, generate compare URL, HALT | ~480 |
 | `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~150 |
 
@@ -43,6 +44,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 - `/skill approval-gate --task verify-open-questions` - Check for unresolved questions
 - `/skill approval-gate --task verify-fix-spec` - Verify fix spec exists for bug reports
 - `/skill approval-gate --task search-prompt-fail` - Search for existing spec/plan candidates before Q/A halt
+- `/skill approval-gate --task verify-schema-api-knowledge` - Verify schema/API/code knowledge before claims
 - `/skill approval-gate --task pre-implementation-analysis` - Analyze interdependencies and expand sub-issues for all approved issues, then yield to assemble-batch
 - `/skill approval-gate --task post-implementation` - After implementation done
 - `/skill approval-gate --task completion` - Invoke when workflow halts at any point
@@ -263,4 +265,17 @@ rules:
     requires: []
     triggers: [approval-gate, brainstorming, spec-creation]
     source: "approval-gate/SKILL.md §search-prompt-fail task"
+
+  - id: approval-gate-skill-010
+    title: "Verify schema/API/code knowledge before claims"
+    conditions:
+      all:
+        - "agent_about_to_make_structural_claim == true"
+        - "verification_performed == false"
+    actions:
+      - INVOKE(verify-schema-api-knowledge)
+    conflicts_with: []
+    requires: []
+    triggers: [engineering-approach]
+    source: "approval-gate/SKILL.md §verify-schema-api-knowledge task"
 ```

--- a/.opencode/skills/engineering-approach/SKILL.md
+++ b/.opencode/skills/engineering-approach/SKILL.md
@@ -97,6 +97,8 @@ During coding:
 
 Before writing ANY implementation code:
 
+- ☐ **Verify all config schemas, API signatures, and code implementations against live documentation before proceeding.** Run `srclight_get_signature` for function signatures, `srclight_get_symbol` for code details, and fetch JSON schemas for config compliance. Tag any unverified assertions as `(unverified)`.
+
 1. **Verify API Signatures**
    - [ ] Check official documentation for correct parameters
    - [ ] Use `srclight_get_signature` or type hints for function signatures


### PR DESCRIPTION
**Summary:**

Added Schema/API/Code Verification enforcement requiring agents to verify claims about config schemas, API signatures, and code implementations against live documentation before making assertions — closing the gap where agents could claim knowledge without verification.

**Outcome:**

Proactive verification section added to 065-verification-honesty.md, critical violation added to 000-critical-rules.md, verify-schema-api-knowledge task added to approval-gate skill, and mandatory checklist item added to engineering-approach skill. Unverified assertions must now be tagged as `(unverified)`.

Fixes #839
Fixes #843
Fixes #877
Fixes #878
Fixes #879