### PR TITLE
Add transitive issue graph verification for closure and re-approval

### DIFF
--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -209,6 +209,111 @@ The "Already implemented" row in the Auto-Dispatch table (Step 6) MUST NOT skip 
 | Closed as "duplicate" | MISSING-TRACEABILITY | conditional | Verify duplicate target exists and covers scope |
 | Closed state unclear (no reason) | VERIFICATION-GAP | flag-for-review | Do NOT skip — verify implementation manually |
 
+#### 5.5 Transitive Issue Graph Verification (MANDATORY on Authorization and Re-Approval)
+
+**When any issue is authorized (approved, re-approved, or `Fixes`-closed), the agent MUST traverse the entire reachable issue graph to verify every node is in a consistent state.** Single-issue verification is insufficient — an authorized issue may have open sub-issues, dangling cross-references, or linked issues in an inconsistent state.
+
+##### Three Edge Types Traversed
+
+| Edge Type | Source | Example | API Access |
+|-----------|--------|---------|------------|
+| **Sub-issue** | GitHub sub-issue link | Plan → Phase sub-issue | `github_issue_read(method=get_sub_issues, issue_number=N)` |
+| **Cross-reference** | Issue body references | `Spec: #M`, `Plan: #N`, `Implements #K` | Parse body text + `github_issue_read(method=get, issue_number=M)` |
+| **Linked issue** | PR/closure references | `Fixes #N`, `Closes #N`, `Related #N` | Parse body text + `github_issue_read(method=get, issue_number=N)` |
+
+##### Graph Traversal Algorithm
+
+```python
+def traverse_issue_graph(root_issue_number, depth_limit=5):
+    """
+    Transitively traverse the issue graph from a root issue.
+    Follows sub-issue, cross-reference, and linked-issue edges.
+    Returns a verification report for every node in the reachable graph.
+    """
+    visited = set()
+    queue = [(root_issue_number, 0)]  # (issue_number, current_depth)
+    findings = []
+
+    while queue:
+        issue_number, depth = queue.pop(0)
+
+        if issue_number in visited:
+            continue
+        visited.add(issue_number)
+
+        if depth > depth_limit:
+            findings.append({
+                "issue": issue_number,
+                "depth": depth,
+                "result": "DEPTH_LIMIT_REACHED",
+                "action": "flag-for-review"
+            })
+            continue
+
+        # Step 1: Read the issue
+        issue = github_issue_read(method="get", issue_number=issue_number)
+
+        # Step 2: Verify the issue's state
+        # (reuse verify-closed-issue logic for closed issues)
+        if issue["state"] == "closed":
+            # Run closed-issue verification (Steps 1-6 of verify-closed-issue)
+            # Record finding
+            pass
+
+        # Step 3: Follow sub-issue edges
+        sub_issues = github_issue_read(method="get_sub_issues", issue_number=issue_number)
+        for sub in sub_issues:
+            queue.append((sub["number"], depth + 1))
+
+        # Step 4: Parse body for cross-references
+        body = issue.get("body", "")
+        for pattern in [r"Spec:\s*#(\d+)", r"Plan:\s*#(\d+)", r"Implements\s*#(\d+)",
+                        r"Fixes\s*#(\d+)", r"Closes\s*#(\d+)", r"Related\s*#(\d+)",
+                        r"Duplicate\s+of\s*#(\d+)"]:
+            for match in re.finditer(pattern, body):
+                ref_num = int(match.group(1))
+                if ref_num not in visited:
+                    queue.append((ref_num, depth + 1))
+
+    return findings
+```
+
+##### When to Traverse
+
+| Trigger | When | Depth Limit |
+|---------|------|-------------|
+| Issue approved/re-approved | `verify-authorization` receives explicit authorization | 5 |
+| Issue closed by `Fixes` keyword (post-merge) | `cleanup` processes merged PR | 5 |
+| Issue being verified as already-implemented | `verify-already-implemented` encounters a closed issue | 3 |
+| Issue encountered during triage | `triage` classifies a closed issue | 3 |
+
+##### Finding Classification for Graph Verification
+
+| Finding | Problem Class | Classification | Action |
+|---------|---------------|----------------|--------|
+| All nodes verified (closed with merged PR or open and consistent) | VERIFIED | auto-proceed | Graph is consistent |
+| Open sub-issue on closed parent | VERIFICATION-GAP | flag-for-review | Parent closure may be premature |
+| Cross-reference to open/closed mismatch | CONFLICTING | flag-for-review | Spec closed but plan open, or vice versa |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Premature sub-issue closure |
+| Depth limit reached | VERIFICATION-GAP | flag-for-review | Graph too deep — investigate manually |
+| Cross-reference 404 | MISSING-TRACEABILITY | flag-for-review | Referenced issue does not exist |
+
+##### Evidence Requirement
+
+Every node in the reachable graph MUST produce an evidence artifact — a `github_issue_read` tool call result. Graph traversal without per-node evidence is a verification honesty violation.
+
+**Report format:**
+
+```
+Issue Graph Verification Report for #<root>
+Nodes visited: <N>
+Max depth: <D>
+Findings:
+  - #<issue>: <state> — <finding> (<classification>)
+  ...
+Overall: CONSISTENT / HAS_FLAGS
+```
+
 #### Finding Classification for Sub-Issue Verification
 
 | Finding | Problem Class | Classification | Action |

