### PR TITLE
[SPEC-FIX #946] Remove closed=verified assumption from skills and guidelines

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -338,6 +338,21 @@ Chat output order (mandatory): 1) Executive summary, 2) URL (if exists), 3) AI b
 
 **See `git-workflow` skill `--task cleanup` for complete post-merge verification and closure workflow.**
 
+## Critical Violation: Assuming Closed Issues Are Verified — ZERO TOLERANCE
+
+**⚠️ Assuming an issue is fully implemented or resolved based solely on its closed state — without verifying a merged PR and success criteria — is a CRITICAL GUIDELINE VIOLATION.** A closed GitHub issue does NOT guarantee the work was completed, merged, or verified.
+
+- 🚫 FORBIDDEN: Skipping verification because an issue is "closed"
+- 🚫 FORBIDDEN: Trusting `state: "closed"` as evidence of implementation without merged PR proof
+- 🚫 FORBIDDEN: Classifying issues as "already implemented" based on closed state alone
+- 🚫 FORBIDDEN: Autoclosing parent issues when sub-issues are closed without merged PR evidence
+- 🚫 FORBIDDEN: Bypassing bug fix spec verification because the bug report is closed
+- ✅ REQUIRED: Verify closed issues have merged PR evidence via `github_pull_request_read` before treating them as resolved
+- ✅ REQUIRED: Check `state_reason` — `"not_planned"` means intentionally skipped, `"duplicate"` requires verifying the target, `"completed"` requires merged PR evidence
+- ✅ REQUIRED: Use `approval-gate --task verify-closed-issue` to verify legitimate closure before skipping, autoclosing, or excluding from implementation
+
+**See `approval-gate --task verify-closed-issue` for the complete verification procedure. See `git-workflow` skill `--task cleanup` for pre-closure sub-issue verification gate.**
+
 ## Critical Violation: Scope Creep — NEVER Do Things Outside the Spec
 
 **⚠️ Implementing changes not explicitly called for in the spec is a CRITICAL GUIDELINE VIOLATION.** The spec defines EXACTLY what to implement.

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -29,6 +29,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | `verify-open-questions` | Check for unresolved questions in spec | ~370 |
 | `verify-fix-spec` | For bug reports, verify fix spec sub-issue exists before closure | ~250 |
 | `search-prompt-fail` | Search GitHub Issues for existing spec/plan candidates before Q/A halt; present candidates or report failure | ~300 |
+| `verify-closed-issue` | Verify that a closed issue was legitimately closed via merged PR; enforce "closed ≠ verified" rule | ~350 |
 | `pre-implementation-analysis` | Analyze interdependencies and expand sub-issues for all approved issues (single or batch), producing flat item list for assemble-batch | ~500 |
 | `verify-schema-api-knowledge` | Verify that the agent has performed live verification before making schema/API/code claims; gate before proceeding | ~350 |
 | `post-implementation` | Push branch, generate compare URL, HALT | ~480 |
@@ -44,6 +45,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 - `/skill approval-gate --task verify-open-questions` - Check for unresolved questions
 - `/skill approval-gate --task verify-fix-spec` - Verify fix spec exists for bug reports
 - `/skill approval-gate --task search-prompt-fail` - Search for existing spec/plan candidates before Q/A halt
+- `/skill approval-gate --task verify-closed-issue` - Verify closed issue was legitimately closed via merged PR
 - `/skill approval-gate --task verify-schema-api-knowledge` - Verify schema/API/code knowledge before claims
 - `/skill approval-gate --task pre-implementation-analysis` - Analyze interdependencies and expand sub-issues for all approved issues, then yield to assemble-batch
 - `/skill approval-gate --task post-implementation` - After implementation done

--- a/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
@@ -30,6 +30,7 @@ Before classification, screen each approved issue against the following categori
 For each approved issue:
 
 1. Check partial/full implementation (merged PR references + success criteria)
+1. Check sub-issue closure verification for already-implemented classification (each sub-issue must be closed via merged PR, not prematurely closed)
 1. Check superseded by batch peer (scope overlap analysis)
 1. Check moot (spec references code that no longer exists/changed; no achievable criteria)
 1. Check stale assumptions (cross-reference with other issues in batch)
@@ -41,7 +42,7 @@ For each approved issue:
 
 | Category | Detection | Auto-resolve | Developer needed? |
 |----------|-----------|-------------|-------------------|
