### PR TITLE
[SPEC] Sub-Agent Extraction for Heavy Skill Tasks

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -676,6 +676,17 @@ When an agent receives an implementation instruction but cannot find an associat
 
 **See `020-go-prohibitions.md` §1 "NEVER DO" and "ALWAYS DO" for the search procedure, and `approval-gate` skill → `verify-qa-mode` task → Step 2.5 for the mandatory search step.** **AUTHORITY: `020-go-prohibitions.md` §1** (this line is a reference only)
 
+## Sub-Agent Extraction Pattern
+
+Skill task files exceeding 1,000 words are extracted into sub-agent execution per the pattern established by spec #984. Each SKILL.md contains a "Sub-Agent Tasks" section with execution mode tables, result contract schemas, and dispatch context schemas. The main agent loads only SKILL.md files and reads compact result contracts (~100-500 words), never loading task files >1,000 words directly.
+
+- Tasks >1,000 words → sub-agent dispatch via `task(subagent_type="general")`
+- Tasks ≤1,000 words → inline execution (spawning overhead exceeds inline cost)
+- Result contracts reference task files as source of truth (no duplication)
+- Dispatch context MUST include `WORKTREE_PATH`, `GIT_OWNER`, `GIT_REPO`, `DEV_NAME`, `DEV_EMAIL`
+
+**See each skill's SKILL.md → "Sub-Agent Tasks" section for execution mode tables and result contract schemas.**
+
 ______________________________________________________________________
 
 **Search guidelines:** Use `srclight_search_symbols` or `grep` to find relevant guidelines.

--- a/.opencode/guidelines/060-tool-usage.md
+++ b/.opencode/guidelines/060-tool-usage.md
@@ -150,3 +150,4 @@ Invoke skills when their trigger keywords match the current task. Each skill def
 | **Priority ordering** | Process skills (approval-gate, brainstorming, writing-plans, systematic-debugging) before implementation skills |
 | **No speculative loading** | Do not load skills "just in case" — load when triggers match |
 | **Skill self-describes boundary** | Each SKILL.md defines what it covers; when in doubt, check `Triggers on:` line |
+| **Sub-agent dispatch priority** | When a SKILL.md Sub-Agent Tasks section marks a task as `sub-agent`, the main agent dispatches via `task()` instead of loading the task file inline. This keeps heavy task files out of the main agent context. Result contracts (~100-500 words) are read instead of the full task file (>1,000 words) |

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -30,7 +30,8 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | `verify-fix-spec` | For bug reports, verify fix spec sub-issue exists before closure | ~250 |
 | `search-prompt-fail` | Search GitHub Issues for existing spec/plan candidates before Q/A halt; present candidates or report failure | ~300 |
 | `verify-closed-issue` | Verify that a closed issue was legitimately closed via merged PR; enforce "closed ≠ verified" rule | ~350 |
-| `pre-implementation-analysis` | Analyze interdependencies and expand sub-issues for all approved issues (single or batch), producing flat item list for assemble-batch | ~500 |
+| `screen-issue` | Per-issue screening for pre-implementation analysis (Gate 1 + Gate 2 + screening categories); dispatched as parallel sub-agents | ~3,000 |
+| `pre-implementation-analysis` | Cross-issue merge of screening results, dependency graph, execution plan for assemble-batch | ~500 |
 | `verify-schema-api-knowledge` | Verify that the agent has performed live verification before making schema/API/code claims; gate before proceeding | ~350 |
 | `post-implementation` | Push branch, generate compare URL, HALT | ~480 |
 | `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~150 |
@@ -48,6 +49,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 - `/skill approval-gate --task verify-closed-issue` - Verify closed issue was legitimately closed via merged PR
 - `/skill approval-gate --task verify-schema-api-knowledge` - Verify schema/API/code knowledge before claims
 - `/skill approval-gate --task pre-implementation-analysis` - Analyze interdependencies and expand sub-issues for all approved issues, then yield to assemble-batch
+- `/skill approval-gate --task screen-issue` - Per-issue screening (dispatched as sub-agent from pre-implementation-analysis)
 - `/skill approval-gate --task post-implementation` - After implementation done
 - `/skill approval-gate --task completion` - Invoke when workflow halts at any point
 - `/skill approval-gate` - Overview only
@@ -160,18 +162,158 @@ This check is invoked:
 4. HALT — do NOT create PR without explicit instruction
 5. WAIT for "create a PR" instruction
 
-## Sub-Agent Spawning
+## Sub-Agent Tasks
 
-This skill is a **heavy skill** — its task files contain significant detail that pollutes context. When the main agent needs authorization verification with re-evaluation, consider spawning a sub-agent via the `task` tool:
+### Execution Mode Table
 
-1. Main agent loads this dispatch document (~597 words)
-2. Main agent identifies the needed task
-3. Main agent spawns sub-agent: `task(subagent_type="general", prompt="Use approval-gate skill --task <task-name> with context: issue=#N, <session-context>")`
-4. Sub-agent loads: this SKILL.md + relevant task file + required guidelines
-5. Sub-agent executes verification in isolation, returns authorization result
-6. Main agent receives result — no full approval-gate content in main context
+| Task | Words | Mode |
+|------|-------|------|
+| `verify-authorization` | 3,319 | sub-agent |
+| `verify-qa-mode` | 2,188 | sub-agent |
+| `verify-already-implemented` | 1,902 | sub-agent |
+| `verify-closed-issue` | 1,763 | sub-agent |
+| `verify-sub-issues` | 1,449 | sub-agent |
+| `post-implementation` | 1,183 | sub-agent |
+| `screen-issue` | 3,037 | sub-agent |
+| `pre-implementation-analysis` | ~3,100 | sub-agent (receives screen-issue results) |
+| `verify-fix-spec` | 1,017 | sub-agent |
+| `verify-blockers` | 722 | inline |
+| `verify-codebase` | 726 | inline |
+| `verify-open-questions` | 531 | inline |
+| `completion` | 769 | inline |
+| `search-prompt-fail` | ~300 | inline |
+| `verify-schema-api-knowledge` | ~350 | inline |
 
-**Sub-agent context parameters:** Pass issue number, `WORKTREE_PATH`, `GIT_OWNER`, `GIT_REPO` from session init. When `WORKTREE_PATH` is set, sub-agents MUST receive it and use it as the base directory for all file operations and git commands.
+### Result Contracts (Sub-Agent Tasks)
+
+#### screen-issue
+
+```yaml
+status: DONE | DONE_WITH_CONCERNS | BLOCKED | OVERFLOW
+task: screen-issue
+issue_number: <N>
+classification: included | excluded | scope-reduced
+category: <already-implemented|superseded|moot|partially-implemented|meta-non-code|null>
+exclude_reason: <reason|null>
+reduce_reason: <reason|null>
+reduced_scope: {completed_phases: [], remaining_phases: []}
+flat_items: [{issue: <N>, title: <str>, phase: <str>}]
+gate_evidence: {gate1_called: bool, gate1_sub_issues_verified: bool, gate1_closure_legitimacy: bool, gate2_criteria_extracted: bool, gate2_criteria_verified: bool, final_classification: <str>}
+requires_developer: bool
+developer_reason: <reason|null>
+file_references: [<path>]
+symbol_references: [<name>]
+concerns: [<str>]
+```
+
+#### verify-authorization
+
+```yaml
+status: DONE | BLOCKED
+task: verify-authorization
+issue_number: <N>
+authorization_result: authorized | unauthorized | needs_approval
+cascade_applied: bool
+sub_issues_verified: bool
+gates_passed: [gate_name]
+blocking_reason: <reason|null>
+```
+
+#### verify-qa-mode
+
+```yaml
+status: DONE
+task: verify-qa-mode
+mode: qa_mode | implementation_mode
+spec_found: bool
+spec_candidates: [<issue_number>]
+routing: <next_task|null>
+```
+
+#### verify-already-implemented
+
+```yaml
+status: DONE
+task: verify-already-implemented
+issue_number: <N>
+classification: already_implemented | partially_implemented | not_implemented
+evidence_summary: <str>
+auto_close_performed: bool
+```
+
+#### verify-closed-issue
+
+```yaml
+status: DONE
+task: verify-closed-issue
+issue_number: <N>
+legitimate: bool
+state_reason: <str>
+merged_pr_evidence: <url|null>
+action: none | reopen | flag
+```
+
+#### verify-sub-issues
+
+```yaml
+status: DONE
+task: verify-sub-issues
+parent_issue: <N>
+sub_issues_count: <int>
+all_verified: bool
+missing_sub_issues: [<phase>]
+auto_created: bool
+```
+
+#### post-implementation
+
+```yaml
+status: DONE
+task: post-implementation
+branch_pushed: bool
+compare_url: <url>
+issues_reported: [<N>]
+```
+
+#### pre-implementation-analysis
+
+```yaml
+status: DONE | BLOCKED
+task: pre-implementation-analysis
+screening_results_count: <int>
+included: [<issue_number>]
+excluded: [{issue: <N>, reason: <str>}]
+scope_reduced: [{issue: <N>, remaining_phases: []}]
+dependency_graph: {serial: [<N>], parallel_groups: [[<N>]]}
+execution_plan_presented: bool
+requires_developer: bool
+developer_reason: <str|null>
+batch_state_file: <path>
+```
+
+#### verify-fix-spec
+
+```yaml
+status: DONE
+task: verify-fix-spec
+bug_report: <N>
+fix_spec_exists: bool
+fix_spec_issue: <N|null>
+action: none | create_fix_spec
+```
+
+### Dispatch Context Schema (All Sub-Agent Tasks)
+
+```yaml
+issue_number: <N>
+batch_peers: [<N>]  # screen-issue only
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```
 
 ## Adversarial Verification Requirements
 

--- a/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
@@ -4,15 +4,18 @@
 
 Analyze interdependencies and determine execution order for all approved issues — whether one or many — producing a flat item list for `assemble-batch` dispatch. Every approval follows this unified path: sub-issue expansion → flat item list → assemble-batch → batch branch → pr-creation → one PR.
 
+**Per-issue screening is performed by the `screen-issue` task**, dispatched as parallel sub-agents (one per issue). This task receives N screening result contracts and performs cross-issue merge + dependency graph building.
+
 ## Entry Criteria
 
 - One or more issues approved (e.g., `Approved: #660`, `Approved: #660, #662, #621`)
 - Each issue has been verified by `verify-authorization`
 - User has explicitly authorized implementation
