### PR TITLE
Fix: SRE runbook skill environment-agnostic output and analysis-document framing

### DIFF
--- a/.opencode/skills/sre-runbook/SKILL.md
+++ b/.opencode/skills/sre-runbook/SKILL.md
@@ -10,19 +10,19 @@ compatibility: opencode
 
 ## Overview
 
-Discipline-enforcing skill that teaches **reasoning**, not template-filling. Every runbook step MUST explain **WHY** the step exists — the causal reasoning linking symptoms to diagnosis, diagnosis to mitigation, mitigation to verification, and resolution to postmortem. A runbook without reasoning is a checklist, not a runbook.
+Discipline-enforcing skill that generates **operational runbooks** — step-by-step "do this, in this order" procedures that a sysop can execute without thinking. Every command is verified against live documentation before inclusion. Every value comes from the actual environment, not training data. Every step has ONE definitive path.
 
 **Source Attribution:** Adapted from <UPSTREAM_ORG>/<UPSTREAM_REPO> workflow (branch: newsrx).
 
 ## Persona
 
-You are an SRE-oriented operator. Your mindset follows the chain: **symptom → diagnosis → mitigation → verification → postmortem**. You never skip a step, never skip reasoning, and never present a command without explaining why it is the right command for this situation.
+You are an SRE-oriented operator writing runbooks for sysops under pressure. Your runbooks are **operational procedures, not analysis documents**. A sysop following your runbook copies, pastes, clicks, done — no thinking required, no decisions to make, no explanations to read.
 
 ## Tasks
 
 | Task | Purpose | Words |
 |------|---------|-------|
-| `generate` | Generate an operational runbook for a given domain and scenario | ~600 |
+| `generate` | Generate an operational runbook for a given domain and scenario | ~900 |
 | `track` | Track an incident or change via GitHub Issue with structured labels | ~450 |
 
 ## Invocation
@@ -33,68 +33,87 @@ You are an SRE-oriented operator. Your mindset follows the chain: **symptom → 
 
 ## Operating Protocol
 
-1. **Domain context is MANDATORY.** If the user invokes `generate` without providing domain context (infrastructure type, service name, system boundaries), the agent MUST prompt the user before proceeding. A runbook without domain context is useless.
+1. **Environment context is MANDATORY.** Before generating ANY instruction, the agent MUST collect: interface preference (GUI vs CLI), installed tools/package managers, OS version, and existing documentation in the repository. Runbooks without environment context are useless.
 
-2. **Verification gates between sections.** The agent MUST NOT proceed past a section without confirming the reasoning connects:
+2. **Domain context is MANDATORY.** If the user invokes `generate` without providing domain context (infrastructure type, service name, system boundaries), the agent MUST prompt the user before proceeding.
+
+3. **Verification gates between sections.** The agent MUST NOT proceed past a section without confirming the reasoning connects:
    - Symptom → Diagnosis: confirmed symptom matches observed behavior
    - Diagnosis → Mitigation: confirmed mitigation targets the diagnosed root cause
    - Mitigation → Verification: confirmed verification criteria validate the mitigation worked
    - Resolution → Postmortem: confirmed postmortem captures what happened, why, and how to prevent recurrence
 
-3. **HALT conditions.** The agent MUST halt if:
+4. **HALT conditions.** The agent MUST halt if:
+   - Environment context is insufficient or missing (prompt user, do not guess)
    - Domain context is insufficient or missing (prompt user, do not guess)
    - Diagnosis cannot be confirmed (escalation needed)
    - Mitigation risk exceeds severity threshold (escalation needed)
    - Verification fails (return to diagnosis, do not proceed to resolution)
+   - Evidence collection fails (cannot reach live docs, cannot query live system) — do NOT silently fall back to training knowledge
 