-| **Already implemented** | Merged PR references issue + all success criteria met | Exclude, mark "already-implemented" | No |
+| **Already implemented** | Merged PR references issue + all success criteria met + sub-issues verified closed via merged PR (not prematurely closed) | Exclude, mark "already-implemented" | No |
 | **Partially implemented** | Merged PR references issue + some success criteria met, some remaining | Include remaining phases only, mark "partially-implemented (phases X,Y done by PR #M)" | No |
 | **Superseded by batch peer** | Issue B's scope fully covers issue A's scope | Exclude A, note "superseded by #B" | No (if unambiguous) / Yes (if ambiguous) |
 | **Moot** | Referenced files/code restructured since spec creation; no remaining success criteria are achievable | Exclude, mark "moot" with reason | No |
@@ -52,7 +53,7 @@ For each approved issue:
 
 #### Screening Outcomes
 
-- **EXCLUDE**: already-implemented, superseded, moot, meta/non-code
+- **EXCLUDE**: already-implemented (verified via merged PR + sub-issues closed via merged PR), superseded, moot, meta/non-code
 - **REDUCE SCOPE**: partially-implemented (include remaining phases only)
 - **SERIALIZE**: same-intent stale assumptions, auto-resolvable conflicts
 - **HALT**: different-intent stale assumptions, unresolvable conflicts
@@ -60,6 +61,40 @@ For each approved issue:
 #### Partial Implementation Detection
 
 When a merged PR references the issue but not all success criteria are met:
+
+#### Already-Implemented Sub-Issue Verification
+
+**🚫 CRITICAL: An issue cannot be classified as "already implemented" if any of its sub-issues were closed without a merged PR.** Before excluding an issue as "already implemented," verify each sub-issue's closure:
+
+```
+For each sub-issue of the candidate "already implemented" issue:
+  child = github_issue_read(method="get", issue_number=sub_issue_number)
+
+  if child.state == "closed":
+    state_reason = child.get("state_reason", "")
+    prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")
+    merged_pr_found = False
+    for pr in prs:
+      pr_detail = github_pull_request_read(method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=pr["number"])
+      if pr_detail.get("merged_at") is not None:
+        merged_pr_found = True
+        break
+
+    if not merged_pr_found and state_reason != "not_planned":
+      # Sub-issue closed without merged PR — NOT legitimate closure
+      # Do NOT classify parent as "already implemented"
+      DOWNGRADE to "partially-implemented" or "scope-reduced"
+
+    if state_reason == "not_planned":
+      # Sub-issue intentionally not implemented
+      # Parent may be "already implemented" for remaining scope only
+      # Reduce scope to exclude intentionally skipped sub-issue
+      MARK as "scope-reduced — sub-issue #{sub_issue_number} intentionally not planned"
+
+  elif child.state == "open":
+    # Open sub-issue means parent is NOT fully implemented
+    DOWNGRADE to "partially-implemented"
+```
 
 1. Identify which phases/criteria are already satisfied by reading the merged PR's diff
 1. Extract remaining phases/criteria as the implementation scope

--- a/.opencode/skills/approval-gate/tasks/verify-already-implemented.md
+++ b/.opencode/skills/approval-gate/tasks/verify-already-implemented.md
@@ -105,6 +105,90 @@ When `verify-already-implemented` identifies issues that were already implemente
 
 **⚠️ CRITICAL:** Do NOT close issues without verifying PR merge via the GitHub API. Assuming a PR was merged without API confirmation is a verification dishonesty violation per `065-verification-honesty.md`.
 
