### PR TITLE
feat(skill): Prose-Driven Phase/Task ↔ Sub-Issue Alignment

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -241,7 +241,7 @@ Chat output order (mandatory): 1) Executive summary, 2) URL (if exists), 3) AI b
 - ✅ REQUIRED: Sub-issues at PHASE level under the plan (not the spec); each linked via `github_sub_issue_write method=add`; single-task plans exempt; auto-create as pre-implementation setup
 - ✅ REQUIRED: Plan is the parent of implementation sub-issues; spec references plan via body linked reference, NOT GitHub sub-issue link
 
-**See `github-sub-issues` skill for complete workflow including single-task exemption, auto-create workflow, and database ID requirement.**
+**See `github-sub-issues` skill for complete workflow including single-task exemption, auto-create workflow, and database ID requirement. Sub-issue verification is consolidated into `approval-gate --task verify-authorization` Step 5 as the single readiness check.**
 
 ## Critical Violation: Stopping After Single Phase in Multi-Task Plan
 

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -4,7 +4,7 @@
 >
 > - Spec + authorization requirements
 > - Plan approval gate
-> - Sub-issue verification gate (under plan)
+> - Sub-issue verification gate (under plan) — consolidated into `approval-gate --task verify-authorization` Step 5
 > - Single-task exemption
 > - Re-evaluation checklist
 > - Bug report response
@@ -204,7 +204,7 @@ Key rules:
 | `000-critical-rules.md` | Critical violations and auditor enforcement |
 | `020-go-prohibitions.md` | GO command restrictions |
 | `140-planning-spec-creation.md` | Spec creation and plan-bridge hierarchy |
-| `github-sub-issues` skill | Sub-issue creation and verification (under plan) |
+| `github-sub-issues` skill | Sub-issue creation and hierarchy tracking (verification superseded by `approval-gate --task verify-authorization`) |
 | `git-workflow` skill `cleanup` task | Post-merge closure workflow |
 | `pr-creation-workflow` skill | PR creation timing |
 | `writing-plans` skill | Plan creation from approved spec |

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -115,7 +115,7 @@ ______________________________________________________________________
 
 ### ✅ MANDATORY
 
-**See `github-sub-issues` skill for the complete auto-create workflow, single-task exemption, database ID requirement, and phase-level structure.**
+**See `github-sub-issues` skill for the complete auto-create workflow, single-task exemption, database ID requirement, and phase-level structure. Sub-issue verification is consolidated into `approval-gate --task verify-authorization` Step 5 as the single readiness check.**
 
 Key points:
 

--- a/.opencode/guidelines/141-planning-status-tracking.md
+++ b/.opencode/guidelines/141-planning-status-tracking.md
@@ -6,17 +6,17 @@
 
 Every spec file SHOULD have a **STATUS** indicator at the top. The format varies by spec complexity:
 
-**For multi-phase specs (recommended format):**
+**For multi-phase specs (prose-driven format — recommended):**
 
 ```markdown
 # Spec: [Feature Name]
 
-STATUS: 1.1
+STATUS: in progress — Authorization Gate, Step 1
 CREATED: 2026-03-24
 
 ---
 
-## Phase 1: [Concern Name] (Gated)
+## Phase 1: Authorization Gate (Gated)
 ...
 ```
 
@@ -37,15 +37,19 @@ STATUS: in progress
 
 | Format | Meaning |
 | -- | -- |
-| `1` | Phase 1, no specific step tracked |
-| `1.2` | Phase 1, step 2 (currently active) |
-| `2.1-3` | Phase 2, steps 1-3 in progress |
+| `in progress — {concern}, Step {N}` | Working on a specific step within a concern (prose-driven, recommended) |
+| `completed — {concern}` | Phase/concern done (prose-driven, recommended) |
+| `{concern} — {task description}` | Active task within a concern (prose-driven, recommended) |
+| `1` | Phase 1, no specific step tracked (numeric, backward-compatible) |
+| `1.2` | Phase 1, step 2 (numeric, backward-compatible) |
+| `2.1-3` | Phase 2, steps 1-3 in progress (numeric, backward-compatible) |
 | `in progress` | Simple spec — currently being worked on |
 | `complete` | Simple spec — all work done |
 | `completed` | All phases done, ready for archive |
 | `1.1 (REVISED - NEEDS APPROVAL)` | Spec was modified, awaiting fresh approval |
+| `in progress — {concern} (REVISED - NEEDS APPROVAL)` | Prose-driven revision marker |
 
-**Advisory note:** `STATUS: phase.step` format is recommended for multi-phase specs. For simple bug fixes or single-task specs, a brief status note like `in progress` or `complete` is acceptable without phase.step numbering.
+**Backward compatibility:** The numeric `X.Y` format (e.g., `1.2`, `2.1-3`) is still recognized by all tools and skills, but is no longer recommended. New specs should use prose-driven STATUS formats that reference concern names rather than numeric phase indices. This makes STATUS markers self-explanatory and resilient to phase renumbering.
 
 **⚠️ CRITICAL: Phase names MUST describe specific concerns, NOT generic activities.**
 
@@ -55,6 +59,14 @@ STATUS: in progress
 #### Revision Status Format
 
 **When a spec or task is modified, the status MUST change:**
+
+```
+STATUS: in progress — Authorization Gate, Step 1
+    ↓ (revision made)
+STATUS: in progress — Authorization Gate, Step 1 (REVISED - NEEDS APPROVAL)
+```
+
+**Numeric revision format (backward-compatible):**
 
 ```
 STATUS: 1.1
@@ -72,7 +84,7 @@ STATUS: 1.1 (REVISED - NEEDS APPROVAL)
 
 **Exempt status updates (do NOT revoke approval):**
 
-- STATUS marker updates only (`STATUS: 1.1` → `STATUS: 1.2`)
+- STATUS marker updates only (`STATUS: in progress — Auth, Step 1` → `STATUS: in progress — Auth, Step 2`, or `STATUS: 1.1` → `STATUS: 1.2`)
 - Bug report additions to existing spec
 
 ### Status Markers (Visual Icons)
@@ -100,6 +112,13 @@ Status markers (`☐`/`↻`/`☑`/`☒`) are recommended for tracking step compl
 
 ### When to Update Status
 
+- **PENDING → `in progress — {concern}, Step 1`**: When spec is created (or `1.1` for backward compatibility)
+- **Step completion**: `in progress — {concern}, Step N` → `in progress — {concern}, Step N+1`
+- **Concern completion**: `in progress — {concern}, Step N` → `completed — {concern}` → `in progress — {next concern}, Step 1`
+- **Final completion**: Last concern → `completed`
+
+**Numeric transitions (backward-compatible):**
+
 - **PENDING → `1.1`**: When spec is created (first phase, first step)
 - **`N.M` → `N.M+1`**: When step M completes
 - **`N.last → N+1.1`**: When last step of phase N completes, move to next phase
@@ -112,7 +131,7 @@ Status markers (`☐`/`↻`/`☑`/`☒`) are recommended for tracking step compl
 When updating status:
 
 1. **Report progress to chat** documenting what was completed
-2. **Edit STATUS field ONLY** (change `STATUS: 1.1` to `STATUS: 1.2` for example)
+2. **Edit STATUS field ONLY** (change `STATUS: in progress — {concern}, Step N` or `STATUS: 1.1` for backward compatibility)
 3. **Never rewrite the entire body** to change status
 
 See `123-github-ai-identity.md` and `github-comments` skill → "Issue Body Update Rules" section for complete rules.
@@ -121,7 +140,7 @@ See `123-github-ai-identity.md` and `github-comments` skill → "Issue Body Upda
 
 If a spec file lacks a `STATUS:` header, the agent MUST:
 
-1. Add the header with `STATUS: 1.1` (default for new specs) — MINIMAL EDIT ONLY (add one line)
+1. Add the header with prose-driven STATUS (e.g., `STATUS: in progress — {concern}, Step 1`) — MINIMAL EDIT ONLY (add one line). For backward compatibility, `STATUS: 1.1` is also acceptable.
 2. If all tasks are marked `☑`, set `STATUS: completed`
 
 ______________________________________________________________________

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -58,7 +58,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 2. **Two-gate authorization model:** Spec approval → plan creation. Plan approval → implementation. Each gate requires explicit authorization.
 3. **Pre-Implementation Verification:** Verify spec or plan exists as GitHub Issue, verify authorization, verify sub-issues under plan (multi-task) — all consolidated in `verify-authorization` Step 5 as the single readiness check. The `github-sub-issues` verification gate is superseded by `verify-authorization`.
 4. **Multi-task cascade:** When plan has sub-issues, authorization cascades from plan to ALL sub-issues. Complete ALL phases, report ONCE, HALT ONCE.
-5. **Spec revision revocation:** If a spec is revised (status changed to REVISED - NEEDS APPROVAL), find linked plan issues by searching for `[PLAN]` issues referencing the spec number in their body and mark them for audit. Revision of a spec revokes approval on its linked plan.
+5. **Spec revision revocation:** If a spec is revised (status contains `REVISED - NEEDS APPROVAL` — in either prose or numeric format), find linked plan issues by searching for `[PLAN]` issues referencing the spec number in their body and mark them for audit. Revision of a spec revokes approval on its linked plan. Prose format example: `STATUS: in progress — {concern} (REVISED - NEEDS APPROVAL)`. Numeric format example: `STATUS: 1.1 (REVISED - NEEDS APPROVAL)`.
 6. **Auto-dispatch after verification:** When all verification gates pass, auto-dispatch to the next skill in the chain. See Dispatch Order below.
 
 ## Dispatch Order
@@ -100,7 +100,7 @@ Already implemented
 |-------------|-------------|
 | **Spec or Plan exists as GitHub Issue** | No local fallback — GitHub Issues only |
 | **Two-gate authorization** | Spec approval → plan creation; Plan approval → implementation |
-| **Explicit authorization** | User says `approved`, `go`, or `approved: N.M` — OVERRIDES `needs-approval` label |
+| **Explicit authorization** | User says `approved`, `go`, `approved: N.M`, or `approved: {concern}` — OVERRIDES `needs-approval` label |
 | **Open questions resolved** | No unresolved items in spec or plan |
 | **Sub-issues verified under plan** | Multi-task plans require phase-level sub-issues (verified in `verify-authorization` Step 5 — single authoritative gate) |
 | **Fix spec for bug reports** | Bug reports must have a fix spec sub-issue before closure (per `000-critical-rules.md`) |

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -56,7 +56,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 
 1. **Mandatory invocation (no decision point):** The agent MUST invoke approval-gate when it encounters `approved`/`go`, authorization questions, or implementation start. Never prompt for invocation — just invoke the skill.
 2. **Two-gate authorization model:** Spec approval → plan creation. Plan approval → implementation. Each gate requires explicit authorization.
-3. **Pre-Implementation Verification:** Verify spec or plan exists as GitHub Issue, verify authorization, verify sub-issues under plan (multi-task), check for blockers.
+3. **Pre-Implementation Verification:** Verify spec or plan exists as GitHub Issue, verify authorization, verify sub-issues under plan (multi-task) — all consolidated in `verify-authorization` Step 5 as the single readiness check. The `github-sub-issues` verification gate is superseded by `verify-authorization`.
 4. **Multi-task cascade:** When plan has sub-issues, authorization cascades from plan to ALL sub-issues. Complete ALL phases, report ONCE, HALT ONCE.
 5. **Spec revision revocation:** If a spec is revised (status changed to REVISED - NEEDS APPROVAL), find linked plan issues by searching for `[PLAN]` issues referencing the spec number in their body and mark them for audit. Revision of a spec revokes approval on its linked plan.
 6. **Auto-dispatch after verification:** When all verification gates pass, auto-dispatch to the next skill in the chain. See Dispatch Order below.
@@ -72,7 +72,7 @@ Spec approved
 
 Plan approved
   → verify-authorization (all gates pass)
-  → sub-issue verification (if multi-phase)
+  → sub-issue verification (Step 5 of verify-authorization, if multi-phase)
   → pre-implementation-analysis (expand sub-issues, classify, build flat item list)
   → divide-and-conquer/assemble-batch (dispatch sub-agents, squash-merge into batch branch)
   → verification-before-completion
@@ -102,7 +102,7 @@ Already implemented
 | **Two-gate authorization** | Spec approval → plan creation; Plan approval → implementation |
 | **Explicit authorization** | User says `approved`, `go`, or `approved: N.M` — OVERRIDES `needs-approval` label |
 | **Open questions resolved** | No unresolved items in spec or plan |
-| **Sub-issues verified under plan** | Multi-task plans require phase-level sub-issues |
+| **Sub-issues verified under plan** | Multi-task plans require phase-level sub-issues (verified in `verify-authorization` Step 5 — single authoritative gate) |
 | **Fix spec for bug reports** | Bug reports must have a fix spec sub-issue before closure (per `000-critical-rules.md`) |
 | **Implementation includes** | All file modifications that alter behavior: source code, skill files, guideline files, config files, test files, TypeScript plugins |
 
@@ -202,7 +202,8 @@ Findings from adversarial verification follow the same three-tier model as `spec
 
 - Related skills: `git-workflow` (branch operations, cleanup), `pr-creation-workflow` (PR timing), `issue-review` (authorization status)
 - Related guidelines: `010-approval-gate.md`, `000-critical-rules.md`, `065-verification-honesty.md`