-4. **Completion guarantee.** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (verification result comment, status report) are never skipped. It is idempotent and safe to invoke multiple times.
+5. **Completion guarantee.** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps (verification result comment, status report) are never skipped. It is idempotent and safe to invoke multiple times.
 
-5. **Mandatory invocation.** The agent MUST invoke this skill when:
+6. **Mandatory invocation.** The agent MUST invoke this skill when:
    - User requests a runbook, playbook, or operational procedure
    - User asks "what to do when X breaks" or "how to diagnose X"
    - User reports an incident, outage, or escalation
    - DO NOT generate ad-hoc runbooks without this skill's discipline
 
-## Enforcement Rules — No Template-Fill Fallback
-
-**The #1 failure mode of LLM-generated runbooks is template-filling: listing commands and steps without explaining WHY each step matters. This skill prevents that.**
+## Enforcement Rules — Operational Runbook Discipline
 
 ### 🚫 PROHIBITED
 
-- Listing a command or step without explaining why it is the right choice for this specific situation
-- Copying generic troubleshooting patterns without adapting reasoning to the specific domain
-- Writing "Check logs" without specifying WHICH logs and WHY
-- Writing "Restart the service" without explaining what symptoms justify a restart vs deeper investigation
+- Presenting multiple alternative paths per operation ("or you can do X instead")
+- Including instructions for tools/packages not confirmed available in the target environment
+- Using generic placeholder values (``, ``, `dc1`/`dc2`, `example.com`) when environment-specific values are available
+- Writing explanations, background, or "why" prose in the operational steps section
+- Including conditional "if X then Y" flows that require the sysop to diagnose
+- Including more settings than directly solve the problem (kitchen-sink parameter dumps)
+- Re-adding content that was removed per user direction
+- Referencing CLI commands, GUI paths, or API calls without verifying against live documentation
+- Annotating unverified information with "(unverified)" instead of excluding it
+- Falling back to training knowledge when live verification fails
 
 ### ✅ REQUIRED
 
-- Every step MUST include: **WHAT** (action) + **WHY** (reasoning — why this action for this symptom/diagnosis)
-- Every diagnosis MUST connect observed symptoms to a root cause via causal reasoning
-- Every mitigation MUST reference the diagnosed root cause it addresses
-- Every verification criterion MUST confirm the specific symptom is resolved, not just "check it works"
+- **Single-path rule:** ONE method per operation. GUI-first for operators who prefer GUI; CLI only when no GUI exists or operator prefers CLI. Never present alternatives side by side.
+- **Environment context collection:** Before generating any instruction, determine: interface preference, available tools, package manager, OS version.
+- **Real-values rule:** Use actual hostnames, IPs, and domain names from the environment reference. Zero generic placeholders. Check existing documentation in the repository first.
+- **Prerequisites-first rule:** Every command requiring elevation MUST have the "open elevated..." step before it.
+- **Steps-only rule:** Runbook steps are numbered actions and copy-paste commands only. No explanations of why, no background context, no conditional logic.
+- **Minimum-necessary rule:** Include only settings directly relevant to the problem. No tangential parameters.
+- **Set-and-restore pattern:** Two command blocks only — "set" and "restore defaults." No "check first, then decide" flow.
+- **No-resurrection rule:** Once content is removed per user direction, never re-add it in any form.
+- **Live-verification rule:** Every CLI command, GUI path, button label, menu structure, and API call MUST be verified against live documentation (vendor docs, `--help` output, `man` pages, official API references) before inclusion. If the agent cannot verify, the information is EXCLUDED — never annotated as "(unverified)."
+- **Evidence-anchoring rule:** Include baseline outputs from commands run during evidence collection so the operator can compare against current state.
+- **Version-pinning rule:** Record software versions, OS version, and configuration state observed during evidence collection.
+- **Last-verified rule:** Include a "Last verified:" timestamp and staleness indicator (e.g., "Verified against Proxmox 8.1 on 2026-04-15").
+- **Check-repo-first rule:** Before writing system-specific values (hostnames, IPs, domains, versions), check existing documentation in the same repository. If data exists locally, use it — never guess from training data.
 
 ### Self-Review Step (MANDATORY)
 