+## Pre-Autoclose Sub-Issue Verification
+
+**🚫 CRITICAL: Before autoclosing an issue as "already implemented," verify that ALL sub-issues (if any) are also legitimately closed. A parent issue cannot be autoclosed if any sub-issue was closed without a merged PR.**
+
+### Step AC-1: Check for Sub-Issues
+
+```
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=issue_number)
+
+if sub_issues:
+    # Parent has sub-issues — each must be verified before autoclose
+    for sub_issue in sub_issues:
+        verify sub_issue is legitimately closed (see Step AC-2)
+else:
+    # No sub-issues — proceed to standard autoclose verification
+    PROCEED to Step 4
+```
+
+### Step AC-2: Verify Each Sub-Issue Closure Reason
+
+```
+For each sub-issue:
+  child = github_issue_read(method="get", issue_number=sub_issue_number)
+
+  if child.state == "closed":
+    state_reason = child.get("state_reason", "")
+
+    if state_reason == "not_planned":
+      # Sub-issue was intentionally not implemented
+      # Parent CANNOT be autoclosed — some work was deliberately skipped
+      VERIFICATION-GAP — flag-for-review
+      HALT autoclose
+
+    elif state_reason == "completed":
+      # Verify a merged PR exists for this sub-issue
+      prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")
+      merged_pr_found = False
+      for pr in prs:
+        pr_detail = github_pull_request_read(method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=pr["number"])
+        if pr_detail.get("merged_at") is not None:
+          merged_pr_found = True
+          break
+
+      if not merged_pr_found:
+        # Closed as "completed" but no merged PR — may be premature closure
+        VERIFICATION-GAP — flag-for-review
+        HALT autoclose
+
+    else:
+      # Closed without clear reason
+      VERIFICATION-GAP — flag-for-review
+      HALT autoclose
+
+  elif child.state == "open":
+    # Open sub-issue — parent CANNOT be autoclosed
+    MISSING-ELEMENT — proceed to normal implementation
+    HALT autoclose
+```
+
+### Step AC-3: Verify Cross-References
+
+```
+For each sub-issue verified as legitimately closed:
+  # Verify the sub-issue's scope is covered by the parent's success criteria
+  child_body = github_issue_read(method="get", issue_number=sub_issue_number)["body"]
+  parent_body = github_issue_read(method="get", issue_number=issue_number)["body"]
+
+  # If sub-issue covers scope not in parent's success criteria:
+  #   The parent may be "implemented" but the sub-issue's specific concern was not addressed
+  #   This is unlikely for autoclose scenarios but should be flagged if detected
+```
+
+### Pre-Autoclose Verification Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|---------|---------------|----------------|--------|
+| All sub-issues closed via merged PR | VERIFIED | auto-proceed | Proceed to autoclose |
+| Sub-issue closed as "not_planned" | VERIFICATION-GAP | flag-for-review | Do NOT autoclose parent — work was intentionally skipped |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Do NOT autoclose — may be premature closure |
+| Sub-issue still open | MISSING-ELEMENT | conditional | Do NOT autoclose — open sub-issues mean parent is not complete |
+| Sub-issue 404 | MISSING-TRACEABILITY | flag-for-review | Developer must resolve missing sub-issue |
+
+**Only proceed to Step 4 (autoclose) when ALL sub-issues are verified as legitimately closed via merged PR.**
+
 ## What This Is NOT
 
 This task does NOT replace:

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -143,6 +143,72 @@ For each sub-issue:
 
 **Evidence artifact:** `github_issue_read(method=get)` for each sub-issue showing actual state, title, labels, and parent link.
 
+#### 5.4 Closed-Issue Verification Before Skipping
+
+**Before skipping a closed issue in any workflow gate (already-implemented, already-handled, auto-dispatch), verify it was closed for the right reason. A closed state alone does NOT mean work is done.**
+
+```
+For each closed issue encountered during verification:
+  issue = github_issue_read(method="get", issue_number=closed_issue_number)
+
+  if issue.state == "closed":
+    # CRITICAL: Do NOT assume closed = verified. Verify closure reason.
+
+    # Check 1: Was it closed via merged PR?
+    # Search for PRs referencing this issue
+    prs = github_search_pull_requests(query=f"Fixes #{closed_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")
+    merged_pr_found = False
+    for pr in prs:
+      pr_detail = github_pull_request_read(method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=pr["number"])
+      if pr_detail.get("merged_at") is not None:
+        merged_pr_found = True
+        break
+
+    # Check 2: Was it closed as "not planned" or duplicate?
+    state_reason = issue.get("state_reason", "")
+    if state_reason == "not_planned":
+      # Issue was intentionally not implemented — may still need implementation
+      # Do NOT skip; treat as if the issue were open for verification purposes
+      VERIFICATION-GAP — flag-for-review
+    elif state_reason == "completed" and not merged_pr_found:
+      # Closed as "completed" but no merged PR found
+      # May have been closed manually without implementation
+      VERIFICATION-GAP — flag-for-review
+    elif state_reason == "completed" and merged_pr_found:
+      # Closed as "completed" with merged PR — legitimate closure
+      # Verify success criteria are actually met (see verify-already-implemented)
+      PROCEED to verify-already-implemented
+    else:
+      # State reason unclear or missing
+      VERIFICATION-GAP — flag-for-review
+```
+
+**Closed-Issue Verification Gate for Auto-Dispatch:**
+
+The "Already implemented" row in the Auto-Dispatch table (Step 6) MUST NOT skip a closed issue without this verification gate passing. Update auto-dispatch logic:
+
+```
+# In auto-dispatch, when detect "already implemented":
+# 1. Run closed-issue verification (Step 5.4)
+# 2. If verification confirms legitimate closure (merged PR + success criteria met):
+#    → Proceed to verify-already-implemented → autoclose if all criteria pass
+# 3. If verification finds closure without merged PR:
+#    → flag-for-review, do NOT autoclose
+# 4. If verification finds "not_planned" closure:
+#    → flag-for-review, treat as open for implementation purposes
+```
+
+**Finding Classification for Closed-Issue Verification:**
+
+| Finding | Problem Class | Classification | Action |
+|---------|---------------|----------------|--------|
+| Closed + merged PR + criteria met | VERIFIED | auto-proceed | Skip to autoclose workflow |
+| Closed + merged PR + criteria NOT met | CONFLICTING | flag-for-review | Investigation needed — PR may not cover full scope |
+| Closed as "completed" + no merged PR | VERIFICATION-GAP | flag-for-review | Manual closure without implementation evidence |
+| Closed as "not_planned" | VERIFICATION-GAP | flag-for-review | Intentionally deferred — may need reopening |
+| Closed as "duplicate" | MISSING-TRACEABILITY | conditional | Verify duplicate target exists and covers scope |
+| Closed state unclear (no reason) | VERIFICATION-GAP | flag-for-review | Do NOT skip — verify implementation manually |
+
 #### Finding Classification for Sub-Issue Verification
 
 | Finding | Problem Class | Classification | Action |