--- a/.opencode/skills/approval-gate/tasks/verify-closed-issue.md
+++ b/.opencode/skills/approval-gate/tasks/verify-closed-issue.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Verify that a closed issue was legitimately closed — checking that a merged PR exists and that no premature closure occurred. This task enforces the rule that "closed" does NOT mean "verified" without evidence.
+Verify that a closed issue was legitimately closed — checking that a merged PR exists and that no premature closure occurred. Verification is transitive: it traverses sub-issues, cross-references, and linked issues recursively to ensure the entire reachable graph is in a consistent state. This task enforces the rule that "closed" does NOT mean "verified" without evidence.
 
 ## Pre-Conditions
 
@@ -182,6 +182,96 @@ body = issue.get("body", "")
 
 **This step is optional and does NOT block the verification result.** It provides additional evidence for downstream callers.
 
+### Step 8: Transitive Graph Traversal (MANDATORY)
+
+**Verification of a single issue is insufficient.** The verified issue may be part of a graph — sub-issues, cross-references, and linked issues must also be verified for consistency. This step traverses the reachable graph from the root issue and verifies every node.
+
+#### 8.1 Collect Adjacent Issues
+
+From the root issue (already verified in Steps 1-7), collect all adjacent issues:
+
+```python
+adjacent = set()
+
+# Edge type 1: Sub-issues
+sub_issues = github_issue_read(method="get_sub_issues", issue_number=root_issue_number)
+for sub in sub_issues:
+    adjacent.add(sub["number"])
+
+# Edge type 2: Cross-references in body
+body = root_issue.get("body", "")
+for pattern in [r"Spec:\s*#(\d+)", r"Plan:\s*#(\d+)", r"Implements\s*#(\d+)",
+                r"Fixes\s*#(\d+)", r"Closes\s*#(\d+)", r"Related\s*#(\d+)",
+                r"Duplicate\s+of\s*#(\d+)"]:
+    for match in re.finditer(pattern, body):
+        adjacent.add(int(match.group(1)))
+
+# Edge type 3: Linked issues from merged PR body
+if merged_pr_found:
+    pr_body = pr_detail.get("body", "")
+    for pattern in [r"Fixes\s*#(\d+)", r"Closes\s*#(\d+)", r"Implements\s*#(\d+)"]:
+        for match in re.finditer(pattern, pr_body):
+            adjacent.add(int(match.group(1)))
+```
+
+#### 8.2 Recursively Verify Each Adjacent Issue
+
+For each issue collected, verify it (recursively) with depth limit:
+
+```python
+visited = set()
+max_depth = 5
+
+def verify_recursive(issue_number, depth):
+    if issue_number in visited or depth > max_depth:
+        return
+    visited.add(issue_number)
+
+    issue = github_issue_read(method="get", issue_number=issue_number)
+
+    # If closed: verify closure (reuse Steps 1-7)
+    if issue["state"] == "closed":
+        result = run_steps_1_through_7(issue_number)
+
+    # If open: check if it SHOULD be closed
+    # (e.g., sub-issue of a closed parent with deliverables in merged PR)
+
+    # Collect further adjacent issues from this node
+    new_adjacent = collect_adjacent(issue_number)
+    for adj in new_adjacent:
+        verify_recursive(adj, depth + 1)
+
+for adj_issue in adjacent:
+    verify_recursive(adj_issue, 1)
+```
+
+#### 8.3 Graph Verification Findings
+
+| Finding | Problem Class | Classification | Action |
+|---------|---------------|----------------|--------|
+| Open sub-issue on closed parent where PR covers deliverables | VERIFICATION-GAP | conditional | Close sub-issue with comment referencing PR |
+| Open sub-issue on closed parent where PR does NOT cover deliverables | VERIFICATION-GAP | flag-for-review | Report — sub-issue work remains |
+| Cross-reference to open issue when parent is closed | CONFLICTING | flag-for-review | Chain incomplete — report |
+| Closed issue without merged PR | VERIFICATION-GAP | flag-for-review | Premature closure |
+| Depth limit reached | VERIFICATION-GAP | flag-for-review | Graph too deep |
+
+#### 8.4 Report
+
+After traversal, produce a graph verification report:
+
+```
+Transitive Graph Verification Report:
+Root: #<root_issue>
+Nodes visited: <N> (of which <M> closed, <K> open)
+Max depth reached: <D>
+Findings:
+  - #<issue>: VERIFICATION-GAP — <description>
+  ...
+Overall: CONSISTENT / HAS_FLAGS
+```
+
+**Evidence requirement:** Every node in the graph MUST have a corresponding `github_issue_read` tool call artifact. Graph breadth determines the number of API calls required — this is expected and necessary for thorough verification.
+
 ## Verification Result Types
 
 | Result | Meaning | Action for Callers |
