### PR TITLE
[SPEC-FIX] Agent bypasses mandatory skills during implementation workflow

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -378,6 +378,32 @@ If you think something ELSE should be changed: 1) STOP, 2) Comment on the issue,
 - ✅ REQUIRED: Main agent only orchestrates — never edits implementation files
 - ✅ REQUIRED: Context window stays clean for orchestration decisions
 
+## Critical Violation: Bypassing Mandatory Skill Invocations During Implementation
+
+**⚠️ Skipping mandatory skill invocations (git-workflow pre-work, divide-and-conquer, verification-before-completion) during the implementation workflow is a CRITICAL GUIDELINE VIOLATION.**
+
+The approval-gate dispatch chain defines a mandatory sequence after plan approval:
+
+1. `git-workflow --task pre-work` — Create worktree, set `WORKTREE_PATH`, verify branch state
+2. `divide-and-conquer --task assemble-batch` — Dispatch sub-agents for implementation
+3. `verification-before-completion` — Verify success criteria before marking complete
+4. `finishing-a-development-branch --task checklist` — Final branch readiness check
+5. `git-workflow --task review-prep` — Push branch, generate compare URL
+
+**Each step is MANDATORY. Skipping any step is a CRITICAL VIOLATION.**
+
+- 🚫 FORBIDDEN: Creating a worktree manually instead of invoking `git-workflow --task pre-work`
+- 🚫 FORBIDDEN: Implementing files directly as the main agent instead of dispatching via `divide-and-conquer`
+- 🚫 FORBIDDEN: Skipping `verification-before-completion` and claiming task completion without evidence
+- 🚫 FORBIDDEN: Pushing changes without invoking `finishing-a-development-branch --task checklist`
+- 🚫 FORBIDDEN: Generating compare URL without invoking `git-workflow --task review-prep`
+- ✅ REQUIRED: Follow the approval-gate dispatch chain in order after plan approval
+- ✅ REQUIRED: Invoke each mandatory skill in sequence
+- ✅ REQUIRED: Verify `WORKTREE_PATH` is set before any file modification
+- ✅ REQUIRED: Use `divide-and-conquer` to dispatch sub-agents for all file modifications on multi-task plans
+
+**See `approval-gate/SKILL.md` → "Dispatch Order" for the complete mandatory sequence. See `using-git-worktrees` skill → `create-worktree` task for worktree creation procedure.**
+
 ## Auditor Skills Enforcement
 
 **⚠️ MANDATORY: Run `spec-auditor` when auditing specs. NO SKIPPING.**

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -81,6 +81,7 @@ Spec approved (existing plan found)
 
 Plan approved
   → verify-authorization (all gates pass)
+  → git-workflow --task pre-work (MANDATORY: worktree creation and environment setup)
   → sub-issue verification (Step 5 of verify-authorization, if multi-phase)
   → pre-implementation-analysis (expand sub-issues, classify, build flat item list)
   → divide-and-conquer/assemble-batch (dispatch sub-agents, squash-merge into batch branch)
@@ -100,6 +101,8 @@ Already implemented
 - Spec approval: Issue title contains `[SPEC` or has `spec` label
 - Plan approval: Issue has `plan` label or `[PLAN]` prefix in title
 - See `verify-authorization.md` Step 5 for full procedure
+
+**⚠️ MANDATORY WORKTREE STEP:** `git-workflow --task pre-work` MUST be invoked between plan approval and any implementation. This step creates the feature branch worktree, sets `WORKTREE_PATH`, and verifies branch state. Skipping this step is a CRITICAL GUIDELINE VIOLATION (see `000-critical-rules.md`).
 
 **Circular dispatch prevention:** Spec approval dispatches to `writing-plans`, which creates a plan. Plan approval dispatches to `executing-plans`. The plan requires its own approval before `executing-plans` can run.
 

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -250,6 +250,18 @@ elif not plan_issues:
 
 **🚫 CRITICAL: This step runs ONLY when ALL prior verification gates (Steps 1-5) pass. If ANY gate fails, HALT — do NOT dispatch.**
 
+#### 6.1 Pre-Implementation Worktree Setup (MANDATORY)
+
+**Before any sub-agent dispatch or file modification, the agent MUST invoke `git-workflow --task pre-work` to:**
+
+1. Create the feature branch in a worktree (`.worktrees/`)
+2. Set the `WORKTREE_PATH` environment variable
+3. Verify branch state and working tree cleanliness
+
+**This step is MANDATORY and CANNOT be skipped.** If the worktree already exists from a previous session, verify it and proceed. If worktree creation fails, HALT — do not proceed without a valid worktree.
+
+**Evidence requirement:** `git worktree list` must show the feature branch worktree, and `WORKTREE_PATH` must be set before any `divide-and-conquer` dispatch.
+
 After all verification gates pass, determine the approval context and auto-dispatch:
 
 #### Auto-Dispatch Context Differentiation

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -63,6 +63,19 @@ Enforces context window safety by mandating pre-flight assessment before non-tri
 11. **Stacking is a prerequisite, not a preference** — feature branches MUST be stacked sequentially (merge-based dependency resolution) as the prerequisite approach. Parallel sub-agent dispatch is OPPORTUNISTIC — it depends on circumstances genuinely allowing it (truly independent codepaths, no shared files, no hidden dependencies). When in doubt, stack.
 12. **Completion guarantee** — idempotent completion on any halt. Invoke `--task completion` before halting regardless of outcome.
 
+## Pre-Dispatch Verification Checkpoint (MANDATORY)
+
+**Before dispatching any sub-agent, the main agent MUST verify:**
+
+1. **Worktree exists:** `git worktree list` shows the feature branch worktree
+2. **WORKTREE_PATH is set:** `echo $WORKTREE_PATH` returns a non-empty path inside the repository (`.worktrees/`)
+3. **git-workflow --task pre-work was invoked:** The worktree was created by the mandatory skill, not manually
+4. **Feature branch is checked out:** The worktree shows the correct branch name
+
+**If ANY check fails:** HALT and invoke `git-workflow --task pre-work` before proceeding.
+
+**Evidence requirement:** Record `git worktree list` output and `WORKTREE_PATH` value before dispatching any sub-agent.
+
 ## Overflow Signal Contract
 
 When a sub-agent determines it cannot fit the assigned work within its context window, it MUST return:

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,9 @@
-______________________________________________________________________
-
-## name: using-git-worktrees description: Use when creating any feature branch. Always invoke before git-workflow pre-work. Triggers on: branch, feature branch, pre-work, worktree, new branch, checkout. type: technique license: MIT compatibility: opencode
+---
+name: using-git-worktrees
+description: Use when creating a feature branch or worktree for implementation. Always invoke before git-workflow pre-work. Triggers on: branch, worktree, feature branch, create worktree, pre-work, WORKTREE_PATH.
+type: discipline-enforcing
+license: MIT
+---
 
 # Skill: using-git-worktrees
 


### PR DESCRIPTION
**Summary:**

Fixes 5 gaps where the agent bypassed mandatory skills (git-workflow pre-work, divide-and-conquer, using-git-worktrees frontmatter) during the implementation workflow, adding enforcement checkpoints to prevent recurrence.

**Outcome:** The approval-gate dispatch chain now mandates worktree creation before implementation, and both divide-and-conquer and critical rules enforce skill invocation as mandatory steps.

Fixes #950
Fixes #951
Fixes #952
Fixes #953