### PR TITLE
Implement #991: Approval-gate graph reconciliation — act on findings

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -385,8 +385,9 @@ Chat output order (mandatory): 1) Executive summary, 2) URL (if exists), 3) AI b
 - ✅ REQUIRED: Verify closed issues have merged PR evidence via `github_pull_request_read` before treating them as resolved
 - ✅ REQUIRED: Check `state_reason` — `"not_planned"` means intentionally skipped, `"duplicate"` requires verifying the target, `"completed"` requires merged PR evidence
 - ✅ REQUIRED: Use `approval-gate --task verify-closed-issue` to verify legitimate closure before skipping, autoclosing, or excluding from implementation
+- ✅ REQUIRED: Use `approval-gate --task reconcile-issue-graph` to act on findings — auto-close verified-complete tickets, reopen verified-incomplete tickets
 
-**See `approval-gate --task verify-closed-issue` for the complete verification procedure. See `git-workflow` skill `--task cleanup` for pre-closure sub-issue verification gate.**
+**See `approval-gate --task reconcile-issue-graph` for reconciliation after graph traversal. See `approval-gate --task verify-closed-issue` for the complete verification procedure. See `git-workflow` skill `--task cleanup` for pre-closure sub-issue verification gate.**
 
 ## Critical Violation: Scope Creep — NEVER Do Things Outside the Spec
 

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -221,6 +221,7 @@ Key rules:
 | Editing config (pyproject.toml, .pre-commit) | Yes | `000-critical-rules.md` §Implementation Without Spec |
 | Editing test files | Yes | `000-critical-rules.md` §Implementation Without Spec |
 | Creating new files of any type | Yes | `000-critical-rules.md` §Implementation Without Spec |
+| **Graph reconciliation** | On approval/re-approval, `reconcile-issue-graph` auto-closes verified-complete tickets and reopens verified-incomplete tickets in the reachable issue graph |
 | Creating new GitHub Issue (spec/plan) | No auth, but mandatory `github-issue-creation` skill | `github-issue-creation` skill |
 | Updating existing issue spec text (revision) | No auth — spec revision ≠ implementation | `010-approval-gate.md` §Revision ≠ Implementation |
 | Updating issue spec to match code reality (drift sync) | No auth — administrative sync | `130-authority-source.md` §Documentation Drift Protocol |

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -33,6 +33,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 | `screen-issue` | Per-issue screening for pre-implementation analysis (Gate 1 + Gate 2 + screening categories); dispatched as parallel sub-agents | ~3,000 |
 | `pre-implementation-analysis` | Cross-issue merge of screening results, dependency graph, execution plan for assemble-batch | ~500 |
 | `verify-schema-api-knowledge` | Verify that the agent has performed live verification before making schema/API/code claims; gate before proceeding | ~350 |
+| `reconcile-issue-graph` | Act on graph traversal findings: auto-close verified-complete, reopen verified-incomplete, flag uncertain | ~600 |
 | `post-implementation` | Push branch, generate compare URL, HALT | ~480 |
 | `completion` | Ensure mandatory completion steps run regardless of workflow outcome | ~150 |
 
@@ -48,6 +49,7 @@ You are an Authorization Gatekeeper. Your focus is ensuring all code changes fol
 - `/skill approval-gate --task search-prompt-fail` - Search for existing spec/plan candidates before Q/A halt
 - `/skill approval-gate --task verify-closed-issue` - Verify closed issue was legitimately closed via merged PR
 - `/skill approval-gate --task verify-schema-api-knowledge` - Verify schema/API/code knowledge before claims
+- `/skill approval-gate --task reconcile-issue-graph` - Act on graph traversal findings
 - `/skill approval-gate --task pre-implementation-analysis` - Analyze interdependencies and expand sub-issues for all approved issues, then yield to assemble-batch
 - `/skill approval-gate --task screen-issue` - Per-issue screening (dispatched as sub-agent from pre-implementation-analysis)
 - `/skill approval-gate --task post-implementation` - After implementation done
@@ -180,6 +182,7 @@ This check is invoked:
 | `verify-blockers` | 722 | inline |
 | `verify-codebase` | 726 | inline |
 | `verify-open-questions` | 531 | inline |