@@ -192,6 +282,8 @@ body = issue.get("body", "")
 | `NOT_PLANNED_CLOSURE` | Closed as "not_planned" | Work was intentionally skipped — may need reopening |
 | `DUPLICATE_OF` | Closed as duplicate of another issue | Verify target issue covers the scope |
 | `BLOCKED_BY_SUB_ISSUE` | Parent cannot close because a sub-issue has a verification gap | Resolve sub-issue verification first |
+| `GRAPH_HAS_FLAGS` | Graph traversal found one or more verification gaps | Resolve flagged issues or acknowledge accepted risk |
+| `GRAPH_CONSISTENT` | All nodes in reachable graph are in a consistent state | Safe to treat as verified — no action needed |
 
 ## Finding Classification
 
@@ -215,6 +307,8 @@ This task is invoked by:
 4. **`cleanup` pre-closure gate** — Before closing parent issues in post-merge workflow
 5. **`verify-fix-spec`** — Before skipping closed bug reports
 
+This task now performs transitive graph traversal (Step 8). Callers should handle `GRAPH_HAS_FLAGS` and `GRAPH_CONSISTENT` result types in addition to the single-issue result types.
+
 ## Context Required
 
 - Issue number to verify
@@ -228,3 +322,4 @@ This task is invoked by:
 - `approval-gate/tasks/verify-authorization.md` Step 5.4: Closed-issue verification gate
 - `approval-gate/tasks/verify-already-implemented.md`: Pre-autoclose sub-issue verification
 - `git-workflow/tasks/cleanup.md`: Pre-closure sub-issue verification gate
+- `010-approval-gate.md §Assuming Closed Issues Are Verified`: Graph traversal prevents this violation

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -58,6 +58,10 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
 7. **Squash to single commit before any PR:** No exceptions.
 8. **Never merge PRs:** Human-only operation.
 
