### PR TITLE
[SPEC-FIX] Add output lineage cascade and question prohibition (#1015)

### DIFF
--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -124,6 +124,7 @@ Already implemented
 | **Sub-issues verified under plan** | Multi-task plans require phase-level sub-issues (verified in `verify-authorization` Step 5 — single authoritative gate) |
 | **Fix spec for bug reports** | Bug reports must have a fix spec sub-issue before closure (per `000-critical-rules.md`) |
 | **Implementation includes** | All file modifications that alter behavior: source code, skill files, guideline files, config files, test files, TypeScript plugins |
+| **Output lineage cascade** | When user approves an investigation/review issue whose sole deliverable is creating a spec, approval cascades to the spec. See `verify-authorization.md` Step 2.1 for the complete cascade procedure. |
 
 ## Fix Spec Verification for Bug Reports
 
@@ -220,6 +221,8 @@ cascade_applied: bool
 sub_issues_verified: bool
 gates_passed: [gate_name]
 blocking_reason: <reason|null>
+cascade_type: plan_cascade | output_lineage_cascade | none
+cascade_parent: <issue_number | null>
 ```
 
 #### verify-qa-mode

--- a/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
@@ -63,6 +63,17 @@ session_vars:
 
 **After all sub-agents return**, assemble screening results.
 
+### Step 0.1: No Questions During Analysis (ZERO TOLERANCE)
+
+**CRITICAL: The `question` tool MUST NOT be invoked at ANY point during the pre-implementation-analysis flow — not just after plan presentation.**
+
+Structural classification decisions (authorization scope, plan structure, sub-issue creation, execution order) are agent intelligence concerns per `000-critical-rules.md` §"Pushing Agent Intelligence Decisions to the User." The agent resolves these autonomously.
+
+If the agent encounters a scenario not covered by existing rules:
+1. Apply the closest applicable rule by analogy
+2. If no analogy exists, resolve with best judgment and document the reasoning in the execution plan
+3. Do NOT escalate to the developer unless the scenario matches one of the five `requires_developer: true` conditions from `screen-issue`
+
 ### Step 0.5: Assemble Gate Evidence Audit Table
 
 From the collected screening results, assemble the full Gate Evidence Audit Table:
@@ -284,7 +295,7 @@ Each parallel issue includes dispatch context:
 Proceeding with execution plan.
 ```
 
-**Checkpoint (MANDATORY):** Before proceeding to `assemble-batch`, verify NO `question` tool calls have been made since the execution plan was presented. If any were made, remove them and proceed autonomously. The execution plan is presented for informational purposes — no confirmation is requested or awaited.
+**Checkpoint (MANDATORY):** Before proceeding to `assemble-batch`, verify NO `question` tool calls have been made at ANY point during the pre-implementation-analysis flow (not just since plan presentation). If any were made, remove them and proceed autonomously. The execution plan is presented for informational purposes — no confirmation is requested or awaited. If any were made, the answers are irrelevant — the agent should have resolved the questions autonomously.
 
 #### Prohibited Actions
 

--- a/.opencode/skills/approval-gate/tasks/screen-issue.md
+++ b/.opencode/skills/approval-gate/tasks/screen-issue.md
@@ -401,5 +401,12 @@ session_vars:
 - HALT for developer review only for unresolvable conflicts and different-intent stale assumptions
 - Auto-detect partially-implemented issues (no developer input needed)
 - Set `requires_reconciliation: true` (NOT `requires_developer: true`) when issue state contradicts verified implementation state — `reconcile-issue-graph` handles this deterministically
-- Set `requires_developer: true` ONLY for: unresolvable conflicts, different-intent stale assumptions, ambiguous supersession, and `uncertain` reconciliation findings after `reconcile-issue-graph` runs
+- Set `requires_developer: true` ONLY for the following conditions (exhaustive list):
+  1. Unresolvable conflicts: contradictory success criteria between batch issues
+  2. Different-intent stale assumptions: Issue A references code Issue B deletes, with different goals
+  3. Ambiguous supersession: partial scope overlap, unclear which is canonical
+  4. `Uncertain` reconciliation findings after `reconcile-issue-graph` runs
+  5. Authorization scope gap: user approves an issue but the implementable target is unclear AND output lineage cascade (Step 2.1) does NOT apply
+
+**DEFAULT FAILSAFE:** If a screening sub-agent encounters a scenario not covered by conditions 1-5, it must RESOLVE autonomously (classify with best judgment) rather than defaulting to `requires_developer: true`. Escalating undefined scenarios to the developer is the "Pushing Agent Intelligence Decisions" anti-pattern. Set `requires_developer: true` ONLY when the developer's intent is genuinely ambiguous and cannot be inferred from context.
 - Produce the result contract as the final output of this task

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -48,6 +48,26 @@ Check that authorization is:
 - Explicit ("approved", "go", "approved: N.M")
 - For the CURRENT issue (not old session)
 
+#### Step 2.1: Authorization Cascade by Output Lineage
+
+When user approves issue #P, and #P's body or comments explicitly state that it created issue #C (e.g., "Spec created: #966"), authorization cascades from #P to #C if ALL conditions are met:
+
+1. #P is a meta/investigation/review issue (no implementation criteria of its own)
+2. #P's sole or primary deliverable is the creation of #C
+3. #C is a spec or plan with implementation criteria
+4. No contradictory evidence (e.g., #P's body says "spec rejected, try again")
+
+When cascade applies:
+- #C is treated as if the user said "Approved: #C"
+- Add comment to #C: "Authorization cascaded from #P (approvable output of approved issue)"
+- Remove `needs-approval` label from #C
+
+When cascade does NOT apply (conditions not met):
+- HALT and inform user: "#P was approved but it is an investigation issue — its spec #C was not named. Please confirm: approve #C?"
+- This is a genuine authorization gap where the developer's intent is ambiguous
+
+**Evidence artifact:** `github_issue_read(method=get_comments)` showing lineage evidence in #P, and `github_issue_write` / `github_add_issue_comment` responses confirming cascade actions on #C.
+
 ### Step 3: Check needs-approval Label
 
 ```python


### PR DESCRIPTION
**Summary:**

Prevents agents from escalating structural classification questions to developers by adding output lineage cascade, exhaustive `requires_developer` conditions with a default-failsafe, and full-flow question tool prohibition during pre-implementation analysis.

**Outcome:** Agents resolve authorization scope, plan structure, and sub-issue creation autonomously instead of asking developers to make these decisions.

Fixes #1015