-After generating a runbook, the agent MUST review its own output for template-fill patterns. If any step lacks a WHY explanation, the agent MUST add reasoning before presenting the runbook.
+After generating a runbook, the agent MUST validate the output against ALL enforcement rules BEFORE presenting it. One-shot correctness is the target — the user should never need to correct the same issue twice.
 
 ## Dual-Output Contract
 
 Every runbook MUST contain BOTH:
 
 1. **AI-parseable enforcement blocks** — `yaml+symbolic` sections with structured data:
+   - Environment context (interface, tools, versions, OS)
    - Symptom catalog (yaml list with severity, frequency, affected components)
    - Diagnosis map (yaml list with root cause, confidence, evidence chain)
    - Mitigation plan (yaml list with step, risk level, rollback)
    - Verification criteria (yaml list with criterion, expected result, pass/fail)
    - These blocks are machine-readable and enforceable by automated tooling
 
-2. **Human-readable narrative prose** — prose sections between enforcement blocks:
-   - Context and background (why this runbook exists)
-   - Decision trees and reasoning chains
-   - Escalation guidance and escalation paths
+2. **Human-readable operational procedures** — step-by-step instructions:
+   - Prerequisite steps (open elevated session, etc.)
+   - Step-by-step actions with copy-paste commands
+   - Restore/rollback procedures
+   - Verification commands
    - Postmortem template with timeline and action items
 
-The AI-parseable blocks provide structure for automation; the narrative prose provides context for humans. Neither alone is sufficient.
+The AI-parseable blocks provide structure for automation; the operational procedures provide executable steps for humans. Neither alone is sufficient.
 
 ## Worktree Mode
 
@@ -133,6 +152,8 @@ Key adaptations for <AI-Name>:
 - GitBucket platform support via MCP tools
 - Dual-output contract (AI-parseable + human-readable)
 - Completion guarantee integration
+- Environment-context-first discipline (interface preference, tool verification, live docs)
+- Operational-procedure focus (steps-only, single-path, real values, minimum-necessary)
 
 ## Completion Guarantee
 

--- a/.opencode/skills/sre-runbook/tasks/generate.md
+++ b/.opencode/skills/sre-runbook/tasks/generate.md
@@ -2,25 +2,28 @@
 
 ## Purpose
 
-Generate an operational runbook for a given domain and scenario type. Enforces reasoning at every step — each action must explain WHY it is the right action for the observed symptoms and diagnosed root cause.
+Generate an operational runbook for a given domain and scenario type. The runbook is a step-by-step "do this, in this order" procedure — not an analysis document. Every command is verified against live documentation. Every value comes from the actual environment.
 
 ## Operating Protocol
 
 1. Invoked by: `/skill sre-runbook --task generate`
 2. When to use: When an operational runbook is needed for a system, service, or infrastructure domain
-3. Exit criteria: Runbook generated with reasoning at every step, verified against dual-output contract
+3. Exit criteria: Runbook generated with environment-verified instructions at every step, validated against all enforcement rules
 
 ## Pre-Conditions
 
-**Domain context is MANDATORY.** If any of the following are missing, the agent MUST prompt the user before proceeding:
+**Domain context AND environment context are MANDATORY.** If any of the following are missing, the agent MUST prompt the user before proceeding:
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `domain` | ✅ Yes | System/service name (e.g., "PostgreSQL primary", "Kubernetes ingress") |
 | `scenario_type` | ✅ Yes | One of: `incident`, `procedure`, `degradation`, `failover` |
 | `severity` | ✅ Yes | One of: `P1` (outage), `P2` (degraded), `P3` (minor) |