+| `reconcile-issue-graph` | ~600 | inline |
 | `completion` | 769 | inline |
 | `search-prompt-fail` | ~300 | inline |
 | `verify-schema-api-knowledge` | ~350 | inline |
@@ -300,6 +303,19 @@ bug_report: <N>
 fix_spec_exists: bool
 fix_spec_issue: <N|null>
 action: none | create_fix_spec
+```
+
+#### reconcile-issue-graph
+
+```yaml
+status: DONE | DONE_WITH_UNCERTAIN
+task: reconcile-issue-graph
+root_issue: <N>
+auto_closed: [<N>]
+reopened: [<N>]
+no_action: [<N>]
+requires_dev_action: [{issue: <N>, current: <state>, needed: <state>, reason: <str>}]
+nodes_visited: <N>
 ```
 
 ### Dispatch Context Schema (All Sub-Agent Tasks)

--- a/.opencode/skills/approval-gate/tasks/reconcile-issue-graph.md
+++ b/.opencode/skills/approval-gate/tasks/reconcile-issue-graph.md
@@ -1,0 +1,138 @@
+# Task: reconcile-issue-graph
+
+Act on findings from the issue graph traversal performed by `verify-authorization` §5.5. This task takes the traversal findings and resolves them — auto-closing verified-complete tickets, reopening verified-incomplete tickets, and flagging uncertain tickets for developer action.
+
+## Pre-Conditions
+
+- Graph traversal complete via `verify-authorization` §5.5
+- Findings list available from traversal output
+- `GIT_OWNER` and `GIT_REPO` from session context
+
+## Entry Criteria
+
+- Graph traversal has produced a findings list
+- Each finding includes: issue number, current state, and traversal classification
+
+## Exit Criteria
+
+- All actionable findings resolved (auto-closed or reopened)
+- Uncertain findings collected in `requires_dev_action` list
+- Reconciliation report output to chat
+
+## Procedure
+
+### Step 1: Categorize Findings
+
+For each finding from the traversal list, classify into one of six categories:
+
+| Category | Condition | Action Class |
+|----------|-----------|-------------|
+| auto-close (merged PR) | Open + merged PR exists (`merged_at` confirmed via GitHub API) | auto-close |
+| auto-close (code verified) | Open + success criteria verified against live code in repo | auto-close |
+| reopen | Closed + no merged PR + code NOT in repo + `state_reason` not `not_planned` or `duplicate` | reopen |
+| no-action (not_planned) | Closed + `state_reason: "not_planned"` | skip |
+| no-action (duplicate) | Closed + `state_reason: "duplicate"` + target verified as covering scope | skip |
+| uncertain | Conflicting or ambiguous signals that prevent confident classification | flag-for-dev |
+
+### Step 2: Verify Auto-Close Candidates
+
+For each auto-close candidate:
+
+1. **Merged PR path**: Call `github_pull_request_read(method=get)` on any associated PR. Confirm `merged_at` is not null. Record PR number and `merged_at` timestamp as evidence.
+2. **Code-in-repo path**: Use `read`, `grep`, or `srclight_get_symbol` to confirm success criteria are met in the live codebase. Record specific file paths and symbol names as evidence.
+3. **If evidence is ambiguous**: Reclassify as `uncertain` and move to `requires_dev_action`.
+
+### Step 3: Verify Reopen Candidates
+
+For each reopen candidate:
+
+1. Call `github_search_pull_requests` for the issue number — confirm no merged PR exists.
+2. Use `read`/`grep`/`srclight_get_symbol` to confirm the code is NOT present in the repo.
+3. Call `github_issue_read(method=get)` to confirm `state_reason` is not `not_planned` or `duplicate`.
+4. **If a merged PR is found**: Reclassify as `no-action` — the closure may have been legitimate via a PR the traversal missed.
+5. **If code IS found in repo**: Reclassify as `uncertain` — conflicting signals require dev judgment.
+
+### Step 4: Process No-Action Findings
+
+For `not_planned` findings: Record issue number and `state_reason`. No further action.
+
+For `duplicate` findings: Verify the target issue exists and covers the scope. If the target is also problematic (closed without merged PR), reclassify the target as a separate finding. If the target is verified, record as no-action.
+
+### Step 5: Collect Uncertain Findings
+
+For each uncertain finding, collect:
+
+- Issue number
+- Current state
+- Needed state (best assessment)
+- Reason determination cannot be made
+
+Add to `requires_dev_action` list in the result contract.
+
+### Step 6: Execute Auto-Close Actions
+
+For each verified auto-close candidate:
+
+1. Call `github_issue_write(method=update, state=closed, state_reason=completed)` on the issue.
+2. Call `github_add_issue_comment` with evidence:
+   - Merged PR: "Auto-closing: merged PR #N confirmed (merged_at: TIMESTAMP). Issue graph reconciliation via `reconcile-issue-graph`."
+   - Code verified: "Auto-closing: success criteria verified against live code (files: [...], symbols: [...]). Issue graph reconciliation via `reconcile-issue-graph`."
+3. Remove `needs-approval` label if present.
+
+### Step 7: Execute Reopen Actions
+
+For each verified reopen candidate:
+
+1. Call `github_issue_write(method=update, state=open)` on the issue.
+2. Call `github_add_issue_comment`: "Reopening: no merged PR found and code not present in repo. Previous closure may have been premature. Issue graph reconciliation via `reconcile-issue-graph`."
+
+### Step 8: Output Reconciliation Report
+
+**When all findings resolved:**
+
+```
+Issue Graph Reconciliation for #<root>:
+  Auto-closed: #N (merged PR #P), #M (code verified)
+  Reopened: #O (no merged PR, code not in repo)
+  No action: #Q (not_planned), #R (duplicate of #S)
+  Nodes visited: <count>
+```
+
+**When uncertain findings remain:**
+
+```
+Issue Graph Reconciliation for #<root>:
+  Auto-closed: #N (merged PR #P)
+  Reopened: #O (no merged PR, code not in repo)
+  Requires dev action:
+    - #X: current=closed, needed=open — cannot verify implementation status (conflicting signals: PR exists but not merged, code may exist in another branch)
+    - #Y: current=open, needed=closed — code appears present but success criteria partially unmet
+  Nodes visited: <count>
+
+🤖 <AI-Name> (<model-id>) ⚠️ needs-dev-action
+```
+
+## Evidence Requirements
+
+Every action MUST produce a live tool-call artifact:
+
+| Action | Required Evidence |
+|--------|-------------------|
+| Auto-close (merged PR) | `github_pull_request_read` response showing `merged_at` |
+| Auto-close (code verified) | `read`/`grep`/`srclight` output confirming code in repo |
+| Reopen | `github_search_pull_requests` showing no merged PR + codebase read showing code NOT present |
+| No-action (not_planned/duplicate) | `github_issue_read` response showing `state_reason` |
+| Uncertain | Conflicting tool-call results that prevent confident classification |
+
+## Context Required
+
+```yaml
+root_issue_number: <N>
+findings: [{issue: <N>, state: <str>, classification: <str>, evidence_summary: <str>}]
+session_vars:
+  GIT_OWNER: <from-session>
+  GIT_REPO: <from-session>
+  DEV_NAME: <from-session>
+  DEV_EMAIL: <from-session>
+  WORKTREE_PATH: <from-session>
+```

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -276,6 +276,18 @@ def traverse_issue_graph(root_issue_number, depth_limit=5):
                     queue.append((ref_num, depth + 1))
 
     return findings
+
+# After traversal completes:
+findings = traverse_issue_graph(root_issue_number)
+
+# INVOKE reconcile-issue-graph to act on findings
+# (previously, findings were only reported as flag-for-review)
+reconcile_result = reconcile_issue_graph(
+    root_issue_number=root_issue_number,
+    findings=findings,
+    GIT_OWNER=GIT_OWNER,
+    GIT_REPO=GIT_REPO
+)
 ```
 
 ##### When to Traverse