@@ -270,7 +336,8 @@ After all verification gates pass, determine the approval context and auto-dispa
 |------------------|---------------|----------------------|
 | **Spec approval** | Issue title contains `[SPEC` or has `spec` label | `writing-plans --task create` |
 | **Plan approval** | Issue has `plan` label or `[PLAN]` prefix in title | `executing-plans --task start` |
-| **Already implemented** | `verify-already-implemented` returns positive | No dispatch — auto-close instead |
+| **Already implemented** | `verify-already-implemented` returns positive (after closed-issue verification in Step 5.4 confirms legitimate closure) | No dispatch — auto-close instead |
+| **Closed but NOT verified** | Step 5.4 closed-issue verification finds closure without merged PR evidence | flag-for-review — do NOT autoclose |
 
 #### Auto-Dispatch Procedure
 

--- a/.opencode/skills/approval-gate/tasks/verify-closed-issue.md
+++ b/.opencode/skills/approval-gate/tasks/verify-closed-issue.md
@@ -1,0 +1,230 @@
+# Task: verify-closed-issue
+
+## Purpose
+
+Verify that a closed issue was legitimately closed — checking that a merged PR exists and that no premature closure occurred. This task enforces the rule that "closed" does NOT mean "verified" without evidence.
+
+## Pre-Conditions
+
+- **Load guideline:** `.opencode/guidelines/065-verification-honesty.md` before proceeding — verification claims must be backed by actual tool calls, not memory
+
+## Entry Criteria
+
+- An issue's closed state needs verification (before skipping, autoclosing parent, or classifying as "already implemented")
+- The issue number is known
+
+## Exit Criteria
+
+- Closed state is verified as legitimate (merged PR exists) OR
+- Closed state is flagged as a VERIFICATION-GAP (no merged PR evidence) with clear reason
+
+## Procedure
+
+### Step 1: Retrieve Issue State
+
+```python
+issue = github_issue_read(method="get", issue_number=N)
+
+if issue["state"] != "closed":
+    # Issue is still open — closed verification does not apply
+    REPORT: "Issue #N is open, not closed. No closed-state verification needed."
+    EXIT with result: NOT_CLOSED
+```
+
+**Evidence artifact:** `github_issue_read(method=get)` response showing `state: "closed"`.
+
+### Step 2: Determine Closure Reason
+
+```python
+state_reason = issue.get("state_reason", "")
+```
+
+| `state_reason` | Interpretation | Next Step |
+|----------------|---------------|-----------|
+| `"completed"` | Issue was marked as done | Step 3 (verify merged PR) |
+| `"not_planned"` | Issue was intentionally not implemented | Step 4 (handle not_planned) |
+| `"duplicate"` | Issue was closed as a duplicate | Step 5 (verify duplicate target) |
+| `None` or empty | No reason recorded | Step 3 (assume completed, verify) |
+
+### Step 3: Verify Merged PR Exists (for "completed" or unknown reason)
+
+**🚫 CRITICAL: A closed issue with `state_reason: "completed"` does NOT guarantee implementation.** Verify via GitHub API.
+
+```python
+# Search for PRs that reference this issue
+prs = github_search_pull_requests(
+    query=f"Fixes #{N} repo:{GIT_OWNER}/{GIT_REPO}"
+)
+
+merged_pr_found = False
+merged_prs = []
+
+for pr in prs:
+    pr_detail = github_pull_request_read(
+        method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=pr["number"]
+    )
+    if pr_detail.get("merged_at") is not None:
+        merged_pr_found = True
+        merged_prs.append({
+            "number": pr_detail["number"],
+            "merged_at": pr_detail["merged_at"],
+            "merged_by": pr_detail.get("merged_by", {})
+        })
+
+if merged_pr_found:
+    REPORT: f"Issue #{N} closed as completed with merged PR evidence: {', '.join(f'#{p['number']}' for p in merged_prs)}"
+    EXIT with result: VERIFIED_CLOSED
+else:
+    # No merged PR found — suspicious closure
+    REPORT: f"Issue #{N} closed as completed but NO merged PR found via 'Fixes #{N}' search"
+    EXIT with result: VERIFICATION_GAP
+```
+
+**Evidence artifact:** `github_search_pull_requests` response + `github_pull_request_read` response showing `merged_at` field for each PR found.
+
+### Step 4: Handle "not_planned" Closure
+
+```python
+# Issue was intentionally not implemented
+REPORT: f"Issue #{N} closed as not_planned — work was intentionally deferred or rejected"
+REPORT: "This issue may need reopening or a new fix spec if the underlying problem persists"
+EXIT with result: NOT_PLANNED_CLOSURE
+```
+
+**Action for callers:**
+
+| Caller Context | Action |
+|---------------|--------|
+| `verify-authorization` auto-dispatch | Do NOT autoclose; flag for review |
+| `verify-already-implemented` | Do NOT classify as "already implemented" |
+| `pre-implementation-analysis` screening | Do NOT exclude from implementation; may need scope reduction |
+| `cleanup` pre-closure gate | Allow parent closure only if remaining scope is verified |
+
+### Step 5: Verify Duplicate Target (for "duplicate" closure)
+
+```python
+# Extract duplicate target from issue body or comments
+# GitHub typically adds "Duplicate of #M" automatically
+# Also check comments for duplicate reference
+
+body = issue.get("body", "")
+comments = github_issue_read(method="get_comments", issue_number=N)
+
+duplicate_target = None
+
+# Search body for duplicate reference
+for line in body.split("\n"):
+    if "duplicate" in line.lower() and "#" in line:
+        # Extract issue number reference
+        import re
+        match = re.search(r'#(\d+)', line)
+        if match:
+            duplicate_target = int(match.group(1))
+            break
+
+# Search comments for duplicate reference
+if not duplicate_target:
+    for comment in comments:
+        if "duplicate" in comment.get("body", "").lower():
+            match = re.search(r'#(\d+)', comment.get("body", ""))
+            if match:
+                duplicate_target = int(match.group(1))
+                break
+
+if duplicate_target:
+    # Verify the duplicate target exists and is not also prematurely closed
+    target = github_issue_read(method="get", issue_number=duplicate_target)
+    REPORT: f"Issue #{N} closed as duplicate of #{duplicate_target} (state: {target['state']})"
+    # Recursively verify the duplicate target if it's also closed
+    # (Call verify-closed-issue recursively for the target, with depth limit)
+    EXIT with result: DUPLICATE_OF, target=duplicate_target
+else:
+    REPORT: f"Issue #{N} closed as duplicate but no duplicate target found"
+    EXIT with result: VERIFICATION_GAP
+```
+
+### Step 6: Check Sub-Issues (After Verifying Parent Closure)
+
+If the issue is a parent with sub-issues, verify EACH sub-issue's closure is legitimate before closing the parent:
+
+```python
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
+
+if sub_issues:
+    for sub_issue in sub_issues:
+        # Recursively verify each sub-issue
+        sub_result = verify_closed_issue(sub_issue["number"])
+
+        if sub_result == VERIFICATION_GAP:
+            REPORT: f"Sub-issue #{sub_issue['number']} closure is a verification gap"
+            # Parent CANNOT be closed until sub-issue is resolved
+            EXIT with result: BLOCKED_BY_SUB_ISSUE
+
+        elif sub_result == NOT_PLANNED_CLOSURE:
+            REPORT: f"Sub-issue #{sub_issue['number']} was closed as not_planned"
+            # Parent MAY be closed for remaining scope only
+            NOTE sub_issue["number"] as "intentionally skipped"
+```
+
+### Step 7: Cross-Reference with Success Criteria
+
+For legitimately closed issues (VERIFIED_CLOSED), optionally verify that the success criteria in the spec were actually met:
+
+```python
+# This step is informational — it does NOT block closure
+# It provides additional confidence that the closed state is accurate
+
+body = issue.get("body", "")
+# Extract success criteria from spec body (if present)
+# Compare against changes in the merged PR
+# Report any discrepancies as informational findings
+```
+
+**This step is optional and does NOT block the verification result.** It provides additional evidence for downstream callers.
+
+## Verification Result Types
+
+| Result | Meaning | Action for Callers |
+|--------|---------|-------------------|
+| `NOT_CLOSED` | Issue is still open | Not applicable — caller should treat as open issue |
+| `VERIFIED_CLOSED` | Closed with merged PR evidence | Safe to treat as legitimately closed |
+| `VERIFICATION_GAP` | Closed without merged PR evidence | Do NOT trust closed state — flag for review |
+| `NOT_PLANNED_CLOSURE` | Closed as "not_planned" | Work was intentionally skipped — may need reopening |
+| `DUPLICATE_OF` | Closed as duplicate of another issue | Verify target issue covers the scope |
+| `BLOCKED_BY_SUB_ISSUE` | Parent cannot close because a sub-issue has a verification gap | Resolve sub-issue verification first |
+
+## Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| Closed + merged PR | VERIFIED | auto-proceed | Trust closed state |
+| Closed "completed" + no merged PR | VERIFICATION-GAP | flag-for-review | Do NOT trust — investigate closure |
+| Closed "not_planned" | VERIFIED | auto-proceed | Work intentionally skipped |
+| Closed "duplicate" + target verified | VERIFIED | auto-proceed | Trust duplicate closure |
+| Closed "duplicate" + target not found | MISSING-TRACEABILITY | flag-for-review | Cannot verify duplicate chain |
+| Closed + no reason recorded | VERIFICATION-GAP | flag-for-review | Investigate closure reason |
+| Parent closed + sub-issue verification gap | VERIFICATION-GAP | flag-for-review | Resolve sub-issue first |
+
+## Integration Points
+
+This task is invoked by:
+
+1. **`verify-authorization` Step 5.4** — Before skipping closed issues in auto-dispatch
+2. **`verify-already-implemented`** — Before autoclosing as "already implemented"
+3. **`pre-implementation-analysis` Step 0** — Before excluding "already implemented" issues from batch
+4. **`cleanup` pre-closure gate** — Before closing parent issues in post-merge workflow
+5. **`verify-fix-spec`** — Before skipping closed bug reports
+
+## Context Required
+
+- Issue number to verify
+- `GIT_OWNER` and `GIT_REPO` from session
+- Downstream callers should handle the result type to make appropriate decisions
+
+## Cross-References
+
+- `000-critical-rules.md`: Closed issues skip sub-issue and cross-reference verification — critical violation
+- `065-verification-honesty.md`: Verification claims must be backed by tool call evidence
+- `approval-gate/tasks/verify-authorization.md` Step 5.4: Closed-issue verification gate
+- `approval-gate/tasks/verify-already-implemented.md`: Pre-autoclose sub-issue verification
+- `git-workflow/tasks/cleanup.md`: Pre-closure sub-issue verification gate