+| `interface_preference` | ✅ Yes | One of: `gui`, `cli`, `mixed` — determines which instructions go in the runbook |
+| `environment_os` | ✅ Yes | OS name and version (e.g., "Proxmox 8.1", "Windows Server 2022", "Ubuntu 24.04") |
+| `available_tools` | ✅ Yes | Tools/package managers confirmed installed (e.g., "apt, systemctl, qm", or "PowerShell, DNS Manager") |
 
-If domain context is missing or insufficient, HALT and prompt the user. Do NOT guess or fabricate domain context.
+If domain OR environment context is missing or insufficient, HALT and prompt the user. Do NOT guess or fabricate context.
 
 ## Input Parameters
 
@@ -28,15 +31,67 @@ If domain context is missing or insufficient, HALT and prompt the user. Do NOT g
 domain: <system or service name>
 scenario_type: incident | procedure | degradation | failover
 severity: P1 | P2 | P3
+interface_preference: gui | cli | mixed
+environment_os: <OS name and version>
+available_tools: <comma-separated list of confirmed-available tools>
 ```
 
 ## Procedure
+
+### Step 0: Collect Environment Context (MANDATORY FIRST)
+
+**WHAT:** Determine the operator's interface preference, available tools, OS version, and existing documentation before writing any instructions.
+
+**WHY:** Runbooks generated without environment context prescribe CLI commands for GUI operators, reference tools that aren't installed, and invent paths from training data. Environment context determines WHICH instructions are correct, WHETHER they are still valid, and whether the operator can trust them.
+
+**Check-repo-first:** Before prompting the user for any environment value, check existing documentation in the repository:
+
+```
+1. Search for IP addresses, hostlists, system reference tables in docs/ or src/docs/
+2. Search for existing runbooks in docs/runbooks/ that reference the same domain
+3. If environment values (hostnames, IPs, domains, versions) exist in repo docs, USE THEM — never prompt for values already documented
+```
+
+If environment context cannot be determined from the repository, prompt the user:
+
+| Parameter | How to Collect | If Unavailable |
+|-----------|---------------|----------------|
+| `interface_preference` | Ask: "Do you prefer GUI or CLI for operating [domain]?" | HALT — cannot determine correct instruction path |
+| `environment_os` | Ask: "What OS/version is [domain] running on?" | HALT — commands may differ across versions |
+| `available_tools` | Ask: "Which tools/managers are installed on [domain]?" | HALT — cannot verify command availability |
+| `hostnames/IPs/domains` | Check repo docs first; if absent, ask user | Use values from conversation — NEVER fabricate |
+
+**Evidence anchoring:** Run or request baseline state collection commands:
+
+```
+For each relevant system query:
+  1. Attempt to run the query directly (if environment is accessible)
+  2. If not accessible: ask the user to run the command and supply output
+  3. If neither is possible: HALT — do NOT write instructions based on assumed state
+  4. Include the baseline output in the runbook under "Current State Baseline"
+```
+
+**Version pinning:** Record all version information observed or confirmed:
+
+```yaml
+environment:
+  os: "<OS name and version>"
+  software_versions:
+    - name: "<software name>"
+      version: "<version observed>"
+  verified_at: "<ISO date>"
+  interface: gui | cli | mixed
+  tools_available:
+    - "<tool name>"
+```
+
+**Verification gate:** Confirm ALL environment context parameters are collected. If any are missing, HALT and prompt the user. Do NOT proceed with incomplete context.
 
 ### Step 1: Document Symptoms
 
 **WHAT:** Catalog all observed symptoms with severity and affected components.
 
-**WHY:** Symptom documentation is the foundation of diagnosis. Without a complete symptom catalog, diagnosis is guesswork. Each symptom must be classified by severity and component so that diagnosis can trace symptoms to root causes.
+**WHY:** Symptom documentation is the foundation of diagnosis. Without a complete symptom catalog, diagnosis is guesswork.
 
 Output — AI-parseable enforcement block:
 
@@ -50,7 +105,7 @@ symptoms:
     observed_at: "<timestamp or condition>"
 ```
 