+- **Per-issue screening results available** (from `screen-issue` sub-agents or inline execution)
 
 ## Exit Criteria
 
-- Each approved issue screened (pre-analysis) and classified by dependency category
+- Each approved issue screened and classified by dependency category
 - Already-implemented, superseded, moot, and meta/non-code issues excluded with reason
 - Partially-implemented issues reduced to remaining phases
 - Sub-issues expanded into flat item list (even for single issues)
@@ -23,327 +26,88 @@ Analyze interdependencies and determine execution order for all approved issues 
 
 ## Procedure
 
-### Step 0: Pre-Analysis Screening
+### Step 0: Collect Screening Results
 
-Before classification, screen each approved issue against the following categories. Issues that fail screening are excluded or scope-reduced BEFORE building the dependency graph.
+Collect per-issue screening results from `screen-issue` sub-agents (parallel) or inline execution.
 
+If screening results are NOT already available from sub-agent dispatch, dispatch `screen-issue` sub-agents:
+
+```
 For each approved issue:
-
-1. Check partial/full implementation (merged PR references + success criteria)
-1. Check sub-issue closure verification for already-implemented classification (each sub-issue must be closed via merged PR, not prematurely closed)
-1. Check superseded by batch peer (scope overlap analysis)
-1. Check moot (spec references code that no longer exists/changed; no achievable criteria)
-1. Check stale assumptions (cross-reference with other issues in batch)
-1. Check revision status (flag in plan, remove `needs-approval` label)
-1. Check for cross-issue sub-issue pairs (default: parent covers; exception: isolated sub-agent)
-1. Classify conflicting pairs: auto-resolvable vs unresolvable
-
-#### Screening Categories
-
-| Category | Detection | Auto-resolve | Developer needed? |
-|----------|-----------|-------------|-------------------|
-| **Already implemented** | Merged PR references issue + Gate 1 passed (sub-issue enumeration gate) + Gate 2 passed (success criteria verification gate) + cross-references consistent | Exclude, mark "already-implemented" | No |
-| **Not implemented despite closure** | `state: closed` + merged PR exists + Gate 1 OR Gate 2 FAILED (sub-issues open/unverified, or success criteria not met) | Reopen or include remaining work, mark "not-implemented-despite-closure — premature closure" | No |
-| **Partially implemented** | Merged PR references issue + some success criteria met, some remaining | Include remaining phases only, mark "partially-implemented (phases X,Y done by PR #M)" | No |
-| **Superseded by batch peer** | Issue B's scope fully covers issue A's scope | Exclude A, note "superseded by #B" | No (if unambiguous) / Yes (if ambiguous) |
-| **Moot** | Referenced files/code restructured since spec creation; no remaining success criteria are achievable | Exclude, mark "moot" with reason | No |
-| **Stale assumptions** | Issue A references code/functions/files that Issue B modifies or deletes | Re-stage A after B only if same intent; otherwise HALT for developer | Yes (if different intent) / No (if same intent) |
-| **Conflicting (auto-resolvable)** | Issues touch same files, can be serialized | Serialize in correct order | No |
-| **Conflicting (unresolvable)** | Contradictory success criteria | Cannot auto-resolve | **Yes** — HALT |
-| **Meta/Non-code** | No code changes required | Exclude, mark "no code changes" | No |
-
-#### Screening Outcomes
-
-- **EXCLUDE**: already-implemented (verified via merged PR + sub-issues closed via merged PR + success criteria verified), superseded, moot, meta/non-code
-- **REOPEN/RE-CLASSIFY**: not-implemented-despite-closure (closed but Gate 1 or Gate 2 failed — include remaining work)
-- **REDUCE SCOPE**: partially-implemented (include remaining phases only)
-- **SERIALIZE**: same-intent stale assumptions, auto-resolvable conflicts
-- **HALT**: different-intent stale assumptions, unresolvable conflicts
-
-#### Partial Implementation Detection
-
-When a merged PR references the issue but not all success criteria are met:
-
-#### Already-Implemented Sub-Issue Verification
-
-**🚫 CRITICAL: An issue cannot be classified as "already implemented" if any of its sub-issues were closed without a merged PR.** Before excluding an issue as "already implemented," verify each sub-issue's closure:
-
-```
-For each sub-issue of the candidate "already implemented" issue:
-  child = github_issue_read(method="get", issue_number=sub_issue_number)
-
-  if child.state == "closed":
-    state_reason = child.get("state_reason", "")
-    prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")
-    merged_pr_found = False
-    for pr in prs:
-      pr_detail = github_pull_request_read(method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=pr["number"])
-      if pr_detail.get("merged_at") is not None:
-        merged_pr_found = True
-        break
-
-    if not merged_pr_found and state_reason != "not_planned":
-      # Sub-issue closed without merged PR — NOT legitimate closure
-      # Do NOT classify parent as "already implemented"
-      DOWNGRADE to "partially-implemented" or "scope-reduced"
-
-    if state_reason == "not_planned":
-      # Sub-issue intentionally not implemented
-      # Parent may be "already implemented" for remaining scope only
-      # Reduce scope to exclude intentionally skipped sub-issue
-      MARK as "scope-reduced — sub-issue #{sub_issue_number} intentionally not planned"
-
-  elif child.state == "open":
-    # Open sub-issue means parent is NOT fully implemented
-    DOWNGRADE to "partially-implemented"
+  Dispatch sub-agent: task(subagent_type="general", prompt="Use screen-issue task for issue #N with dispatch context: ...")
+  Collect result contract
 ```
 
-#### Mandatory Sub-Issue Enumeration Gate (Gate 1)
+**Dispatch context per sub-agent:**
 
-**🚫 CRITICAL — ZERO TOLERANCE: Before classifying ANY issue as "already-implemented," the agent MUST call `github_issue_read(method=get_sub_issues)` for that issue. Skipping this gate is a CRITICAL GUIDELINE VIOLATION. If `get_sub_issues` is not called, the classification is INVALID.**
-
-This gate ensures the agent cannot skip the sub-issue traversal prescribed in the "Already-Implemented Sub-Issue Verification" section above. The existing section describes what to check; this gate enforces that the check ACTUALLY HAPPENS.
-
-**Mandatory gate procedure — every candidate "already-implemented" issue MUST pass through ALL steps:**
-
-1. **ENUMERATE:** Call `github_issue_read(method=get_sub_issues, issue_number=<candidate>)` — no exceptions, no shortcuts
-2. **VERIFY EACH CHILD:** For EVERY sub-issue returned, call `github_issue_read(method=get, issue_number=<sub_issue_number>)` — do NOT trust cached state; verify against live GitHub API
-3. **CHECK CLOSURE LEGITIMACY:** For each closed sub-issue, search for merged PR evidence via `github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")`. If closed without merged PR and `state_reason != "not_planned"` → DOWNGRADE to "partially-implemented"
-4. **CHECK OPEN SUB-ISSUES:** If ANY sub-issue is open → the parent CANNOT be "already-implemented" — DOWNGRADE to "partially-implemented"
-5. **PRODUCE EVIDENCE:** Each sub-issue MUST produce a tool-call artifact showing its state was verified. Blanket assertions ("all sub-issues checked") WITHOUT per-sub-issue tool-call evidence are VERIFICATION-GAP findings
-
-**Gate 1 failure triggers:**
-
-| Failure Condition | Classification | Action |
-|-----------------|----------------|--------|
-| `get_sub_issues` not called | CRITICAL VIOLATION | Classification is INVALID — retry with gate |
-| Open sub-issue found | DOWNGRADE | "partially-implemented" — open sub-issue remains |
-| Sub-issue closed without merged PR | DOWNGRADE | "partially-implemented" — premature closure suspected |
-| Sub-issue closed as "not_planned" | SCOPE-REDUCE | "scope-reduced" — exclude intentionally skipped sub-issue |
-| No evidence artifacts produced | VERIFICATION-GAP | Re-run gate with evidence collection |
-
-#### Success Criteria Verification Gate (Gate 2)
-
-**🚫 CRITICAL — ZERO TOLERANCE: After Gate 1 passes (all sub-issues legitimately closed), the agent MUST verify every success criterion from the issue body against the live codebase. `state:closed` + merged PR does NOT shortcut this gate — closed issues require the SAME evidence as open issues, plus the additional merged PR evidence.**
-
-A merged PR proves code was merged. It does NOT prove that success criteria are met, that changes are complete, or that no files were accidentally omitted. The merged PR is a **prerequisite gate** (needed to begin verification), NOT proof of implementation. Verification against the live codebase IS the evidence.
-
-**Mandatory gate procedure — every candidate "already-implemented" issue MUST pass through ALL steps:**
-
-1. **EXTRACT CRITERIA:** Read the issue body and extract every success criterion (checkboxes, bullet points with "must"/"shall"/"should", testable assertions)
-2. **VERIFY EACH CRITERION:** For each success criterion, perform a direct verification action against the current state of `dev`:
-   - Criterion says "file X contains Y" → `read` file X, verify Y exists
-   - Criterion says "command Z returns expected output" → run command Z, verify output
-   - Criterion says "no lint failures" → run lint command, verify zero failures
-   - Criterion says "test T passes" → run test T, verify it passes
-   - Criterion references a skill task → `read` the task file, verify the claimed content exists
-3. **EVIDENCE REQUIRED:** Each criterion MUST produce a tool-call artifact. Assertions without tool-call evidence are VERIFICATION-GAP findings. "I checked earlier" or "the PR merged" are NOT evidence.
-4. **FAILURE HANDLING:** If ANY criterion fails or is unverified → DOWNGRADE to "partially-implemented" or "not-implemented-despite-closure"
-
-**Gate 2 failure triggers:**
-
-| Failure Condition | Classification | Action |
-|-----------------|----------------|--------|
-| No success criteria extracted | VERIFICATION-GAP | Re-read issue body; if criteria cannot be found, flag for review |
-| Criterion fails verification | DOWNGRADE | "partially-implemented" — criterion not met despite closure |
-| Criterion unverified (no tool call) | VERIFICATION-GAP | Re-run verification; if unverifiable, flag for review |
-| Success criteria not in issue body | MISSING-ELEMENT | Search comments; if absent, flag for developer to confirm |
-| Agent claims "all criteria met" without evidence | CRITICAL VIOLATION | Re-run gate with evidence collection |
-
-#### Cross-Reference Traversal
-
-After both Gate 1 and Gate 2 pass, check the issue body for cross-references and verify those referenced issues have consistent state. This prevents scenarios where a spec references a plan that has been closed, or a plan references a spec that is still open, indicating inconsistent closure.
-
-**Mandatory cross-reference check:**
-
-```
-For each candidate "already-implemented" issue:
-  body = github_issue_read(method="get", issue_number=candidate)
-  
-  # Parse body for cross-reference patterns
-  for pattern in [r"Spec:\s*#(\d+)", r"Plan:\s*#(\d+)", r"Implements\s*#(\d+)"]:
-    for match in re.finditer(pattern, body):
-      ref_num = int(match.group(1))
-      ref_issue = github_issue_read(method="get", issue_number=ref_num)
-      
-      # Verify referenced issue has consistent state
-      if ref_issue["state"] == "open" and candidate is classified as "already-implemented":
-        # Referenced issue is open but candidate claims done — INCONSISTENT
-        DOWNGRADE to "partially-implemented" or flag-for-review
-      
-      if ref_issue["state"] == "closed":
-        # Verify referenced issue was legitimately closed (merged PR exists)
-        # Reuse closed-issue verification logic from verify-authorization Step 5.4
+```yaml
+issue_number: <N>
+batch_peers: [<list of all approved issue numbers except this one>]
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
 ```
 
-**Cross-reference failure triggers:**
+**After all sub-agents return**, assemble screening results.
 
-| Failure Condition | Classification | Action |
-|-----------------|----------------|--------|
-| Referenced issue is open | CONFLICTING | DOWNGRADE or flag-for-review — state mismatch |
-| Referenced issue closed without merged PR | VERIFICATION-GAP | Flag for review — may be premature closure |
-| Cross-reference 404 | MISSING-TRACEABILITY | Flag for developer — referenced issue doesn't exist |
+### Step 0.5: Assemble Gate Evidence Audit Table
 
-**Key principle:** Even if Gate 1 and Gate 2 pass, cross-reference inconsistencies invalidate the "already-implemented" classification. The full issue graph must be consistent.
-
-1. Identify which phases/criteria are already satisfied by reading the merged PR's diff
-1. Extract remaining phases/criteria as the implementation scope
-1. Include in execution plan with reduced scope: `#N (phases 2, 3 remaining — phase 1 done by PR #M)`
-1. Sub-agent receives context: which phases are already done, what remains
-1. Do NOT ask the developer to specify — auto-detect
-
-#### Cross-Issue Sub-Issue Handling
-
-When both a parent issue and its sub-issues are in the approved batch:
-
-1. **Detect:** For each issue, check `github_issue_read(method=get_sub_issues)`. If any sub-issue number is also in the approved set, flag the pair.
-
-1. **Default behavior:** Omit sub-issues from execution plan — parent's cascade covers them. Sub-agent for parent receives the full spec including all phases.
-
-1. **Exception — isolated sub-issues:** If a sub-issue has a well-isolated scope (clear boundaries, no file overlap with parent's other phases), dispatch it to its own sub-agent for parallelism. Isolation criteria:
-
-   - Touches completely different files from parent's other phases
-   - No dependency on parent's other phases
-   - Can be merged independently
-
-1. **Edge case:** Parent is excluded (already implemented) but sub-issues aren't. Include sub-issues independently since parent's cascade doesn't apply.
-
-#### Stale Spec Assumption Detection
-
-When issue A's spec references code/functions/files that issue B modifies or deletes:
-
-1. **Same intent (auto-resolvable):** Issue A says "delete `parseEnvFromOutput()`" and Issue B also deletes it → same intent, serialize, no conflict. B before A is sufficient; A's implementation will find the function already gone.
-
-1. **Different intent (HALT for developer):** Issue A says "modify `parseEnvFromOutput()`" and Issue B deletes it → agent cannot determine if A's intent is still valid or if A should be adjusted. HALT and present to developer: "Issue #A references `parseEnvFromOutput()` but Issue #B deletes it. Should #A's spec be revised, or is the modification still needed?"
-
-1. **Do NOT auto-re-stage when intent differs.** The agent must not assume it knows whether the developer wants the function modified or deleted.
-
-#### Merge-Time Conflict Handling (Batch Assembly)
-
-When two issues are independent during implementation but may conflict when squash-merged into the batch branch:
-
-1. **Detect:** Issues that touch the same file in different sections or in overlapping but non-contradictory ways.
-
-1. **Action — Batch assembly ordering:**
-
-   - The `assemble-batch` task handles squash-merge ordering automatically
-   - Issues are squash-merged into the batch branch in dependency/serial order
-   - Later issues may need to resolve conflicts from earlier squash-merges during the batch assembly step
-   - Tier 1-2 conflicts (formatting/whitespace): auto-resolve per `conflict-resolution` skill
-   - Tier 3 conflicts (intent): HALT and flag for developer review
-
-1. **Do NOT block execution.** All issues proceed with implementation immediately. Conflict resolution happens at batch assembly time, not during implementation.
-
-1. **Note in execution plan:** "#A and #B may conflict at batch assembly — `assemble-batch` will handle merge ordering."
-
-#### Revision Status Handling
-
-When an issue in the batch has STATUS marked as `REVISED - NEEDS APPROVAL`:
-
-1. **"approved #N" covers the revised spec.** The developer explicitly authorized the issue number. The spec body (including revisions) is authoritative.
-
-1. **Flag in execution plan:** "#N has REVISED status — using revised spec as implementation scope."
-
-1. **Remove `needs-approval` label** from the issue post-approval (per existing approval-gate rule: explicit auth overrides label).
-
-### Step 0.5: Gate Evidence Audit (MANDATORY — ZERO TOLERANCE)
-
-**🚫 CRITICAL — STRUCTURAL CHECKPOINT: After Step 0 screening and BEFORE sub-issue expansion, the agent MUST verify that Gate 1 and Gate 2 were actually EXECUTED (not just read) for every issue classified as "already-implemented." This step is a mechanical audit — it checks whether evidence artifacts exist. It is NOT advisory text the agent can skip.**
-
-**Why this step exists:** Previous fixes (#979, #980, PR #981) added Gate 1 and Gate 2 as text instructions to `pre-implementation-analysis.md`. Subsequent agent sessions read these instructions and skipped them anyway — no `get_sub_issues` calls, no per-sub-issue evidence, no success criteria verification. Text-based guardrails are insufficient; this step adds a structural checkpoint that halts advancement unless evidence exists.
-
-**If NO issues were classified as "already-implemented":** This step passes trivially. Skip to Step 1.
-
-**If ANY issues were classified as "already-implemented":** Perform the following audit:
-
-#### GA-1: Verify Gate 1 Evidence Exists
-
-For EACH issue classified as "already-implemented":
-
-1. **Check sub-issue enumeration call:** Did you call `github_issue_read(method=get_sub_issues, issue_number=<candidate>)` during Step 0 screening? If NO → STOP. Return to Step 0 and re-run Gate 1 for this issue before proceeding.
-
-2. **Check per-sub-issue evidence:** For EACH sub-issue returned by `get_sub_issues`, did you produce a tool-call artifact (`github_issue_read(method=get, issue_number=<sub>)`) verifying its state? If NO → STOP. Return to Step 0 and re-run Gate 1 verification.
-
-3. **Check closure legitimacy evidence:** For each closed sub-issue, did you search for merged PR evidence? If NO → STOP. Return to Step 0 and re-run Gate 1 closure legitimacy check.
-
-#### GA-2: Verify Gate 2 Evidence Exists
-
-For EACH issue classified as "already-implemented":
-
-1. **Extract success criteria:** Did you read the issue body and extract every success criterion? If NO → STOP. Return to Step 0 and re-run Gate 2 for this issue.
-
-2. **Verify each criterion:** For each success criterion, did you perform a direct verification action (read, grep, lint, test) against the current `dev` branch? If NO → STOP. Return to Step 0 and re-run Gate 2 verification.
-
-3. **Evidence artifacts:** For each criterion, is there a tool-call artifact documenting the verification? If NO → STOP. Return to Step 0 and re-run with evidence collection.
-
-#### GA-3: Produce the Gate Evidence Audit Table
-
-**This table is a MANDATORY structural artifact.** `assemble-batch` (Step 1 of assemble-batch.md) checks for this table before proceeding. If the table is missing, `assemble-batch` returns here.
-
-For all "already-implemented" classifications, produce:
+From the collected screening results, assemble the full Gate Evidence Audit Table:
 
 ```markdown
 ## Gate Evidence Audit Table
 
 | Issue # | Sub-issues Enumerated? (Gate 1) | All Sub-issues Verified? | Closure Legitimacy Verified? | Success Criteria Extracted? (Gate 2) | All Criteria Verified vs Codebase? | Final Classification |
 |---------|----------------------------------|--------------------------|-------------------------------|--------------------------------------|-----------------------------------|---------------------|
-| #N | ✅/❌ | ✅/❌ | ✅/❌ | ✅/❌ | ✅/❌ | already-implemented / partially-implemented / not-implemented-despite-closure |
+| #N | ✅/❌ | ✅/❌ | ✅/❌ | ✅/❌ | ✅/❌ | <classification> |
 ```
+
+Each row comes from the `gate_evidence` field of the corresponding `screen-issue` result contract.
 
 **If ANY row has ❌ in columns 2-5:** That issue's classification is INVALID. It MUST be DOWNGRADED:
 - ❌ in Gate 1 columns → DOWNGRADE to "partially-implemented" (sub-issues not verified)
 - ❌ in Gate 2 columns → DOWNGRADE to "partially-implemented" or "not-implemented-despite-closure" (success criteria not verified)
 
-**After downgrades:** Remove downgraded issues from "already-implemented" list. Add them to the "partially-implemented" list in the execution plan. Re-classify per Screening Categories table.
-
-#### GA-4: Verify Audit Table Completeness
-
-Before proceeding to Step 1:
-1. The Gate Evidence Audit Table includes ALL issues classified as "already-implemented"
-2. Every column has ✅ or ❌ (no blank entries)
-3. All ❌ entries have been actioned (downgrade applied, issue moved to correct list)
-4. The table is present in the chat output (not hidden in agent reasoning)
+**After downgrades:** Remove downgraded issues from "already-implemented" list. Add them to the "partially-implemented" list in the execution plan. Re-classify per screening results.
 
 **If the table is incomplete:** HALT and complete it before proceeding.
 
-### Step 1: Sub-Issue Expansion (MANDATORY)
+### Step 1: Assemble Flat Item List
 
-**Every approved issue — whether single or batch — MUST undergo sub-issue expansion before classification.**
+From the collected screening results, assemble the flat item list:
 
-For each approved issue:
+- For each `included` issue: add its `flat_items` to the execution list
+- For each `excluded` issue: add to "Excluded" section with reason
+- For each `scope-reduced` issue: add its remaining phases to the execution list
+- For issues with `requires_developer: true`: HALT for developer review
 
-1. **Query sub-issues:** `github_issue_read(method="get_sub_issues", issue_number=N)`
-2. **If sub-issues exist:** Expand the parent into its sub-issues as individual implementation items. The parent's spec body provides context; each sub-issue defines a phase.
-3. **If no sub-issues (single-task):** The issue IS the flat item — no expansion needed.
-4. **Build the flat item list:** Each sub-issue (or single issue) becomes one row in the execution plan. This is the input to `assemble-batch`.
+### Step 2: Cross-Issue Analysis
 
-**Why expansion is mandatory even for single issues:**
+Analyze cross-issue relationships using file/symbol references from screening results. **No additional API calls needed** — screening results already contain verified file and symbol references.
 
-- Single issue = batch of one = one sub-agent in `assemble-batch`
-- Eliminates forked code paths between "single issue" and "batch" workflows
-- Sub-issue expansion produces a uniform data structure regardless of count
+#### Cross-Issue Checks
 
-**Expansion rules:**
+1. **Stale assumptions across issues:** If issue A's `file_references` overlap with issue B's `file_references`, check intent alignment:
+   - Same intent → serialize (B before A if B provides the canonical change)
+   - Different intent → HALT for developer review
 
-| Parent Type | Expansion Action |
-|-----------|-------------------|
-| Single-task spec (no sub-issues) | Item = the issue itself |
-| Multi-task spec (has sub-issues) | Items = each sub-issue (parent provides context) |
-| Multi-task spec with some sub-issues NOT in batch | Items = sub-issues in batch only |
+1. **Supersession across issues:** If issue B's `file_references` are a superset of issue A's, and B's scope description fully encompasses A's:
+   - Unambiguous → exclude A (superseded by B)
+   - Ambiguous → HALT for developer review
 
-### Step 2: Read All Remaining (Non-Excluded) Issues
+1. **Cross-issue sub-issue pairs:** If a parent and its sub-issues are both included:
+   - Default: omit sub-issues — parent's cascade covers them
+   - Exception: isolated sub-issues with no file overlap → dispatch to own sub-agent
+   - Edge case: parent excluded but sub-issues included → include independently
 
-For each issue that survived screening, read the full issue body and comments:
-
-```python
-for issue_number in remaining_issues:
-    issue = github_issue_read(method="get", issue_number=issue_number)
-    comments = github_issue_read(method="get_comments", issue_number=issue_number)
-```
+1. **Merge-time conflict risk:** Issues touching the same file in different sections. Noted in execution plan for `assemble-batch` handling. Do NOT block execution.
 
 ### Step 3: Classify Each Issue
 
-Determine each issue's category:
+Determine each issue's category based on cross-issue analysis:
 
 | Category | Criteria | Action |
 |----------|----------|--------|
@@ -354,14 +118,14 @@ Determine each issue's category:
 
 **Classification heuristics:**
 
-1. **File overlap analysis**: Scan each issue's body for file path references, directory references, or component names that map to files in the repo.
-1. **Skill overlap**: Issues using the same skills that mutate shared state (e.g., both update `000-critical-rules.md`) are conflict-risk.
-1. **Logical ordering**: When Issue A's output becomes Issue B's input (e.g., A creates a skill that B references), A must precede B.
-1. **Scope analysis**: `.opencode/`-only changes vs `src/` changes vs doc-only changes.
+1. **File overlap analysis:** Use `file_references` from screening results. No API calls needed.
+1. **Skill overlap:** Issues using the same skills that mutate shared state (e.g., both update `000-critical-rules.md`) are conflict-risk.
+1. **Logical ordering:** When Issue A's output becomes Issue B's input (e.g., A creates a skill that B references), A must precede B.
+1. **Scope analysis:** `.opencode/`-only changes vs `src/` changes vs doc-only changes.
 
-**Add edges from pre-analysis screening:**
+**Add edges from screening results:**
 
-- Same-intent stale assumption pairs → must-precede edge (the issue providing the canonical change precedes)
+- Same-intent stale assumption pairs → must-precede edge
 - Cross-issue sub-issue pairs → dependency edge (parent covers sub-issues unless isolated)
 
 ### Step 4: Build Dependency Graph
@@ -369,7 +133,7 @@ Determine each issue's category:
 Create a directed graph where:
 
 - Nodes = remaining (non-excluded) approved issues
-- Edges = "must-precede" relationships (including stale-assumption and cross-sub-issue edges from Step 0)
+- Edges = "must-precede" relationships (including stale-assumption and cross-sub-issue edges from cross-issue analysis)
 - Groups = sets of issues with no inter-dependencies (parallel-safe)
 
 ```markdown
@@ -482,6 +246,7 @@ The ONLY conditions requiring developer input during batch approval analysis:
 - **Unresolvable conflicts**: Contradictory success criteria between issues in batch
 - **Stale spec assumptions (different intent)**: Issue A references code that Issue B deletes, and A's intent differs from B's
 - **Ambiguous supersession**: Two issues partially overlap, unclear which supersedes which
+- **screen-issue returned `requires_developer: true`**: Any screening sub-agent flagged for developer review
 
 When any of these triggers fire, HALT and present the conflict to the developer with a clear question. Do NOT attempt to auto-resolve.
 
@@ -493,14 +258,13 @@ Before dispatching any parallel worktrees, the orchestrating agent MUST capture 
 git rev-parse origin/dev
 ```
 
-This `dev_base_hash` MUST be included in the dispatch context for each parallel issue. See Step 7 for the complete dispatch context schema.
+This `dev_base_hash` MUST be included in the dispatch context for each parallel issue. See Step 8 for the complete dispatch context schema.
 
 ### Step 8: Dispatch Context for Parallel Issues
 
 For each issue in a parallel-safe group, the dispatch context MUST include worktree information:
 
 ```yaml
-# Dispatch Context Per Issue
 issue: <number>
 branch: "spec/<short-name>"
 worktree_path: ".worktrees/spec-<short-name>"
@@ -702,7 +466,7 @@ A cross-issue sub-issue pair exists when:
 
 - Issue A is a parent issue with sub-issues
 - One or more of A's sub-issues are also in the approved batch
-- Detected via `github_issue_read(method=get_sub_issues)` for each issue
+- Detected via `flat_items` from screening results
 
 ### Merge-Time Conflict Detection
 
@@ -711,6 +475,48 @@ Issues have a merge-time conflict risk when:
 - They touch the same file but in different sections or with non-contradictory changes
 - They are independent during implementation but may produce overlapping diffs
 - This is distinct from conflict-risk (which affects implementation order)
+
+## Adversarial Interdependency Verification
+
+**Before trusting spec-claimed dependencies, verify them against actual codebase state.** Use `file_references` and `symbol_references` from screening results to avoid redundant API calls.
+
+### Verify File Overlap Claims Against Actual Code
+
+For each pair of issues with overlapping `file_references`, use srclight to verify actual dependency:
+- `srclight_get_dependents` or `srclight_get_callers` to verify import/call chains
+- If spec claims "A modifies X which B needs" but srclight shows no dependency → VERIFICATION-GAP
+- If srclight shows dependency not mentioned in either spec → MISSING-ELEMENT
+
+### Verify Must-Precede Claims
+
+For each must-precede relationship claimed in specs:
+- Check if A actually creates/modifies symbols that B uses
+- `srclight_get_callers(symbol_name="<symbol_from_A>", project="<project>")`
+- If callers include code from B's scope → dependency verified
+- If callers do NOT include code from B's scope → VERIFICATION-GAP
+
+### Verify Independence Claims
+
+For each pair of issues claimed as "independent":
+- `srclight_get_dependents(symbol_name="<key_symbol>", project="<project>", transitive=True)`
+- If transitive dependents include code from the other issue's scope → NOT independent
+- Downgrade from "parallel-safe" to "conflict-risk" or "must-precede"
+
+### Verify Code References Exist
+
+For each file path or symbol from screening `file_references`/`symbol_references`:
+- File paths: verify with glob or read that the file exists
+- Symbol names: verify with srclight_get_signature that the symbol exists
+- If file/symbol does not exist → VERIFICATION-GAP
+
+### Finding Classification
+
+| Finding | Problem Class | Classification | Action |
+|--------|---------------|----------------|--------|
+| File overlap claimed but no actual dependency | VERIFICATION-GAP | flag-for-review | Re-classify as independent unless other evidence |
+| Dependency exists but not mentioned in specs | MISSING-ELEMENT | conditional | Add to dependency graph, adjust execution order |
+| Independence claimed but transitive dependency exists | CONFLICTING | conditional | Downgrade to conflict-risk or must-precede |
+| Code reference to non-existent file/symbol | VERIFICATION-GAP | flag-for-review | Developer must confirm: planned or typo |
 
 ## Red Flags
 
@@ -726,14 +532,14 @@ Issues have a merge-time conflict risk when:
 - HALT between plan presentation and `assemble-batch`
 - Ask "Proceed?", "Shall I?", or any confirmation solicitation after plan presentation
 - Auto-re-stage issues with different-intent stale assumptions
-- Skip Gate 1 (sub-issue enumeration) for any candidate "already-implemented" issue
+- Skip gate evidence audit table assembly from screening results
+- Proceed without verifying all screening result contracts are collected
 - Classify an issue as "already-implemented" while it has open sub-issues or unverified success criteria
-- Proceed to Step 1 (sub-issue expansion) without completing the Gate Evidence Audit Table for all "already-implemented" classifications
-- Classify an issue as "already-implemented" without a corresponding `get_sub_issues` tool-call artifact in the current session
 
 **Always:**
 
-- Run pre-analysis screening (Step 0) before classification
+- Collect per-issue screening results before cross-issue analysis
+- Assemble the Gate Evidence Audit Table from screening results
 - Present the full dependency graph to the developer in chat
 - Classify every issue before execution
 - Execute must-precede issues first
@@ -742,67 +548,5 @@ Issues have a merge-time conflict risk when:
 - Report each issue's classification in the execution plan
 - Proceed immediately to `assemble-batch` after presenting the plan
 - Auto-detect partially-implemented issues (no developer input needed)
-- Call `github_issue_read(method=get_sub_issues)` for every candidate "already-implemented" issue (Gate 1)
-- Verify each success criterion against the live codebase before classifying as "already-implemented" (Gate 2)
-- Complete the Gate Evidence Audit Table (Step 0.5) before proceeding to Step 1
-- Produce a per-issue `get_sub_issues` tool-call artifact in the current session for every "already-implemented" classification
-- HALT for developer review only for unresolvable conflicts and different-intent stale assumptions
-
-## Adversarial Interdependency Verification
-
-**Before trusting spec-claimed dependencies, verify them against actual codebase state.** Specs may claim "Issue A must precede Issue B" based on assumed file overlap that doesn't exist, or miss dependencies that do exist.
-
-### Verify File Overlap Claims Against Actual Code
-
-```
-For each spec claiming file overlap with another spec:
-  - Extract file paths mentioned in each spec body
-  - Use srclight_get_dependents or srclight_get_callers to verify actual import/call chains
-  - If spec claims "A modifies X which B needs" but srclight shows no dependency → VERIFICATION-GAP
-  - If srclight shows dependency not mentioned in either spec → MISSING-ELEMENT
-```
-
-**Evidence artifact:** `srclight_get_dependents` and `srclight_get_callers` results for symbols mentioned in specs.
-
-### Verify Must-Precede Claims
-
-```
-For each must-precede relationship claimed in specs:
-  - Check if A actually creates/modifies symbols that B uses
-  - srclight_get_callers(symbol_name="<symbol_from_A>", project="<project>")
-  - If callers include code from B's scope → dependency verified
-  - If callers do NOT include code from B's scope → VERIFICATION-GAP (may not actually need serialization)
-```
-
-**Evidence artifact:** Caller graph results showing whether the claimed dependency exists in actual code.
-
-### Verify Independence Claims
-
-```
-For each pair of issues claimed as "independent":
-  - Use srclight_get_dependents(symbol_name="<key_symbol>", project="<project>", transitive=True)
-  - If transitive dependents include code from the other issue's scope → NOT independent
-  - Downgrade from "parallel-safe" to "conflict-risk" or "must-precede"
-```
-
-**Evidence artifact:** Transitive dependency graph showing whether claimed independence holds.
-
-### Verify Code References Exist
-
-```
-For each file path or symbol mentioned in any spec:
-  - File paths: verify with glob or read that the file exists
-  - Symbol names: verify with srclight_get_signature that the symbol exists
-  - If file/symbol does not exist → VERIFICATION-GAP (flag-for-review: planned but not yet implemented, or typo)
-```
-
-**Evidence artifact:** Search/glob results confirming existence or absence of referenced code.
-
-### Finding Classification
-
-| Finding | Problem Class | Classification | Action |
-|--------|---------------|----------------|--------|
-| File overlap claimed but no actual dependency | VERIFICATION-GAP | flag-for-review | Re-classify as independent unless other evidence |
-| Dependency exists but not mentioned in specs | MISSING-ELEMENT | conditional | Add to dependency graph, adjust execution order |
-| Independence claimed but transitive dependency exists | CONFLICTING | conditional | Downgrade to conflict-risk or must-precede |
-| Code reference to non-existent file/symbol | VERIFICATION-GAP | flag-for-review | Developer must confirm: planned or typo |
+- HALT for developer review only for unresolvable conflicts, different-intent stale assumptions, and ambiguous supersession
+- Verify screening result `requires_developer` field and HALT if true

--- a/.opencode/skills/approval-gate/tasks/screen-issue.md
+++ b/.opencode/skills/approval-gate/tasks/screen-issue.md
@@ -1,0 +1,399 @@
+# Task: screen-issue
+
+## Purpose
+
+Per-issue screening for pre-implementation analysis. Screen a single approved issue against screening categories (already-implemented, superseded, moot, stale assumptions, partial implementation, revision status, meta/non-code, cross-issue sub-issue handling). Produce a compact result contract for cross-issue merge.
+
+## Entry Criteria
+
+- Single issue number to screen (passed via dispatch context)
+- Issue has been verified by `verify-authorization`
+- User has explicitly authorized implementation
+- `GIT_OWNER` and `GIT_REPO` available from dispatch context
+
+## Exit Criteria
+
+- Issue classified into one screening category
+- Gate 1 (sub-issue enumeration) executed if applicable
+- Gate 2 (success criteria verification) executed if applicable
+- Compact result contract produced (~100-500 words, YAML-structured)
+
+## Procedure
+
+### Step 1: Read Issue Body and Comments
+
+Read the full issue body and all comments for the target issue.
+
+```
+issue = github_issue_read(method="get", issue_number=<target>)
+comments = github_issue_read(method="get_comments", issue_number=<target>)
+```
+
+### Step 2: Screening Categories Check
+
+Check each category in order:
+
+| Category | Detection | Auto-resolve | Developer needed? |
+|----------|-----------|-------------|-------------------|
+| **Already implemented** | Merged PR references issue + Gate 1 passed (sub-issue enumeration gate) + Gate 2 passed (success criteria verification gate) + cross-references consistent | Exclude, mark "already-implemented" | No |
+| **Not implemented despite closure** | `state: closed` + merged PR exists + Gate 1 OR Gate 2 FAILED (sub-issues open/unverified, or success criteria not met) | Reopen or include remaining work, mark "not-implemented-despite-closure — premature closure" | No |
+| **Partially implemented** | Merged PR references issue + some success criteria met, some remaining | Include remaining phases only, mark "partially-implemented (phases X,Y done by PR #M)" | No |
+| **Superseded by batch peer** | Issue B's scope fully covers issue A's scope | Exclude A, note "superseded by #B" | No (if unambiguous) / Yes (if ambiguous) |
+| **Moot** | Referenced files/code restructured since spec creation; no remaining success criteria are achievable | Exclude, mark "moot" with reason | No |
+| **Stale assumptions** | Issue A references code/functions/files that Issue B modifies or deletes | Re-stage A after B only if same intent; otherwise HALT for developer | Yes (if different intent) / No (if same intent) |
+| **Conflicting (auto-resolvable)** | Issues touch same files, can be serialized | Serialize in correct order | No |
+| **Conflicting (unresolvable)** | Contradictory success criteria | Cannot auto-resolve | **Yes** — HALT |
+| **Meta/Non-code** | No code changes required | Exclude, mark "no code changes" | No |
+| **Revision status** | STATUS contains `REVISED - NEEDS APPROVAL` | Flag in execution plan, remove `needs-approval` label | No |
+
+#### Screening Outcomes
+
+- **EXCLUDE**: already-implemented (verified via merged PR + sub-issues closed via merged PR + success criteria verified), superseded, moot, meta/non-code
+- **REOPEN/RE-CLASSIFY**: not-implemented-despite-closure (closed but Gate 1 or Gate 2 failed — include remaining work)
+- **REDUCE SCOPE**: partially-implemented (include remaining phases only)
+- **SERIALIZE**: same-intent stale assumptions, auto-resolvable conflicts
+- **HALT**: different-intent stale assumptions, unresolvable conflicts
+
+#### Superseded Detection
+
+Issue A is superseded by batch peer B when:
+
+- B's file list is a superset of A's file list
+- B's scope description fully encompasses A's scope
+- All of A's success criteria would be met by implementing B
+
+**Ambiguous supersession** (partial overlap, unclear which is canonical): HALT for developer review.
+
+#### Moot Detection
+
+An issue is moot when:
+
+- Its spec references files/directories that have been restructured or removed since spec creation
+- None of its remaining success criteria are achievable given the current codebase state
+- The problem it describes no longer exists
+
+#### Stale Assumption Detection
+
+An issue has stale assumptions when:
+
+- Its spec references specific function names, class names, or file paths that another issue in the batch modifies or deletes
+- The reference is integral to the issue's implementation instructions (not just background context)
+
+**Same intent (auto-resolvable):** Both issues want the same outcome for the referenced code.
+**Different intent (HALT):** The issues have conflicting goals for the referenced code.
+
+When issue A's spec references code/functions/files that issue B modifies or deletes:
+
+1. **Same intent (auto-resolvable):** Issue A says "delete `parseEnvFromOutput()`" and Issue B also deletes it → same intent, serialize, no conflict. B before A is sufficient; A's implementation will find the function already gone.
+
+1. **Different intent (HALT for developer):** Issue A says "modify `parseEnvFromOutput()`" and Issue B deletes it → agent cannot determine if A's intent is still valid or if A should be adjusted. HALT and present to developer: "Issue #A references `parseEnvFromOutput()` but Issue #B deletes it. Should #A's spec be revised, or is the modification still needed?"
+
+1. **Do NOT auto-re-stage when intent differs.** The agent must not assume it knows whether the developer wants the function modified or deleted.
+
+#### Meta/Non-Code Detection
+
+An issue is meta/non-code when:
+
+- The body describes behavioral rules without file modifications
+- The issue tracks observability or enforcement without requiring code changes
+- The "implementation" is just acknowledging a pattern, not writing code
+- All success criteria are satisfied by existence of documentation or rules already in place
+
+#### Revision Status Handling
+
+When an issue has STATUS marked as `REVISED - NEEDS APPROVAL`:
+
+1. **"approved #N" covers the revised spec.** The developer explicitly authorized the issue number. The spec body (including revisions) is authoritative.
+
+1. **Flag in execution plan:** "#N has REVISED status — using revised spec as implementation scope."
+
+1. **Remove `needs-approval` label** from the issue post-approval (per existing approval-gate rule: explicit auth overrides label).
+
+#### Partial Implementation Detection
+
+When a merged PR references the issue but not all success criteria are met:
+
+1. Identify which phases/criteria are already satisfied by reading the merged PR's diff
+1. Extract remaining phases/criteria as the implementation scope
+1. Include in execution plan with reduced scope: `#N (phases 2, 3 remaining — phase 1 done by PR #M)`
+1. Sub-agent receives context: which phases are already done, what remains
+1. Do NOT ask the developer to specify — auto-detect
+
+### Step 3: Gate 1 — Sub-Issue Enumeration (MANDATORY for already-implemented candidates)
+
+**🚫 CRITICAL — ZERO TOLERANCE: Before classifying ANY issue as "already-implemented," the agent MUST call `github_issue_read(method=get_sub_issues)` for that issue. Skipping this gate is a CRITICAL GUIDELINE VIOLATION. If `get_sub_issues` is not called, the classification is INVALID.**
+
+This gate ensures the agent cannot skip the sub-issue traversal. The section below describes what to check; this gate enforces that the check ACTUALLY HAPPENS.
+
+**Mandatory gate procedure — every candidate "already-implemented" issue MUST pass through ALL steps:**
+
+1. **ENUMERATE:** Call `github_issue_read(method=get_sub_issues, issue_number=<candidate>)` — no exceptions, no shortcuts
+2. **VERIFY EACH CHILD:** For EVERY sub-issue returned, call `github_issue_read(method=get, issue_number=<sub_issue_number>)` — do NOT trust cached state; verify against live GitHub API
+3. **CHECK CLOSURE LEGITIMACY:** For each closed sub-issue, search for merged PR evidence via `github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")`. If closed without merged PR and `state_reason != "not_planned"` → DOWNGRADE to "partially-implemented"
+4. **CHECK OPEN SUB-ISSUES:** If ANY sub-issue is open → the parent CANNOT be "already-implemented" — DOWNGRADE to "partially-implemented"
+5. **PRODUCE EVIDENCE:** Each sub-issue MUST produce a tool-call artifact showing its state was verified. Blanket assertions ("all sub-issues checked") WITHOUT per-sub-issue tool-call evidence are VERIFICATION-GAP findings
+
+**Already-Implemented Sub-Issue Verification:**
+
+```
+For each sub-issue of the candidate "already implemented" issue:
+  child = github_issue_read(method="get", issue_number=sub_issue_number)
+
+  if child.state == "closed":
+    state_reason = child.get("state_reason", "")
+    prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{GIT_OWNER}/{GIT_REPO}")
+    merged_pr_found = False
+    for pr in prs:
+      pr_detail = github_pull_request_read(method="get", owner=GIT_OWNER, repo=GIT_REPO, pullNumber=pr["number"])
+      if pr_detail.get("merged_at") is not None:
+        merged_pr_found = True
+        break
+
+    if not merged_pr_found and state_reason != "not_planned":
+      DOWNGRADE to "partially-implemented" or "scope-reduced"
+
+    if state_reason == "not_planned":
+      MARK as "scope-reduced — sub-issue #{sub_issue_number} intentionally not planned"
+
+  elif child.state == "open":
+    DOWNGRADE to "partially-implemented"
+```
+
+**Gate 1 failure triggers:**
+
+| Failure Condition | Classification | Action |
+|-----------------|----------------|--------|
+| `get_sub_issues` not called | CRITICAL VIOLATION | Classification is INVALID — retry with gate |
+| Open sub-issue found | DOWNGRADE | "partially-implemented" — open sub-issue remains |
+| Sub-issue closed without merged PR | DOWNGRADE | "partially-implemented" — premature closure suspected |
+| Sub-issue closed as "not_planned" | SCOPE-REDUCE | "scope-reduced" — exclude intentionally skipped sub-issue |
+| No evidence artifacts produced | VERIFICATION-GAP | Re-run gate with evidence collection |
+
+### Step 4: Gate 2 — Success Criteria Verification (MANDATORY after Gate 1 passes)
+
+**🚫 CRITICAL — ZERO TOLERANCE: After Gate 1 passes (all sub-issues legitimately closed), the agent MUST verify every success criterion from the issue body against the live codebase. `state:closed` + merged PR does NOT shortcut this gate — closed issues require the SAME evidence as open issues, plus the additional merged PR evidence.**
+
+A merged PR proves code was merged. It does NOT prove that success criteria are met, that changes are complete, or that no files were accidentally omitted. The merged PR is a **prerequisite gate** (needed to begin verification), NOT proof of implementation. Verification against the live codebase IS the evidence.
+
+**Mandatory gate procedure — every candidate "already-implemented" issue MUST pass through ALL steps:**
+
+1. **EXTRACT CRITERIA:** Read the issue body and extract every success criterion (checkboxes, bullet points with "must"/"shall"/"should", testable assertions)
+2. **VERIFY EACH CRITERION:** For each success criterion, perform a direct verification action against the current state of `dev`:
+   - Criterion says "file X contains Y" → `read` file X, verify Y exists
+   - Criterion says "command Z returns expected output" → run command Z, verify output
+   - Criterion says "no lint failures" → run lint command, verify zero failures
+   - Criterion says "test T passes" → run test T, verify it passes
+   - Criterion references a skill task → `read` the task file, verify the claimed content exists
+3. **EVIDENCE REQUIRED:** Each criterion MUST produce a tool-call artifact. Assertions without tool-call evidence are VERIFICATION-GAP findings. "I checked earlier" or "the PR merged" are NOT evidence.
+4. **FAILURE HANDLING:** If ANY criterion fails or is unverified → DOWNGRADE to "partially-implemented" or "not-implemented-despite-closure"
+
+**Gate 2 failure triggers:**
+
+| Failure Condition | Classification | Action |
+|-----------------|----------------|--------|
+| No success criteria extracted | VERIFICATION-GAP | Re-read issue body; if criteria cannot be found, flag for review |
+| Criterion fails verification | DOWNGRADE | "partially-implemented" — criterion not met despite closure |
+| Criterion unverified (no tool call) | VERIFICATION-GAP | Re-run verification; if unverifiable, flag for review |
+| Success criteria not in issue body | MISSING-ELEMENT | Search comments; if absent, flag for developer to confirm |
+| Agent claims "all criteria met" without evidence | CRITICAL VIOLATION | Re-run gate with evidence collection |
+
+### Step 5: Cross-Reference Traversal
+
+After both Gate 1 and Gate 2 pass, check the issue body for cross-references and verify those referenced issues have consistent state. This prevents scenarios where a spec references a plan that has been closed, or a plan references a spec that is still open, indicating inconsistent closure.
+
+**Mandatory cross-reference check:**
+
+```
+For each candidate "already-implemented" issue:
+  body = github_issue_read(method="get", issue_number=candidate)
+  
+  for pattern in [r"Spec:\s*#(\d+)", r"Plan:\s*#(\d+)", r"Implements\s*#(\d+)"]:
+    for match in re.finditer(pattern, body):
+      ref_num = int(match.group(1))
+      ref_issue = github_issue_read(method="get", issue_number=ref_num)
+      
+      if ref_issue["state"] == "open" and candidate is classified as "already-implemented":
+        DOWNGRADE to "partially-implemented" or flag-for-review
+      
+      if ref_issue["state"] == "closed":
+        # Verify referenced issue was legitimately closed (merged PR exists)
+        # Reuse closed-issue verification logic from verify-authorization Step 5.4
+```
+
+**Cross-reference failure triggers:**
+
+| Failure Condition | Classification | Action |
+|-----------------|----------------|--------|
+| Referenced issue is open | CONFLICTING | DOWNGRADE or flag-for-review — state mismatch |
+| Referenced issue closed without merged PR | VERIFICATION-GAP | Flag for review — may be premature closure |
+| Cross-reference 404 | MISSING-TRACEABILITY | Flag for developer — referenced issue doesn't exist |
+
+**Key principle:** Even if Gate 1 and Gate 2 pass, cross-reference inconsistencies invalidate the "already-implemented" classification. The full issue graph must be consistent.
+
+### Step 6: Gate Evidence Audit
+
+After screening, produce the Gate Evidence Audit for this single issue.
+
+#### GA-1: Verify Gate 1 Evidence Exists
+
+1. **Check sub-issue enumeration call:** Did you call `github_issue_read(method=get_sub_issues, issue_number=<candidate>)` during screening? If NO → STOP. Return to Step 3 and re-run Gate 1 before proceeding.
+
+2. **Check per-sub-issue evidence:** For EACH sub-issue returned by `get_sub_issues`, did you produce a tool-call artifact (`github_issue_read(method=get, issue_number=<sub>)`) verifying its state? If NO → STOP. Return to Step 3 and re-run Gate 1 verification.
+
+3. **Check closure legitimacy evidence:** For each closed sub-issue, did you search for merged PR evidence? If NO → STOP. Return to Step 3 and re-run Gate 1 closure legitimacy check.
+
+#### GA-2: Verify Gate 2 Evidence Exists
+
+1. **Extract success criteria:** Did you read the issue body and extract every success criterion? If NO → STOP. Return to Step 4 and re-run Gate 2 for this issue.
+
+2. **Verify each criterion:** For each success criterion, did you perform a direct verification action (read, grep, lint, test) against the current `dev` branch? If NO → STOP. Return to Step 4 and re-run Gate 2 verification.
+
+3. **Evidence artifacts:** For each criterion, is there a tool-call artifact documenting the verification? If NO → STOP. Return to Step 4 and re-run with evidence collection.
+
+#### GA-3: Produce the Gate Evidence Audit Row
+
+For this issue, produce the audit row:
+
+```markdown
+| Issue # | Sub-issues Enumerated? (Gate 1) | All Sub-issues Verified? | Closure Legitimacy Verified? | Success Criteria Extracted? (Gate 2) | All Criteria Verified vs Codebase? | Final Classification |
+|---------|----------------------------------|--------------------------|-------------------------------|--------------------------------------|-----------------------------------|---------------------|
+| #N | ✅/❌ | ✅/❌ | ✅/❌ | ✅/❌ | ✅/❌ | already-implemented / partially-implemented / not-implemented-despite-closure |
+```
+
+**If ANY column has ❌ in columns 2-5:** The classification is INVALID. It MUST be DOWNGRADED:
+- ❌ in Gate 1 columns → DOWNGRADE to "partially-implemented" (sub-issues not verified)
+- ❌ in Gate 2 columns → DOWNGRADE to "partially-implemented" or "not-implemented-despite-closure" (success criteria not verified)
+
+#### GA-4: Verify Audit Row Completeness
+
+1. The audit row exists for this issue
+2. Every column has ✅ or ❌ (no blank entries)
+3. All ❌ entries have been actioned (downgrade applied, classification corrected)
+4. The row is included in the result contract
+
+**If the row is incomplete:** HALT and complete it before producing the result contract.
+
+### Step 7: Sub-Issue Expansion
+
+Expand the issue into its sub-issues (flat item list):
+
+1. **Query sub-issues:** `github_issue_read(method="get_sub_issues", issue_number=N)`
+2. **If sub-issues exist:** Expand the parent into its sub-issues as individual implementation items. The parent's spec body provides context; each sub-issue defines a phase.
+3. **If no sub-issues (single-task):** The issue IS the flat item — no expansion needed.
+4. **Build the flat item list:** Each sub-issue (or single issue) becomes one flat item. This is the input to the merge phase.
+
+**Expansion rules:**
+
+| Parent Type | Expansion Action |
+|-----------|-------------------|
+| Single-task spec (no sub-issues) | Item = the issue itself |
+| Multi-task spec (has sub-issues) | Items = each sub-issue (parent provides context) |
+| Multi-task spec with some sub-issues NOT in batch | Items = sub-issues in batch only |
+
+### Step 8: Cross-Issue Sub-Issue Handling
+
+When both a parent and its sub-issues are in the approved batch:
+
+1. **Detect:** If any sub-issue number is also in `batch_peers`, flag the pair.
+
+1. **Default behavior:** Omit sub-issues from execution plan — parent's cascade covers them. Sub-agent for parent receives the full spec including all phases.
+
+1. **Exception — isolated sub-issues:** If a sub-issue has a well-isolated scope (clear boundaries, no file overlap with parent's other phases), dispatch it to its own sub-agent for parallelism. Isolation criteria:
+
+   - Touches completely different files from parent's other phases
+   - No dependency on parent's other phases
+   - Can be merged independently
+
+1. **Edge case:** Parent is excluded (already implemented) but sub-issues aren't. Include sub-issues independently since parent's cascade doesn't apply.
+
+### Step 9: Extract File and Symbol References
+
+For cross-issue dependency analysis (done by the merge phase), extract:
+
+- File paths mentioned in the issue body
+- Symbol names (functions, classes) referenced
+- Skill/directory references
+
+Use `srclight_get_dependents` or `srclight_get_callers` where possible to verify actual dependencies:
+
+```
+For each file path or symbol mentioned in the issue:
+  - File paths: verify with glob or read that the file exists
+  - Symbol names: verify with srclight_get_signature that the symbol exists
+  - For key symbols: srclight_get_dependents(symbol_name="<symbol>", project="<project>", transitive=True)
+  - For claimed dependencies: srclight_get_callers(symbol_name="<symbol>", project="<project>")
+```
+
+**Evidence artifact:** Search/glob/srclight results confirming existence or absence of referenced code.
+
+### Step 10: Produce Result Contract
+
+The result contract MUST be YAML-structured, compact (~100-500 words):
+
+```yaml
+status: DONE | DONE_WITH_CONCERNS | BLOCKED | OVERFLOW
+task: screen-issue
+issue_number: <N>
+classification: included | excluded | scope-reduced
+category: <screening category, e.g. already-implemented, superseded, moot, partially-implemented, meta-non-code, null>
+exclude_reason: <reason if excluded, null if included>
+reduce_reason: <reason if scope-reduced, null otherwise>
+reduced_scope:
+  completed_phases: []
+  remaining_phases: []
+flat_items:
+  - issue: <N or sub-issue number>
+    title: <title>
+    phase: <phase description>
+gate_evidence:
+  gate1_called: true | false
+  gate1_sub_issues_verified: true | false
+  gate1_closure_legitimacy: true | false
+  gate2_criteria_extracted: true | false
+  gate2_criteria_verified: true | false
+  final_classification: already-implemented | partially-implemented | included | not-implemented-despite-closure
+requires_developer: true | false
+developer_reason: <reason if true, null if false>
+file_references:
+  - <file path>
+symbol_references:
+  - <symbol name>
+concerns:
+  - <concern text, if any>
+```
+
+## Dispatch Context Schema
+
+```yaml
+issue_number: <N>
+batch_peers: [<list of other issue numbers in batch>]
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```
+
+## Red Flags
+
+**Never:**
+
+- Skip Gate 1 (sub-issue enumeration) for any candidate "already-implemented" issue
+- Classify an issue as "already-implemented" while it has open sub-issues or unverified success criteria
+- Proceed past Gate Evidence Audit without completing the audit row for all "already-implemented" classifications
+- Classify an issue as "already-implemented" without a corresponding `get_sub_issues` tool-call artifact in the current session
+- Auto-re-stage issues with different-intent stale assumptions
+- Claim "all criteria met" without per-criterion tool-call evidence
+- Skip cross-reference traversal after Gate 1 and Gate 2 pass
+- Trust cached sub-issue state or closure status without live API verification
+
+**Always:**
+
+- Call `github_issue_read(method=get_sub_issues)` for every candidate "already-implemented" issue (Gate 1)
+- Verify each success criterion against the live codebase before classifying as "already-implemented" (Gate 2)
+- Complete the Gate Evidence Audit row (Step 6) before producing the result contract
+- Produce a per-issue `get_sub_issues` tool-call artifact in the current session for every "already-implemented" classification
+- HALT for developer review only for unresolvable conflicts and different-intent stale assumptions
+- Auto-detect partially-implemented issues (no developer input needed)
+- Produce the result contract as the final output of this task

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -245,6 +245,51 @@ When `WORKTREE_PATH` is set:
 
 If `WORKTREE_PATH` is NOT set, operate normally from the project root.
 
+## Sub-Agent Tasks
+
+### Execution Mode Table
+
+| Task | Words | Mode |
+|------|-------|------|
+| `assemble-batch` | 2,782 | sub-agent |
+| `orchestrate` | ~400 | inline |
+| `assess` | ~300 | inline |
+| `decompose` | ~300 | inline |
+| `dispatch` | ~250 | inline |
+| `completion-checkpoint` | ~300 | inline |
+| `overflow-signal` | ~200 | inline |
+| `merge` | ~150 | inline |
+| `context-passing` | ~200 | inline |
+| `purification-and-enforcement` | ~250 | inline |
+| `completion` | ~150 | inline |
+
+### Result Contracts (Sub-Agent Tasks)
+
+#### assemble-batch
+
+```yaml
+status: DONE | DONE_WITH_CONCERNS | BLOCKED | OVERFLOW
+task: assemble-batch
+issues_dispatched: [<N>]
+issues_completed: [<N>]
+issues_failed: [<N>]
+batch_branch: <branch_name>
+batch_state_file: <path>
+results: [{issue: <N>, status: <str>, summary: <str>}]
+```
+
+### Dispatch Context Schema
+
+```yaml
+batch_state_file: <path>
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```
+
 ## Sub-Agent Spawning
 
 This skill is a **heavy skill** — its orchestration logic can run in isolation. When the main agent needs divide-and-conquer execution, spawn a sub-agent via the `task` tool:

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -95,6 +95,113 @@ Developer confirms "PR merged"
 cleanup: Verify merge via API → Close issues
 ```
 
+## Sub-Agent Tasks
+
+### Execution Mode Table
+
+| Task | Words | Mode |
+|------|-------|------|
+| `cleanup` | 6,457 | sub-agent |
+| `pr-creation` | 5,312 | sub-agent |
+| `review-prep` | 4,241 | sub-agent |
+| `provenance` | 3,664 | sub-agent |
+| `pre-work` | 1,898 | sub-agent |
+| `release-promotion` | 1,811 | sub-agent |
+| `rebase-pending` | 1,666 | sub-agent |
+| `implementation` | ~400 | inline |
+| `completion` | ~200 | inline |
+| `check-pr` | ~50 | inline |
+
+### Result Contracts (Sub-Agent Tasks)
+
+#### pre-work
+
+```yaml
+status: DONE | BLOCKED
+task: pre-work
+worktree_path: <path>
+branch_name: <str>
+branch_created: bool
+setup_complete: bool
+tests_passing: bool
+```
+
+#### review-prep
+
+```yaml
+status: DONE
+task: review-prep
+branch_pushed: bool
+compare_url: <url>
+commits_count: <int>
+```
+
+#### pr-creation
+
+```yaml
+status: DONE | BLOCKED
+task: pr-creation
+pr_number: <N|null>
+pr_url: <url|null>
+squash_performed: bool
+```
+
+#### cleanup
+
+```yaml
+status: DONE
+task: cleanup
+branches_deleted: [<name>]
+issues_closed: [<N>]
+stashes_preserved: [<name>]
+sub_issues_verified: bool
+```
+
+#### provenance
+
+```yaml
+status: DONE
+task: provenance
+tier_used: 1 | 2 | 3
+issues_created: [<N>]
+prs_created: [<N>]
+submodules_processed: [<name>]
+```
+
+#### release-promotion
+
+```yaml
+status: DONE | BLOCKED
+task: release-promotion
+tag_created: bool
+tag_name: <str>
+release_url: <url|null>
+submodules_promoted: [<name>]
+```
+
+#### rebase-pending
+
+```yaml
+status: DONE | BLOCKED
+task: rebase-pending
+rebased_prs: [<N>]
+conflicts_detected: [{pr: <N>, tier: 1|2|3}]
+conflicts_resolved: [<N>]
+```
+
+### Dispatch Context Schema
+
+```yaml
+branch_name: <str>
+worktree_path: <path>
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```
+
 ## Sub-Agent Spawning
 
 This skill is a **heavy skill** — its task files contain significant detail that pollutes context. When the main agent needs git-workflow execution, consider spawning a sub-agent via the `task` tool:

--- a/.opencode/skills/github-sub-issues/SKILL.md
+++ b/.opencode/skills/github-sub-issues/SKILL.md
@@ -118,6 +118,41 @@ When matching STATUS to sub-issues, match the concern name in the STATUS to the 
 - Treating sub-issue creation as a separate implementation phase
 - Implementing a phase that exists only as text in plan issue body
 
+## Sub-Agent Tasks
+
+### Execution Mode Table
+
+| Task | Words | Mode |
+|------|-------|------|
+| `create-sub-issue` | ~300 | inline |
+| `link-sub-issue` | ~200 | inline |
+| `track-hierarchy` | ~250 | inline |
+
+**Note:** All tasks are under 1,000 words — inline execution. No sub-agent dispatch needed for individual sub-issue operations. However, bulk creation (3+ sub-issues at once) benefits from sub-agent dispatch to keep creation API responses out of main context.
+
+### Dispatch Context Schema (Bulk Creation)
+
+```yaml
+parent_plan: <N>
+phases: [{title: <str>, body: <str>, labels: [<str>]}]
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```
+
+### Result Contract (Bulk Creation)
+
+```yaml
+status: DONE
+task: create-sub-issues
+sub_issues_created: [<N>]
+sub_issues_linked: [<N>]
+parent_issue: <N>
+```
+
 ## Cross-Reference Verification (MANDATORY)
 
 **🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -387,6 +387,56 @@ When auditing a plan, runbook, process flow, checklist, or reference document, u
 - **Backward compatibility:** `--issue N` produces identical results to previous behavior
 - **Worktree awareness check:** Skills that perform git operations, read/write files, or dispatch sub-agents MUST include a "Worktree Mode" section and pass `WORKTREE_PATH` in sub-agent dispatch contexts. Missing worktree awareness is a medium-severity finding.
 
+## Sub-Agent Tasks
+
+### Execution Mode Table
+
+| Task | Words | Mode |
+|------|-------|------|
+| `structure` | ~400 | inline |
+| `content-quality` | ~500 | inline |
+| `traceability` | ~300 | inline |
+| `operational` | ~300 | inline |
+| `fidelity` | ~600 | sub-agent |
+| `concerns` | ~400 | inline |
+| `operational-flow` | ~400 | inline |
+| `determinism` | ~300 | inline |
+| `error-recovery` | ~350 | inline |
+| `principles` | ~350 | inline |
+| `ground-truth` | ~500 | sub-agent |
+| `sub-issue-fidelity` | ~350 | inline |
+| `concern-coverage` | ~350 | inline |
+| `prose-structure` | ~250 | inline |
+| `fresh-start` | ~400 | inline |
+
+**Note:** Individual subtasks are lightweight. Sub-agent dispatch is recommended for the full audit (all subtasks per document type) when running 3+ subtasks together, not for individual subtasks.
+
+### Dispatch Context Schema (Full Audit as Sub-Agent)
+
+```yaml
+source: {type: issue|file|url, identifier: <str>}
+document_type: <auto|spec|plan|process-flow|runbook|checklist|reference-doc>
+subtasks: [<task_name>]
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```
+
+### Result Contract (Full Audit)
+
+```yaml
+status: DONE | DONE_WITH_CONCERNS | OVERFLOW
+task: spec-auditor
+document_type: <str>
+confidence: High | Medium | Low
+changes_made: [{subtask: <str>, problem_class: <str>, fix: <str>, classification: auto-fix|conditional}]
+findings_not_acted_on: [{subtask: <str>, problem_class: <str>, reason: <str>}]
+issue_url: <url|null>
+```
+
 ## Sub-Agent Spawning
 
 This skill is a **heavy skill** — quality audits with all subtasks consume significant context. When the main agent needs a spec audit, consider spawning a sub-agent via the `task` tool:

--- a/.opencode/skills/spec-creation/SKILL.md
+++ b/.opencode/skills/spec-creation/SKILL.md
@@ -177,6 +177,44 @@ Findings from evidence verification follow the three-tier model:
 | conditional | Requires scope/safety check before applying (traceability gap, STATUS claim) | Verify scope, then apply if safe |
 | flag-for-review | Requires domain judgment (contradictions, ambiguous STATUS exemption) | Report in findings, do not apply |
 
+## Sub-Agent Tasks
+
+### Execution Mode Table
+
+| Task | Words | Mode |
+|------|-------|------|
+| `write` | 1,410 | sub-agent |
+| `requirements` | ~500 | inline |
+| `decompose` | ~400 | inline |
+| `traceability` | ~300 | inline |
+| `risk` | ~400 | inline |
+| `change-control` | ~300 | inline |
+
+### Result Contract (write)
+
+```yaml
+status: DONE | OVERFLOW
+task: write
+issue_number: <N>
+issue_url: <url>
+spec_created: bool
+self_review_passed: bool
+needs_approval_label_added: bool
+```
+
+### Dispatch Context Schema
+
+```yaml
+spec_content: <structured outputs from prerequisite tasks>
+exploration_results: <brainstorming output reference>
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```
+
 ## Cross-References
 
 - **Calls:** `github-issue-creation` (spec persistence — `write` task invokes pre-creation → single-task-check → creation)

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -232,6 +232,43 @@ The spec itself is the stable reference. Whether the plan is combined or separat
 - Plan approved and complete → PROCEED to implementation
 - Combined spec+plan → plan inherits spec approval status; no separate plan approval needed
 
+## Sub-Agent Tasks
+
+### Execution Mode Table
+
+| Task | Words | Mode |
+|------|-------|------|
+| `create` | 1,598 | sub-agent |
+| `validate` | ~500 | inline |
+| `retroactive` | ~600 | inline |
+| `clean-room` | ~500 | inline |
+
+### Result Contract (create)
+
+```yaml
+status: DONE | OVERFLOW
+task: create
+plan_issue: <N|null>
+plan_url: <url|null>
+combined: bool
+sub_issues_created: [<N>]
+self_review_passed: bool
+```
+
+### Dispatch Context Schema
+
+```yaml
+spec_issue: <N>
+single_task: bool
+single_task_determination: <str>
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```
+
 ## Cross-Reference Verification (MANDATORY)
 
 **🚫 CRITICAL: Each cross-reference must be verified against actual skill content. Assertions without verification are VERIFICATION-GAP findings.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/sub-agent-extraction
+
+- **Sub-Agent Extraction for Heavy Skill Tasks** (#984, #985, #986, #987, #988) - Extracted task files over 1,000 words into sub-agent execution pattern, reducing main agent context consumption by ~88%. Created `screen-issue` task for per-issue screening, revised `pre-implementation-analysis` from 5,635w to 3,137w, and added Sub-Agent Tasks sections with execution mode tables and result contracts to 7 SKILL.md files.
+
 ### batch/apr-16-enforcement-batch
 
 - **Secret Detection Semaphore Documentation** (#840, #919) - Added `.opencode/docs/secret-detection.md` documenting the detect-secrets semaphore mechanism, configuration options, and opt-in workflow for credential leak prevention.


### PR DESCRIPTION
**Summary:**

Extracts heavy skill task files (>1,000 words) into sub-agent execution, transforming the main agent into a pure router that loads only SKILL.md files and reads compact result contracts (~100-500 words each), freeing ~88% of orchestration overhead context for actual work.

**Outcome:** AI agents will consume significantly less context window during orchestration, enabling more complex multi-task plans without context overflow. Heavy tasks like `screen-issue`, `pr-creation`, and `cleanup` now run in isolation with structured result contracts.

Implements #984
Implements #985
Implements #986
Implements #987
Implements #988