### PR TITLE
feat(skill): SRE Runbook skill with Proxmox reference templates

### DIFF
--- a/.opencode/skills/sre-runbook/SKILL.md
+++ b/.opencode/skills/sre-runbook/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: sre-runbook
+description: Use when generating operational runbooks for infrastructure incidents or procedures. Triggers on: runbook, SRE, on-call, incident, outage, escalation, playbook, procedure, operation, diagnose, troubleshoot, debug
+type: discipline-enforcing
+license: MIT
+compatibility: opencode
+---
+
+# Skill: sre-runbook
+
+## Overview
+
+Discipline-enforcing skill that teaches **reasoning**, not template-filling. Every runbook step MUST explain **WHY** the step exists — the causal reasoning linking symptoms to diagnosis, diagnosis to mitigation, mitigation to verification, and resolution to postmortem. A runbook without reasoning is a checklist, not a runbook.
+
+**Source Attribution:** Adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
+
+## Persona
+
+You are an SRE-oriented operator. Your mindset follows the chain: **symptom → diagnosis → mitigation → verification → postmortem**. You never skip a step, never skip reasoning, and never present a command without explaining why it is the right command for this situation.
+
+## Tasks
+
+| Task | Purpose | Words |
+|------|---------|-------|
+| `generate` | Generate an operational runbook for a given domain and scenario | ~600 |
+| `track` | Track an incident or change via GitHub Issue with structured labels | ~450 |
+
+## Invocation
+
+- `/skill sre-runbook` — Overview only
+- `/skill sre-runbook --task generate` — Generate an operational runbook
+- `/skill sre-runbook --task track` — Track an incident or change via GitHub Issue
+
+## Operating Protocol
+
+1. **Domain context is MANDATORY.** If the user invokes `generate` without providing domain context (infrastructure type, service name, system boundaries), the agent MUST prompt the user before proceeding. A runbook without domain context is useless.
+
+2. **Verification gates between sections.** The agent MUST NOT proceed past a section without confirming the reasoning connects:
+   - Symptom → Diagnosis: confirmed symptom matches observed behavior
+   - Diagnosis → Mitigation: confirmed mitigation targets the diagnosed root cause
+   - Mitigation → Verification: confirmed verification criteria validate the mitigation worked
+   - Resolution → Postmortem: confirmed postmortem captures what happened, why, and how to prevent recurrence
+
+3. **HALT conditions.** The agent MUST halt if:
+   - Domain context is insufficient or missing (prompt user, do not guess)
+   - Diagnosis cannot be confirmed (escalation needed)
+   - Mitigation risk exceeds severity threshold (escalation needed)
+   - Verification fails (return to diagnosis, do not proceed to resolution)
+
+4. **Completion guarantee.** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (verification result comment, status report) are never skipped. It is idempotent and safe to invoke multiple times.
+
+5. **Mandatory invocation.** The agent MUST invoke this skill when:
+   - User requests a runbook, playbook, or operational procedure
+   - User asks "what to do when X breaks" or "how to diagnose X"
+   - User reports an incident, outage, or escalation
+   - DO NOT generate ad-hoc runbooks without this skill's discipline
+
+## Enforcement Rules — No Template-Fill Fallback
+
+**The #1 failure mode of LLM-generated runbooks is template-filling: listing commands and steps without explaining WHY each step matters. This skill prevents that.**
+
+### 🚫 PROHIBITED
+
+- Listing a command or step without explaining why it is the right choice for this specific situation
+- Copying generic troubleshooting patterns without adapting reasoning to the specific domain
+- Writing "Check logs" without specifying WHICH logs and WHY
+- Writing "Restart the service" without explaining what symptoms justify a restart vs deeper investigation
+
+### ✅ REQUIRED
+
+- Every step MUST include: **WHAT** (action) + **WHY** (reasoning — why this action for this symptom/diagnosis)
+- Every diagnosis MUST connect observed symptoms to a root cause via causal reasoning
+- Every mitigation MUST reference the diagnosed root cause it addresses
+- Every verification criterion MUST confirm the specific symptom is resolved, not just "check it works"
+
+### Self-Review Step (MANDATORY)
+
+After generating a runbook, the agent MUST review its own output for template-fill patterns. If any step lacks a WHY explanation, the agent MUST add reasoning before presenting the runbook.
+
+## Dual-Output Contract
+
+Every runbook MUST contain BOTH:
+
+1. **AI-parseable enforcement blocks** — `yaml+symbolic` sections with structured data:
+   - Symptom catalog (yaml list with severity, frequency, affected components)
+   - Diagnosis map (yaml list with root cause, confidence, evidence chain)
+   - Mitigation plan (yaml list with step, risk level, rollback)
+   - Verification criteria (yaml list with criterion, expected result, pass/fail)
+   - These blocks are machine-readable and enforceable by automated tooling
+
+2. **Human-readable narrative prose** — prose sections between enforcement blocks:
+   - Context and background (why this runbook exists)
+   - Decision trees and reasoning chains
+   - Escalation guidance and escalation paths
+   - Postmortem template with timeline and action items
+
+The AI-parseable blocks provide structure for automation; the narrative prose provides context for humans. Neither alone is sufficient.
+
+## Worktree Mode
+
+When invoked from a worktree context (`WORKTREE_PATH` is set):
+
+- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
+- ALL `read`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
+- ALL `write`/`edit` tool calls MUST prefix `filePath` with `WORKTREE_PATH/`
+- Runbook output files MUST resolve within the worktree, not the main repo
+
+**Verification guard:** Before running any command, verify:
+```bash
+git -C $WORKTREE_PATH rev-parse --show-toplevel
+```
+If the result does NOT match `WORKTREE_PATH`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
+
+If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+
+## Cross-References
+
+- Related skills: `systematic-debugging` (root cause analysis discipline), `verification-before-completion` (evidence gates), `github-issue-creation` (issue creation discipline)
+- Related guidelines: `010-approval-gate.md` (authorization), `000-critical-rules.md` (no implementation without spec)
+
+## Platform Compatibility
+
+- **GitHub:** Use GitHub MCP tools for issue tracking
+- **GitBucket:** Use Python client from gitbucket-api skill
+- **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+
+## Source Attribution
+
+This skill is adapted from the <UPSTREAM_ORG>/<UPSTREAM_REPO> repository (branch: newsrx). The original workflow enforces reasoning-first runbook generation to prevent template-filling anti-patterns.
+
+Key adaptations for <AI-Name>:
+- Integration with existing systematic-debugging and verification-before-completion skills
+- GitBucket platform support via MCP tools
+- Dual-output contract (AI-parseable + human-readable)
+- Completion guarantee integration
+
+## Completion Guarantee
+
+**⚠️ If this workflow halts at ANY point** — including error, failure, or early termination — invoke `--task completion` before halting. This ensures:
+- Verification results are documented
+- Status report is produced
+- No orphaned state is left behind
+
+The completion task is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/sre-runbook/reference/proxmox-cluster-quorum-loss.md
+++ b/.opencode/skills/sre-runbook/reference/proxmox-cluster-quorum-loss.md
@@ -1,0 +1,579 @@
+---
+name: proxmox-cluster-quorum-loss
+description: Reference template for Proxmox cluster quorum loss runbook. Demonstrates prose-driven pattern with reasoning at every step. NOT a canonical project runbook.
+type: reference
+license: MIT
+compatibility: opencode
+---
+
+# REFERENCE TEMPLATE — NOT A CANONICAL PROJECT RUNBOOK
+
+> This file is a **reference template** demonstrating the prose-driven runbook pattern defined by the `sre-runbook` skill. It shows both prompt patterns (what a user would invoke) and output patterns (what the agent would generate). Adapt this template to your infrastructure — do not use it as-is without validating against your environment.
+
+## Prompt Pattern (Invocation)
+
+```
+/skill sre-runbook --task generate
+domain: Proxmox VE cluster
+scenario_type: incident
+severity: P1
+```
+
+Expected agent behavior: Generate a full runbook following the five-step protocol (symptoms → diagnosis → mitigation → verification → postmortem), with reasoning at every step.
+
+---
+
+## Symptom Catalog
+
+Why this matters: Quorum loss is the most dangerous Proxmox failure mode because it doesn't just break one node — it freezes the entire cluster's ability to make consensus decisions. Virtual machines may continue running, but no management operations (start, stop, migrate, snapshot) can occur. The cluster effectively becomes read-only at the management layer while VMs run in an isolated state.
+
+The symptoms below are ordered by diagnostic priority — the symptoms that most strongly indicate quorum loss appear first.
+
+```yaml+symbolic
+schema_version: "1.0"
+symptoms:
+  - description: "Cluster commands return 'cluster not ready - quorum?' or 'waiting for quorum'"
+    severity: P1
+    affected_components:
+      - "pve-cluster"
+      - "corosync"
+    frequency: always
+    observed_at: "Any pvecm or qm command during quorum loss"
+    diagnostic_priority: 1
+    reasoning: "This is the definitive symptom. The 'quorum?' message is Proxmox's explicit way of telling you the cluster consensus layer is broken. No other failure mode produces this specific message."
+
+  - description: "pvecm status shows 'Node does not have quorum' or vote count below majority"
+    severity: P1
+    affected_components:
+      - "corosync"
+    frequency: always
+    observed_at: "pvecm status command output"
+    diagnostic_priority: 1
+    reasoning: "Direct confirmation from the cluster manager. The vote count being below the majority threshold (e.g., 1 of 3 votes) is the objective measure of quorum loss. This symptom confirms what the error messages suggest."
+
+  - description: "Web UI shows 'Connection error' or 'cluster filesystem not available'"
+    severity: P1
+    affected_components:
+      - "pveproxy"
+      - "pmxcfs"
+    frequency: always
+    observed_at: "Browser access to Proxmox web interface"
+    diagnostic_priority: 2
+    reasoning: "The web UI depends on the cluster filesystem (pmxcfs), which requires quorum to operate. When quorum is lost, pmxcfs becomes read-only, so the UI can display cached state but cannot execute changes. This is why the UI shows 'not available' rather than a complete failure."
+
+  - description: "VMs continue running but cannot be managed (start/stop/migrate)"
+    severity: P2
+    affected_components:
+      - "qemu-server"
+      - "pve-ha-manager"
+    frequency: always
+    observed_at: "Attempted management operations"
+    diagnostic_priority: 2
+    reasoning: "This is the paradox of quorum loss that confuses new operators: VMs are still running because QEMU/KVM is a local process on each node, but you can't control them because management requires cluster consensus. The VMs are running in a 'frozen management' state, not a failed state."
+
+  - description: "Corosync logs show 'quorum lost' or membership changes"
+    severity: P1
+    affected_components:
+      - "corosync"
+    frequency: always
+    observed_at: "journalctl -u corosync or /var/log/corosync.log"
+    diagnostic_priority: 3
+    reasoning: "Corosync is the consensus layer. Its logs are the ground truth for quorum events. Checking these logs tells you WHEN quorum was lost and which nodes participated in the membership change, which is critical for root cause analysis."
+```
+
+### Quick-Reference: Symptom → Action Matrix
+
+| Symptom | First Action | Why |
+|---------|-------------|-----|
+| "quorum?" error messages | `pvecm status` | Confirm quorum state before taking any other action |
+| `pvecm` shows no quorum | Check which nodes are online | You need to know how many votes are available before deciding recovery path |
+| Web UI "not available" | SSH to any remaining node | UI depends on quorum; SSH works locally without cluster consensus |
+| VMs can't be managed | Verify VMs are still running locally | Don't assume VMs are down — check `qm list` on each node first |
+
+### Detailed Procedural: Understanding Why Each Symptom Occurs
+
+Proxmox uses a quorum-based consensus system built on Corosync. Every cluster state change — starting a VM, migrating storage, updating the cluster filesystem — requires a majority vote from configured nodes. When fewer than half the nodes are online, no majority exists, and the cluster enters a "frozen" state where:
+
+1. **The cluster filesystem (pmxcfs) becomes read-only.** This is why the web UI shows errors — it can read cached configuration but cannot write any changes.
+
+2. **HA manager stops fencing decisions.** Without quorum, the HA manager cannot safely determine which node should own a VM, so it suspends all fencing. This is actually protective — fencing without quorum could cause split-brain shutdowns.
+
+3. **VMs continue running locally.** QEMU processes are independent of the cluster layer. A VM started on node A keeps running on node A regardless of cluster state. This is by design — a quorum failure should not automatically kill running workloads.
+
+Understanding this architecture is critical because it determines your recovery strategy: you must restore quorum first, then address any VM state inconsistencies that occurred during the quorum loss period.
+
+---
+
+## Diagnosis Map
+
+Why this matters: Quorum loss has three distinct root causes, each requiring a different recovery path. Misdiagnosis leads to wrong recovery actions — for example, trying to force quorum on a network-partitioned cluster makes the partition permanent.
+
+```yaml+symbolic
+schema_version: "1.0"
+diagnosis:
+  - root_cause: "Node failure — one or more cluster nodes are offline"
+    confidence: high
+    severity: P1
+    evidence_chain:
+      - symptom: "pvecm status shows fewer votes than expected"
+        evidence: "pvecm status shows 1 of 3 votes; offline nodes show 'Node X: offline'"
+        reasoning: "Node failure is the most common cause. When a node's corosync process stops, its vote is removed from the quorum calculation. If this drops the total below majority, quorum is lost. You confirm this by checking which nodes the cluster marks as offline."
+      - symptom: "Cluster commands return quorum errors"
+        evidence: "Commands fail immediately with 'cluster not ready'"
+        reasoning: "If only one node's vote remains, the cluster cannot reach majority. Commands fail because the local node cannot commit any state change without cluster agreement."
+    affected_components:
+      - "pve-cluster"
+      - "corosync"
+    escalation_threshold: "30 minutes without quorum recovery"
+    decision_tree:
+      - condition: "Majority of nodes confirmed offline (e.g., 2 of 3)"
+        action: "Proceed to forced quorum recovery (Task 2.1 in mitigation)"
+        reasoning: "When a genuine majority of nodes is offline, forced quorum on the surviving node is the correct recovery path because the alternative (waiting for nodes to return) may leave the cluster unusable for an extended period."
+      - condition: "Nodes are online but cannot reach each other"
+        action: "Diagnose network issue first — do NOT force quorum"
+        reasoning: "Forcing quorum during a network partition creates two independent clusters. This is called split-brain and is far worse than quorum loss because both sides believe they own the cluster state."
+
+  - root_cause: "Network partition — nodes are online but cannot communicate"
+    confidence: medium
+    severity: P1
+    evidence_chain:
+      - symptom: "pvecm status shows nodes as 'online' but ping between nodes fails"
+        evidence: "Node A shows Node B as online, but `ping <node-b-ip>` times out"
+        reasoning: "A network partition means corosync heartbeats have stopped but the nodes themselves haven't crashed. The nodes are running but isolated. You differentiate this from node failure by checking whether the nodes respond to ICMP or SSH — if they do, it's a partition, not a failure."
+      - symptom: "Corosync logs show repeated membership changes"
+        evidence: "journalctl shows ' Membership change' entries with node join/leave cycles"
+        reasoning: "Unstable membership (nodes repeatedly joining and leaving) is a hallmark of network partitions. The corosync ring becomes intermittent, causing the quorum calculation to fluctuate. This is different from a clean node failure which produces a single membership change."
+    affected_components:
+      - "corosync"
+      - "network infrastructure"
+    escalation_threshold: "15 minutes — network partitions degrade quickly"
+    decision_tree:
+      - condition: "Ping between all nodes fails"
+        action: "Diagnose network layer (switch, VLAN, firewall)"
+        reasoning: "If no inter-node connectivity exists, the network infrastructure is the blocker. Fixing the network resolves the quorum issue organically without risk of split-brain."
+      - condition: "Partial connectivity — some nodes can reach each other"
+        action: "Isolate the partition boundary and fix connectivity before any cluster actions"
+        reasoning: "Partial connectivity is the most dangerous state because it can cause inconsistent cluster state. Never force quorum in a partially connected environment."
+
+  - root_cause: "Corosync configuration error — nodes exist but cannot form consensus"
+    confidence: low
+    severity: P2
+    evidence_chain:
+      - symptom: "pvecm status shows all nodes but quorum is still missing"
+        evidence: "All 3 nodes show as online with 0 expected votes"
+        reasoning: "If corosync configuration is corrupted (wrong ring0 address, wrong expected votes), the cluster may have all nodes online but still fail to reach consensus. This is rare but occurs after manual configuration edits or failed cluster joins."
+      - symptom: "Corosync logs show 'config error' or 'vote not counted'"
+        evidence: "journalctl shows corosync configuration parse errors"
+        reasoning: "Configuration errors prevent corosync from correctly calculating quorum. If corosync cannot parse the node list correctly, votes won't be counted even from online nodes."
+    affected_components:
+      - "corosync"
+      - "pve-cluster"
+    escalation_threshold: "Escalate immediately — this requires Corosync expertise"
+    decision_tree:
+      - condition: "Configuration file has obvious errors (wrong IPs, missing nodelist entries)"
+        action: "Fix configuration and restart corosync"
+        reasoning: "A clear config error is safe to fix because the cluster is already in a broken state. The fix cannot make things worse."
+      - condition: "Configuration appears correct but consensus still fails"
+        action: "Do NOT modify config — escalate to Corosync/Proxmox expertise"
+        reasoning: "If the configuration looks correct but consensus fails, the issue is likely in the corosync protocol layer or cluster state database. These require deep expertise to diagnose safely."
+```
+
+### Quick-Reference: Diagnosis Decision Tree
+
+```
+Quorum lost?
+├── pvecm status: Are nodes offline?
+│   ├── YES → Node failure path
+│   │   └── Majority offline? → Force quorum on survivor
+│   └── NO → Network partition path
+│       └── Can nodes ping each other?
+│           ├── NO → Fix network first
+│           └── PARTIAL → Isolate boundary, fix before cluster actions
+│           └── YES → Corosync config path
+│               └── Config looks wrong? → Fix and restart
+│               └── Config looks correct? → ESCALATE
+```
+
+### Detailed Procedural: Diagnosis Reasoning
+
+The key diagnostic principle for quorum loss is: **rule out network partitions before attempting any recovery action.** Forced quorum recovery on a network-partitioned cluster creates a permanent split-brain condition. Always verify network connectivity between all cluster nodes before deciding on a recovery path.
+
+**Diagnostic sequence (why this order):**
+
+1. **Run `pvecm status` first** — this tells you the objective quorum state (votes, online nodes, expected votes). All subsequent decisions depend on this information.
+
+2. **Then check node reachability** — SSH or ping to each node shown as "offline" by pvecm. If you can reach an "offline" node, it's a network issue, not a node failure.
+
+3. **Then check corosync logs** — these tell you the timeline and mechanism of quorum loss, which confirms the root cause category.
+
+4. **Only then decide on recovery path** — with confirmed diagnosis, you can safely choose between forced quorum, network repair, or configuration fix.
+
+---
+
+## Mitigation Plan
+
+Why this matters: Quorum recovery is destructive if done wrong. Force-quorum on the wrong node can corrupt cluster state. Recovery without verification can leave phantom quorum artifacts. Every mitigation step below includes rollback because the cost of a wrong step exceeds the cost of an extra verification.
+
+```yaml+symbolic
+schema_version: "1.0"
+mitigation:
+  - step: "Verify network connectivity between ALL cluster nodes"
+    targets_root_cause: "Network partition (diagnosis 2)"
+    risk_level: low
+    rollback: "No rollback needed — this is a read-only diagnostic step"
+    reasoning: "Before ANY recovery action, you must confirm network connectivity. This is the gate that prevents split-brain. If connectivity is broken, fix the network first — cluster recovery cannot succeed on a partitioned network."
+    verification: "Ping all cluster node IPs from each node. Confirm zero packet loss."
+
+  - step: "If network is intact and nodes are offline: force quorum on the surviving node"
+    targets_root_cause: "Node failure (diagnosis 1)"
+    risk_level: high
+    rollback: "pvecm expected 3 (restore expected votes to original count) — ALWAYS restore original votes after recovery"
+    reasoning: "Force quorum (`pvecm expected 1`) tells corosync that the current node's vote is sufficient for consensus. This is necessary when a genuine majority of nodes is offline, but it creates a single-node consensus which is fragile. You MUST restore expected votes to the original count once offline nodes return."
+    verification: "pvecm status shows 'Has quorum: Yes' after force command"
+
+  - step: "If network partition detected: fix network connectivity, do NOT force quorum"
+    targets_root_cause: "Network partition (diagnosis 2)"
+    risk_level: medium
+    rollback: "Revert network changes if they don't restore connectivity within 5 minutes"
+    reasoning: "Forcing quorum during a network partition creates two independent clusters that both believe they own the cluster state. This causes split-brain, which is far worse than the original quorum loss. The correct approach is to fix the network, which allows natural quorum to return."
+    verification: "All nodes can ping all other nodes. pvecm status shows quorum restored."
+
+  - step: "For each offline node: verify it's truly offline before excluding from recovery"
+    targets_root_cause: "Node failure (diagnosis 1)"
+    risk_level: low
+    rollback: "No rollback needed — this is a diagnostic step"
+    reasoning: "A node may appear offline in pvecm status due to corosync timeout but still be running. Check via ICMP ping, SSH, and iDRAC/IPMI before assuming it's failed. A node that's running but out-of-sync with the cluster requires a different recovery path (rejoin) than a truly offline node (rebuild)."
+    verification: "Physical console, iDRAC/IPMI, or remote management confirms node state."
+
+  - step: "Restore expected votes after nodes return"
+    targets_root_cause: "Node failure (diagnosis 1) — cleanup after force quorum"
+    risk_level: medium
+    rollback: "If corosync becomes unstable after restoring votes, reduce expected votes back to the count of currently-online nodes and investigate"
+    reasoning: "After force quorum recovery, expected votes is set to 1. Leaving it at 1 means any subsequent node failure causes immediate quorum loss again. Restoring to the original count (e.g., 3 for a 3-node cluster) re-enables proper majority consensus and fault tolerance."
+    verification: "pvecm status shows 'Expected votes: 3' (or original count) and 'Has quorum: Yes'"
+
+  - step: "Verify cluster sync after recovery"
+    targets_root_cause: "All root causes — post-recovery validation"
+    risk_level: low
+    rollback: "Sync issues after recovery indicate state corruption — escalate, do NOT force sync"
+    reasoning: "After quorum recovery, the cluster filesystem may have divergent state between nodes. Verifying sync confirms that the recovery didn't introduce state inconsistency, which could cause future failures."
+    verification: "pvecm update runs without errors on all nodes. /etc/pve/ content is identical across all nodes."
+```
+
+### Quick-Reference: Mitigation Steps (Condensed)
+
+| Step | Command | Risk | Rollback |
+|------|---------|------|----------|
+| Verify network | `ping <node-ip>` from each node | Low | N/A (diagnostic) |
+| Force quorum (node failure only) | `pvecm expected 1` | **High** | `pvecm expected 3` |
+| Fix network (partition only) | Network infrastructure repair | Medium | Revert changes after 5 min |
+| Verify nodes offline | ICMP/SSH/iDRAC check | Low | N/A (diagnostic) |
+| Restore expected votes | `pvecm expected 3` | Medium | `pvecm expected <online-count>` |
+| Verify cluster sync | `pvecm update` on all nodes | Low | Escalate on failure |
+
+### Detailed Procedural: Mitigation Reasoning
+
+**Why force quorum is HIGH risk:** The `pvecm expected 1` command tells the cluster "trust this one node's decisions." If you run this on a node that's actually network-partitioned (not offline), you've just created a second cluster. Both clusters will try to manage the same VMs, storage, and network resources. This is split-brain — the single most destructive condition in clustered computing.
+
+**Why expected votes restoration matters:** During force quorum, expected votes is 1. This means the cluster tolerates zero additional node failures. Restoring expected votes to 3 means the cluster regains its ability to survive one node failure — which is the whole point of having a 3-node cluster.
+
+**Why cluster sync verification matters:** The cluster filesystem (pmxcfs) was in read-only mode during quorum loss. Any changes made on the quorum-holding node may not have propagated. After recovery, check that `/etc/pve/` content is consistent across all nodes. Divergence means state inconsistency that will cause future failures.
+
+---
+
+## Verification Criteria
+
+Why this matters: Verification must confirm that quorum is restored AND that cluster state is consistent. Checking quorum alone is insufficient — a cluster can have quorum while still having divergent state between nodes.
+
+```yaml+symbolic
+schema_version: "1.0"
+verification:
+  - criterion: "Cluster has quorum"
+    expected_result: "pvecm status shows 'Has quorum: Yes' and 'Expected votes: 3' (original count)"
+    maps_to_symptom: "Cluster commands return 'cluster not ready - quorum?'"
+    pass_condition: "pvecm status output shows quorum with original expected vote count"
+    fail_action: "Return to diagnosis — quorum not restored. Check if forced quorum command was applied correctly and if nodes can communicate."
+
+  - criterion: "All cluster nodes are online and synced"
+    expected_result: "pvecm status shows all nodes as online. /etc/pve/ content matches across nodes."
+    maps_to_symptom: "Web UI shows 'cluster filesystem not available'"
+    pass_condition: "All node entries in pvecm show 'online' status AND diff of /etc/pve/ between nodes shows zero differences"
+    fail_action: "If nodes are offline: investigate node failure. If /etc/pve/ differs: force cluster sync from the node with the most recent/correct state."
+
+  - criterion: "VM management operations succeed"
+    expected_result: "qm start, qm stop, and qm migrate commands complete without quorum errors"
+    maps_to_symptom: "VMs cannot be managed (start/stop/migrate)"
+    pass_condition: "At least one VM start, one VM stop, and (if applicable) one VM migration complete without errors"
+    fail_action: "Check if pmxcfs is still in read-only mode. `pvecm update` may need to be run to force state synchronization."
+
+  - criterion: "Corosync stable with no membership changes for 5 minutes"
+    expected_result: "journalctl -u corosync --since '5 minutes ago' shows no membership change entries"
+    maps_to_symptom: "Corosync logs show repeated membership changes"
+    pass_condition: "Zero membership change entries in last 5 minutes"
+    fail_action: "If membership changes continue: the underlying network or node health issue is not resolved. Return to diagnosis."
+```
+
+### Quick-Reference: Verification Checklist
+
+```
+[ ] pvecm status shows quorum with expected votes = original count
+[ ] All nodes show 'online' in pvecm status
+[ ] /etc/pve/ content is identical across nodes (diff check)
+[ ] VM start/stop/migrate operations succeed without errors
+[ ] Corosync stable for 5 minutes (no membership changes in logs)
+```
+
+### Detailed Procedural: Verification Reasoning
+
+**Why check /etc/pve/ consistency, not just quorum:** Quorum confirms consensus capability, but the cluster filesystem may have diverged during the outage. A cluster with quorum but divergent state will appear healthy until it tries to make a decision that conflicts with the divergent state — then it will fail in ways that are very hard to diagnose. Checking `/etc/pve/` consistency after recovery prevents this.
+
+**Why verify VM management, not just corosync:** Corosync quorum is necessary but not sufficient for VM management. The cluster filesystem must also be writable (pmxcfs must have transitioned from read-only to read-write). Testing actual VM operations confirms the full management stack is functional.
+
+**Why 5 minutes of stability:** Corosync membership changes indicate the cluster is still converging. If the cluster loses and regains quorum repeatedly (flapping), the underlying issue (network instability or node health problems) isn't resolved. Five minutes of stable membership is a reasonable confidence threshold.
+
+---
+
+## Postmortem Template
+
+```yaml+symbolic
+schema_version: "1.0"
+postmortem:
+  incident_title: "Proxmox Cluster Quorum Loss — <date>"
+  severity: P1
+  duration: "<time from first symptom detection to quorum restoration>"
+  root_cause_category: "configuration | dependency | capacity | code | security"
+  contributing_factors:
+    - factor: "<e.g., 'No redundant network paths between cluster nodes'>"
+      reasoning: "<why this factor contributed to the incident>"
+    - factor: "<e.g., 'No automated quorum monitoring or alerting'>"
+      reasoning: "<why this lack of monitoring allowed the incident to persist>"
+    - factor: "<e.g., 'Expected votes not documented in runbook'>"
+      reasoning: "<why this documentation gap slowed recovery>"
+  action_items:
+    - action: "Implement quorum monitoring alert"
+      owner: "<role or team>"
+      reasoning: "Quorum loss is P1 but often not detected until operators try to manage VMs. An alert on quorum status enables faster response."
+    - action: "Add redundant network paths for corosync ring"
+      owner: "<role or team>"
+      reasoning: "Single network path failure caused complete cluster isolation. Redundant paths (ring1/ring0) prevent network-induced quorum loss."
+    - action: "Document expected votes and force quorum procedure"
+      owner: "<role or team>"
+      reasoning: "Operators need to know the correct expected votes value (3 for a 3-node cluster) and the exact commands. Without documentation, responders may make incorrect assumptions about cluster configuration."
+```
+
+### Postmortem Narrative Template
+
+```markdown
+## Incident Timeline
+
+| Time | Event | Reasoning |
+|------|-------|-----------|
+| <T+0> | First symptom detected | <What triggered detection — alert, user report, automated check?> |
+| <T+?> | Diagnosis confirmed | <How was root cause identified? What evidence confirmed it?> |
+| <T+?> | Mitigation started | <Which recovery path was chosen and why?> |
+| <T+?> | Quorum restored | <How was quorum confirmed? What verification was run?> |
+| <T+?> | Cluster fully verified | <What confirmed full recovery beyond quorum restoration?> |
+
+## Root Cause Analysis
+
+<Explain the causal chain from root cause to symptoms. NOT just "node X went down" — explain WHY that caused quorum loss (e.g., "Node X's failure removed 1 of 3 votes, dropping quorum below majority threshold of 2").>
+
+## Contributing Factors
+
+1. **<Factor>**: <Why this contributed to the incident or slowed resolution>
+2. **<Factor>**: <Why this contributed>
+3. **<Factor>**: <Why this contributed>
+
+## Action Items
+
+| Action | Owner | Priority | Reasoning |
+|--------|-------|----------|-----------|
+| <Action> | <Owner> | P1/P2/P3 | <Why this prevents recurrence or speeds recovery> |
+
+## Lessons Learned
+
+<What was surprising? What assumptions were wrong? What would we do differently?>
+```
+
+---
+
+## Escalation Paths
+
+Why different escalation paths matter: Quorum loss can be caused by different root causes, and each requires different expertise. Routing to the wrong team wastes time during an incident.
+
+```yaml+symbolic
+schema_version: "1.0"
+escalation:
+  - condition: "Quorum not restored within 30 minutes of detection"
+    escalate_to: "Senior infrastructure engineer with Proxmox cluster experience"
+    reasoning: "Quorum loss that persists for 30+ minutes likely indicates a complex failure (multiple nodes, network partition, or corosync corruption) that requires experienced troubleshooting beyond standard runbook procedures."
+    escalation_action: "Add 'escalation' label to tracking issue. Provide pvecm status, corosync logs, and network diagnostic output."
+
+  - condition: "Network partition detected as root cause"
+    escalate_to: "Network engineering team"
+    reasoning: "Network partitions affecting cluster communication are infrastructure-level problems that require network diagnostic tools and authority that SRE/ops teams typically don't have."
+    escalation_action: "Provide ping/traceroute results between cluster nodes, switch configuration review, and VLAN status."
+
+  - condition: "Corosync configuration error detected"
+    escalate_to: "Proxmox/corosync specialist"
+    reasoning: "Corosync configuration errors can corrupt cluster state if fixed incorrectly. This requires expertise in corosync internals, quorum device configuration, and Proxmox cluster mesh protocols."
+    escalation_action: "Provide /etc/corosync/corosync.conf from all nodes, corosync log output, and pvecm status."
+```
+
+---
+
+## AI Agent Enforcement — State Machine
+
+This section defines the state machine that governs AI agent behavior when executing this runbook. Each state transition requires confirmation of the condition before proceeding.
+
+```yaml+symbolic
+schema_version: "1.0"
+state_machine:
+  id: proxmox-quorum-loss-runbook
+  initial_state: symptom_detection
+  states:
+    - name: symptom_detection
+      description: "Catalog observed symptoms and confirm quorum loss"
+      required_evidence:
+        - "pvecm status output showing no quorum"
+        - "At least one 'quorum?' error message"
+      transitions:
+        - to: diagnosis
+          condition: "All symptoms catalogued with severity and affected components"
+          action: "Proceed to diagnosis with evidence"
+
+    - name: diagnosis
+      description: "Trace symptoms to root cause through evidence chains"
+      required_evidence:
+        - "pvecm status showing vote counts"
+        - "Network connectivity test results between all nodes"
+        - "Corosync log entries showing quorum loss event"
+      transitions:
+        - to: mitigation_node_failure
+          condition: "Confirmed: nodes offline, network intact"
+          action: "Proceed to node failure mitigation path"
+        - to: mitigation_network_partition
+          condition: "Confirmed: network partition between nodes"
+          action: "Proceed to network partition mitigation path"
+        - to: mitigation_config_error
+          condition: "Confirmed: corosync configuration error"
+          action: "Proceed to config error mitigation path"
+        - to: escalation
+          condition: "Diagnosis cannot be confirmed (low confidence)"
+          action: "HALT and escalate"
+
+    - name: mitigation_node_failure
+      description: "Force quorum on surviving node after confirming nodes offline"
+      required_evidence:
+        - "Verified network connectivity is intact"
+        - "Confirmed offline nodes are truly offline (iDRAC/IPMI/physical)"
+      transitions:
+        - to: verification
+          condition: "Quorum forced on surviving node. pvecm expected votes restored."
+          action: "Proceed to verification"
+
+    - name: mitigation_network_partition
+      description: "Fix network connectivity without forcing quorum"
+      required_evidence:
+        - "Ping/traceroute results showing partition boundary"
+        - "Switch/VLAN configuration review"
+      transitions:
+        - to: verification
+          condition: "Network connectivity restored. pvecm shows quorum."
+          action: "Proceed to verification"
+
+    - name: mitigation_config_error
+      description: "Fix corosync configuration"
+      required_evidence:
+        - "Configuration diff showing error"
+        - "Corosync log showing configuration parse failure"
+      transitions:
+        - to: verification
+          condition: "Configuration fixed. Corosync restarted. pvecm shows quorum."
+          action: "Proceed to verification"
+
+    - name: verification
+      description: "Confirm quorum, cluster sync, VM management, and stability"
+      required_evidence:
+        - "pvecm status shows quorum with original expected votes"
+        - "/etc/pve/ content matches across all nodes"
+        - "VM start/stop/migrate operations succeed"
+        - "Corosync stable for 5 minutes (no membership changes)"
+      transitions:
+        - to: postmortem
+          condition: "All verification criteria pass"
+          action: "Proceed to postmortem"
+        - to: diagnosis
+          condition: "Any verification criterion fails"
+          action: "Return to diagnosis — do NOT proceed to postmortem"
+
+    - name: postmortem
+      description: "Document incident timeline, root cause, and action items"
+      required_evidence:
+        - "Complete timeline with timestamps"
+        - "Root cause analysis with causal chain"
+        - "Action items with owners and reasoning"
+      transitions:
+        - to: resolved
+          condition: "Postmortem complete and tracking issue updated"
+          action: "Close incident tracking issue"
+
+    - name: escalation
+      description: "HALT — escalation required"
+      required_evidence:
+        - "Reason for escalation documented"
+        - "Diagnostic output collected for escalation target"
+      transitions: []
+
+    - name: resolved
+      description: "Incident resolved and documented"
+      transitions: []
+```
+
+### AI Agent Rules
+
+```yaml+symbolic
+rules:
+  - id: quorum-loss-001
+    title: "Network partition check before force quorum"
+    conditions:
+      all:
+        - "diagnosis == 'node_failure'"
+        - "network_connectivity_verified == false"
+    actions:
+      - HALT
+      - REQUIRE: "Verify network connectivity before proceeding with force quorum"
+    source: "proxmox-cluster-quorum-loss.md §Mitigation"
+
+  - id: quorum-loss-002
+    title: "Expected votes must be restored after force quorum"
+    conditions:
+      all:
+        - "force_quorum_applied == true"
+        - "expected_votes_restored == false"
+    actions:
+      - REQUIRE: "Restore expected votes to original count before proceeding to verification"
+    source: "proxmox-cluster-quorum-loss.md §Mitigation"
+
+  - id: quorum-loss-003
+    title: "Cluster sync verification required"
+    conditions:
+      all:
+        - "quorum_restored == true"
+        - "cluster_sync_verified == false"
+    actions:
+      - HALT
+      - REQUIRE: "Verify /etc/pve/ consistency before proceeding"
+    source: "proxmox-cluster-quorum-loss.md §Verification"
+
+  - id: quorum-loss-004
+    title: "Do NOT force quorum during network partition"
+    conditions:
+      all:
+        - "network_partition_detected == true"
+        - "proposed_action == 'force_quorum'"
+    actions:
+      - BLOCK
+      - REASON: "Force quorum during network partition creates split-brain"
+    source: "proxmox-cluster-quorum-loss.md §Mitigation"
+```