-- Related skill tasks: `approval-gate --task verify-sub-issues` (sub-issue verification), `git-workflow --task cleanup` (post-merge closure)
+- Related skill tasks: `approval-gate --task verify-authorization` (sub-issue verification is Step 5 — single authoritative gate), `git-workflow --task cleanup` (post-merge closure)
+- Superseded: `github-sub-issues` verification gate is superseded by `approval-gate --task verify-authorization` Step 5
 - Related subtask: `spec-auditor --task ground-truth` (adversarial metadata verification model)
 - Label state machine: `141-planning-status-tracking.md §10` (label add/remove actions for this skill)
 

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -79,9 +79,84 @@ When user provides explicit authorization, it **OVERRIDES** the needs-approval l
 | NO auth AND label present | HALT - wait for authorization |
 | NO auth AND no label | Check other blockers |
 
-### Step 5: Auto-Dispatch After Successful Verification
+### Step 5: Verify Sub-Issue Structure (for Plan Approval)
 
-**🚫 CRITICAL: This step runs ONLY when ALL prior verification gates (Steps 1-4) pass. If ANY gate fails, HALT — do NOT dispatch.**
+**This gate is the SINGLE AUTHORITATIVE verification point for sub-issue readiness.** The `github-sub-issues` skill's verification gate is superseded — all sub-issue verification logic lives here.
+
+#### 5.1 Determine Plan Type
+
+```
+plan_issue = github_issue_read(method="get", issue_number=N)
+
+# Check if this is a plan (has plan label or [PLAN] prefix)
+is_plan = "plan" in [l["name"] for l in plan_issue["labels"]] or plan_issue["title"].startswith("[PLAN]")
+
+if is_plan:
+    # Determine single-task vs multi-task
+    phases = parse_phases_from_plan_body(plan_issue["body"])
+    is_single_task = len(phases) == 1
+```
+
+#### 5.2 Verify Sub-Issues Under Plan (Multi-Task Only)
+
+**Single-task exemption:** If the plan has exactly ONE implementation phase with no decomposition, skip sub-issue verification entirely.
+
+For multi-task plans:
+
+```python
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=plan_issue)
+
+# Verify sub-issues exist under the plan (NOT the spec)
+if not sub_issues:
+    # Auto-create sub-issues under the plan
+    # Plan approval covers sub-issue creation — no separate auth needed
+    # See github-sub-issues --task create-sub-issue for creation procedure
+    pass
+
+# Verify sub-issue structure matches plan phases
+for phase in phases:
+    matching_sub_issue = find_sub_issue_for_phase(sub_issues, phase)
+    if not matching_sub_issue:
+        # HALT: sub-issue structure incomplete
+        pass
+
+# Verify sub-issue bodies contain phase context (Phase 1 enrichment)
+for sub_issue in sub_issues:
+    body = github_issue_read(method="get", issue_number=sub_issue["number"])["body"]
+    if phase_context_insufficient(body):
+        # Report: sub-issue body lacks phase context
+        pass
+```
+
+#### 5.3 Adversarial Verification of Sub-Issue State
+
+**Before trusting any sub-issue claim, verify against actual GitHub API state.**
+
+```
+For each sub-issue:
+  child = github_issue_read(method="get", issue_number=sub_issue_number)
+  - Verify child.state matches claimed state (do NOT trust cache)
+  - If child.state == "closed" → verify merged PR exists (not premature closure)
+  - Verify child is linked under plan (NOT spec) → STRUCTURE-VIOLATION if under spec
+  - Verify needs-approval label absent if parent plan has explicit authorization
+```
+
+**Evidence artifact:** `github_issue_read(method=get)` for each sub-issue showing actual state, title, labels, and parent link.
+
+#### Finding Classification for Sub-Issue Verification
+
+| Finding | Problem Class | Classification | Action |
+|---------|---------------|----------------|--------|
+| No sub-issues on multi-task plan | MISSING-ELEMENT | auto-create | Auto-create under plan, proceed |
+| Sub-issue linked under spec (not plan) | STRUCTURE-VIOLATION | auto-fix | Re-link under correct parent |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Report — may be premature closure |
+| Sub-issue needs-approval stale (parent authorized) | STRUCTURE-VIOLATION | auto-fix | Remove label |
+| Sub-issue body lacks phase context | MISSING-ELEMENT | conditional | Report, fall back to plan body |
+| Sub-issue 404 | MISSING-TRACEABILITY | flag-for-review | Developer must resolve |
+
+### Step 6: Auto-Dispatch After Successful Verification
+
+**🚫 CRITICAL: This step runs ONLY when ALL prior verification gates (Steps 1-5) pass. If ANY gate fails, HALT — do NOT dispatch.**
 
 After all verification gates pass, determine the approval context and auto-dispatch:
 
@@ -122,7 +197,7 @@ If a spec is revised (status changed to `REVISED - NEEDS APPROVAL`):
 #### Auto-Dispatch Edge Cases
 
 - **Spec already has a plan:** `writing-plans --task create` handles this (skips or updates per its existing logic)
-- **Multi-task plan with missing sub-issues:** `verify-sub-issues` gate fails → HALT, no dispatch
+- **Multi-task plan with missing sub-issues:** Step 5 sub-issue verification gate fails → HALT, no dispatch
 - **Batch approval:** Each plan in batch gets its own dispatch cycle after batch state is established
 
 ### Step 2.5: Adversarial Verification — Verify Authorization Against Actual State
@@ -196,7 +271,8 @@ For plan issues (detected in Step 5):
 
 ## Context Required
 
-- Related tasks: `verify-sub-issues`, `verify-codebase`
+- Related tasks: `verify-sub-issues` (delegated sub-issue verification detail), `verify-codebase`
+- Sub-issue verification gate: This task (Step 5) is the SINGLE AUTHORITATIVE verification point. `github-sub-issues` skill's verification gate is superseded by this gate.
 - Auto-dispatch targets: `writing-plans` (spec approval), `executing-plans` (plan approval)
 - Dispatch context for plan approval: pass `plan_issue=#N` and `spec_issue=#M` (extracted from plan body)
 - Label state machine: `141-planning-status-tracking.md §10` (remove `needs-approval`, add `in-progress` on approval)

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -188,7 +188,10 @@ After all verification gates pass, determine the approval context and auto-dispa
 
 #### Spec Revision Revocation Detection
 
-If a spec is revised (status changed to `REVISED - NEEDS APPROVAL`):
+If a spec is revised (status contains `REVISED - NEEDS APPROVAL` — in either prose or numeric format):
+
+Prose format: `STATUS: in progress — {concern} (REVISED - NEEDS APPROVAL)`
+Numeric format: `STATUS: 1.1 (REVISED - NEEDS APPROVAL)`
 
 1. Search for `[PLAN]` issues that reference the spec number in their body
 2. Mark found plans for audit (their authorization is revoked by the spec revision)

--- a/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
@@ -43,39 +43,46 @@ sub_issues = github_issue_read(method="get_sub_issues", issue_number=plan_issue)
 
 **For multi-task plans with sub-issues:**
 
-1. Extract subtask number from authorization:
-   - "approved: 1.2" → subtask 1.2
-   - "approved: X.Y" → subtask X.Y
-   - "approved" (no number) → check STATUS for current phase
+1. Extract subtask from authorization:
+    - "approved: 1.2" → subtask 1.2 (numeric format, backward-compatible)
+    - "approved: X.Y" → subtask X.Y (numeric format, backward-compatible)
+    - "approved: {concern}" → find phase matching concern name (prose format)
+    - "approved" (no number) → check STATUS for current phase
 
 2. Get plan issue STATUS:
-   ```python
-   plan = github_issue_read(method="get", issue_number=plan_issue)
-   # Parse STATUS from body
-   # STATUS format: "STATUS: X.Y" or "STATUS: completed"
-   # If STATUS not found, default to first subtask (1.1)
-   ```
+    ```python
+    plan = github_issue_read(method="get", issue_number=plan_issue)
+    # Parse STATUS from body
+    # Prose-driven formats (recommended):
+    #   "STATUS: in progress — {concern}, Step {N}"
+    #   "STATUS: completed — {concern}"
+    #   "STATUS: {concern} — {task description}"
+    #   "STATUS: in progress — {concern} (REVISED - NEEDS APPROVAL)"
+    # Numeric formats (backward-compatible):
+    #   "STATUS: X.Y" or "STATUS: completed"
+    # If STATUS not found, default to first concern's first step
+    ```
 
 3. Determine which subtask to implement:
-   - If authorized for X.Y → use X.Y (explicit override)
-   - If "approved" (no number) AND STATUS found → use STATUS value
-   - If "approved" (no number) AND STATUS missing → use first subtask (1.1)
-   - POST COMMENT explaining which subtask is being implemented
+    - If authorized for concern name or X.Y → use that subtask (explicit override)
+    - If "approved" (no number) AND STATUS found → use STATUS value
+    - If "approved" (no number) AND STATUS missing → use first concern, first step
+    - POST COMMENT explaining which subtask is being implemented
 
 4. Verify subtask exists:
-   - If subtask X.Y exists in sub-issues → PROCEED
-   - If subtask X.Y NOT in sub-issues → HALT and report: "Subtask X.Y not found. Available subtasks: [list]"
+   - If subtask X.Y or concern name exists in sub-issues → PROCEED
+   - If subtask X.Y or concern name NOT in sub-issues → HALT and report: "Subtask not found. Available subtasks: [list]"
 
 5. Report to user (MANDATORY - no silent halts):
-   ```markdown
-   Proceeding to implement subtask X.Y.
-   
-   Authorization: "approved" (no phase specified)
-   STATUS: X.Y (or "not found, defaulting to first subtask")
-   Sub-issue: #NNN
-   
-   Starting implementation now.
-   ```
+```markdown
+Proceeding to implement subtask for {concern} (or X.Y).
+
+Authorization: "approved" (no phase specified)
+STATUS: {concern}, Step {N} (or "not found, defaulting to first concern")
+Sub-issue: #NNN
+
+Starting implementation now.
+```
 
 6. **Why STATUS Gate Matters:**
    - Prevents parallel execution of subtasks
@@ -124,11 +131,12 @@ Auto-creating sub-issues for an approved multi-task plan does NOT require separa
 
 | Scenario | Action |
 |----------|--------|
-| STATUS matches authorized subtask | ✅ PROCEED - report which subtask |
+| STATUS matches authorized subtask (prose or numeric) | ✅ PROCEED - report which subtask and concern |
 | STATUS mismatch | ⛔ HALT - report mismatch clearly |
 | STATUS is "completed" | ⛔ HALT - spec already complete |
-| STATUS not found + "approved" | ✅ PROCEED - default to first subtask (1.1), report decision |
+| STATUS not found + "approved" | ✅ PROCEED - default to first concern's first step, report decision |
 | STATUS not found + "approved: X.Y" | ✅ PROCEED - use specified X.Y, report decision |
+| STATUS not found + "approved: {concern}" | ✅ PROCEED - find phase matching concern name, report decision |
 | Single-phase plan (no STATUS) | ✅ PROCEED - no gate needed |
 | Subtask not in sub-issues list | ⛔ HALT - report available subtasks |
 
@@ -144,7 +152,7 @@ Auto-creating sub-issues for an approved multi-task plan does NOT require separa
 ```markdown
 **STATUS Gate Verification:**
 - Authorization: "approved" (no phase specified)
-- STATUS field: Not found → Defaulting to first subtask (1.1)
+- STATUS field: Not found → Defaulting to first concern's first step
 - Sub-issue: #473
 - Proceeding with implementation
 ```
@@ -164,12 +172,12 @@ Auto-creating sub-issues for an approved multi-task plan does NOT require separa
 
 | Issue | Resolution |
 |-------|------------|
-| STATUS mismatch | POST report: "STATUS mismatch: authorized for X.Y but STATUS is Z.W. Please update STATUS or authorize correct subtask." |
-| STATUS not found | Default to first subtask (1.1), POST report: "STATUS not found. Defaulting to first subtask (1.1). Add 'STATUS: X.Y' to plan issue for tracking." |
+| STATUS mismatch | POST report: "STATUS mismatch: authorized for {concern}/{X.Y} but STATUS is {actual}. Please update STATUS or authorize correct subtask." |
+| STATUS not found | Default to first concern's first step, POST report: "STATUS not found. Defaulting to first concern. Add 'STATUS: in progress — {concern}, Step 1' to plan issue for tracking." |
 | Sub-issue not linked | Auto-create and link, POST report: "Created N sub-issues for phase tracking." |
 | Single-phase plan with STATUS | Ignore STATUS, proceed, POST report: "Single-phase plan, ignoring STATUS field." |