--- a/.opencode/skills/approval-gate/tasks/verify-fix-spec.md
+++ b/.opencode/skills/approval-gate/tasks/verify-fix-spec.md
@@ -59,10 +59,52 @@ Examine sub-issues for:
 
 | Case | Handling |
 |------|----------|
-| Bug report is already closed with merged PR | Skip check — already resolved |
+| Bug report is already closed | **Do NOT skip — verify closure is legitimate via merged PR.** See "Closed Bug Report Verification" below |
 | Bug report has multiple fix spec sub-issues | Report all; this is valid for multiple root causes |
 | Sub-issue exists but is not a fix spec | Ignore for this check; still need a proper fix spec |
 | Issue was misclassified as bug | Skip this check; not applicable |
+
+### Closed Bug Report Verification
+
+**🚫 CRITICAL: A closed bug report does NOT mean the fix is already resolved.** Before skipping verification for a closed bug report, verify that the closure is legitimate:
+
+```
+if bug_report.state == "closed":
+    # Do NOT assume closed = resolved. Verify closure reason.
+
+    # Step 1: Check closure reason
+    state_reason = bug_report.get("state_reason", "")
+
+    if state_reason == "not_planned":
+        # Bug was intentionally not fixed — may still need a fix spec
+        # Do NOT skip; the bug may need to be reopened or a new fix spec created
+        REPORT: "Bug closed as not_planned — fix spec still needed if bug is valid"
+        PROCEED to Step 2 (fix spec verification)
+
+    elif state_reason == "completed":
+        # Verify a merged PR exists that fixes this bug
+        prs = github_search_pull_requests(query=f"Fixes #{bug_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")
+        merged_pr_found = False
+        for pr in prs:
+            pr_detail = github_pull_request_read(method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=pr["number"])
+            if pr_detail.get("merged_at") is not None:
+                merged_pr_found = True
+                break
+
+        if merged_pr_found:
+            # Bug was closed via merged PR — legitimate closure
+            # Still check for fix spec sub-issue (it may exist from before the fix)
+            PROCEED to Step 2 (fix spec verification)
+        else:
+            # Closed as "completed" but no merged PR — suspicious closure
+            REPORT: "Bug closed as completed but no merged PR found — verification gap"
+            PROCEED to Step 2 (fix spec may still be needed)
+
+    else:
+        # State reason unclear
+        REPORT: "Bug closed without clear reason — verification gap"
+        PROCEED to Step 2 (fix spec verification)
+```
 
 ## Cross-References
 

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -582,6 +582,70 @@ This enables automatic closure by GitBucket/GitHub.
 | Draft PR | Sub-issues remain open until PR is merged (correct behavior) |
 | Multiple sub-issues in one PR | Include all in "Fixes #N, #M, #P" annotation |
 