--- a/.opencode/skills/sre-runbook/reference/proxmox-node-failure-recovery.md
+++ b/.opencode/skills/sre-runbook/reference/proxmox-node-failure-recovery.md
@@ -1,0 +1,463 @@
+---
+name: proxmox-node-failure-recovery
+description: Reference template for Proxmox full node failure recovery. Demonstrates prose-driven pattern with different escalation paths from the quorum loss template. NOT a canonical project runbook.
+type: reference
+license: MIT
+compatibility: opencode
+---
+
+# REFERENCE TEMPLATE — NOT A CANONICAL PROJECT RUNBOOK
+
+> This file is a **reference template** demonstrating the prose-driven runbook pattern. It shows both prompt patterns (what a user would invoke) and output patterns (what the agent would generate). Adapt this template to your infrastructure — do not use it as-is without validating against your environment.
+
+## Prompt Pattern (Invocation)
+
+```
+/skill sre-runbook --task generate
+domain: Proxmox VE cluster
+scenario_type: incident
+severity: P1
+```
+
+Expected agent behavior: Generate a full runbook following the five-step protocol (symptoms → diagnosis → mitigation → verification → postmortem), with reasoning at every step.
+
+---
+
+## Symptom Catalog
+
+Node failure is distinct from quorum loss: a single node is completely unreachable, but the rest of the cluster retains quorum and continues operating. The critical question is whether VMs on the failed node need immediate recovery or can wait for the node to return.
+
+```yaml+symbolic
+schema_version: "1.0"
+symptoms:
+  - description: "Node completely unreachable via SSH, ping, and web UI"
+    severity: P1
+    affected_components: ["pve-node", "qemu-server", "network"]
+    frequency: always
+    reasoning: "Total unreachability across all protocols indicates the node is down at the OS or hardware level, not just a service failure."
+
+  - description: "pvecm status shows node as 'offline' while cluster retains quorum"
+    severity: P1
+    affected_components: ["corosync", "pve-cluster"]
+    frequency: always
+    reasoning: "Unlike quorum loss, the remaining nodes still have a majority. The cluster continues to function for VMs on surviving nodes. The offline node's VMs are the primary concern."
+
+  - description: "VMs on the failed node show as 'unknown' status in cluster view"
+    severity: P2
+    affected_components: ["qemu-server", "pve-ha-manager"]
+    frequency: always
+    reasoning: "The cluster knows the VMs existed but cannot determine their state because the hosting node is unreachable. They may still be running on the dead node if it has power but no network, or they may have been killed by the hardware failure."
+
+  - description: "HA manager attempts fencing of the failed node"
+    severity: P1
+    affected_components: ["pve-ha-manager"]
+    frequency: sometimes
+    reasoning: "If HA is configured, the manager will attempt to recover HA-managed VMs by fencing the failed node and restarting VMs on surviving nodes. This is expected behavior but needs monitoring — fencing failures indicate deeper problems."
+
+  - description: "iDRAC/IPMI shows powered off or hardware error state"
+    severity: P1
+    affected_components: ["hardware", "bmc"]
+    frequency: sometimes
+    reasoning: "Remote management interfaces (iDRAC, IPMI, iLO) operate independently of the OS. If they also show failure, the problem is hardware-level. If they show the node as powered off, someone or something shut it down."
+```
+
+### Quick-Reference: Symptom → Action
+
+| Symptom | First Action | Why |
+|---------|-------------|-----|
+| Node unreachable | Check iDRAC/IPMI | Hardware vs OS failure determines recovery path |
+| Cluster retains quorum | Focus on VM recovery, not cluster | Remaining cluster is healthy — prioritize workload recovery |
+| VMs show 'unknown' | Check if VMs are actually running | Don't assume VMs are down — verify via iDRAC console |
+| HA fencing triggering | Verify HA manager progress | HA should auto-recover managed VMs; intervene only if fencing stalls |
+
+---
+
+## Diagnosis Map
+
+The three root causes for node failure, eachrequiring a different recovery approach.
+
+```yaml+symbolic
+schema_version: "1.0"
+diagnosis:
+  - root_cause: "Hardware failure — power supply, disk, motherboard, or RAM"
+    confidence: high
+    severity: P1
+    evidence_chain:
+      - symptom: "iDRAC/IPMI shows hardware error or powered off state"
+        reasoning: "Hardware management controllers report directly from the BMC layer. If they show errors, the OS may not have had time to log anything before the node went down."
+      - symptom: "Node does not respond to power-on via remote management"
+        reasoning: "If remote power-on fails, the hardware is physically damaged. No amount of software recovery will help."
+    decision_tree:
+      - condition: "iDRAC shows specific hardware error (PSU, disk, ECC memory)"
+        action: "Order replacement part, begin VM evacuation from other nodes"
+        reasoning: "Hardware replacement takes time. VMs should not wait — evacuate them to surviving nodes now."
+      - condition: "iDRAC shows powered off but no error"
+        action: "Attempt remote power-on; if successful, investigate OS-level cause"
+        reasoning: "A clean power-off may indicate an OS panic or administrator action rather than hardware failure."
+
+  - root_cause: "OS or kernel panic — software crash"
+    confidence: medium
+    severity: P1
+    evidence_chain:
+      - symptom: "iDRAC shows node powered on but SSH fails"
+        reasoning: "Hardware is up but OS is not responding. This could be a kernel panic, filesystem corruption, or hung init."
+      - symptom: "Console shows kernel panic or stack trace"
+        reasoning: "Definitive evidence of OS-level failure. The panic message tells you which subsystem crashed."
+    decision_tree:
+      - condition: "Kernel panic visible on console"
+        action: "Attempt reboot; if panic recurs, investigate driver/hardware incompatibility"
+        reasoning: "One-time panics can be transient. Recurring panics indicate a systemic problem that needs root cause analysis before the node returns to production."
+      - condition: "Console unresponsive (no login prompt)"
+        action: "Force reboot via iDRAC; monitor boot sequence for errors"
+        reasoning: "An unresponsive console may indicate a hung init or filesystem corruption. A clean reboot often resolves transient hangs."
+
+  - root_cause: "Storage failure — ZFS pool degraded or disk failure"
+    confidence: medium
+    severity: P1
+    evidence_chain:
+      - symptom: "Node is online but VMs are frozen or I/O errors in logs"
+        reasoning: "Storage failure doesn't always crash the node — it may leave the OS running while making VMs unusable. ZFS pools enter a degraded state before going offline."
+      - symptom: "ZFS pool status shows DEGRADED or FAULTED"
+        reasoning: "ZFS provides explicit pool state. DEGRADED means resilience is reduced but data is available. FAULTED means data is at risk."
+    decision_tree:
+      - condition: "Pool DEGRADED with available spares"
+        action: "Replace failed disk, run zpool scrub, continue operations"
+        reasoning: "DEGRADED with spares means ZFS is already rebuilding. The node can continue serving data, but performance may be reduced during rebuild."
+      - condition: "Pool FAULTED with no redundancy"
+        action: "HALT — escalate to storage specialist; data recovery may be needed"
+        reasoning: "A FAULTED pool with no redundancy means data loss has occurred or is imminent. Do not attempt normal recovery — this requires specialized data recovery procedures."
+```
+
+### Quick-Reference: Diagnosis Decision Tree
+
+```
+Node unreachable?
+├── iDRAC/IPMI reachable?
+│   ├── YES → Check hardware status
+│   │   ├── Hardware error → Hardware failure path
+│   │   ├── Powered off → Try remote power-on
+│   │   └── Powered on, no OS → OS/kernel panic path
+│   └── NO → Network failure (check switch port, cable)
+└── Node online but VMs frozen?
+    └── Check ZFS pool status
+        ├── DEGRADED → Replace disk, scrub
+        └── FAULTED → ESCALATE — data recovery needed
+```
+
+---
+
+## Mitigation Plan
+
+```yaml+symbolic
+schema_version: "1.0"
+mitigation:
+  - step: "Assess node state via iDRAC/IPMI"
+    targets_root_cause: "All root causes — initial triage"
+    risk_level: low
+    rollback: "No rollback needed — diagnostic step"
+    reasoning: "Remote management gives you hardware state without requiring OS access. This determines the entire recovery path."
+    verification: "iDRAC/IPMI responds with power state and hardware status"
+
+  - step: "Evacuate VMs from failed node (if HA not configured)"
+    targets_root_cause: "All root causes — workload recovery"
+    risk_level: medium
+    rollback: "VMs can be migrated back once node recovers"
+    reasoning: "HA-managed VMs auto-recover. Non-HA VMs need manual evacuation. Prioritize production workloads over development VMs."
+    verification: "All critical VMs running on surviving nodes"
+
+  - step: "Attempt node reboot via iDRAC (for OS/kernel panic)"
+    targets_root_cause: "OS or kernel panic"
+    risk_level: low
+    rollback: "If reboot doesn't resolve, proceed to hardware investigation"
+    reasoning: "A reboot resolves most transient kernel panics. Monitor the boot sequence via iDRAC console to catch recurring panics."
+    verification: "Node boots, SSH accessible, pvecm status shows node online"
+
+  - step: "Replace failed hardware component (for hardware failure)"
+    targets_root_cause: "Hardware failure"
+    risk_level: medium
+    rollback: "If replacement doesn't resolve, escalate to vendor support"
+    reasoning: "Hardware replacement is straightforward but requires physical access and parts. Run hardware diagnostics on the replacement before returning node to production."
+    verification: "Node passes hardware diagnostics, boots cleanly, rejoins cluster"
+
+  - step: "Replace failed disk and resilver ZFS pool (for storage failure)"
+    targets_root_cause: "Storage failure"
+    risk_level: medium
+    rollback: "Remove replacement disk if resilver fails; pool remains in pre-replacement state"
+    reasoning: "ZFS resilvering rebuilds data from redundancy. Monitor resilver progress — do not add load during resilver."
+    verification: "zpool status shows pool ONLINE with no errors; scrub completes without errors"
+
+  - step: "Verify node rejoins cluster cleanly"
+    targets_root_cause: "All root causes — post-recovery validation"
+    risk_level: low
+    rollback: "If node cannot rejoin, remove from cluster and re-add"
+    reasoning: "A node that was offline may have stale cluster state. Verify pvecm status, corosync connectivity, and /etc/pve/ sync before declaring recovery complete."
+    verification: "pvecm status shows all nodes online with quorum; /etc/pve/ content matches across nodes"
+```
+
+### Quick-Reference: Mitigation Steps
+
+| Step | Action | Risk | Rollback |
+|------|--------|------|----------|
+| Assess via iDRAC | Check power/hardware state | Low | N/A |
+| Evacuate VMs | Migrate to surviving nodes | Medium | Migrate back |
+| Reboot node | iDRAC power cycle | Low | Hardware investigation |
+| Replace hardware | Physical component swap | Medium | Escalate to vendor |
+| Replace disk + resilver | zpool replace + scrub | Medium | Remove replacement disk |
+| Verify cluster rejoin | pvecm status, sync check | Low | Remove and re-add node |
+
+---
+
+## Verification Criteria
+
+```yaml+symbolic
+schema_version: "1.0"
+verification:
+  - criterion: "Failed node is online and rejoined to cluster"
+    expected_result: "pvecm status shows all nodes online; node responds to SSH"
+    pass_condition: "Node appears online in pvecm status AND SSH access works"
+    fail_action: "If node won't rejoin: remove from cluster (pvecm delnode) and re-add"
+
+  - criterion: "All evacuated VMs running on surviving or recovered nodes"
+    expected_result: "qm list shows expected VMs running on appropriate nodes"
+    pass_condition: "All production VMs are in 'running' state"
+    fail_action: "Check VM migration logs; re-migrate any failed VMs"
+
+  - criterion: "ZFS pool healthy (if storage failure occurred)"
+    expected_result: "zpool status shows ONLINE with no errors"
+    pass_condition: "Pool state is ONLINE AND scrub completes without errors"
+    fail_action: "If resilver hasn't completed, wait. If errors persist, escalate to storage specialist."
+
+  - criterion: "Cluster filesystem synchronized across all nodes"
+    expected_result: "/etc/pve/ content matches on all nodes"
+    pass_condition: "Diff of /etc/pve/ between all nodes shows no differences"
+    fail_action: "Run pvecm update to force sync; if differences persist, investigate cluster state corruption"
+```
+
+---
+
+## Postmortem Template
+
+```yaml+symbolic
+schema_version: "1.0"
+postmortem:
+  incident_title: "Proxmox Node Failure — <node-name> — <date>"
+  severity: P1
+  duration: "<time from detection to full recovery>"
+  root_cause_category: "hardware | software | storage | unknown"
+  contributing_factors:
+    - factor: "<e.g., 'No VM HA configured for production workloads'>"
+      reasoning: "<why this made recovery harder or slower>"
+    - factor: "<e.g., 'No spare hardware available for replacement'>"
+      reasoning: "<why this extended downtime>"
+  action_items:
+    - action: "<e.g., 'Configure HA for all production VMs'>"
+      owner: "<role>"
+      reasoning: "HA provides automatic VM recovery without manual intervention"
+    - action: "<e.g., 'Maintain spare hardware for cluster nodes'>"
+      owner: "<role>"
+      reasoning: "Hardware replacement took hours because parts were not on-site"
+```
+
+### Postmortem Narrative Template
+
+```markdown
+## Incident Timeline
+
+| Time | Event | Reasoning |
+|------|-------|-----------|
+| <T+0> | Node failure detected | <How detected — monitoring, user report, HA alert?> |
+| <T+?> | Diagnosis confirmed | <Hardware failure, OS panic, or storage failure?> |
+| <T+?> | VM evacuation started | <Which VMs were prioritized and why?> |
+| <T+?> | Node recovery attempted | <Reboot, hardware replacement, or disk replacement?> |
+| <T+?> | Node rejoined cluster | <How was clean rejoin verified?> |
+
+## Root Cause Analysis
+
+<Explain the causal chain from root cause to symptoms. Why did the node fail? What made it worse?>
+
+## Action Items
+
+| Action | Owner | Priority | Reasoning |
+|--------|-------|----------|-----------|
+| <Action> | <Owner> | P1/P2/P3 | <Why this prevents recurrence> |
+```
+
+---
+
+## Escalation Paths
+
+Different from the quorum loss template — node failure escalates to hardware/vendor support and data recovery teams, not network engineering.
+
+```yaml+symbolic
+schema_version: "1.0"
+escalation:
+  - condition: "Hardware diagnostics show component failure (PSU, motherboard, RAM)"
+    escalate_to: "Hardware vendor support"
+    reasoning: "Hardware component replacement requires vendor RMA or on-site support that SRE teams cannot provide independently."
+    escalation_action: "Provide iDRAC hardware log, serial numbers, and failure details to vendor."
+
+  - condition: "ZFS pool FAULTED with data loss risk"
+    escalate_to: "Storage and backup recovery team"
+    reasoning: "Data loss risk requires specialized recovery tools (ZFS send/recv from backup, or commercial recovery). SRE should not attempt data recovery without backup team involvement."
+    escalation_action: "Provide zpool status, zpool history, and backup inventory to recovery team."
+
+  - condition: "HA-managed VMs not recovering after 15 minutes"
+    escalate_to: "Service owners of affected VMs"
+    reasoning: "HA should auto-recover, but if fencing is stuck or recovery stalls, service owners need to know their workloads are impacted and may need to activate DR plans."
+    escalation_action: "Notify service owners with current VM status and estimated recovery time."
+
+  - condition: "Node cannot rejoin cluster after recovery"
+    escalate_to: "Proxmox cluster specialist"
+    reasoning: "Cluster rejoin failures involve corosync configuration, cluster state database, and quorum interactions that require deep Proxmox expertise."
+    escalation_action: "Provide pvecm status, corosync config, and /etc/pve/ state from all nodes."
+```
+
+---
+
+## AI Agent Enforcement — State Machine
+
+```yaml+symbolic
+schema_version: "1.0"
+state_machine:
+  id: proxmox-node-failure-runbook
+  initial_state: symptom_detection
+  states:
+    - name: symptom_detection
+      description: "Catalog symptoms and confirm node failure (not quorum loss)"
+      required_evidence:
+        - "pvecm status showing specific node offline"
+        - "Cluster retains quorum (2 of 3 nodes online)"
+      transitions:
+        - to: diagnosis
+          condition: "Symptoms catalogued; quorum confirmed intact"
+          action: "Proceed to diagnosis"
+
+    - name: diagnosis
+      description: "Determine root cause: hardware, OS, or storage"
+      required_evidence:
+        - "iDRAC/IPMI status showing hardware state"
+        - "Node ping/SSH results from surviving nodes"
+      transitions:
+        - to: mitigation_hardware
+          condition: "iDRAC shows hardware error or no power"
+          action: "Proceed to hardware failure path"
+        - to: mitigation_os_panic
+          condition: "iDRAC shows powered on but OS unresponsive"
+          action: "Proceed to OS panic path"
+        - to: mitigation_storage
+          condition: "Node responsive but ZFS pool degraded/faulted"
+          action: "Proceed to storage failure path"
+        - to: escalation
+          condition: "Diagnosis inconclusive"
+          action: "HALT and escalate"
+
+    - name: mitigation_hardware
+      description: "Replace failed hardware component"
+      transitions:
+        - to: vm_evacuation
+          condition: "VM evacuation in progress"
+          action: "Evacuate VMs to surviving nodes while hardware is replaced"
+        - to: verification
+          condition: "Hardware replaced, node boots cleanly"
+          action: "Proceed to verification"
+
+    - name: mitigation_os_panic
+      description: "Reboot node and investigate kernel panic"
+      transitions:
+        - to: verification
+          condition: "Node reboots successfully and rejoins cluster"
+          action: "Proceed to verification"
+        - to: escalation
+          condition: "Reboot fails or panic recurs"
+          action: "Escalate — may be hardware or deeper OS issue"
+
+    - name: mitigation_storage
+      description: "Replace failed disk and resilver ZFS pool"
+      transitions:
+        - to: verification
+          condition: "Disk replaced, resilver complete, pool ONLINE"
+          action: "Proceed to verification"
+
+    - name: vm_evacuation
+      description: "Migrate VMs off failed node to surviving nodes"
+      transitions:
+        - to: verification
+          condition: "All critical VMs running on surviving nodes"
+          action: "Proceed to verification after node recovery"
+
+    - name: verification
+      description: "Confirm full cluster recovery"
+      required_evidence:
+        - "All nodes online in pvecm status"
+        - "/etc/pve/ synchronized across nodes"
+        - "ZFS pools healthy (if storage issue)"
+        - "All production VMs running"
+      transitions:
+        - to: postmortem
+          condition: "All verification criteria pass"
+          action: "Proceed to postmortem"
+        - to: diagnosis
+          condition: "Any verification criterion fails"
+          action: "Return to diagnosis"
+
+    - name: postmortem
+      description: "Document timeline, root cause, and action items"
+      transitions:
+        - to: resolved
+          condition: "Postmortem complete"
+          action: "Close incident tracking issue"
+
+    - name: escalation
+      description: "HALT — expertise required"
+      transitions: []
+
+    - name: resolved
+      description: "Incident resolved and documented"
+      transitions: []
+```
+
+### AI Agent Rules
+
+```yaml+symbolic
+rules:
+  - id: node-failure-001
+    title: "Confirm quorum before focusing on single node"
+    conditions:
+      all:
+        - "cluster_has_quorum == false"
+    actions:
+      - HALT
+      - REQUIRE: "Resolve quorum loss first — this runbook assumes cluster retains quorum"
+    source: "proxmox-node-failure-recovery.md §Symptom Catalog"
+
+  - id: node-failure-002
+    title: "Verify iDRAC/IPMI before attempting SSH"
+    conditions:
+      all:
+        - "node_unreachable_via_ssh == true"
+        - "idrac_status_checked == false"
+    actions:
+      - REQUIRE: "Check iDRAC/IPMI first — hardware state determines recovery path"
+    source: "proxmox-node-failure-recovery.md §Diagnosis Map"
+
+  - id: node-failure-003
+    title: "Do not attempt data recovery on FAULTED ZFS pool without backup team"
+    conditions:
+      all:
+        - "zfs_pool_status == 'FAULTED'"
+        - "backup_team_notified == false"
+    actions:
+      - HALT
+      - REQUIRE: "Escalate to storage/backup team before any recovery attempt"
+    source: "proxmox-node-failure-recovery.md §Diagnosis Map"
+
+  - id: node-failure-004
+    title: "Verify cluster rejoin after node recovery"
+    conditions:
+      all:
+        - "node_recovered == true"
+        - "cluster_sync_verified == false"
+    actions:
+      - REQUIRE: "Verify /etc/pve/ consistency and pvecm status before declaring recovery complete"
+    source: "proxmox-node-failure-recovery.md §Verification"
+```

