### PR TITLE
Issue graph reconciliation: codebase-first verification + duplicate plan detection

### DIFF
--- a/.opencode/skills/approval-gate/tasks/reconcile-issue-graph.md
+++ b/.opencode/skills/approval-gate/tasks/reconcile-issue-graph.md
@@ -34,6 +34,16 @@ For each finding from the traversal list, classify into one of six categories:
 | no-action (duplicate) | Closed + `state_reason: "duplicate"` + target verified as covering scope | skip |
 | uncertain | Conflicting or ambiguous signals that prevent confident classification | flag-for-dev |
 
+### Step 1.5: Cross-Reference Plan Scope Check
+
+For each sub-issue finding in the traversal list:
+
+1. **Identify the parent plan** — call `github_issue_read(method=get_sub_issues, owner=GIT_OWNER, repo=GIT_REPO, issue_number=<N>)` on each finding's parent to confirm the plan relationship. Record the parent plan issue number.
+2. **Read the parent plan body** — call `github_issue_read(method=get, owner=GIT_OWNER, repo=GIT_REPO, issue_number=<plan_N>)` and extract the spec reference using the pattern `Spec: #N`.
+3. **Search for other plans referencing the same spec** — call `github_search_issues(query="label:plan \"Spec: #<spec_N>\" in:body repo:<GIT_OWNER>/<GIT_REPO>", owner=GIT_OWNER, repo=GIT_REPO)`. Collect all plan issue numbers returned.
+4. **Compare plan scopes for overlap** — for each additional plan found, call `github_issue_read(method=get)` to read its body. Extract phase titles and compare with the current plan's phases. Record overlapping phase titles.
+5. **If overlap exists**: Add a finding to the `uncertain` classification with reason `"duplicate plan track — requires dev action to determine which plan owns deliverables"`. Record: spec number, all plan numbers referencing that spec, and the overlapping phase titles.
+
 ### Step 2: Verify Auto-Close Candidates
 
 For each auto-close candidate:
@@ -41,6 +51,24 @@ For each auto-close candidate:
 1. **Merged PR path**: Call `github_pull_request_read(method=get)` on any associated PR. Confirm `merged_at` is not null. Record PR number and `merged_at` timestamp as evidence.
 2. **Code-in-repo path**: Use `read`, `grep`, or `srclight_get_symbol` to confirm success criteria are met in the live codebase. Record specific file paths and symbol names as evidence.
 3. **If evidence is ambiguous**: Reclassify as `uncertain` and move to `requires_dev_action`.
+
+### Step 2.5: Evidence Gate
+
+For each `auto-close` candidate, produce at least one live evidence artifact using `read`, `grep`, or `srclight_get_symbol` before the candidate can proceed to Step 6. The evidence artifact must reference specific file paths, symbol names, or grep patterns that verify the success criteria are met. Record each artifact with a unique identifier (e.g., `evidence-<issue_number>-1`).
+
+- **Merged PR path**: The `github_pull_request_read` result from Step 2 is sufficient evidence. Record as `evidence-<N>-1: github_pull_request_read(PullRequest=<P>) → merged_at=<timestamp>`.
+- **Code-in-repo path**: Require at least one `read`, `grep`, or `srclight_get_symbol` tool call confirming the specific code or symbol that satisfies the success criteria. Record as `evidence-<N>-1: <tool>(<target>) → <result_summary>`.
+
+Candidates without evidence artifacts are reclassified as `uncertain` with reason "no evidence artifact produced for auto-close candidate".
+
+### Step 2.7: Comment Conflict Detection
+
+For each `auto-close` candidate, scan all comments on the issue for conflicting signals that would prevent confident auto-closure.
+
+1. Call `github_issue_read(method=get_comments, owner=GIT_OWNER, repo=GIT_REPO, issue_number=<N>)` for each candidate.
+2. For each comment, check for conflict phrases within 24 hours of the reconciliation run timestamp: `"needs work"`, `"verification gap"`, `"not complete"`, `"partial"`, `"⚠️"`.
+3. If any comment posted within the 24-hour window contains a conflict phrase, reclassify the candidate from `auto-close` to `uncertain` with reason `"comment-content conflict: issue comments flag incomplete work"`. Record the conflicting comment ID and phrase.
+4. If no conflicting comments are found within the 24-hour window, the candidate passes this gate.
 
 ### Step 3: Verify Reopen Candidates
 