+## Pre-Closure Sub-Issue Verification Gate (CRITICAL)
+
+**🚫 CRITICAL: Before closing ANY issue, verify that closed sub-issues were legitimately closed via merged PR. A closed state alone does NOT mean work is done.**
+
+This verification gate runs BEFORE the sub-issue double-check (which verifies open sub-issues remain). This gate verifies that already-closed sub-issues were legitimately closed.
+
+### Verification Procedure
+
+```
+For each sub-issue of the parent issue:
+  child = github_issue_read(method="get", issue_number=sub_issue_number)
+
+  if child.state == "closed":
+    state_reason = child.get("state_reason", "")
+
+    # Verify closure is legitimate (not premature)
+    prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")
+    merged_pr_found = False
+    for pr in prs:
+      pr_detail = github_pull_request_read(method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=pr["number"])
+      if pr_detail.get("merged_at") is not None:
+        merged_pr_found = True
+        break
+
+    if state_reason == "completed" and merged_pr_found:
+      # Legitimate closure — sub-issue was implemented and merged
+      PROCEED — sub-issue verified
+
+    elif state_reason == "completed" and not merged_pr_found:
+      # Closed as "completed" but NO merged PR — likely premature closure
+      VERIFICATION-GAP — flag-for-review
+      # Do NOT close parent — investigate this sub-issue first
+
+    elif state_reason == "not_planned":
+      # Intentionally not implemented — acceptable if documented
+      # Parent CAN be closed if remaining sub-issues are legitimate
+      NOTE — sub-issue was intentionally skipped
+
+    elif state_reason == "duplicate":
+      # Closed as duplicate — verify target issue exists and covers scope
+      # Check if the duplicate target is also legitimately closed
+      VERIFICATION-GAP — conditional (verify duplicate covers scope)
+
+    else:
+      # No clear closure reason
+      VERIFICATION-GAP — flag-for-review
+
+  elif child.state == "open":
+    # Open sub-issue — handled by Sub-Issue Double-Check below
+    PASS — handled by next section
+```
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|---------|---------------|----------------|--------|
+| Closed + merged PR | VERIFIED | auto-proceed | Sub-issue verified as legitimately closed |
+| Closed "completed" + no merged PR | VERIFICATION-GAP | flag-for-review | Investigate — may be premature closure |
+| Closed "not_planned" | VERIFIED | auto-proceed | Intentionally skipped — parent can close remaining scope |
+| Closed "duplicate" | VERIFICATION-GAP | conditional | Verify duplicate target covers scope |
+| Open sub-issue | MISSING-ELEMENT | conditional | Handled by Sub-Issue Double-Check below |
+
+**Only proceed to parent closure after ALL closed sub-issues are verified as legitimately closed or intentionally skipped.**
+
 ## Sub-Issue Double-Check (CRITICAL)
 
 After closing child issues addressed by PR, ALWAYS verify remaining sub-issues before closing parent.