--- a/.opencode/skills/sre-runbook/tasks/generate.md
+++ b/.opencode/skills/sre-runbook/tasks/generate.md
@@ -1,0 +1,181 @@
+# Task: generate
+
+## Purpose
+
+Generate an operational runbook for a given domain and scenario type. Enforces reasoning at every step — each action must explain WHY it is the right action for the observed symptoms and diagnosed root cause.
+
+## Operating Protocol
+
+1. Invoked by: `/skill sre-runbook --task generate`
+2. When to use: When an operational runbook is needed for a system, service, or infrastructure domain
+3. Exit criteria: Runbook generated with reasoning at every step, verified against dual-output contract
+
+## Pre-Conditions
+
+**Domain context is MANDATORY.** If any of the following are missing, the agent MUST prompt the user before proceeding:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `domain` | ✅ Yes | System/service name (e.g., "PostgreSQL primary", "Kubernetes ingress") |
+| `scenario_type` | ✅ Yes | One of: `incident`, `procedure`, `degradation`, `failover` |
+| `severity` | ✅ Yes | One of: `P1` (outage), `P2` (degraded), `P3` (minor) |
+
+If domain context is missing or insufficient, HALT and prompt the user. Do NOT guess or fabricate domain context.
+
+## Input Parameters
+
+```
+domain: <system or service name>
+scenario_type: incident | procedure | degradation | failover
+severity: P1 | P2 | P3
+```
+
+## Procedure
+
+### Step 1: Document Symptoms
+
+**WHAT:** Catalog all observed symptoms with severity and affected components.
+
+**WHY:** Symptom documentation is the foundation of diagnosis. Without a complete symptom catalog, diagnosis is guesswork. Each symptom must be classified by severity and component so that diagnosis can trace symptoms to root causes.
+
+Output — AI-parseable enforcement block:
+
+```yaml
+symptoms:
+  - description: "<observed behavior>"
+    severity: P1 | P2 | P3
+    affected_components:
+      - "<component name>"
+    frequency: always | intermittent | one-time
+    observed_at: "<timestamp or condition>"
+```
+
+Plus human-readable narrative explaining context and background.
+
+**Verification gate:** Confirm each symptom matches observed behavior. If symptoms are ambiguous, HALT and prompt for clarification.
+
+### Step 2: Diagnose Root Cause
+
+**WHAT:** Trace symptoms to root cause through causal reasoning chains.
+
+**WHY:** Diagnosis without reasoning is pattern-matching, not engineering. Each diagnosis step must explain why this root cause is the most likely explanation for the observed symptoms, citing evidence (logs, metrics, state).
+
+Output — AI-parseable enforcement block:
+
+```yaml
+diagnosis:
+  - root_cause: "<identified root cause>"
+    confidence: high | medium | low
+    severity: P1 | P2 | P3
+    evidence_chain:
+      - symptom: "<symptom from Step 1>"
+        evidence: "<log output, metric, state observation>"
+        reasoning: "<why this evidence supports this root cause>"
+    affected_components:
+      - "<component name>"
+    escalation_threshold: "<time or condition that triggers escalation>"
+```
+
+Plus human-readable narrative with decision tree explaining reasoning.
+
+**Verification gate:** Confirm diagnosis connects to symptoms via evidence. If diagnosis is unconfirmed (low confidence), do NOT proceed to mitigation — escalate instead.
+
+### Step 3: Define Mitigation Steps
+
+**WHAT:** Define specific mitigation actions that target the diagnosed root cause.
+
+**WHY:** Mitigation steps must address the diagnosed root cause, not just suppress symptoms. Each step must explain why this action resolves the root cause, and what risk it carries.
+
+Output — AI-parseable enforcement block:
+
+```yaml
+mitigation:
+  - step: "<mitigation action>"
+    targets_root_cause: "<reference to diagnosis entry>"
+    risk_level: low | medium | high
+    rollback: "<rollback procedure if mitigation fails>"
+    reasoning: "<why this action addresses the root cause>"
+```
+
+Plus human-readable narrative with decision trees for conditional mitigation paths.
+
+**Verification gate:** Confirm each mitigation step targets a diagnosed root cause. If mitigation does not address the root cause, return to Step 2.
+
+### Step 4: Define Verification Criteria
+
+**WHAT:** Define specific, measurable criteria that confirm the mitigation resolved the symptoms.
+
+**WHY:** Verification must confirm symptoms are resolved, not just that something changed. Each criterion must map to a specific symptom from Step 1 and confirm it is no longer present.
+
+Output — AI-parseable enforcement block:
+
+```yaml
+verification:
+  - criterion: "<what to verify>"
+    expected_result: "<expected outcome>"
+    maps_to_symptom: "<reference to symptom from Step 1>"
+    pass_condition: "<exact condition for pass>"
+    fail_action: "<what to do if verification fails>"
+```
+
+Plus human-readable narrative explaining verification methodology.
+
+**Verification gate:** Confirm each criterion maps to a symptom. If verification fails, return to Step 2 (re-diagnose) — do NOT proceed to postmortem.
+
+### Step 5: Postmortem Template
+
+**WHAT:** Generate a postmortem template capturing what happened, why, and how to prevent recurrence.
+
+**WHY:** Postmortems close the feedback loop. Without postmortems, the same incident recurs. The template must capture causal reasoning, not just timelines.
+
+Output — AI-parseable enforcement block:
+
+```yaml
+postmortem:
+  incident_title: "<title>"
+  severity: P1 | P2 | P3
+  duration: "<time from detection to resolution>"
+  root_cause_category: "<configuration | dependency | capacity | code | security>"
+  contributing_factors:
+    - "<factor with reasoning>"
+  action_items:
+    - action: "<preventive action>"
+      owner: "<role or team>"
+      reasoning: "<why this prevents recurrence>"
+```
+
+Plus human-readable narrative with timeline template and action item tracking.
+
+## HALT Conditions
+
+| Condition | Action |
+|-----------|--------|
+| Domain context missing or insufficient | HALT, prompt user for context |
+| Diagnosis unconfirmed (low confidence) | HALT, escalate — do NOT mitigate |
+| Mitigation risk exceeds severity threshold | HALT, escalate before proceeding |
+| Verification fails | Return to Step 2, do NOT proceed to postmortem |
+| Escalation needed | HALT, create GitHub Issue with `escalation` label |
+
+## Output Contract
+
+The generated runbook is saved as a Markdown file in `docs/runbooks/` with both:
+1. AI-parseable yaml+symbolic enforcement blocks (structured data for automation)
+2. Human-readable narrative prose (context and reasoning for humans)
+
+File naming convention: `docs/runbooks/<domain>-<scenario_type>.md`
+
+## Self-Review Step (MANDATORY)
+
+After generating the runbook, the agent MUST review its own output for template-fill patterns. Check:
+1. Does every step include WHY reasoning? If not, add it.
+2. Does every diagnosis connect to symptoms via evidence? If not, add evidence chains.
+3. Does every mitigation target a diagnosed root cause? If not, add reasoning.
+4. Does every verification criterion map to a specific symptom? If not, add mappings.
+5. Does the postmortem template include action items with reasoning? If not, add reasoning.
+
+If any step lacks reasoning, the runbook is incomplete. Add reasoning before presenting.
+
+## Context Required
+
+- Related skills: `sre-runbook` (parent skill), `systematic-debugging` (root cause discipline), `verification-before-completion` (evidence gates)
+- Related tasks: `track`