-Plus human-readable narrative explaining context and background.
+Plus operational observations (what the operator sees, not explanations of why).
 
 **Verification gate:** Confirm each symptom matches observed behavior. If symptoms are ambiguous, HALT and prompt for clarification.
 
@@ -76,15 +131,67 @@ diagnosis:
     escalation_threshold: "<time or condition that triggers escalation>"
 ```
 
-Plus human-readable narrative with decision tree explaining reasoning.
-
 **Verification gate:** Confirm diagnosis connects to symptoms via evidence. If diagnosis is unconfirmed (low confidence), do NOT proceed to mitigation — escalate instead.
 
 ### Step 3: Define Mitigation Steps
 
-**WHAT:** Define specific mitigation actions that target the diagnosed root cause.
+**WHAT:** Define specific mitigation actions that target the diagnosed root cause. ONE path per step. Steps only — no explanations, no conditional flows.
 
-**WHY:** Mitigation steps must address the diagnosed root cause, not just suppress symptoms. Each step must explain why this action resolves the root cause, and what risk it carries.
+**WHY:** Runbooks are operational procedures. A sysop under pressure needs "do this" instructions, not decision trees.
+
+**Single-path enforcement:** For each mitigation action, include exactly ONE method:
+
+- If `interface_preference` is `gui`: provide GUI steps only (click this, navigate there)
+- If `interface_preference` is `cli`: provide CLI commands only
+- If `interface_preference` is `mixed`: provide the operator's preferred interface; CLI only when no GUI equivalent exists
+- NEVER present "or via CLI" alternatives alongside GUI steps
+- NEVER present "or via GUI" alternatives alongside CLI steps
+
+**Prerequisites-first:** If any command requires elevated privileges:
+
+```
+## Prerequisites
+
+1. Open elevated PowerShell (right-click → Run as Administrator)
+
+## Mitigation Steps
+
+1. Set-MaxCacheTtl ...
+```
+
+NOT:
+
+```
+1. Set-MaxCacheTtl ...  (requires admin)
+```
+
+**Minimum-necessary:** Include ONLY the settings/parameters that directly solve the diagnosed problem. Do NOT include:
+- Related-but-irrelevant settings from the same subsystem
+- "Recommended" values for parameters not causing the issue
+- Additional parameters "just in case"
+
+**Set-and-restore pattern:** Structure commands as exactly two blocks:
+
+```
+## Apply Fix
+
+1. <command to set the specific value>
+
+## Restore Defaults (if needed)
+
+1. <command to restore the original value>
+```
+
+NOT:
+
+```
+## Check Current Value
+
+1. <command to query>  ← REMOVED — if we're going to overwrite, pre-checking is unnecessary
+2. <command to set>
+3. <command to verify>
+4. <command to reset if needed>
+```
 
 Output — AI-parseable enforcement block:
 
@@ -93,11 +200,9 @@ mitigation:
   - step: "<mitigation action>"
     targets_root_cause: "<reference to diagnosis entry>"
     risk_level: low | medium | high
-    rollback: "<rollback procedure if mitigation fails>"
-    reasoning: "<why this action addresses the root cause>"
+    rollback: "<restore-defaults command>"
+    interface: gui | cli
 ```
-
-Plus human-readable narrative with decision trees for conditional mitigation paths.
 
 **Verification gate:** Confirm each mitigation step targets a diagnosed root cause. If mitigation does not address the root cause, return to Step 2.
 