--- a/.opencode/skills/issue-review/tasks/analyze-and-spec.md
+++ b/.opencode/skills/issue-review/tasks/analyze-and-spec.md
@@ -157,8 +157,28 @@ Produce prose exec summary for chat:
 | Bug already has a fix spec sub-issue | Skip creation; report existing fix spec in chat |
 | Root cause is in a dependency | Note in fix spec; fix may be "work around" or "update dependency" |
 | Bug is actually expected behavior | Report misclassification; suggest closing as not-a-bug |
-| Issue is closed bug report | Skip analysis — closed bugs are already-handled or stale |
+| Issue is closed bug report | Do NOT skip — verify sub-issues are closed and cross-references resolved; if all verified, classify as `already-handled`; otherwise proceed with analysis or flag for review |
 | Fix spec creation fails | HALT; report error in chat; retry is developer's decision |
+
+## Closed Issue Verification Gate
+
+**⚠️ NEVER skip analysis for a closed issue without verification.** A closed issue may have:
+
+1. **Open sub-issues** — The parent is closed but child issues remain open (premature parent closure)
+2. **Unresolved cross-references** — The spec → plan chain may still have pending links
+3. **Erroneous closure** — No merged PR, `state_reason` is "not_planned" instead of "completed"
+
+### Verification Procedure
+
+Before classifying a closed bug report as `already-handled` or `stale`:
+
+1. **Check sub-issues:** `github_issue_read(method="get_sub_issues", issue_number=N)` — if any sub-issue is open, the parent closure is premature
+2. **Check cross-references:** Read issue body for `Spec: #N`, `Plan: #N` references — verify referenced issues are also resolved
+3. **Check closure correctness:** Verify `state_reason == "completed"` AND a merged PR exists (search for PRs referencing the issue)
+4. **If all verified:** Classify as `already-handled` and skip analysis
+5. **If any check fails:** Proceed with analysis (root cause may still need fix spec) or flag for review
+
+**Evidence requirement:** Each check must produce a tool-call artifact. Do NOT assume "closed" = "verified."
 
 ## Cross-References
 