--- a/.opencode/skills/sre-runbook/tasks/track.md
+++ b/.opencode/skills/sre-runbook/tasks/track.md
@@ -1,0 +1,201 @@
+# Task: track
+
+## Purpose
+
+Track an incident or change via GitHub Issue with structured labels and prose narrative. Lightweight incident tracking for two-person teams — no CABs, no SLA databases, no change advisory boards.
+
+## Operating Protocol
+
+1. Invoked by: `/skill sre-runbook --task track`
+2. When to use: When tracking an incident, outage, or change through its lifecycle
+3. Exit criteria: GitHub Issue created/updated with structured labels and prose narrative
+
+## Pre-Conditions
+
+**A runbook must exist OR the user must provide an incident description.** If neither is available, the agent MUST prompt the user before proceeding.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `incident_type` | ✅ Yes | One of: `incident`, `change`, `degradation` |
+| `severity` | ✅ Yes | One of: `P1` (outage), `P2` (degraded), `P3` (minor) |
+| `description` | ✅ Yes | Prose description of the incident or change |
+
+If parameters are missing, HALT and prompt the user. Do NOT guess severity or type.
+
+## Input Parameters
+
+```
+incident_type: incident | change | degradation
+severity: P1 | P2 | P3
+description: <prose description of what happened or what changed>
+```
+
+## Procedure
+
+### Step 1: Classify the Incident
+
+**WHAT:** Determine incident type and severity from user input and observed evidence.
+
+**WHY:** Classification drives the escalation path, label set, and response urgency. Misclassification leads to wrong response speed or wrong audience.
+
+Classification rubric:
+
+| Incident Type | When to Use | Label |
+|---------------|-------------|-------|
+| `incident` | Active outage or service disruption | `incident` |
+| `change` | Planned or completed infrastructure change | `change` |
+| `degradation` | Performance degradation without full outage | `degradation` |
+
+Severity rubric:
+
+| Severity | Definition | Response Target |
+|----------|------------|-----------------|
+| P1 | Complete outage or data loss risk | Immediate |
+| P2 | Degraded performance or partial failure | Within 1 hour |
+| P3 | Minor impact, non-blocking | Next business day |
+
+Output:
+- `incident_type` label
+- `severity` label
+- Classification reasoning (WHY this type and severity)
+
+### Step 2: Create GitHub Issue
+
+**WHAT:** Create a GitHub Issue with structured labels and prose narrative body.
+
+**WHY:** GitHub Issues provide the single source of truth for incident tracking. Structured labels enable filtering; prose narrative provides context for humans.
+
+**Follow `github-issue-creation` skill discipline** — do NOT bypass issue creation validation. Invoke `/skill github-issue-creation --task pre-creation` before creating the issue.
+
+Issue structure:
+
+```markdown
+## Incident Tracking: <title>
+
+**Type:** <incident_type>
+**Severity:** P1 | P2 | P3
+**Status:** investigating | mitigating | resolved | postmortem
+
+### Timeline
+
+| Time | Event | Reasoning |
+|------|-------|-----------|
+| <timestamp> | <event description> | <WHY this matters> |
+
+### Classification Reasoning
+
+<Why this incident type and severity were chosen>
+
+### Impact
+
+<What is affected and how>
+
+### Mitigation Steps (if applicable)
+
+<Steps taken or planned, with reasoning for each>
+
+### Verification
+
+<How we confirm the incident is resolved>
+
+### Postmortem Link (if applicable)
+
+<Link to postmortem issue when available>
+```
+
+Label set:
+- Always: `incident` or `change` or `degradation`
+- Always: `P1` or `P2` or `P3`
+- Optionally: `escalation` (if escalation threshold reached)
+
+### Step 3: Update Timeline Entries
+
+**WHAT:** As the incident progresses, add timeline entries to the GitHub Issue body.
+
+**WHY:** Timeline entries create the audit trail. Without them, postmortems lack data. Each entry must include reasoning — not just what happened, but why it matters.
+
+**Update workflow:**
+1. Read current issue body via `github_issue_read`
+2. Add new timeline entry with timestamp, event, and reasoning
+3. Update status field if changed
+4. Update issue via `github_issue_write`
+
+**Each timeline entry MUST include:**
+- Timestamp (or relative marker if exact time unknown)
+- Event description (WHAT)
+- Reasoning (WHY this event matters or why this action was taken)
+
+### Step 4: Escalation Criteria
+
+**WHAT:** Determine when to escalate based on severity thresholds and time thresholds.
+
+**WHY:** Escalation prevents incidents from lingering without adequate response. Clear criteria remove ambiguity about when and how to escalate.
+
+Escalation thresholds:
+
+| Severity | Escalate If | Action |
+|----------|-------------|--------|
+| P1 | Not mitigated within 30 minutes | Add `escalation` label, notify on-call lead |
+| P2 | Not mitigated within 2 hours | Add `escalation` label, notify on-call |
+| P3 | Not resolved within 1 business day | Reassess severity, consider upgrading |
+
+When escalation threshold is reached:
+1. Add `escalation` label to the issue
+2. Add timeline entry noting escalation and reasoning
+3. HALT runbook tracking — escalation requires human decision
+
+### Step 5: Change Tracking (for `change` type only)
+
+**WHAT:** Document what changed, the risk level, and the rollback plan.
+
+**WHY:** Changes without rollback plans are incidents waiting to happen. Every change MUST have a rollback plan documented before execution.
+
+Required fields for change tracking:
+
+```yaml
+change:
+  what_changed: "<description>"
+  risk_level: low | medium | high
+  rollback_plan: "<steps to revert the change>"
+  reasoning: "<why this change is necessary>"
+```
+
+### Step 6: Close with Postmortem
+
+**WHAT:** When the incident is resolved, add postmortem link and close.
+
+**WHY:** Closing without postmortem documentation means the same incident recurs. Every P1 and P2 incident must have a postmortem. P3 incidents may close with a brief retrospective.
+
+**After generating postmortem (via `generate` task or manually):**
+1. Add postmortem link to tracking issue
+2. Update status to `resolved` or `postmortem`
+3. If postmortem action items exist, create follow-up issues
+4. Close the tracking issue only after postmortem is complete
+
+**Do NOT close issues before postmortem for P1/P2 incidents.** See `git-workflow --task cleanup` for post-merge closure workflow.
+
+## HALT Conditions
+
+| Condition | Action |
+|-----------|--------|
+| Missing incident description | HALT, prompt user for context |
+| Unable to classify incident type | HALT, present options to user |
+| Escalation threshold reached | HALT, add `escalation` label, notify on-call |
+| GitHub Issue creation validation fails | HALT, follow `github-issue-creation` skill guidance |
+
+## Output
+
+A GitHub Issue with:
+- Structured labels: `<incident_type>` + `<severity>` + optionally `escalation`
+- Prose narrative body following the template above
+- Timeline entries with reasoning at every step
+- Linked postmortem (for P1/P2 incidents)
+
+## Cross-References
+
+- Related skills: `sre-runbook` (parent skill), `github-issue-creation` (issue creation discipline), `verification-before-completion` (evidence gates)
+- Related tasks: `generate`
+
+## Context Required
+
+- Related guidelines: `010-approval-gate.md` (authorization), `000-critical-rules.md` (issue closure rules)


### PR DESCRIPTION
## Summary

Implements spec #870 — creates an `sre-runbook` skill that teaches the AI agent how to generate prose-driven operational runbooks for infrastructure incidents and procedures.

## Outcome

- **Phase 1:** Core skill framework — `SKILL.md` with discipline-enforcing rules, `tasks/generate.md` with verification gates and HALT conditions, `tasks/track.md` with lightweight incident/change tracking
- **Phase 2:** Two Proxmox reference templates demonstrating the prose-driven pattern — cluster quorum loss and node failure recovery, both with dual-audience output (AI-parseable yaml+symbolic + human-readable narrative), escalation paths, and state machines

Fixes #870
Fixes #894
Fixes #895