@@ -292,11 +304,17 @@ def traverse_issue_graph(root_issue_number, depth_limit=5):
 | Finding | Problem Class | Classification | Action |
 |---------|---------------|----------------|--------|
 | All nodes verified (closed with merged PR or open and consistent) | VERIFIED | auto-proceed | Graph is consistent |
-| Open sub-issue on closed parent | VERIFICATION-GAP | flag-for-review | Parent closure may be premature |
-| Cross-reference to open/closed mismatch | CONFLICTING | flag-for-review | Spec closed but plan open, or vice versa |
-| Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Premature sub-issue closure |
+| Open + merged PR exists | VERIFIED | auto-close | Auto-close as completed via reconcile-issue-graph |
+| Open + code in repo verified | VERIFIED | auto-close | Auto-close as completed via reconcile-issue-graph |
+| Closed + no merged PR + code NOT in repo | VERIFICATION-GAP | reopen | Reopen as open via reconcile-issue-graph |
+| Open sub-issue on closed parent | VERIFICATION-GAP | flag-for-review | Parent closure may be premature — uncertain, requires dev judgment |
+| Cross-reference to open/closed mismatch | CONFLICTING | flag-for-review | Spec closed but plan open, or vice versa — uncertain |
+| Sub-issue closed without merged PR | VERIFICATION-GAP | reopen | Reopen via reconcile-issue-graph |
+| Closed + state_reason not_planned | VERIFIED | no-action | Intentionally skipped — do not change |
+| Closed + state_reason duplicate + target OK | VERIFIED | no-action | Duplicate properly resolved |
 | Depth limit reached | VERIFICATION-GAP | flag-for-review | Graph too deep — investigate manually |
 | Cross-reference 404 | MISSING-TRACEABILITY | flag-for-review | Referenced issue does not exist |