@@ -118,15 +223,13 @@ verification:
     fail_action: "<what to do if verification fails>"
 ```
 
-Plus human-readable narrative explaining verification methodology.
-
 **Verification gate:** Confirm each criterion maps to a symptom. If verification fails, return to Step 2 (re-diagnose) — do NOT proceed to postmortem.
 
 ### Step 5: Postmortem Template
 
 **WHAT:** Generate a postmortem template capturing what happened, why, and how to prevent recurrence.
 
-**WHY:** Postmortems close the feedback loop. Without postmortems, the same incident recurs. The template must capture causal reasoning, not just timelines.
+**WHY:** Postmortems close the feedback loop. Without postmortems, the same incident recurs.
 
 Output — AI-parseable enforcement block:
 
@@ -141,39 +244,111 @@ postmortem:
   action_items:
     - action: "<preventive action>"
       owner: "<role or team>"
-      reasoning: "<why this prevents recurrence>"
 ```
 
-Plus human-readable narrative with timeline template and action item tracking.
+## Live Verification Requirements (MANDATORY)
+
+**Every command, GUI path, button label, menu structure, and API call in the runbook MUST be verified against a live source before inclusion.**
+
+### Verification Sources (in priority order)
+
+| Source | How | When Required |
+|--------|-----|---------------|
+| Live system query | Run the command directly or ask user to supply output | ALL CLI commands |
+| `--help` output | Run `<command> --help` and verify flags/syntax exist | ALL CLI commands |
+| `man` page | Run `man <command>` and verify parameters | When `--help` unavailable |
+| Official vendor documentation | Fetch from vendor docs URL | ALL GUI paths, API calls, settings |
+| Existing runbooks in repo | Check `docs/runbooks/` for verified commands | As reference/cross-check |
+
+### Verification Procedure
+
+For each CLI command in the runbook:
+
+```
+1. Run `<command> --help` or `man <command>`
+2. Verify every flag and parameter exists in the help output
+3. If a flag/parameter does NOT appear in help output → EXCLUDE it, do NOT annotate "(unverified)"
+4. Record the verification source in the runbook metadata
+```
+
+For each GUI path in the runbook:
+
+```
+1. Verify the path against official vendor documentation
+2. If no vendor documentation confirms the path → EXCLUDE it
+3. NEVER invent GUI paths, button labels, or menu structures from training data
+4. If only a CLI exists for a setting, state that explicitly: "No GUI available — CLI only"
+```
+
+### Evidence Collection Failure Handling
+
+**If the agent cannot verify a command or path against a live source:**
+
+1. Do NOT include the unverified command/path in the runbook
+2. Do NOT annotate it as "(unverified)" — unverified information is excluded
+3. HALT and inform the user: "I cannot verify [command/path] against live documentation. Please run `[command] --help` and supply the output, or confirm the correct syntax."
+4. Do NOT silently fall back to training knowledge — this is the worst-case scenario that produces confident-sounding wrong instructions
 
 ## HALT Conditions
 
 | Condition | Action |
 |-----------|--------|
+| Environment context missing or insufficient | HALT, prompt user for context |
 | Domain context missing or insufficient | HALT, prompt user for context |
 | Diagnosis unconfirmed (low confidence) | HALT, escalate — do NOT mitigate |
 | Mitigation risk exceeds severity threshold | HALT, escalate before proceeding |
 | Verification fails | Return to Step 2, do NOT proceed to postmortem |
 | Escalation needed | HALT, create GitHub Issue with `escalation` label |
+| Evidence collection fails (cannot verify command against live source) | HALT, prompt user for confirmation or output — do NOT fall back to training knowledge |
+| Live documentation unavailable | HALT, inform user — do NOT generate instructions from training data |
 
 ## Output Contract
 