--- a/.opencode/skills/issue-review/tasks/triage.md
+++ b/.opencode/skills/issue-review/tasks/triage.md
@@ -38,14 +38,14 @@ Scan gathered data for these signals:
 | Body has "Edge Cases" section | `audit` |
 | Body has "Affected Files" table | `audit` |
 | Body has "Risk Assessment" table | `audit` |
-| Comments contain "approved" or "go" | Check if also implemented → `already-handled` |
+| Comments contain "approved" or "go" | Check if also implemented AND sub-issues verified closed AND cross-references resolved → `already-handled` |
 | Comments contain audit finding patterns | `just-review` (if no new non-audit comments) |
 | `needs-approval` label present, no explicit auth | `just-review` (report auth status) |
 | Body uses bug report language ("crash", "error", "broken") | `analyze-and-spec` |
 | Body contains "steps to reproduce" | `analyze-and-spec` |
 | Body describes unexpected behavior or regression | `analyze-and-spec` |
 | `bug` label present | `analyze-and-spec` (unless content clearly is not a bug) |
-| Issue is closed AND PR merged | `already-handled` |
+| Issue is closed AND PR merged AND sub-issues verified closed AND cross-references resolved | `already-handled` |
 | Body is unclear, vague, or request for information (not a bug) | `qa` |
 | Title has `[SPEC]` but body is a bug report | `analyze-and-spec` (content over prefix) |
 
@@ -101,6 +101,19 @@ Verification: Bug language detected, but root cause unclear — may need clarifi
 
 Each sub-issue gets its own independent triage decision. A parent may be `audit` while a sub-issue is `qa`.
 
+## Closed Issue Verification in Triage
+
+**Before classifying any closed issue as `already-handled`, verify:**
+
+1. **Sub-issues resolved:** `github_issue_read(method="get_sub_issues", issue_number=N)` — all sub-issues must be closed
+2. **Cross-references resolved:** Spec → plan chain must be complete (plan closed, all sub-issues under plan closed)
+3. **Closure correctness:** `state_reason == "completed"` AND merged PR exists (search PRs referencing the issue)
+
+If any verification fails, do NOT classify as `already-handled`. Instead:
+- Route to `analyze-and-spec` (if bug report with open fix spec)
+- Route to `audit` (if spec with open sub-issues)
+- Report as `flag-for-review` with specific verification failures
+
 ## Confidence Levels
 
 | Level | Meaning |
@@ -115,7 +128,7 @@ Each sub-issue gets its own independent triage decision. A parent may be `audit`
 |------|----------|
 | No comments, no phases, no bug language | `qa` (unclear intent, ask for clarification) |
 | No comments, but bug language present | `analyze-and-spec` (bug language is sufficient) |
-| Issue is closed | Check if `already-handled` or stale |
+| Issue is closed | Verify sub-issues closed, cross-references resolved, closure correctness → then classify as `already-handled` or `stale` |
 | Mixed signals (phases + bug language) | AI verification breaks tie; document reasoning |
 | Title says spec but body is bug | Redirect to `analyze-and-spec` |
 | Body lacks formal sections but clear feature | Redirect to `audit` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/946-closed-issue-verification
+
+- **Closed Issue Verification Gates** (#946) - Fixed "closed = verified" assumption across 8 skill files and 1 guideline. Closed issues are no longer trusted without merged PR evidence. Added `verify-closed-issue` task with 7-step verification procedure, pre-closure sub-issue verification gate in cleanup, closed-issue verification in auto-dispatch, and critical violation in `000-critical-rules.md`.
+
 ### batch/apr-15-enforcement-batch
 
 - **Byline Format Drift Audit** (#866) - Audited and corrected `<AI-Name>`/`<ModelID>` placeholder tokens across all guidelines and skills. Replaced hardcoded agent/model references with runtime-resolvable placeholders. Added critical violation for hardcoded identity values in `000-critical-rules.md`.


### PR DESCRIPTION
**Summary:**

Ensures that closed GitHub issues are never treated as verified without merged PR evidence, eliminating the assumption that "closed = already handled" across all workflow skills.

**Outcome:** Agents will now verify closed issues have legitimate closure (merged PR, correct state_reason, sub-issues verified) before skipping, autoclosing, or excluding them from implementation batches.

Fixes #946
Fixes #947
Fixes #948
Fixes #949