+| Cannot determine | CONFLICTING | flag-for-review | Conflicting signals — report for dev action |
 
 ##### Evidence Requirement
 
@@ -311,7 +329,13 @@ Max depth: <D>
 Findings:
   - #<issue>: <state> — <finding> (<classification>)
   ...
-Overall: CONSISTENT / HAS_FLAGS
+Reconciliation: (via reconcile-issue-graph)
+  Auto-closed: #<n1> (merged PR #<pr1>), #<n2> (code verified)
+  Reopened: #<n3> (no merged PR, code not in repo)
+  No action: #<n5> (not_planned), #<n6> (duplicate of #<n7>)
+  Requires dev action: (if uncertain findings remain)
+    - #<n8>: current=<state>, needed=<state> — <reason>
+Overall: CONSISTENT / HAS_FLAGS / RECONCILED
 ```
 
 #### Finding Classification for Sub-Issue Verification
@@ -442,6 +466,7 @@ After all verification gates pass, determine the approval context and auto-dispa
 | **Spec approval** | Issue title contains `[SPEC` or has `spec` label | `writing-plans --task create` |
 | **Plan approval** | Issue has `plan` label or `[PLAN]` prefix in title | `executing-plans --task start` |
 | **Already implemented** | `verify-already-implemented` returns positive (after closed-issue verification in Step 5.4 confirms legitimate closure) | No dispatch — auto-close instead |
+| **Reconciled during verification** | reconcile-issue-graph returned auto-closed or reopened tickets | Include reconciled tickets in chat output; proceed with dispatch |
 | **Closed but NOT verified** | Step 5.4 closed-issue verification finds closure without merged PR evidence | flag-for-review — do NOT autoclose |
 
 #### Auto-Dispatch Procedure

--- a/.opencode/skills/approval-gate/tasks/verify-closed-issue.md
+++ b/.opencode/skills/approval-gate/tasks/verify-closed-issue.md
@@ -249,11 +249,13 @@ for adj_issue in adjacent:
 
 | Finding | Problem Class | Classification | Action |
 |---------|---------------|----------------|--------|
-| Open sub-issue on closed parent where PR covers deliverables | VERIFICATION-GAP | conditional | Close sub-issue with comment referencing PR |
-| Open sub-issue on closed parent where PR does NOT cover deliverables | VERIFICATION-GAP | flag-for-review | Report — sub-issue work remains |
-| Cross-reference to open issue when parent is closed | CONFLICTING | flag-for-review | Chain incomplete — report |
-| Closed issue without merged PR | VERIFICATION-GAP | flag-for-review | Premature closure |
-| Depth limit reached | VERIFICATION-GAP | flag-for-review | Graph too deep |
+| Open sub-issue on closed parent where PR covers deliverables | VERIFICATION-GAP | auto-close | Auto-close sub-issue with comment referencing PR via reconcile-issue-graph |
+| Open sub-issue on closed parent where PR does NOT cover deliverables | VERIFICATION-GAP | flag-for-review | Sub-issue work remains — report for dev action |
+| Cross-reference to open issue when parent is closed | CONFLICTING | flag-for-review | Chain incomplete — uncertain, requires dev judgment |
+| Closed issue without merged PR | VERIFICATION-GAP | reopen | Reopen via reconcile-issue-graph — premature closure |
+| Closed + state_reason not_planned | VERIFIED | no-action | Intentionally skipped |
+| Depth limit reached | VERIFICATION-GAP | flag-for-review | Graph too deep — investigate manually |
+| Cross-reference 404 | MISSING-TRACEABILITY | flag-for-review | Referenced issue does not exist |
 
 #### 8.4 Report
 
@@ -284,18 +286,21 @@ Overall: CONSISTENT / HAS_FLAGS
 | `BLOCKED_BY_SUB_ISSUE` | Parent cannot close because a sub-issue has a verification gap | Resolve sub-issue verification first |
 | `GRAPH_HAS_FLAGS` | Graph traversal found one or more verification gaps | Resolve flagged issues or acknowledge accepted risk |
 | `GRAPH_CONSISTENT` | All nodes in reachable graph are in a consistent state | Safe to treat as verified — no action needed |
+| `ACTION_TAKEN` | Reconciliation took action on one or more findings (auto-closed or reopened tickets) | Process reconcile result for updated ticket states |
 
 ## Finding Classification
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
 | Closed + merged PR | VERIFIED | auto-proceed | Trust closed state |
-| Closed "completed" + no merged PR | VERIFICATION-GAP | flag-for-review | Do NOT trust — investigate closure |
-| Closed "not_planned" | VERIFIED | auto-proceed | Work intentionally skipped |
-| Closed "duplicate" + target verified | VERIFIED | auto-proceed | Trust duplicate closure |
+| Closed "completed" + no merged PR | VERIFICATION-GAP | reopen | Reopen via reconcile-issue-graph — premature closure |
+| Closed "not_planned" | VERIFIED | no-action | Work intentionally skipped — do not change |
+| Closed "duplicate" + target verified | VERIFIED | no-action | Duplicate properly resolved |
 | Closed "duplicate" + target not found | MISSING-TRACEABILITY | flag-for-review | Cannot verify duplicate chain |
-| Closed + no reason recorded | VERIFICATION-GAP | flag-for-review | Investigate closure reason |
-| Parent closed + sub-issue verification gap | VERIFICATION-GAP | flag-for-review | Resolve sub-issue first |
+| Closed + no reason recorded | VERIFICATION-GAP | flag-for-review | Investigate closure reason — uncertain |
+| Parent closed + sub-issue verification gap | VERIFICATION-GAP | flag-for-review | Resolve sub-issue first — uncertain |
+| Open + merged PR exists | VERIFIED | auto-close | Auto-close as completed via reconcile-issue-graph |
+| Open + code in repo verified | VERIFIED | auto-close | Auto-close as completed via reconcile-issue-graph |
 
 ## Integration Points
 
@@ -306,6 +311,7 @@ This task is invoked by:
 3. **`pre-implementation-analysis` Step 0** — Before excluding "already implemented" issues from batch
 4. **`cleanup` pre-closure gate** — Before closing parent issues in post-merge workflow
 5. **`verify-fix-spec`** — Before skipping closed bug reports
+6. **`reconcile-issue-graph`** — Acts on findings from graph traversal (auto-close, reopen, flag uncertain)
 
 This task now performs transitive graph traversal (Step 8). Callers should handle `GRAPH_HAS_FLAGS` and `GRAPH_CONSISTENT` result types in addition to the single-issue result types.
 


### PR DESCRIPTION
**Summary:**

Adds a graph reconciliation task to the approval-gate skill that detects and acts on orphan sub-issues, stale references, and wrong parentage before implementation proceeds.

**Outcome:** Developers will have confidence that sub-issue graph integrity is verified before any implementation begins, preventing orphaned issues and stale references from causing process failures.

Implements #991
Plan: #993
Implements #994, #995, #996, #997