@@ -74,9 +102,9 @@ Add to `requires_dev_action` list in the result contract.
 For each verified auto-close candidate:
 
 1. Call `github_issue_write(method=update, state=closed, state_reason=completed)` on the issue.
-2. Call `github_add_issue_comment` with evidence:
-   - Merged PR: "Auto-closing: merged PR #N confirmed (merged_at: TIMESTAMP). Issue graph reconciliation via `reconcile-issue-graph`."
-   - Code verified: "Auto-closing: success criteria verified against live code (files: [...], symbols: [...]). Issue graph reconciliation via `reconcile-issue-graph`."
+2. Call `github_add_issue_comment` with evidence (including Step 2.5 artifact reference):
+   - Merged PR: "Auto-closing: merged PR #N confirmed (merged_at: TIMESTAMP) (evidence: merged_at via github_pull_request_read). Issue graph reconciliation via `reconcile-issue-graph`."
+   - Code verified: "Auto-closing: success criteria verified against live code (files: [...], symbols: [...]) (evidence: <artifact description from Step 2.5>). Issue graph reconciliation via `reconcile-issue-graph`."
 3. Remove `needs-approval` label if present.
 
 ### Step 7: Execute Reopen Actions
@@ -107,10 +135,14 @@ Issue Graph Reconciliation for #<root>:
   Requires dev action:
     - #X: current=closed, needed=open — cannot verify implementation status (conflicting signals: PR exists but not merged, code may exist in another branch)
     - #Y: current=open, needed=closed — code appears present but success criteria partially unmet
+  Duplicate Plan Tracks:
+    - Spec #S: plans #P1, #P2 — overlapping phases: [phase title, phase title]
   Nodes visited: <count>
 
 🤖 <AI-Name> (<model-id>) ⚠️ needs-dev-action
 ```
+
+If no duplicate plan tracks were found, omit the `Duplicate Plan Tracks` section entirely.
 
 ## Evidence Requirements
 
@@ -123,6 +155,9 @@ Every action MUST produce a live tool-call artifact:
 | Reopen | `github_search_pull_requests` showing no merged PR + codebase read showing code NOT present |
 | No-action (not_planned/duplicate) | `github_issue_read` response showing `state_reason` |
 | Uncertain | Conflicting tool-call results that prevent confident classification |
+| Evidence gate | `read`/`grep`/`srclight_get_symbol` output for auto-close candidates (mandatory — candidates without artifacts reclassified as `uncertain`) |
+| Comment conflict scan | `github_issue_read(method=get_comments)` output confirming no contradicting comments within 24-hour window |
+| Cross-reference check | `github_search_issues` output showing plans referencing the same spec + `github_issue_read` output confirming scope overlap |
 
 ## Context Required
 

--- a/.opencode/skills/issue-operations/tasks/pre-creation.md
+++ b/.opencode/skills/issue-operations/tasks/pre-creation.md
@@ -76,6 +76,24 @@ The check is content-coverage, not structural conformity. A spec that covers all
 2. Report missing content areas (not missing headers, missing *content*)
 3. Do NOT proceed with creation
 
+### Step 3.5: Check for Duplicate Plans
+
+**Before creating any plan issue, check whether an existing plan already references the same spec.** This mirrors the duplicate plan check in `writing-plans/tasks/create.md` Step 1.6 and ensures that even when plan creation is invoked via a different path, the duplication check is performed.
+
+1. Using `github_search_issues`, search for issues labeled `plan` in the repository:
+   ```
+   github_search_issues(query="label:plan", owner=GIT_OWNER, repo=GIT_REPO, state="open")
+   ```
+2. Filter results for those whose body contains `Spec: #<spec_number>` referencing the spec that will be planned.
+3. If one or more existing plans are found:
+   - Collect each existing plan's issue number, title, and URL
+   - Read each existing plan's body to extract its phase scope
+   - Present the overlap to the developer in chat: list each existing plan with its URL and a scope summary
+   - Offer the developer a choice:
+     - **"proceed with new plan (will add reference to existing plan)"** — continue creation, adding `Supersedes/replaces #N` or `Parallel track to #N` in the new plan body
+     - **"halt and review existing plan first"** — HALT and present the existing plan for review
+4. If no existing plans are found for the same spec, proceed without modification.
+
 ### Step 4: Report Validation Result
 
 **If all checks pass:**

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -213,6 +213,7 @@ The spec itself is the stable reference. Whether the plan is combined or separat
 ## Operating Protocol
 
 1. Read approved spec from GitHub Issue
