### PR TITLE
fix(approval-gate): add critical violation for inline screening of batch approvals (#990)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -662,6 +662,20 @@ Structural decisions — single-task vs multi-task classification, phase decompo
 
 **See `approval-gate` skill → `verify-already-implemented` task → "Auto-Close Procedure" for the post-merge issue closure workflow. See `finishing-a-development-branch` skill → `checklist` task for issue-closure verification steps.**
 
+## Critical Violation: Inline Screening of Batch Approvals
+
+**⚠️ When more than 3 issues are approved in a batch, the agent MUST dispatch `screen-issue` sub-agents for per-issue screening. Loading all issue bodies into the orchestrator's own context is a CRITICAL GUIDELINE VIOLATION.**
+
+- 🚫 FORBIDDEN: Fetching all approved issue bodies into orchestrator context before sub-agent dispatch
+- 🚫 FORBIDDEN: Running screening logic inline when batch size > 3
+- ✅ REQUIRED: Dispatch one `screen-issue` sub-agent per approved issue
+- ✅ REQUIRED: Orchestrator receives only compact result contracts (~100-500 words each)
+- ✅ REQUIRED: Cross-issue merge and dependency graph built from result contracts, not raw issue bodies
+
+**Why 3 as the threshold:** Single approvals and pairs can reasonably be screened inline. Three or more issues risk context exhaustion and require sub-agent isolation. The `screen-issue` sub-agent architecture exists precisely to prevent the orchestrator from blowing out its context window on batch approvals.
+
+**AUTHORITY:** `approval-gate/tasks/pre-implementation-analysis.md` Step -1
+
 ## Critical Violation: Silent Halt Without Prompt — No Spec/Plan Search Before Stopping
 
 **⚠️ Halting silently when no spec/plan exists for an implementation request — without first searching GitHub Issues for candidates and presenting them — is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -330,6 +330,7 @@ Every task in this skill that reads a metadata claim (label, comment, STATUS mar
 | Authorization currency | Verify spec has not been revised after most recent authorization comment | `github_issue_read(method=get_comments)` → compare revision timestamps | STRUCTURE-VIOLATION |
 | Sub-issue state (open/closed) | Verify sub-issue state via GitHub API, not from cached or claimed state | `github_issue_read(method=get, issue_number=N)` → check `state` field | VERIFICATION-GAP |
 | Fix spec existence | Verify fix spec sub-issue exists and has correct labels/STATUS for its maturity | `github_issue_read(method=get_sub_issues)` → verify each child | MISSING-TRACEABILITY |
+| Batch screening dispatch (>3 issues) | Verify `screen-issue` sub-agents were dispatched (not inline screening) when batch size > 3 | Check for `task(subagent_type="general")` dispatch calls per issue | STRUCTURE-VIOLATION |
 
 ### Evidence Artifacts
 

--- a/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
@@ -26,6 +26,16 @@ Analyze interdependencies and determine execution order for all approved issues 
 
 ## Procedure
 
+### Step -1: Batch Size Check and Dispatch Decision (MANDATORY FIRST)
+
+Before reading ANY issue body:
+
+1. COUNT the number of approved issues
+2. If count ≤ 3: inline screening is PERMITTED (proceed to Step 0)
+3. If count > 3: sub-agent dispatch is MANDATORY — do NOT read any issue body into orchestrator context
+
+**⚠️ CRITICAL VIOLATION:** Reading issue bodies for >3 issues into orchestrator context before sub-agent dispatch is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Inline Screening of Batch Approvals. The orchestrator's context window must stay clean for cross-issue merge and dependency graph building — not consumed by raw issue bodies.
+
 ### Step 0: Collect Screening Results
 
 Collect per-issue screening results from `screen-issue` sub-agents (parallel) or inline execution.


### PR DESCRIPTION
## Summary

Adds enforcement to prevent agents from inline-screening batch approvals instead of dispatching `screen-issue` sub-agents, which blows out the orchestrator's context window.

## Outcome

Agents receiving batch approvals >3 issues must now dispatch sub-agents for per-issue screening; three files updated with critical violation, mandatory batch-size guard, and verification table row.

Fixes #990