+### PR Body Keyword Discipline
+
+**`Fixes`/`Closes` auto-close issues on merge — bypassing verification gates.** For plans with sub-issues, use `Implements` instead. See `review-prep.md` → "PR Body Keyword Discipline" for the complete rules.
+
 ## Role in Orchestration Architecture
 
 Git-workflow handles **pure git operations only**. Implementation logic is handled by `divide-and-conquer` orchestration layer.

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -153,7 +153,41 @@ for issue_num in closure_candidates:
 5. Close the plan issue
 
 ```python
-def plan_closure_path(plan_num, plan_issue):
+def check_deliverables_in_pr(sub_detail, pr_files):
+    """
+    Check whether a sub-issue's deliverables are covered by
+    the merged PR's file list.
+    """
+    body = sub_detail.get("body", "") or ""
+    title = sub_detail.get("title", "") or ""
+    deliverable_patterns = re.findall(
+        r"(?:deliverable|file|path|modif(?:y|ied|ication)):\s*`?([^\s`*#]+)`?",
+        body,
+        re.IGNORECASE,
+    )
+    title_paths = re.findall(r"`([^`]+)`", title)
+
+    candidates = deliverable_patterns + title_paths
+
+    if not candidates:
+        # No explicit deliverables — check if sub-issue number
+        # appears in PR body (Fixes #N, Implements #N, etc.)
+        sub_num = sub_detail.get("number")
+        if sub_num and any(
+            f"#{sub_num}" in (ref or "")
+            for ref in [pr_body]
+        ):
+            return True
+        # No deliverables and not referenced in PR — cannot verify
+        return False
+
+    for candidate in candidates:
+        if any(candidate in f for f in pr_files):
+            return True
+
+    return False
+
+def plan_closure_path(plan_num, plan_issue, pr_files=None, merged_pr_number=None):
     plan_body = plan_issue.get("body", "")
 
     spec_match = re.search(r"(?:Spec|For spec):\s*#(\d+)", plan_body)
@@ -166,8 +200,29 @@ def plan_closure_path(plan_num, plan_issue):
     for sub in sub_issues:
         sub_detail = github_issue_read(method="get", issue_number=sub["number"])
         if sub_detail.get("state") == "open":
-            github_issue_write(method="update", issue_number=sub["number"],
-                              state="closed", state_reason="completed")
+            deliverables_covered = (
+                pr_files is not None
+                and check_deliverables_in_pr(sub_detail, pr_files)
+            )
+
+            if deliverables_covered:
+                github_issue_write(
+                    method="update", issue_number=sub["number"],
+                    state="closed", state_reason="completed"
+                )
+                github_add_issue_comment(
+                    issue_number=sub["number"],
+                    body=f"Closing: deliverables verified in merged PR #{merged_pr_number}. "
+                         f"Parent #{plan_num} was closed by the same PR."
+                )
+            else:
+                # Flag for review — do NOT auto-close
+                github_add_issue_comment(
+                    issue_number=sub["number"],
+                    body=f"⚠️ Deliverables for this sub-issue were NOT found in "
+                         f"merged PR #{merged_pr_number}. Parent #{plan_num} was closed, "
+                         f"but this sub-issue remains open pending developer review."
+                )
 
     plan_detail = github_issue_read(method="get", issue_number=plan_num)
     if plan_detail.get("state") == "open":
@@ -231,6 +286,82 @@ for spec_num in [i for i in closure_candidates if is_spec(i)]:
 ```
 
 **Safety rule: NEVER close an issue that still has open children or open linked plans.**
+
+#### Step 2.7.7: Transitive Graph Reconciliation
+
+**After processing all closure candidates, traverse the issue graph for consistency.** This step catches orphaned sub-issues, dangling cross-references, and other graph inconsistencies that the per-issue closure paths miss.
+
+```python
+def reconcile_issue_graph(merged_pr_number, pr_files):
+    """
+    After closing issues referenced in PR body, traverse the entire
+    reachable graph to find and reconcile orphaned nodes.
+    """
+    root_issues = closure_candidates  # Already collected in Step 2.7.1
+    visited = set()
+    queue = [(issue_num, 0) for issue_num in root_issues]
+    orphaned = []
+    reconciled = []
+
+    while queue:
+        issue_num, depth = queue.pop(0)
+        if issue_num in visited or depth > 5:
+            continue
+        visited.add(issue_num)
+
+        issue = github_issue_read(method="get", issue_number=issue_num)
+
+        # Check sub-issues of this node
+        sub_issues = github_issue_read(method="get_sub_issues", issue_number=issue_num)
+        for sub in sub_issues:
+            sub_detail = github_issue_read(method="get", issue_number=sub["number"])
+
+            if sub_detail["state"] == "open" and issue["state"] == "closed":
+                # Open sub-issue on closed parent — potential orphan
+                # Check if deliverables are in PR file list
+                deliverables_covered = check_deliverables_in_pr(
+                    sub_detail, pr_files
+                )
+                if deliverables_covered:
+                    # Close sub-issue with evidence
+                    github_issue_write(
+                        method="update", issue_number=sub["number"],
+                        state="closed", state_reason="completed"
+                    )
+                    github_add_issue_comment(
+                        issue_number=sub["number"],
+                        body=f"Closing: deliverables verified in merged PR #{merged_pr_number}. " +
+                             f"Parent #{issue_num} was closed by the same PR."
+                    )
+                    reconciled.append(sub["number"])
+                else:
+                    orphaned.append(sub["number"])
+
+            # Recurse into sub-issue's own graph
+            queue.append((sub["number"], depth + 1))
+
+        # Parse cross-references
+        body = issue.get("body", "")
+        for pattern in [r"Spec:\s*#(\d+)", r"Plan:\s*#(\d+)",
+                        r"Fixes\s*#(\d+)", r"Implements\s*#(\d+)"]:
+            for match in re.finditer(pattern, body):
+                ref = int(match.group(1))
+                if ref not in visited:
+                    queue.append((ref, depth + 1))
+
+    return {"orphaned": orphaned, "reconciled": reconciled, "visited": visited}
+```
+
+**Reporting:** After reconciliation, report to chat:
+
+```
+Issue Graph Reconciliation:
+Reconciled (closed with PR evidence): #<n1>, #<n2>, ...
+Orphaned (still open — deliverables not in PR): #<m1>, #<m2>, ...
+Total nodes visited: <N>
+```
+
+**If orphaned sub-issues remain:** Do NOT close them. Report them as verification gaps requiring developer attention.
 
 ### Step 3: Switch to Dev and Sync
 

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -564,6 +564,25 @@ Any halt point where the agent reports completion MUST produce this format. Skip
 
 **These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
 
+### PR Body Keyword Discipline (CRITICAL)
+
+**GitHub's `Fixes #N` and `Closes #N` keywords auto-close the referenced issue on PR merge.** This bypasses all verification gates. For multi-task plans with sub-issues, this creates orphaned sub-issues because GitHub does NOT cascade closure to children.
+
+#### Keyword Selection Rules
+
+| Keyword | Auto-Closes Issue? | Use When |
+|---------|-------------------|----------|
+| `Fixes #N` | YES — GitHub auto-closes #N on merge | Single-issue specs with NO sub-issues |
+| `Closes #N` | YES — GitHub auto-closes #N on merge | Same as `Fixes` — prefer `Fixes` for bugs, `Closes` for features |
+| `Implements #N` | NO — informational reference only | Multi-task plans, specs with sub-issues, any issue where graph may be incomplete |
+| `Related #N` | NO — weak reference | Tangentially related issues |
+
+**Rule of thumb:** If the issue has sub-issues or is part of a plan-bridge hierarchy (spec → plan → sub-issues), use `Implements` instead of `Fixes`. The cleanup task's graph reconciliation step will handle proper closure after verifying the entire graph.
+
+**Exception:** `Fixes` is acceptable for leaf issues (no sub-issues, no cross-references) where auto-closure is safe.
+
+**When in doubt:** Use `Implements`. It's always safe — it never auto-closes, and the cleanup task handles closure properly.
+
 ## Context Required
 
 - Related skills: `pr-creation-workflow` (PR timing)


### PR DESCRIPTION
**Summary:**

Adds transitive issue graph verification so that when an issue is closed or re-approved, the agent recursively verifies sub-issues, cross-references, and linked issues to prevent orphaned sub-issues and unverified closure chains.

**Outcome:** Agents now traverse the full issue graph (depth 5) on re-approval and post-merge cleanup, closing verified sub-issues with evidence and flagging gaps for review. PR body keyword discipline prevents `Fixes` from auto-closing plans with open sub-issues.

Implements #975