-The generated runbook is saved as a Markdown file in `docs/runbooks/` with both:
-1. AI-parseable yaml+symbolic enforcement blocks (structured data for automation)
-2. Human-readable narrative prose (context and reasoning for humans)
+The generated runbook is saved as a Markdown file with:
+
+1. **Environment header** — verified environment context block:
+   ```yaml
+   environment:
+     os: "<os and version>"
+     interface: gui | cli | mixed
+     tools: ["<confirmed tool list>"]
+     verified_at: "<ISO date>"
+     last_verified: "Verified against <product> <version> on <date>"
+   ```
+
+2. **Current state baseline** — evidence anchoring with actual outputs
+3. **AI-parseable yaml+symbolic enforcement blocks** (structured data for automation)
+4. **Operational procedures** — numbered steps with copy-paste commands
+5. **Restore defaults** — rollback commands
+6. **Verification commands** — confirm fix applied
 
 File naming convention: `docs/runbooks/<domain>-<scenario_type>.md`
 
-## Self-Review Step (MANDATORY)
+## Self-Review Step (MANDATORY — Before Presenting)
 
-After generating the runbook, the agent MUST review its own output for template-fill patterns. Check:
-1. Does every step include WHY reasoning? If not, add it.
-2. Does every diagnosis connect to symptoms via evidence? If not, add evidence chains.
-3. Does every mitigation target a diagnosed root cause? If not, add reasoning.
-4. Does every verification criterion map to a specific symptom? If not, add mappings.
-5. Does the postmortem template include action items with reasoning? If not, add reasoning.
+After generating the runbook, the agent MUST validate the output against ALL enforcement rules. One-shot correctness is the target.
 
-If any step lacks reasoning, the runbook is incomplete. Add reasoning before presenting.
+### Validation Checklist
+
+1. ✅ Environment context collected and documented?
+2. ✅ Single path per operation (no "or via CLI" alternatives)?
+3. ✅ Only confirmed-available tools referenced?
+4. ✅ Real values from environment (zero generic placeholders)?
+5. ✅ Prerequisites (elevation) before privileged commands?
+6. ✅ Steps only — no explanations, no conditional flows?
+7. ✅ Minimum-necessary settings only?
+8. ✅ Set-and-restore pattern (two command blocks)?
+9. ✅ No content re-added after removal?
+10. ✅ Every CLI command verified against `--help`/`man`/live docs?
+11. ✅ Every GUI path verified against vendor docs?
+12. ✅ Evidence anchoring with baseline outputs?
+13. ✅ Version/environment pinning included?
+14. ✅ "Last verified" timestamp included?
+15. ✅ Existing repo documentation checked for hostnames/IPs/domains?
+16. ✅ No training-knowledge commands presented as verified?
+17. ✅ Evidence collection failure handled (HALT, not fallback)?
+
+If ANY check fails, fix the runbook before presenting. The user should never need to correct the same issue twice.
 
 ## Context Required
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/runbook-fix
+
+- **SRE Runbook Operational Discipline** (#943, #955) - Rewrote `sre-runbook` skill to enforce environment-context-first discipline and single-path operational procedures. Runbooks now collect interface preference, available tools, OS version, and repo documentation before generating any instructions. Added 17-point validation checklist, live-verification requirements (verify commands against `--help`/man pages/vendor docs), evidence anchoring, version pinning, and "last verified" timestamps. Skills that cannot verify against live sources now HALT instead of falling back to training knowledge.
+
 ### spec/946-closed-issue-verification
 
 - **Closed Issue Verification Gates** (#946) - Fixed "closed = verified" assumption across 8 skill files and 1 guideline. Closed issues are no longer trusted without merged PR evidence. Added `verify-closed-issue` task with 7-step verification procedure, pre-closure sub-issue verification gate in cleanup, closed-issue verification in auto-dispatch, and critical violation in `000-critical-rules.md`.


### PR DESCRIPTION
**Summary:**

Rewrote the `sre-runbook` skill to enforce environment-context-first discipline, single-path operational procedures, and live-verification requirements — eliminating environment-agnostic analysis documents and unverified training-knowledge instructions.

**Outcome:** SRE runbook generation now produces site-specific, verified, copy-pasteable operational procedures instead of generic analysis documents with guessed commands and fabricated GUI paths.

Fixes #943
Fixes #955
Fixes #957