+1.5. Check for existing plans referencing the same spec — if found, surface overlap and require developer acknowledgment (see `tasks/create.md` Step 1.6 for the full duplicate plan check procedure)
 2. **Decision gate:** Evaluate combined vs separate plan using `single_task_determination` and `single_task` inputs — see `tasks/create.md` Step 1.5
 3. Map file structure (all files to create/modify with responsibilities)
 4. Plan phase structure by judgment (prose-driven)

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -63,6 +63,29 @@ Before reading the approved spec, invoke `verification-enforcement --task verify
 
    - Proceed to Step 2 (Map file structure) — plan content will be stored in a separate [PLAN] issue created at Step 6a
 
+### Step 1.6: Duplicate Plan Check
+
+Before mapping file structure, check whether existing plans already reference the same spec. This prevents accidental plan duplication and ensures the developer is aware of overlapping implementation tracking.
+
+**Procedure:**
+
+1. Using `github_search_issues`, search for issues labeled `plan` in the repository:
+   ```
+   github_search_issues(query="label:plan", owner=GIT_OWNER, repo=GIT_REPO, state="open")
+   ```
+2. Filter results for those whose body contains `Spec: #<spec_number>` referencing the current spec number.
+3. If one or more existing plans are found:
+   - Collect each existing plan's issue number, title, and URL
+   - Read each existing plan's body to extract its phase scope (phase names, file structure, and concern boundaries)
+   - Present the overlap to the developer in chat: list each existing plan with its URL and a scope summary
+   - Offer the developer a choice:
+     - **"proceed with new plan (will add reference to existing plan)"** — record the existing plan reference and add an explicit `Supersedes/replaces #N` or `Parallel track to #N` statement in the new plan body
+     - **"halt and review existing plan first"** — HALT and present the existing plan for review
+4. If the developer chooses to proceed, include the relationship statement in the new plan body at the top, immediately after the spec reference:
+   - If the new plan replaces an existing plan: `Supersedes/replaces #N` where N is the existing plan issue number
+   - If the new plan covers a parallel concern: `Parallel track to #N` where N is the existing plan issue number
+5. If no existing plans are found for the same spec, proceed without modification.
+
 2. **Map file structure:**
 
    - List all files that will be created or modified


### PR DESCRIPTION
## Summary

Harden the `reconcile-issue-graph` task with mandatory codebase verification before auto-closing, add duplicate plan detection to both reconciliation and plan creation workflows, and prevent false closures caused by trusting issue metadata over live code evidence.

## Outcome

- **Phase 1:** Added Step 2.5 Evidence Gate and Step 2.7 Comment Conflict Detection to `reconcile-issue-graph.md` — every auto-close now requires a live codebase evidence artifact, and conflicting comments reclassify findings as `uncertain`
- **Phase 2:** Added Step 1.5 Cross-Reference Plan Scope Check to detect overlapping plans for the same spec during reconciliation, flagging duplicates as `uncertain`
- **Phase 3:** Added Step 1.6 Duplicate Plan Check to `writing-plans/tasks/create.md`, updated `writing-plans/SKILL.md` Operating Protocol, and added a plan-duplication gate to `issue-operations/tasks/pre-creation.md`

Fixes #1009
Fixes #1011
Fixes #1012
Fixes #1013