-| Subtask not in list | HALT, POST report: "Subtask X.Y not found. Available subtasks: [list]. Please authorize a valid subtask." |
-| Plan issue missing STATUS field | Default to first subtask (1.1), proceed, report to chat |
+| Subtask not in list | HALT, POST report: "Subtask {X.Y}/{concern} not found. Available subtasks: [list]. Please authorize a valid subtask." |
+| Plan issue missing STATUS field | Default to first concern's first step, proceed, report to chat |
 
 ## Adversarial Verification: Sub-Issue State
 

--- a/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
+++ b/.opencode/skills/approval-gate/tasks/verify-sub-issues.md
@@ -1,5 +1,7 @@
 # Task: verify-sub-issues
 
+> **Note:** Sub-issue verification is consolidated into `verify-authorization` Step 5 as the single authoritative readiness check. This task remains available for standalone invocation when detailed sub-issue inspection is needed, but the pre-implementation gate is `verify-authorization` Step 5.
+
 ## Purpose
 
 Verify sub-issue structure and STATUS gate for multi-task plans before implementation. Sub-issues are verified under the plan issue, not the spec issue.

--- a/.opencode/skills/concern-separation-auditor/SKILL.md
+++ b/.opencode/skills/concern-separation-auditor/SKILL.md
@@ -20,6 +20,7 @@ Concern Separation Auditor analyzes spec phase structures to identify deployment
 |------|---------|-------|
 | `audit-phases` | Analyze phase structure for concern quality | ~400 |
 | `check-independence` | Validate deployment independence between phases | ~300 |
+| `concern-coverage` | Verify sub-issue bodies reflect Plan concern boundaries | ~350 |
 
 ## Invocation
 
@@ -93,6 +94,7 @@ This skill analyzes ACTUAL concerns, not static templates.
 | `programming-principles` in Cross-References section | File exists at `.opencode/skills/programming-principles/SKILL.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `audit-phases` | File exists at `.opencode/skills/concern-separation-auditor/tasks/audit-phases.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `check-independence` | File exists at `.opencode/skills/concern-separation-auditor/tasks/check-independence.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `concern-coverage` | File exists at `.opencode/skills/concern-separation-auditor/tasks/concern-coverage.md` | MISSING-TRACEABILITY if missing |
 | `spec-auditor` orchestration behavior | Matches actual SKILL.md: `concerns` subtask delegates to this skill | CONFLICTING if mismatched |
 | `writing-plans` clean-room behavior | Matches actual SKILL.md: `clean-room` task for fidelity generation | CONFLICTING if mismatched |
 | `programming-principles` principle definitions | Matches actual SKILL.md: SoC and Blast Radius principles defined there | CONFLICTING if mismatched |

--- a/.opencode/skills/concern-separation-auditor/tasks/concern-coverage.md
+++ b/.opencode/skills/concern-separation-auditor/tasks/concern-coverage.md
@@ -1,0 +1,109 @@
+# Task: concern-coverage
+
+## Purpose
+
+Verify that sub-issue bodies reflect the Plan's concern boundaries. For each sub-issue, check that its concern scope matches its corresponding Plan phase. Report mismatches between concern boundaries in sub-issues and Plan phases.
+
+**Trigger:** When `concerns` subtask runs on a Plan that has sub-issues, this task extends the analysis to verify that sub-issue concern boundaries align with Plan phase concern boundaries.
+
+## Procedure
+
+### Step 1: Read the Plan Issue
+
+Read the Plan issue via GitHub MCP (`github_issue_read method=get`). Parse the Plan body to identify phase boundaries and the concern scope of each phase.
+
+### Step 2: Read Sub-Issues
+
+Read all sub-issues under the Plan via GitHub MCP (`github_issue_read method=get_sub_issues`). For each sub-issue:
+- Read the full body (`github_issue_read method=get`)
+- Record: issue number, title, body content, concern scope
+
+### Step 3: Determine Concern Boundaries per Plan Phase
+
+For each Plan phase, determine its concern boundary:
+- What is the primary concern (e.g., data layer, API layer, UI layer)?
+- What steps/tasks fall within the concern?
+- What steps/tasks fall outside the concern?
+
+Use the same concern analysis logic from `audit-phases`:
+- Keyword hints (migration/schema → data layer, API/endpoint → business logic)
+- Deployment independence
+- Risk profile grouping
+- Blast radius considerations
+
+### Step 4: Map Sub-Issues to Plan Phases
+
+For each sub-issue, find the corresponding Plan phase via semantic matching:
+- Match by title similarity
+- Match by body content overlap
+- Record unmatched sub-issues or Plan phases without sub-issues
+
+### Step 5: Compare Concern Boundaries
+
+For each matched sub-issue ↔ Plan phase pair:
+1. Extract the concern scope expressed in the sub-issue body
+2. Compare against the Plan phase's concern boundary
+3. Identify mismatches:
+   - **Sub-issue concern is narrower than Plan phase**: Sub-issue omits tasks that belong to the Plan phase's concern
+   - **Sub-issue concern is wider than Plan phase**: Sub-issue includes tasks from another concern
+   - **Sub-issue concern crosses Plan phase boundaries**: Sub-issue mixes tasks from multiple Plan phases
+
+### Step 6: Report Findings
+
+Report all mismatches as findings using the v3 auto-fix format.
+
+## Finding Types
+
+| Finding Type | Severity | Description |
+|-------------|----------|-------------|
+| CONCERN_SCOPE_NARROWER | MEDIUM | Sub-issue body omits tasks within the Plan phase's concern boundary |
+| CONCERN_SCOPE_WIDER | MEDIUM | Sub-issue body includes tasks outside the Plan phase's concern boundary |
+| CONCERN_BOUNDARY_CROSSED | HIGH | Sub-issue body mixes tasks from multiple Plan phase concerns |
+
+## Semantic Matching Before Reporting
+
+Before reporting a concern boundary mismatch:
+1. Verify the Plan phase actually defines a single concern (not a mixed-concern phase itself)
+2. If the Plan phase itself has mixed concerns, the sub-issue may correctly include cross-boundary tasks
+3. Only report mismatches where the sub-issue concern scope deviates from a well-defined Plan phase concern
+
+## Report Format
+
+```
+Subtask: concerns (concern-coverage)
+Finding: [CONCERN_SCOPE_NARROWER|CONCERN_SCOPE_WIDER|CONCERN_BOUNDARY_CROSSED] - [summary]
+Location: [Plan phase name / sub-issue number]
+Context: [why concern alignment matters for this Plan/sub-issue pair]
+Classification: flag-for-review
+Fix Action: flagged for review — [reason]
+Severity: [HIGH|MEDIUM|LOW]
+```
+
+## Why Flag-for-Review (Not Auto-Fix)
+
+Concern boundary adjustments in sub-issues require context judgment:
+- A wider sub-issue scope may intentionally group tightly coupled tasks
+- A narrower scope may be a valid scoping decision
+- Cross-boundary tasks may reflect legitimate inter-concern dependencies
+- The agent has full context about deployment needs and domain constraints
+
+All findings are reported for agent review. The agent decides whether to adjust sub-issue scope.
+
+## When to Run
+
+- After `audit-phases` when the Plan has sub-issues
+- When verifying that enriched sub-issue bodies maintain proper concern separation
+- As an extension of `concerns` subtask in spec-auditor for Plans with sub-issues
+
+## When to Skip
+
+- Plans without sub-issues (fall back to `audit-phases` only)
+- Single-task Plans (no phases to analyze)
+
+## Scope Boundaries
+
+- Read-only analysis of Plan issue and sub-issues via GitHub MCP
+- Does NOT modify sub-issue scope or content (flag-for-review only)
+- Must use GitHub MCP tools for all issue operations
+
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -97,6 +97,7 @@ authorization: "User approved #<N> on <date>"
 depth: <current decomposition depth, starting at 0>
 max_depth: <DIVIDE_AND_CONQUER_MAX_DEPTH or 3>
 prior_context: "<AI-composed intent and context from prior sub-agents>"
+decision_log_reference: "<URL or reference to the Decision Log on the Plan issue, or 'see Decision Log on Plan #N' — the sub-agent can retrieve full decision history from this reference>"
 phase_progress:
   completed_phases: "<prose listing of completed phases by concern name, not just number>"
   concern_boundaries_crossed: "<prose description of architectural concern transitions encountered>"
@@ -127,6 +128,7 @@ status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
 files_changed: ["<path>"]
 summary: "<what was implemented and key decisions>"
 concerns: "<only if DONE_WITH_CONCERNS>"
+decision_log_entry: "<prose summary of design decisions made during this phase — no prescribed format, the agent decides structure>"
 plan_issue: <number or empty>
 phase_progress:
   completed_phases: "<prose listing of phases completed, named by concern>"
@@ -138,6 +140,8 @@ exec_summary: "<1-2 sentence executive summary for chat output, or empty string>
 ```
 
 **Phase progress in results** enables the orchestrator to compose `phase_progress` for subsequent sub-agents. The completed phases, concern boundaries crossed, and verification evidence from prior sub-agent results feed directly into the next dispatch context's `phase_progress` field.
+
+**Decision Log persistence.** The `decision_log_entry` field captures design decisions made during a phase. After each sub-agent returns, the orchestrator appends this entry as a dedicated GitHub Issue comment on the Plan issue — this is the Decision Log. It persists across session restarts because it lives on the GitHub Issue, not in transient agent context. The Decision Log uses comments (not Plan body edits) for lightweight, append-only durability. The `decision_log_entry` is prose-driven — no prescribed format, the agent decides the structure that best communicates what was decided and why.
 
 ## Worktree Mode
 

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -97,6 +97,10 @@ authorization: "User approved #<N> on <date>"
 depth: <current decomposition depth, starting at 0>
 max_depth: <DIVIDE_AND_CONQUER_MAX_DEPTH or 3>
 prior_context: "<AI-composed intent and context from prior sub-agents>"
+phase_progress:
+  completed_phases: "<prose listing of completed phases by concern name, not just number>"
+  concern_boundaries_crossed: "<prose description of architectural concern transitions encountered>"
+  verification_evidence: "<prose summary of what was verified and the outcomes>"
 sub_task:
   description: "<what this sub-agent must implement>"
   scope: "<files, modules, functions>"
@@ -110,7 +114,9 @@ env_vars:
   DEV_EMAIL: "<from-session>"
 ```
 
-**Invariants:** `WORKTREE_PATH` is MANDATORY — no exceptions. If empty: FATAL ERROR → HALT. `plan_issue` is set when dispatched from plan approval flow.
+**Phase progress is prose-driven.** The `phase_progress` section communicates what information must travel between phases — completed phases should be named by the concern they address, concern boundaries should describe the architectural transition point, and verification evidence should summarize what was confirmed and the outcome. The agent composing the context decides how to encode this; the requirement is the information, not the format.
+
+**Invariants:** `WORKTREE_PATH` is MANDATORY — no exceptions. If empty: FATAL ERROR → HALT. `plan_issue` is set when dispatched from plan approval flow. `phase_progress` is composed by the orchestrator from prior sub-agent results and the Plan STATUS marker — it accumulates across the batch as each issue completes.
 
 ## Sub-agent Result Contract
 
@@ -122,10 +128,16 @@ files_changed: ["<path>"]
 summary: "<what was implemented and key decisions>"
 concerns: "<only if DONE_WITH_CONCERNS>"
 plan_issue: <number or empty>
+phase_progress:
+  completed_phases: "<prose listing of phases completed, named by concern>"
+  concern_boundaries_crossed: "<prose description of architectural concern transitions>"
+  verification_evidence: "<prose summary of what was verified and outcomes>"
 verification_passed: true | false
 compare_url: "<compare URL from review-prep, or empty string>"
 exec_summary: "<1-2 sentence executive summary for chat output, or empty string>"
 ```
+
+**Phase progress in results** enables the orchestrator to compose `phase_progress` for subsequent sub-agents. The completed phases, concern boundaries crossed, and verification evidence from prior sub-agent results feed directly into the next dispatch context's `phase_progress` field.
 
 ## Worktree Mode
 

--- a/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
+++ b/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
@@ -73,8 +73,9 @@ For each issue in execution order:
      sub_issue_body: "<phase prose from sub-issue body, not just parent reference>"
      spec: "<full spec body from GitHub Issue>"
      authorization: "User approved #A, #B, #C on <date>"
-     prior_context: "<AI-composed intent and context from prior issues>"
-     phase_progress:
+      prior_context: "<AI-composed intent and context from prior issues>"
+      decision_log_reference: "<URL or reference to the Decision Log on the Plan issue — the sub-agent can retrieve full decision history from this reference>"
+      phase_progress:
        completed_phases: "<prose listing of completed phases by concern name, accumulated from prior sub-agent results and Plan STATUS>"
        concern_boundaries_crossed: "<prose description of architectural concern transitions between the prior sub-agent's work and this sub-agent's work>"
        verification_evidence: "<prose summary of what was verified in prior phases and the outcomes>"
@@ -103,23 +104,34 @@ For each issue in execution order:
 
 6. **Compose prior_context and phase_progress** for the next issue based on what was implemented:
 
-    prior_context (intent and context):
-    - Design decisions made
-    - Edge cases handled
-    - Assumptions that later issues depend on
-    - Interfaces exposed that later issues should use
-    - NOT a change summary (that's in git) — intent and context only
+     prior_context (intent and context):
+     - Design decisions made
+     - Edge cases handled
+     - Assumptions that later issues depend on
+     - Interfaces exposed that later issues should use
+     - NOT a change summary (that's in git) — intent and context only
 
-    phase_progress (accumulated from sub-agent result + Plan STATUS):
-    - completed_phases: append the just-completed phase concern name to the running list
-    - concern_boundaries_crossed: if the next issue's concern differs from the just-completed issue's concern, note the transition
-    - verification_evidence: append what was verified and the outcome
+     phase_progress (accumulated from sub-agent result + Plan STATUS):
+     - completed_phases: append the just-completed phase concern name to the running list
+     - concern_boundaries_crossed: if the next issue's concern differs from the just-completed issue's concern, note the transition
+     - verification_evidence: append what was verified and the outcome
 
-    Both prior_context and phase_progress are prose-driven. The orchestrator composes them intelligently — no fixed template, no rigid schema.
+     Both prior_context and phase_progress are prose-driven. The orchestrator composes them intelligently — no fixed template, no rigid schema.
 
-7. **Mark prior issue's branch as frozen** — no rebasing, amending, or force-pushing
+7. **Append the sub-agent's decision_log_entry to the Decision Log on the Plan issue.** After collecting each sub-agent's result, post their `decision_log_entry` as a dedicated GitHub Issue comment on the Plan issue. The Decision Log persists design decisions across phase boundaries and session restarts.
 
-8. **Handle failures:**
+   **Decision Log storage:** Use a dedicated GitHub Issue comment on the Plan issue, NOT the Plan body. Rationale:
+   - Append-only — new decisions are added without editing existing content
+   - Lightweight — appending a comment doesn't require re-editing the entire Plan body
+   - Survives session restarts — comments persist on the GitHub Issue independently of any agent session
+   - Doesn't bloat the Plan body — the Plan body stays focused on phase structure and STATUS markers
+   - Sequential — comments are naturally ordered chronologically
+
+   The orchestrator posts the decision log entry after each sub-agent returns. If posting fails, log the failure and continue — the Decision Log is a durability enhancement, not a blocking gate. The `decision_log_entry` is also returned in the sub-agent result for immediate use by subsequent dispatches within the same session.
+
+8. **Mark prior issue's branch as frozen** — no rebasing, amending, or force-pushing
+
+9. **Handle failures:**
 
    - If sub-agent fails: record failure
    - For independent issues: continue to next issue
@@ -280,5 +292,6 @@ assemble-batch:
 08. **Intent-and-context metadata** — AI-composed, no fixed template, focus on why not what
 09. **Conflict resolution tiers** — auto-resolve 1-2, HALT on tier 3 during dependency merges
 10. **Always batch mode** — single issue = batch of one, no special-case path
+11. **Decision Log persistence** — after each sub-agent returns, append `decision_log_entry` as a dedicated GitHub Issue comment on the Plan issue. Decision Log uses comments (not body edits) for lightweight, append-only, session-surviving persistence
 
 Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
+++ b/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
@@ -54,25 +54,28 @@ For each issue in execution order:
      - Tiers 1-2 (trivial/formatting): Auto-resolve per `conflict-resolution` skill
      - Tier 3 (intent conflict): HALT and flag for developer review
 
-2. **Build dispatch context** with AI-composed intent-and-context metadata:
+  2. **Build dispatch context** with AI-composed intent-and-context metadata:
 
-   ```yaml
-   batch:
-     authorized_issues: [#A, #B, #C]
-     completed_issues: [<completed>]
-   issue: #<current>
-   spec: "<full spec body from GitHub Issue>"
-   authorization: "User approved #A, #B, #C on <date>"
-   prior_context: "<AI-composed intent and context from prior issues>"
-   dependency_branches: ["spec/<prior-branch>"]
-   env_vars:
-     WORKTREE_PATH: ".worktrees/spec-<name>"
-     BRANCH_NAME: "spec/<name>"
-     GIT_OWNER: "<from-session>"
-     GIT_REPO: "<from-session>"
-     DEV_NAME: "<from-session>"
-     DEV_EMAIL: "<from-session>"
-   ```
+    Sub-issues contain phase context in their body (enriched during creation via `create-sub-issue`). When composing dispatch context, reference the sub-issue body for phase-specific context rather than re-reading the Plan body. The sub-issue body should already include: why the phase exists, what it must accomplish, how to verify completion, edge cases, and dependencies. If the sub-issue body is insufficient (only contains `**Parent Plan:** #M`), fall back to reading the Plan body for the relevant phase section.
+
+    ```yaml
+    batch:
+      authorized_issues: [#A, #B, #C]
+      completed_issues: [<completed>]
+    issue: #<current>
+    sub_issue_body: "<phase prose from sub-issue body, not just parent reference>"
+    spec: "<full spec body from GitHub Issue>"
+    authorization: "User approved #A, #B, #C on <date>"
+    prior_context: "<AI-composed intent and context from prior issues>"
+    dependency_branches: ["spec/<prior-branch>"]
+    env_vars:
+      WORKTREE_PATH: ".worktrees/spec-<name>"
+      BRANCH_NAME: "spec/<name>"
+      GIT_OWNER: "<from-session>"
+      GIT_REPO: "<from-session>"
+      DEV_NAME: "<from-session>"
+      DEV_EMAIL: "<from-session>"
+    ```
 
 3. **Spawn sub-agent** via `task(subagent_type="general", prompt=...)`
 

--- a/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
+++ b/.opencode/skills/divide-and-conquer/tasks/assemble-batch.md
@@ -54,28 +54,39 @@ For each issue in execution order:
      - Tiers 1-2 (trivial/formatting): Auto-resolve per `conflict-resolution` skill
      - Tier 3 (intent conflict): HALT and flag for developer review
 
-  2. **Build dispatch context** with AI-composed intent-and-context metadata:
+   2. **Build dispatch context** with AI-composed intent-and-context metadata and phase progress:
 
-    Sub-issues contain phase context in their body (enriched during creation via `create-sub-issue`). When composing dispatch context, reference the sub-issue body for phase-specific context rather than re-reading the Plan body. The sub-issue body should already include: why the phase exists, what it must accomplish, how to verify completion, edge cases, and dependencies. If the sub-issue body is insufficient (only contains `**Parent Plan:** #M`), fall back to reading the Plan body for the relevant phase section.
+     Sub-issues contain phase context in their body (enriched during creation via `create-sub-issue`). When composing dispatch context, reference the sub-issue body for phase-specific context rather than re-reading the Plan body. The sub-issue body should already include: why the phase exists, what it must accomplish, how to verify completion, edge cases, and dependencies. If the sub-issue body is insufficient (only contains `**Parent Plan:** #M`), fall back to reading the Plan body for the relevant phase section.
 
-    ```yaml
-    batch:
-      authorized_issues: [#A, #B, #C]
-      completed_issues: [<completed>]
-    issue: #<current>
-    sub_issue_body: "<phase prose from sub-issue body, not just parent reference>"
-    spec: "<full spec body from GitHub Issue>"
-    authorization: "User approved #A, #B, #C on <date>"
-    prior_context: "<AI-composed intent and context from prior issues>"
-    dependency_branches: ["spec/<prior-branch>"]
-    env_vars:
-      WORKTREE_PATH: ".worktrees/spec-<name>"
-      BRANCH_NAME: "spec/<name>"
-      GIT_OWNER: "<from-session>"
-      GIT_REPO: "<from-session>"
-      DEV_NAME: "<from-session>"
-      DEV_EMAIL: "<from-session>"
-    ```
+     **Phase progress composition:** Before each sub-agent dispatch, compose the `phase_progress` section from:
+     - The Plan STATUS marker (which phases are marked complete) — read from the plan issue body or sub-issue STATUS markers
+     - Prior sub-agent results — the `completed_phases`, `concern_boundaries_crossed`, and `verification_evidence` fields returned by preceding sub-agents
+     - The orchestrator's own judgment about concern boundaries — when a new sub-agent's work crosses into a different architectural concern (e.g., from data layer to UI layer, from orchestration to enforcement), name the transition in `concern_boundaries_crossed`
+
+     Phase progress is prose-driven: state what information must travel, trust the orchestrator to decide how to encode it. Completed phases should be named by the concern they address (e.g., "dispatch context schema" rather than "Phase 1"), concern boundaries should describe the architectural transition point, and verification evidence should summarize what was confirmed.
+
+     ```yaml
+     batch:
+       authorized_issues: [#A, #B, #C]
+       completed_issues: [<completed>]
+     issue: #<current>
+     sub_issue_body: "<phase prose from sub-issue body, not just parent reference>"
+     spec: "<full spec body from GitHub Issue>"
+     authorization: "User approved #A, #B, #C on <date>"
+     prior_context: "<AI-composed intent and context from prior issues>"
+     phase_progress:
+       completed_phases: "<prose listing of completed phases by concern name, accumulated from prior sub-agent results and Plan STATUS>"
+       concern_boundaries_crossed: "<prose description of architectural concern transitions between the prior sub-agent's work and this sub-agent's work>"
+       verification_evidence: "<prose summary of what was verified in prior phases and the outcomes>"
+     dependency_branches: ["spec/<prior-branch>"]
+     env_vars:
+       WORKTREE_PATH: ".worktrees/spec-<name>"
+       BRANCH_NAME: "spec/<name>"
+       GIT_OWNER: "<from-session>"
+       GIT_REPO: "<from-session>"
+       DEV_NAME: "<from-session>"
+       DEV_EMAIL: "<from-session>"
+     ```
 
 3. **Spawn sub-agent** via `task(subagent_type="general", prompt=...)`
 
@@ -90,13 +101,21 @@ For each issue in execution order:
 
 5. **Collect result** from sub-agent
 
-6. **Compose prior_context** for the next issue based on what was implemented:
+6. **Compose prior_context and phase_progress** for the next issue based on what was implemented:
 
-   - Design decisions made
-   - Edge cases handled
-   - Assumptions that later issues depend on
-   - Interfaces exposed that later issues should use
-   - NOT a change summary (that's in git) — intent and context only
+    prior_context (intent and context):
+    - Design decisions made
+    - Edge cases handled
+    - Assumptions that later issues depend on
+    - Interfaces exposed that later issues should use
+    - NOT a change summary (that's in git) — intent and context only
+
+    phase_progress (accumulated from sub-agent result + Plan STATUS):
+    - completed_phases: append the just-completed phase concern name to the running list
+    - concern_boundaries_crossed: if the next issue's concern differs from the just-completed issue's concern, note the transition
+    - verification_evidence: append what was verified and the outcome
+
+    Both prior_context and phase_progress are prose-driven. The orchestrator composes them intelligently — no fixed template, no rigid schema.
 
 7. **Mark prior issue's branch as frozen** — no rebasing, amending, or force-pushing
 

--- a/.opencode/skills/divide-and-conquer/tasks/context-passing.md
+++ b/.opencode/skills/divide-and-conquer/tasks/context-passing.md
@@ -86,6 +86,14 @@ The orchestrator builds phase_progress incrementally. Before each sub-agent disp
 
 There is no fixed template, no rigid YAML schema, no mandatory section headers. The orchestrator describes progress in natural prose that communicates what the next sub-agent needs to know. The information requirement is the rule; the encoding is up to the agent.
 
+### Decision Log for Full Context History
+
+`prior_context` in the dispatch context carries the most recent intent summary — it is designed for immediate consumption by the next sub-agent. For the full history of design decisions across ALL phases, the orchestrator and sub-agents should reference the **Decision Log** persisted on the Plan issue.
+
+The Decision Log is an append-only sequence of GitHub Issue comments on the Plan issue. Each comment captures one sub-agent's `decision_log_entry` — the design decisions made during that phase. It survives session restarts because it lives on the GitHub Issue, not in transient agent context.
+
+When `prior_context` references a decision that may need fuller explanation, the orchestrator should note "see Decision Log on Plan #N" so the sub-agent can retrieve the full context history if needed.
+
 ## Edge Cases
 
 ### Context Lost Between Steps

--- a/.opencode/skills/divide-and-conquer/tasks/context-passing.md
+++ b/.opencode/skills/divide-and-conquer/tasks/context-passing.md
@@ -4,7 +4,7 @@ Migrated from `implementation-workflow` task context-passing.
 
 ## Purpose
 
-Reference document for yield-back context patterns between subtasks in the divide-and-conquer orchestration chain.
+Reference document for yield-back context patterns between subtasks in the divide-and-conquer orchestration chain, including phase progress information that must travel across phase boundaries.
 
 ## Entry Criteria
 
@@ -63,6 +63,29 @@ compare_url: string (actionable link)
 exec_summary: string (markdown, human-readable)
 ```
 
+### Phase Progress — What Travels at Phase Boundaries
+
+When the orchestrator dispatches a sub-agent for a phase that follows a prior phase, the dispatch context MUST carry phase progress information composed from prior sub-agent results and the Plan STATUS marker. This information ensures each phase knows what has already been accomplished and can act accordingly.
+
+**Phase progress is prose-driven.** The requirement is that the information travels — the agent composing the context decides how to encode it. The following information must be present:
+
+- **Completed phases by concern name.** Each completed phase should be identified by the concern it addresses, not just a phase number. For example: "dispatch context schema" rather than "Phase 1", "assemble-batch phase progress" rather than "Phase 3". The concern name makes the progress meaningful to the receiving sub-agent.
+
+- **Concern boundaries crossed.** When the current phase's work transitions from one architectural concern to another (e.g., from data layer to UI, from orchestration to enforcement, from schema definition to runtime behavior), this transition must be documented. The boundary description should explain what concern the previous phase addressed and what concern the current phase enters.
+
+- **Verification evidence.** What was verified in prior phases and the outcome. This is not a test log — it is a prose summary of what the sub-agent confirmed and the result. For example: "verified that the dispatch context contract includes the new phase_progress field and all invariants hold" rather than "3/3 tests passed".
+
+**How it is composed:**
+
+The orchestrator builds phase_progress incrementally. Before each sub-agent dispatch:
+1. Read the Plan STATUS marker to identify which phases are already complete
+2. Accumulate `completed_phases`, `concern_boundaries_crossed`, and `verification_evidence` from each prior sub-agent's result
+3. If this sub-agent's work crosses a concern boundary, note the transition in `concern_boundaries_crossed`
+
+**How it is NOT composed:**
+
+There is no fixed template, no rigid YAML schema, no mandatory section headers. The orchestrator describes progress in natural prose that communicates what the next sub-agent needs to know. The information requirement is the rule; the encoding is up to the agent.
+
 ## Edge Cases
 
 ### Context Lost Between Steps
@@ -72,6 +95,10 @@ If a yield-back produces empty or missing fields:
 1. HALT orchestration
 2. Report which context field is missing
 3. Wait for manual intervention
+
+### Phase Progress with No Prior Phases
+
+For the first sub-agent dispatched (no prior phases completed), `phase_progress` should still be present but note that no prior phases exist. For example: "No phases completed yet. This is the first phase." This ensures the field is never absent — it is either populated with prior progress or explicitly states that no progress has been made.
 
 ### Pre-Work Asks for Auth Again
 

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -26,9 +26,15 @@ spec_issue: <number, extracted from plan body>
 GIT_OWNER: "<from-session>"
 GIT_REPO: "<from-session>"
 WORKTREE_PATH: "<worktree path>"
+phase_progress:
+  completed_phases: "<prose listing of completed phases by concern name, from Plan STATUS>"
+  concern_boundaries_crossed: "<prose description of architectural concern transitions from plan>"
+  verification_evidence: "<prose summary of what was verified and outcomes>"
 ```
 
 **Verification:** If `plan_issue` is not present in the dispatch context, HALT — this skill requires plan context to track progress against the correct issue.
+
+**Phase progress composition:** Before dispatching to `divide-and-conquer`, `executing-plans` reads the Plan STATUS marker and concern boundary annotations to compose the initial `phase_progress`. If no phases are complete yet, the field notes that explicitly. The `assemble-batch` task then maintains and extends phase progress as each sub-agent completes.
 
 ## Tasks
 

--- a/.opencode/skills/executing-plans/tasks/start.md
+++ b/.opencode/skills/executing-plans/tasks/start.md
@@ -10,11 +10,22 @@ This task dispatches plan execution to `divide-and-conquer --task assemble-batch
 
 1. **Verify plan approval** — confirm the plan issue has explicit approval in comments
 2. **Verify prerequisites** — feature branch exists, working tree clean, dependencies ready
-3. **Dispatch to divide-and-conquer:**
+3. **Read Plan STATUS to compose initial phase progress** — before dispatching, read the plan issue body to determine which phases (if any) are already marked complete. Compose the initial `phase_progress` for the dispatch context:
+   - If no phases are complete yet: `completed_phases: "No phases completed yet. This is the first phase."`, `concern_boundaries_crossed: ""`, `verification_evidence: ""`
+   - If prior phases are complete: list them by concern name using the concern boundary annotations in the plan body, note any transitions between concerns, and summarize verification outcomes from the plan STATUS markers
+4. **Dispatch to divide-and-conquer:**
 
 ```
 /skill divide-and-conquer --task assemble-batch
 ```
+
+When dispatching, the `executing-plans` skill passes `phase_progress` alongside `plan_issue`, `spec_issue`, `GIT_OWNER`, `GIT_REPO`, and `WORKTREE_PATH`. The `assemble-batch` task then maintains and extends phase progress as each sub-agent completes, feeding it forward into subsequent dispatch contexts.
+
+The phase progress information comes from two sources:
+- The Plan STATUS marker (which phases are marked complete with ☑)
+- Concern boundary annotations in the plan body (prose descriptions of architectural concern transitions)
+
+Phase progress is prose-driven — the orchestrating agent describes progress in natural prose. The requirement is that the information travels, not that it follows a rigid schema.
 
 The `assemble-batch` task handles:
 

--- a/.opencode/skills/github-sub-issues/SKILL.md
+++ b/.opencode/skills/github-sub-issues/SKILL.md
@@ -33,13 +33,34 @@ The hierarchy is: **Spec → (linked reference) → Plan → Sub-issues**. Sub-i
 
 Single-task plans do NOT require sub-issues. A plan is "single-task" if it has exactly ONE implementation task/phase with no decomposition needed. If single-task: proceed without sub-issue verification. If multi-task: sub-issues are MANDATORY.
 
-## Sub-Issue Verification Gate (MANDATORY Before Implementation)
+## Sub-Issue Verification Gate (SUPERSEDED — Use `approval-gate --task verify-authorization`)
+
+**⚠️ This verification gate is SUPERSEDED.** Sub-issue verification is now consolidated into `approval-gate --task verify-authorization` (Step 5) as the single authoritative readiness check. The content below is retained for reference only.
+
+**Authoritative check:** `approval-gate --task verify-authorization` Step 5 handles:
+- Verifying sub-issues exist under the Plan
+- Verifying sub-issue structure matches Plan phases
+- Verifying sub-issue bodies contain phase context (leveraging Phase 1 enrichment)
+- Adversarial verification of sub-issue state (open/closed, labels, parent linkage)
+- Auto-creating sub-issues under the plan when missing
+
+**This skill (`github-sub-issues`) remains the authoritative source for:**
+- Sub-issue creation (`create-sub-issue` task)
+- Sub-issue linking (`link-sub-issue` task)
+- Hierarchy tracking (`track-hierarchy` task)
+
+---
+
+<details>
+<summary>Historical verification gate content (reference only — do NOT invoke this gate directly)</summary>
 
 1. Call `github_issue_read method=get_sub_issues` on the **plan** issue (not the spec)
 2. **If empty AND multi-task:** AUTO-CREATE sub-issues under the plan immediately, then proceed — no separate authorization needed
 3. **If sub-issues exist:** Verify phase being implemented is among them, proceed
 
 **Authorization for the parent plan covers sub-issue creation.** When `get_sub_issues` returns empty for an approved multi-task plan, auto-create and proceed.
+
+</details>
 
 ## Phase-Level vs Step-Level
 
@@ -117,6 +138,7 @@ Before invoking any cross-referenced skill:
 
 ## Cross-References
 
-- Related skills: `git-workflow` (before starting implementation), `approval-gate` (pre-implementation check), `writing-plans` (auto-dispatch chain: writing-plans → github-sub-issues)
+- Related skills: `approval-gate` (sub-issue verification gate — the single authoritative readiness check), `git-workflow` (before starting implementation), `writing-plans` (auto-dispatch chain: writing-plans → github-sub-issues)
+- Superseded gate: `github-sub-issues` verification gate is superseded by `approval-gate --task verify-authorization` Step 5
 - Related guidelines: `010-approval-gate.md`, `000-critical-rules.md`
 - Issue format: See `143-planning-spec-templates.md` for spec structure and `144-planning-spec-examples.md` for examples

--- a/.opencode/skills/github-sub-issues/SKILL.md
+++ b/.opencode/skills/github-sub-issues/SKILL.md
@@ -96,7 +96,21 @@ Use the `.id` field from response (e.g., `4129879155`), NOT the issue number (e.
 
 ## STATUS Gate Verification
 
-Before implementing ANY subtask: get parent STATUS, extract authorized subtask, verify match, report decision to user. STATUS format: `STATUS: X.Y` where X = phase, Y = subtask within phase.
+Before implementing ANY subtask: get parent STATUS, extract authorized subtask, verify match, report decision to user.
+
+**STATUS format recognition (prose-driven, backward-compatible):**
+
+| Format | Example | Meaning |
+|--------|---------|---------|
+| `in progress — {concern}, Step {N}` | `in progress — Authorization Gate, Step 1` | Working on a specific step (prose-driven, recommended) |
+| `completed — {concern}` | `completed — Authorization Gate` | Phase/concern done (prose-driven, recommended) |
+| `{concern} — {task description}` | `Authorization Gate — verify label state` | Active task within concern (prose-driven, recommended) |
+| `X.Y` | `1.2` | Phase 1, step 2 (numeric, backward-compatible) |
+| `completed` | `completed` | All work done (both formats) |
+| `X.Y (REVISED - NEEDS APPROVAL)` | `1.2 (REVISED - NEEDS APPROVAL)` | Spec was modified (numeric, backward-compatible) |
+| `{concern} (REVISED - NEEDS APPROVAL)` | `Authorization Gate (REVISED - NEEDS APPROVAL)` | Spec was modified (prose-driven) |
+
+When matching STATUS to sub-issues, match the concern name in the STATUS to the sub-issue title/description. Numeric `X.Y` format is still recognized for backward compatibility but prose-driven formats are recommended for new specs and plans.
 
 ## Prohibited Halts
 

--- a/.opencode/skills/github-sub-issues/tasks/create-sub-issue.md
+++ b/.opencode/skills/github-sub-issues/tasks/create-sub-issue.md
@@ -35,7 +35,19 @@ sub_issues = github_issue_read(method="get_sub_issues", issue_number=M)
 # If sub-issues exist for this phase, skip
 ```
 
-### Step 3: Create Sub-Issue
+### Step 3: Extract Phase Prose from Plan Body
+
+Read the full plan issue body and locate the section for the target phase. Extract all prose that a sub-agent needs to implement this phase independently — without re-reading the plan. This includes:
+
+- **Why this phase exists**: The concern it addresses and its place in the overall design
+- **What it must accomplish**: Tasks, deliverables, and behavioral requirements
+- **How to verify completion**: Success criteria and testable outcomes
+- **What could go wrong**: Edge cases, known risks, and failure modes
+- **What must be done first**: Dependencies on prior phases or external prerequisites
+
+The agent decides how to structure this content within the sub-issue body. There is no prescribed section format, no fill-in-the-blanks template, and no required headers. The prose from the plan body should flow naturally, preserving the author's intent and context.
+
+### Step 4: Create Sub-Issue
 
 ```python
 sub_issue = github_issue_write(
@@ -43,12 +55,14 @@ sub_issue = github_issue_write(
     owner=GIT_OWNER,
     repo=GIT_REPO,
     title=f"[Task: #{M}] {phase_description}",
-    body=f"**Parent Plan:** #{M}\n\n{phase_content}",
+    body=f"**Parent Plan:** #{M}\n\n{phase_prose}",
     labels=["task"]
 )
 ```
 
 **Title format:** `[Task: #PLAN] Phase Description`
+
+**Body requirement:** The sub-issue body MUST contain enough phase context for a sub-agent to implement the phase independently. A body that contains only `**Parent Plan:** #M` is insufficient — the phase prose extracted in Step 3 must be included.
 
 ### Step 4: Link to Plan
 

--- a/.opencode/skills/github-sub-issues/tasks/track-hierarchy.md
+++ b/.opencode/skills/github-sub-issues/tasks/track-hierarchy.md
@@ -39,7 +39,17 @@ PLAN #M: [PLAN] Feature Name
 └── Task #P3: [Task: #M] Phase 3 - Description
 ```
 
-### Step 4: Identify Gaps
+### Step 4: Verify Sub-Issue Context Sufficiency
+
+**For each sub-issue:**
+- Read the sub-issue body and verify it contains sufficient phase context for a sub-agent to operate independently
+- A sub-issue body that contains only `**Parent Plan:** #M` fails this check — it lacks the phase prose needed for autonomous implementation
+- Verify that the body communicates: why this phase exists, what it must accomplish, how to verify completion, what could go wrong, and what must be done first
+- This check is prose-agnostic — it verifies information presence, not format or section structure
+
+If a sub-issue fails the context check, flag it for re-creation via `create-sub-issue` with phase prose extraction.
+
+### Step 5: Identify Gaps
 
 **For each phase in plan:**
 - Check if corresponding sub-issue exists
@@ -49,13 +59,14 @@ PLAN #M: [PLAN] Feature Name
 - Check if it matches a phase
 - If orphan (no matching phase): flag for review
 
-### Step 5: Report in Chat
+### Step 6: Report in Chat
 
 ## Common Issues
 
 | Issue | Resolution |
 |-------|------------|
 | Sub-issues missing for phases | Auto-create via `create-sub-issue` |
+| Sub-issues lack phase context | Re-create via `create-sub-issue` with prose extraction |
 | Orphan sub-issues found | Flag for manual review |
 | Hierarchy mismatch | Rebuild hierarchy tree |
 

--- a/.opencode/skills/plan-fidelity-auditor/SKILL.md
+++ b/.opencode/skills/plan-fidelity-auditor/SKILL.md
@@ -25,6 +25,7 @@ Plan Fidelity Auditor generates a clean-room plan from the spec's problem statem
 | `audit` | Full audit workflow (default) | ~600 |
 | `compare` | Compare clean-room plan against existing plan | ~500 |
 | `report` | Report findings (renamed from auto-fix) | ~300 |
+| `sub-issue-fidelity` | Verify sub-issue alignment with Plan phases | ~350 |
 
 ## Invocation
 
@@ -129,6 +130,7 @@ Only substantive differences after semantic matching are reported.
 | Task table entry `audit` | File exists at `.opencode/skills/plan-fidelity-auditor/tasks/audit.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `compare` | File exists at `.opencode/skills/plan-fidelity-auditor/tasks/compare.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `report` | File exists at `.opencode/skills/plan-fidelity-auditor/tasks/report.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `sub-issue-fidelity` | File exists at `.opencode/skills/plan-fidelity-auditor/tasks/sub-issue-fidelity.md` | MISSING-TRACEABILITY if missing |
 | `spec-auditor` orchestration behavior | Matches actual SKILL.md: `fidelity` subtask delegates to this skill | CONFLICTING if mismatched |
 | `writing-plans` clean-room invocation | Matches actual SKILL.md: `clean-room` task exists for generating plans | CONFLICTING if mismatched |
 | `brainstorming` recommendation behavior | Matches actual SKILL.md: exploration skill for deeper analysis | CONFLICTING if mismatched |

--- a/.opencode/skills/plan-fidelity-auditor/tasks/sub-issue-fidelity.md
+++ b/.opencode/skills/plan-fidelity-auditor/tasks/sub-issue-fidelity.md
@@ -1,0 +1,97 @@
+# Task: sub-issue-fidelity
+
+## Purpose
+
+Verify that sub-issues under a Plan align with the Plan's phases. For each Plan phase, confirm a corresponding sub-issue exists. For each sub-issue, confirm its body content matches the Plan phase prose. Reports discrepancies as findings — does NOT auto-fix.
+
+**Trigger:** When a Plan has sub-issues and plan-fidelity audit needs to verify alignment between Plan phases and sub-issue content.
+
+## Procedure
+
+### Step 1: Read the Plan Issue
+
+Read the Plan issue via GitHub MCP (`github_issue_read method=get`). Extract:
+- Issue number
+- Issue title
+- Issue body (the Plan prose with phases)
+
+### Step 2: Read Sub-Issues
+
+Read all sub-issues under the Plan via GitHub MCP (`github_issue_read method=get_sub_issues`). For each sub-issue:
+- Read the full body (`github_issue_read method=get`)
+- Record: issue number, title, body content
+
+### Step 3: Parse Plan Phases
+
+Parse the Plan body into a structured list of phases:
+- Extract phase names and their prose content
+- Identify each phase's key tasks, deliverables, and success criteria as stated in the Plan
+
+### Step 4: Verify Phase-to-Sub-Issue Mapping
+
+For each Plan phase:
+1. Search sub-issues for a semantic match (title or body references the phase)
+2. If no matching sub-issue exists → report `MISSING_SUB_ISSUE`
+3. If the sub-issue title/phase name doesn't semantically match → report `MISMATCHED_PHASE_NAME`
+
+### Step 5: Verify Sub-Issue Body Content
+
+For each sub-issue that maps to a Plan phase:
+1. Compare the sub-issue body against the Plan phase prose
+2. Check that key tasks from the Plan phase appear in the sub-issue body
+3. Check that success criteria or deliverables from the Plan phase appear in the sub-issue body
+4. If the sub-issue body is missing substantial Plan prose → report `INCOMPLETE_SUB_ISSUE_BODY`
+5. If a task in the sub-issue is not traceable to the Plan phase → report `TASK_NOT_IN_SUB_ISSUE`
+
+### Step 6: Report Findings
+
+Report all findings using the v3 auto-fix format.
+
+## Finding Types
+
+| Finding Type | Severity | Description |
+|-------------|----------|-------------|
+| MISSING_SUB_ISSUE | HIGH | Plan phase has no corresponding sub-issue |
+| MISMATCHED_PHASE_NAME | MEDIUM | Sub-issue name doesn't semantically match Plan phase name |
+| INCOMPLETE_SUB_ISSUE_BODY | MEDIUM | Sub-issue body is missing substantial Plan phase content |
+| TASK_NOT_IN_SUB_ISSUE | LOW | A Plan phase task is not represented in the sub-issue |
+
+## Semantic Matching
+
+Before reporting `MISSING_SUB_ISSUE`, attempt semantic matching:
+- Phase "Database Schema Migration" ↔ Sub-issue "Schema Updates" → match (same concept)
+- Phase "API Endpoints" ↔ Sub-issue "REST API Implementation" → match (same concept)
+- Phase "Authentication" ↔ Sub-issue "OAuth2 Setup" → match if OAuth2 is the auth method
+
+Only report `MISSING_SUB_ISSUE` when no semantic match exists after thorough comparison.
+
+## Report Format
+
+```
+Subtask: sub-issue-fidelity
+Finding: [MISSING_SUB_ISSUE|MISMATCHED_PHASE_NAME|INCOMPLETE_SUB_ISSUE_BODY|TASK_NOT_IN_SUB_ISSUE] - [summary]
+Location: [Plan phase name / sub-issue number]
+Context: [why this matters for plan-sub-issue alignment]
+Classification: [auto-fix|conditional|flag-for-review]
+Fix Action: [what was done OR "flagged for review — [reason]"]
+Severity: [HIGH|MEDIUM|LOW]
+```
+
+## Auto-Fix Classification
+
+| Finding Type | Classification | Fix Action |
+|-------------|----------------|-----------|
+| MISSING_SUB_ISSUE | flag-for-review | Creating sub-issues requires authorization per approval-gate |
+| MISMATCHED_PHASE_NAME | flag-for-review | Renaming requires author judgment about scope |
+| INCOMPLETE_SUB_ISSUE_BODY | auto-fix | Sub-issue body should reflect Plan phase prose per the spec |
+| TASK_NOT_IN_SUB_ISSUE | auto-fix | Adding traceable tasks aligns sub-issues with Plan phases |
+
+## Scope Boundaries
+
+- Read-only analysis of Plan issue and sub-issues via GitHub MCP
+- Auto-fix applies to INCOMPLETE_SUB_ISSUE_BODY and TASK_NOT_IN_SUB_ISSUE findings only (updating sub-issue bodies with Plan phase prose)
+- Does NOT create or delete sub-issues (MISSING_SUB_ISSUE is flag-for-review)
+- Does NOT rename sub-issues (MISMATCHED_PHASE_NAME is flag-for-review)
+- Must use GitHub MCP tools for all issue operations
+
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -38,6 +38,8 @@ You are a Content-Aware Audit Orchestrator. Your focus is determining document t
 | `error-recovery` | Runbook error recovery and rollback checks | ~350 |
 | `principles` | Engineering principle violations from programming-principles skill | ~350 |
 | `ground-truth` | Adversarial verification of metadata claims against direct evidence | ~500 |
+| `sub-issue-fidelity` | Verify sub-issue alignment with Plan phases (delegated from plan-fidelity-auditor) | ~350 |
+| `concern-coverage` | Verify sub-issue concern boundaries match Plan phases (delegated from concern-separation-auditor) | ~350 |
 
 ## Invocation
 
@@ -50,6 +52,8 @@ You are a Content-Aware Audit Orchestrator. Your focus is determining document t
 - `/skill spec-auditor --issue N --task concerns` — Phase structure checks only
 - `/skill spec-auditor --issue N --task principles` — Engineering principle checks only
 - `/skill spec-auditor --issue N --task ground-truth` — Metadata verification checks only
+- `/skill spec-auditor --issue N --task sub-issue-fidelity` — Sub-issue alignment with Plan phases only
+- `/skill spec-auditor --issue N --task concern-coverage` — Sub-issue concern boundary checks only
 - `/skill spec-auditor --file path --type plan` — Audit with manual type override
 - `/skill spec-auditor --url URL --type runbook` — Audit with manual type override
 - `/skill spec-auditor` — Overview only
@@ -101,8 +105,8 @@ One of `--issue`, `--file`, or `--url` is mandatory (except for overview mode). 
 
     | Document Type | Baseline Subtasks | Conditional Subtasks |
     |---------------|-------------------|---------------------|
-    | Spec | `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles` | `content-quality`, `traceability`, `operational`, `concerns` |
-    | Plan | `fresh-start`, `structure`, `ground-truth`, `principles` | `content-quality`, `concerns` |
+     | Spec | `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles` | `content-quality`, `traceability`, `operational`, `concerns`, `sub-issue-fidelity`, `concern-coverage` |
+     | Plan | `fresh-start`, `structure`, `ground-truth`, `principles` | `content-quality`, `concerns`, `sub-issue-fidelity`, `concern-coverage` |
     | Process Flow | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | `operational-flow`, `determinism` |
     | Runbook/SOP | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | `operational-flow`, `determinism`, `error-recovery` |
     | Checklist | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | — |
@@ -110,14 +114,16 @@ One of `--issue`, `--file`, or `--url` is mandatory (except for overview mode). 
 
    **Conditional subtask selection guidance (Spec-type only):**
 
-   | Issue Type | Typically Relevant Subtasks |
-   |------------|---------------------------|
-   | Simple bug fix | Baseline only |
-   | Feature with phases | Baseline + `concerns` |
-   | Infrastructure change | Baseline + `operational` + `concerns` |
-   | Complex multi-phase spec | All subtasks |
-   | Spec with external dependencies | Baseline + `traceability` + `operational` |
-   | Single-task spec (no phases) | Baseline (skip `concerns`) |
+    | Issue Type | Typically Relevant Subtasks |
+    |------------|---------------------------|
+    | Simple bug fix | Baseline only |
+    | Feature with phases | Baseline + `concerns` |
+    | Infrastructure change | Baseline + `operational` + `concerns` |
+    | Complex multi-phase spec | All subtasks |
+    | Spec with external dependencies | Baseline + `traceability` + `operational` |
+    | Single-task spec (no phases) | Baseline (skip `concerns`) |
+    | Spec with sub-issues | Baseline + `sub-issue-fidelity` + `concern-coverage` |
+    | Plan with sub-issues | Baseline + `sub-issue-fidelity` + `concern-coverage` |
 
 4. **All findings are classified and acted on per the auto-fix model.** Safe findings are fixed directly; ambiguous findings are flagged for developer review.
 
@@ -169,6 +175,8 @@ This is a v3 core principle. Previous versions (v2) were report-only — finding
 | PLAN-BLEED | Replace code/DDL with requirements table; note moved content for plan | Spec boundary is always correct; HOW belongs in the plan, not the spec |
 | GROUND-TRUTH-MISMATCH (STATUS) | Update STATUS marker to reflect actual content maturity | STATUS is metadata, not content; correcting it removes false tracking |
 | GROUND-TRUTH-MISMATCH (auth superseded) | Add re-approval note to document body | Revision revokes approval is a mandatory rule; noting it is mechanical |
+| INCOMPLETE_SUB_ISSUE_BODY | Update sub-issue body with Plan phase prose | Sub-issue should reflect Plan phase prose per the spec; alignment is always correct |
+| TASK_NOT_IN_SUB_ISSUE | Add traceable task from Plan phase to sub-issue | Traceability is always correct; adding tasks aligns sub-issues with phases |
 
 **Conditional findings:**
 
@@ -201,6 +209,11 @@ This is a v3 core principle. Previous versions (v2) were report-only — finding
 | GROUND-TRUTH-MISMATCH (cross-ref mismatch) | Referenced issue exists but content differs from claim; intent requires domain judgment |
 | GROUND-TRUTH-MISMATCH (code ref missing) | Referenced file/function may be planned but not implemented; requires developer to confirm |
 | GROUND-TRUTH-MISMATCH (STATUS inflated) | STATUS says COMPLETE but content is immature; may be intentional tracking |
+| MISSING_SUB_ISSUE | Creating sub-issues requires authorization per approval-gate |
+| MISMATCHED_PHASE_NAME | Renaming requires author judgment about scope |
+| CONCERN_SCOPE_NARROWER | Narrower scope may be valid scoping decision |
+| CONCERN_SCOPE_WIDER | Wider scope may intentionally group coupled tasks |
+| CONCERN_BOUNDARY_CROSSED | Cross-boundary tasks may reflect legitimate dependencies |
 
 **Reporting format (v3 — includes Classification and Fix Action):**
 ```
@@ -236,7 +249,9 @@ spec-auditor (orchestrator)
 ├── determinism.md          — Deterministic behavior and state dependency checks (NEW)
 ├── error-recovery.md       — Runbook error recovery and rollback checks (NEW)
 ├── principles.md           — Engineering principle violations from programming-principles skill (NEW)
-└── ground-truth.md         — Adversarial verification of metadata claims against direct evidence (NEW)
+├── ground-truth.md         — Adversarial verification of metadata claims against direct evidence (NEW)
+├── sub-issue-fidelity.md   — Verify sub-issue alignment with Plan phases (delegated from plan-fidelity-auditor) (NEW)
+└── concern-coverage.md     — Verify sub-issue concern boundaries match Plan phases (delegated from concern-separation-auditor) (NEW)
 ```
 
 Each subtask is loaded via `--task` and produces findings in the report format above.
@@ -276,6 +291,13 @@ Existing classes remain, plus two new ones:
 | **PLAN-BLEED** | Spec prescribing HOW instead of WHAT; implementation details belong in the plan |
 | **PLAN-BLEED-AMBIGUOUS** | Content that could be either a requirement or implementation detail; requires domain judgment |
 | **GROUND-TRUTH-MISMATCH** | Metadata claim (STATUS, label, cross-ref, code ref, auth) contradicts actual state |
+| **MISSING_SUB_ISSUE** | Plan phase has no corresponding sub-issue (from sub-issue-fidelity) |
+| **MISMATCHED_PHASE_NAME** | Sub-issue name doesn't semantically match Plan phase name (from sub-issue-fidelity) |
+| **INCOMPLETE_SUB_ISSUE_BODY** | Sub-issue body missing substantial Plan phase content (from sub-issue-fidelity) |
+| **TASK_NOT_IN_SUB_ISSUE** | Plan phase task not represented in sub-issue (from sub-issue-fidelity) |
+| **CONCERN_SCOPE_NARROWER** | Sub-issue body omits tasks within Plan phase's concern boundary (from concern-coverage) |
+| **CONCERN_SCOPE_WIDER** | Sub-issue body includes tasks outside Plan phase's concern boundary (from concern-coverage) |
+| **CONCERN_BOUNDARY_CROSSED** | Sub-issue body mixes tasks from multiple Plan phase concerns (from concern-coverage) |
 
 ## Audit Findings Handling
 
@@ -395,6 +417,8 @@ This skill is a **heavy skill** — quality audits with all subtasks consume sig
 | Task table entry `error-recovery` | File exists at `.opencode/skills/spec-auditor/tasks/error-recovery.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `principles` | File exists at `.opencode/skills/spec-auditor/tasks/principles.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `ground-truth` | File exists at `.opencode/skills/spec-auditor/tasks/ground-truth.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `sub-issue-fidelity` | File exists at `.opencode/skills/spec-auditor/tasks/sub-issue-fidelity.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `concern-coverage` | File exists at `.opencode/skills/spec-auditor/tasks/concern-coverage.md` | MISSING-TRACEABILITY if missing |
 | Described behavior of `issue-review` | Matches actual SKILL.md: `audit` task delegates to spec-auditor | CONFLICTING if mismatched |
 | Described behavior of `writing-plans` | Matches actual SKILL.md: `clean-room` task generates plans | CONFLICTING if mismatched |
 | Described behavior of `programming-principles` | Matches actual SKILL.md: defines engineering principles | CONFLICTING if mismatched |
@@ -422,7 +446,7 @@ Before invoking any cross-referenced skill:
 - Related skills: `brainstorming` (exploration), `spec-creation` (creation-time discipline for traceability and operational requirements), `writing-plans` (clean-room generation for fidelity subtask), `issue-review` (delegates to spec-auditor via audit task), `programming-principles` (authoritative principle definitions for principles subtask — this subtask checks compliance, that skill defines the principles)
 - Related guidelines: `000-critical-rules.md` (auditor enforcement), `140-planning-spec-creation.md`
 - Label state machine: `141-planning-status-tracking.md §10` (add `needs-revision` when audit requires changes; replace with `needs-approval` on re-submission)
-- Delegated from: `plan-fidelity-auditor` (now `fidelity` subtask), `concern-separation-auditor` (now `concerns` subtask)
+- Delegated from: `plan-fidelity-auditor` (now `fidelity` and `sub-issue-fidelity` subtasks), `concern-separation-auditor` (now `concerns` and `concern-coverage` subtasks)
 
 ## Key Differences from v1
 

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -70,7 +70,9 @@ One of `--issue`, `--file`, or `--url` is mandatory (except for overview mode). 
 
    | Signal | Type Suggested | Weight |
    |--------|---------------|--------|
-   | `STATUS:` header with phase.step format | Spec | 3 |
+   | `STATUS:` header with prose-driven format (`in progress — {concern}`) | Spec | 3 |
+   | `STATUS:` header with phase.step format (`1.1`, `1.2`, `2.1`) | Spec | 3 |
+   | `STATUS:` header with `(REVISED - NEEDS APPROVAL)` suffix | Spec | 2 |
    | Phase/step numbering (`1.1`, `1.2`, `2.1`) | Spec | 2 |
    | Success criteria section | Spec | 2 |
    | `STATUS:` header without approval tracking | Plan | 2 |
@@ -173,7 +175,7 @@ This is a v3 core principle. Previous versions (v2) were report-only — finding
 | ERROR-RECOVERY-GAP | Add prerequisites, scope, escalation, and version stub sections | Standard boilerplate for runbooks; developer fills in |
 | SRP_VIOLATION (phase rename) | Rename phase/step to describe the single specific responsibility | Specific responsibility names are always better than generic ones |
 | PLAN-BLEED | Replace code/DDL with requirements table; note moved content for plan | Spec boundary is always correct; HOW belongs in the plan, not the spec |
-| GROUND-TRUTH-MISMATCH (STATUS) | Update STATUS marker to reflect actual content maturity | STATUS is metadata, not content; correcting it removes false tracking |
+| GROUND-TRUTH-MISMATCH (STATUS) | Update STATUS marker to reflect actual content maturity (prose or numeric format, matching the document's convention) | STATUS is metadata, not content; correcting it removes false tracking |
 | GROUND-TRUTH-MISMATCH (auth superseded) | Add re-approval note to document body | Revision revokes approval is a mandatory rule; noting it is mechanical |
 | INCOMPLETE_SUB_ISSUE_BODY | Update sub-issue body with Plan phase prose | Sub-issue should reflect Plan phase prose per the spec; alignment is always correct |
 | TASK_NOT_IN_SUB_ISSUE | Add traceable task from Plan phase to sub-issue | Traceability is always correct; adding tasks aligns sub-issues with phases |

--- a/.opencode/skills/spec-auditor/tasks/concern-coverage.md
+++ b/.opencode/skills/spec-auditor/tasks/concern-coverage.md
@@ -1,0 +1,105 @@
+# Task: concern-coverage
+
+## Purpose
+
+Verify that sub-issue bodies reflect the Plan's concern boundaries. For each sub-issue, check that its concern scope matches its corresponding Plan phase. Report mismatches between concern boundaries in sub-issues and Plan phases.
+
+**Delegated from:** concern-separation-auditor (`concern-coverage` task). Now a subtask within spec-auditor.
+
+## Procedure
+
+### Step 1: Read the Plan Issue
+
+Read the Plan issue via GitHub MCP (`github_issue_read method=get`). Parse the Plan body to identify phase boundaries and the concern scope of each phase.
+
+### Step 2: Read Sub-Issues
+
+Read all sub-issues under the Plan via GitHub MCP (`github_issue_read method=get_sub_issues`). For each sub-issue, read the full body via `github_issue_read method=get`.
+
+### Step 3: Determine Concern Boundaries per Plan Phase
+
+For each Plan phase, determine its concern boundary:
+- What is the primary concern (data layer, API layer, UI layer, etc.)?
+- What steps/tasks fall within the concern?
+- What steps/tasks fall outside the concern?
+
+Use the same concern analysis logic from `concerns` subtask:
+- Keyword hints (migration/schema → data layer, API/endpoint → business logic)
+- Deployment independence
+- Risk profile grouping
+- Blast radius considerations
+
+### Step 4: Map Sub-Issues to Plan Phases
+
+For each sub-issue, find the corresponding Plan phase via semantic matching:
+- Match by title similarity
+- Match by body content overlap
+- Record unmatched sub-issues or Plan phases without sub-issues
+
+### Step 5: Compare Concern Boundaries
+
+For each matched sub-issue ↔ Plan phase pair:
+1. Extract the concern scope expressed in the sub-issue body
+2. Compare against the Plan phase's concern boundary
+3. Identify mismatches:
+   - **Sub-issue concern is narrower**: Sub-issue omits tasks within the Plan phase's concern
+   - **Sub-issue concern is wider**: Sub-issue includes tasks from another concern
+   - **Sub-issue concern crosses boundaries**: Sub-issue mixes tasks from multiple Plan phases
+
+### Step 6: Report Findings
+
+Report all mismatches as findings using the v3 auto-fix format.
+
+## Finding Types
+
+| Finding Type | Severity | Description |
+|-------------|----------|-------------|
+| CONCERN_SCOPE_NARROWER | MEDIUM | Sub-issue body omits tasks within the Plan phase's concern boundary |
+| CONCERN_SCOPE_WIDER | MEDIUM | Sub-issue body includes tasks outside the Plan phase's concern boundary |
+| CONCERN_BOUNDARY_CROSSED | HIGH | Sub-issue body mixes tasks from multiple Plan phase concerns |
+
+## Semantic Matching Before Reporting
+
+Before reporting a concern boundary mismatch:
+1. Verify the Plan phase actually defines a single concern (not a mixed-concern phase itself)
+2. If the Plan phase itself has mixed concerns, the sub-issue may correctly include cross-boundary tasks
+3. Only report mismatches where the sub-issue concern scope deviates from a well-defined Plan phase concern
+
+## Report Format
+
+```
+Subtask: concern-coverage
+Finding: [CONCERN_SCOPE_NARROWER|CONCERN_SCOPE_WIDER|CONCERN_BOUNDARY_CROSSED] - [summary]
+Location: [Plan phase name / sub-issue number]
+Context: [why concern alignment matters for this Plan/sub-issue pair]
+Classification: flag-for-review
+Fix Action: flagged for review — [reason]
+Severity: [HIGH|MEDIUM|LOW]
+```
+
+## Why Flag-for-Review (Not Auto-Fix)
+
+All concern-coverage findings are flag-for-review because:
+- A wider sub-issue scope may intentionally group tightly coupled tasks
+- A narrower scope may be a valid scoping decision
+- Cross-boundary tasks may reflect legitimate inter-concern dependencies
+- The agent has full context about deployment and domain constraints
+
+## When to Run
+
+- When `concerns` subtask runs on a Plan that has sub-issues
+- When verifying that enriched sub-issue bodies maintain proper concern separation
+- As an extension of `concerns` subtask for Plans with sub-issues
+
+## When to Skip
+
+- Plans without sub-issues (fall back to `concerns` only)
+- Single-task Plans with no phases
+
+## Scope Boundaries
+
+- Read-only analysis of Plan issue and sub-issues via GitHub MCP
+- Does NOT modify sub-issue scope or content (flag-for-review only)
+- Must use GitHub MCP tools for all issue operations
+
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/spec-auditor/tasks/structure.md
+++ b/.opencode/skills/spec-auditor/tasks/structure.md
@@ -23,7 +23,8 @@ This subtask verifies content quality and completeness, not structural conformit
 | Concern-named phases | MISSING-ELEMENT | Do phase names describe specific concerns, not generic activities? ("Database Schema Setup", not "Implementation") | flag-for-review |
 
 **Advisory guidelines (not mandatory):**
-- STATUS with `phase.step` format (e.g., `STATUS: 1.2`) is recommended for multi-phase specs but not required
+- STATUS with prose-driven format (e.g., `STATUS: in progress — Authorization Gate, Step 1`) is recommended for multi-phase specs — it references concern names rather than numeric phase indices, making progress tracking self-explanatory and resilient to phase renumbering
+- STATUS with `phase.step` format (e.g., `STATUS: 1.2`) is backward-compatible but no longer recommended
 - CREATED date is recommended but not mandatory
 - Phase/step numbering is recommended for multi-phase specs, optional for simple specs
 - Status markers (`☐`/`↻`/`☑`/`☒`) are recommended but any clear progress indicator works

--- a/.opencode/skills/spec-auditor/tasks/sub-issue-fidelity.md
+++ b/.opencode/skills/spec-auditor/tasks/sub-issue-fidelity.md
@@ -1,0 +1,102 @@
+# Task: sub-issue-fidelity
+
+## Purpose
+
+Verify that sub-issues under a Plan align with the Plan's phases. For each Plan phase, confirm a corresponding sub-issue exists. For each sub-issue, confirm its body content matches the Plan phase prose.
+
+**Delegated from:** plan-fidelity-auditor (`sub-issue-fidelity` task). Now a subtask within spec-auditor.
+
+## Procedure
+
+### Step 1: Read the Plan Issue
+
+Read the Plan issue via GitHub MCP (`github_issue_read method=get`). Extract the Plan body with all phases.
+
+### Step 2: Read Sub-Issues
+
+Read all sub-issues under the Plan via GitHub MCP (`github_issue_read method=get_sub_issues`). For each sub-issue, read the full body via `github_issue_read method=get`.
+
+### Step 3: Parse Plan Phases
+
+Parse the Plan body into a structured list of phases with:
+- Phase names
+- Phase prose content (tasks, deliverables, success criteria)
+
+### Step 4: Verify Phase-to-Sub-Issue Mapping
+
+For each Plan phase:
+1. Search sub-issues for a semantic match (title or body references the phase)
+2. If no matching sub-issue exists → report `MISSING_SUB_ISSUE`
+3. If the sub-issue title/phase name doesn't semantically match → report `MISMATCHED_PHASE_NAME`
+
+### Step 5: Verify Sub-Issue Body Content
+
+For each mapped sub-issue:
+1. Compare the sub-issue body against the Plan phase prose
+2. Check that key tasks from the Plan phase appear in the sub-issue body
+3. Check that success criteria/deliverables from the Plan phase appear in the sub-issue body
+4. If sub-issue body is missing substantial Plan prose → report `INCOMPLETE_SUB_ISSUE_BODY`
+5. If a Plan phase task is not in the sub-issue → report `TASK_NOT_IN_SUB_ISSUE`
+
+### Step 6: Report Findings
+
+Report all findings using the v3 auto-fix format.
+
+## Finding Types
+
+| Finding Type | Severity | Description |
+|-------------|----------|-------------|
+| MISSING_SUB_ISSUE | HIGH | Plan phase has no corresponding sub-issue |
+| MISMATCHED_PHASE_NAME | MEDIUM | Sub-issue name doesn't semantically match Plan phase name |
+| INCOMPLETE_SUB_ISSUE_BODY | MEDIUM | Sub-issue body missing substantial Plan phase content |
+| TASK_NOT_IN_SUB_ISSUE | LOW | Plan phase task not represented in sub-issue |
+
+## Auto-Fix Classification
+
+| Finding Type | Classification | Fix Action |
+|-------------|----------------|-----------|
+| MISSING_SUB_ISSUE | flag-for-review | Creating sub-issues requires authorization per approval-gate |
+| MISMATCHED_PHASE_NAME | flag-for-review | Renaming requires author judgment |
+| INCOMPLETE_SUB_ISSUE_BODY | auto-fix | Update sub-issue body with Plan phase prose |
+| TASK_NOT_IN_SUB_ISSUE | auto-fix | Add traceable tasks to align with Plan phases |
+
+## Semantic Matching
+
+Before reporting `MISSING_SUB_ISSUE`, attempt semantic matching:
+- Phase "Database Schema Migration" ↔ Sub-issue "Schema Updates" → match
+- Phase "API Endpoints" ↔ Sub-issue "REST API Implementation" → match
+- Phase "Authentication" ↔ Sub-issue "OAuth2 Setup" → match if OAuth2 is auth method
+
+Only report `MISSING_SUB_ISSUE` when no semantic match exists.
+
+## Report Format
+
+```
+Subtask: sub-issue-fidelity
+Finding: [MISSING_SUB_ISSUE|MISMATCHED_PHASE_NAME|INCOMPLETE_SUB_ISSUE_BODY|TASK_NOT_IN_SUB_ISSUE] - [summary]
+Location: [Plan phase name / sub-issue number]
+Context: [why this matters for plan-sub-issue alignment]
+Classification: [auto-fix|conditional|flag-for-review]
+Fix Action: [what was done OR "flagged for review — [reason]"]
+Severity: [HIGH|MEDIUM|LOW]
+```
+
+## When to Run
+
+- When a Plan has sub-issues
+- When verifying that enriched sub-issue bodies align with Plan phases
+- As an extension of `fidelity` subtask for Plans with sub-issues
+
+## When to Skip
+
+- Plans without sub-issues (fall back to `fidelity` only)
+- Single-task Plans with no phases
+
+## Scope Boundaries
+
+- Read-only analysis of Plan issue and sub-issues via GitHub MCP
+- Auto-fix applies to INCOMPLETE_SUB_ISSUE_BODY and TASK_NOT_IN_SUB_ISSUE only
+- Does NOT create or delete sub-issues (MISSING_SUB_ISSUE is flag-for-review)
+- Does NOT rename sub-issues (MISMATCHED_PHASE_NAME is flag-for-review)
+
+Co-authored with AI: <AI-Name> (<model-id>)

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -42,10 +42,11 @@ Create an implementation plan from an approved spec.
 
 6. **Create plan issue:**
 
-     - Title: `[PLAN] <Feature Name>`
-     - Labels: `plan` + `needs-approval`
-     - Body: Spec reference as prose (e.g., `Spec: #784`), then plan with header, file structure, phases with TDD tasks
-     - Do NOT link plan as sub-issue of spec — the plan references the spec via body text only
+   - Title: `[PLAN] <Feature Name>`
+      - Labels: `plan` + `needs-approval`
+      - Body: Spec reference as prose (e.g., `Spec: #784`), then plan with header, file structure, phases with TDD tasks
+      - Initial STATUS: Use prose-driven format. Set `STATUS: in progress — {first concern}, Step 1` (or backward-compatible `STATUS: 1.1` if the spec uses numeric STATUS convention). The STATUS concern name should match the first phase's concern name.
+      - Do NOT link plan as sub-issue of spec — the plan references the spec via body text only
 
    **Phase body requirements (critical):** Each phase in the plan body MUST include the information a sub-agent needs to implement the phase independently, without re-reading the plan. This means each phase section must contain:
 

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -42,12 +42,22 @@ Create an implementation plan from an approved spec.
 
 6. **Create plan issue:**
 
-    - Title: `[PLAN] <Feature Name>`
-    - Labels: `plan` + `needs-approval`
-    - Body: Spec reference as prose (e.g., `Spec: #784`), then plan with header, file structure, phases with TDD tasks
-    - Do NOT link plan as sub-issue of spec — the plan references the spec via body text only
+     - Title: `[PLAN] <Feature Name>`
+     - Labels: `plan` + `needs-approval`
+     - Body: Spec reference as prose (e.g., `Spec: #784`), then plan with header, file structure, phases with TDD tasks
+     - Do NOT link plan as sub-issue of spec — the plan references the spec via body text only
 
-    After plan issue is created, create sub-issues under the plan (not the spec) for each phase via `github-sub-issues --task create-sub-issue`.
+     **Phase body requirements (critical):** Each phase in the plan body MUST include the information a sub-agent needs to implement the phase independently, without re-reading the plan. This means each phase section must contain:
+
+     - Why this phase exists — the concern it addresses and its place in the overall design
+     - What it must accomplish — tasks, deliverables, and behavioral requirements
+     - How to verify completion — success criteria and testable outcomes
+     - What could go wrong — edge cases, known risks, and failure modes
+     - What must be done first — dependencies on prior phases or external prerequisites
+
+     This is a prose-driven requirement: state what information must be present, not what section headers to use. The agent writing the plan decides how to organize this content naturally within the phase description.
+
+     After plan issue is created, create sub-issues under the plan (not the spec) for each phase via `github-sub-issues --task create-sub-issue`.
 
 7. **Self-review:**
 

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -47,17 +47,25 @@ Create an implementation plan from an approved spec.
      - Body: Spec reference as prose (e.g., `Spec: #784`), then plan with header, file structure, phases with TDD tasks
      - Do NOT link plan as sub-issue of spec — the plan references the spec via body text only
 
-     **Phase body requirements (critical):** Each phase in the plan body MUST include the information a sub-agent needs to implement the phase independently, without re-reading the plan. This means each phase section must contain:
+   **Phase body requirements (critical):** Each phase in the plan body MUST include the information a sub-agent needs to implement the phase independently, without re-reading the plan. This means each phase section must contain:
 
-     - Why this phase exists — the concern it addresses and its place in the overall design
-     - What it must accomplish — tasks, deliverables, and behavioral requirements
-     - How to verify completion — success criteria and testable outcomes
-     - What could go wrong — edge cases, known risks, and failure modes
-     - What must be done first — dependencies on prior phases or external prerequisites
+      - Why this phase exists — the concern it addresses and its place in the overall design
+      - What it must accomplish — tasks, deliverables, and behavioral requirements
+      - How to verify completion — success criteria and testable outcomes
+      - What could go wrong — edge cases, known risks, and failure modes
+      - What must be done first — dependencies on prior phases or external prerequisites
 
-     This is a prose-driven requirement: state what information must be present, not what section headers to use. The agent writing the plan decides how to organize this content naturally within the phase description.
+      This is a prose-driven requirement: state what information must be present, not what section headers to use. The agent writing the plan decides how to organize this content naturally within the phase description.
 
-     After plan issue is created, create sub-issues under the plan (not the spec) for each phase via `github-sub-issues --task create-sub-issue`.
+      **Concern boundary annotations (prose-driven):** When a phase transitions from one architectural concern to another — for example, from data modelling to enforcement logic, from orchestration to error handling, from schema definition to runtime behavior — the plan MUST annotate this transition. The annotation is prose, not a rigid marker. It should describe:
+
+      - What concern the phase is leaving (the prior concern's scope)
+      - What concern the phase is entering (the new concern's scope)
+      - What information the new concern needs from the prior concern (the handoff point)
+
+      These annotations enable `assemble-batch` to compose accurate `concern_boundaries_crossed` in the dispatch context, so sub-agents understand the architectural transitions they are participating in. Concern boundary annotations should be woven into the phase description naturally, not as separate structured fields.
+
+      After plan issue is created, create sub-issues under the plan (not the spec) for each phase via `github-sub-issues --task create-sub-issue`.
 
 7. **Self-review:**
 


### PR DESCRIPTION
## Summary

Implements spec #862 — fixes six structural friction points where the prose-driven, AI-intelligent workflow breaks down at phase/sub-issue boundaries.

## Outcome

- **Phase 1:** Sub-issues now contain sufficient phase prose (why, what, verify, edge cases, dependencies) instead of empty `**Parent Plan:** #M` shells
- **Phase 2:** New `sub-issue-fidelity` and `concern-coverage` tasks for plan-fidelity-auditor and concern-separation-auditor
- **Phase 3:** Dispatch context carries phase progress (completed phases, concern boundaries, verification evidence) across phase boundaries
- **Phase 4:** Single verification gate — `approval-gate --task verify-authorization` consolidates sub-issue verification; `github-sub-issues` verification gate superseded
- **Phase 5:** Prose-driven STATUS format (`in progress — {concern}`) with backward-compatible `X.Y` recognition
- **Phase 6:** Decision Log persists on Plan issue via GitHub comments, surviving session restarts

Fixes #862
Fixes #888
Fixes #889
Fixes #890
Fixes #891
Fixes #892
Fixes #893