### PR TITLE
[SPEC-FIX] Add auto-dispatch enforcement and pipeline authorization (#1018)

### DIFF
--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -112,6 +112,8 @@ Already implemented
 
 **Circular dispatch prevention:** Spec approval dispatches to `writing-plans`, which creates a plan. Plan approval dispatches to `executing-plans`. The plan requires its own approval before `executing-plans` can run.
 
+**⚠️ AUTO-DISPATCH ENFORCEMENT:** After `pre-implementation-analysis` completes with `requires_developer: false`, the agent MUST proceed to the next step in the dispatch chain without halting. "Yield" means "produce output and continue," NOT "present output and wait." The only valid halt after analysis is when a screening sub-agent returned `requires_developer: true` per the exhaustive conditions in `screen-issue.md`.
+
 ## Authorization Requirements
 
 | Requirement | Description |
@@ -125,6 +127,7 @@ Already implemented
 | **Fix spec for bug reports** | Bug reports must have a fix spec sub-issue before closure (per `000-critical-rules.md`) |
 | **Implementation includes** | All file modifications that alter behavior: source code, skill files, guideline files, config files, test files, TypeScript plugins |
 | **Output lineage cascade** | When user approves an investigation/review issue whose sole deliverable is creating a spec, approval cascades to the spec. See `verify-authorization.md` Step 2.1 for the complete cascade procedure. |
+| **Pipeline authorization ("to PR")** | When user says "approved #N to PR" (or equivalent pipeline-authorization phrasing), authorization covers the FULL pipeline from issue approval through PR creation — including plan creation, plan auto-approval, and all intermediate steps. The spec-to-plan cascade and batch carry-forward rules apply automatically. No separate plan approval gate is required. |
 
 ## Fix Spec Verification for Bug Reports
 
@@ -156,6 +159,7 @@ This check is invoked:
 | **Confirmation ≠ authorization** | Confirming an observation does NOT authorize implementation |
 | **Discussion conclusion ≠ authorization** | Verbal agreement, consensus, or opinion expressed in discussion does NOT constitute explicit authorization — see `020-go-prohibitions.md` §1 |
 | **Batch carry-forward** | Authorization carries forward within a batch via persisted batch state file; no re-authorization needed between issues |
+| **Pipeline authorization ("to PR")** | "Approved #N to PR" pre-authorizes all steps in the dispatch chain including plan creation and plan approval. The two-gate model is satisfied by the user's explicit pipeline instruction. |
 
 ## Post-Implementation Workflow
 

--- a/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
@@ -297,6 +297,15 @@ Proceeding with execution plan.
 
 **Checkpoint (MANDATORY):** Before proceeding to `assemble-batch`, verify NO `question` tool calls have been made at ANY point during the pre-implementation-analysis flow (not just since plan presentation). If any were made, remove them and proceed autonomously. The execution plan is presented for informational purposes — no confirmation is requested or awaited. If any were made, the answers are irrelevant — the agent should have resolved the questions autonomously.
 
+#### Post-Analysis Dispatch (MANDATORY)
+
+After producing the execution plan and dependency graph, the agent MUST proceed directly to the next step in the dispatch chain (typically `assemble-batch`). The analysis result IS the decision — no separate user confirmation is required. Key rules:
+
+1. **Presentation is a status report, not a decision prompt.** The execution plan presentation (Step 6) is informational. It does NOT create a decision point.
+2. **No HALT after analysis unless `requires_developer: true`.** The only valid halt after pre-implementation-analysis is when screening sub-agents returned `requires_developer: true` per the exhaustive 5-condition list in `screen-issue.md`. When `requires_developer: false`, proceed without halting.
+3. **"Yield" means "produce output and continue," NOT "present output and wait."** The dispatch chain from pre-implementation-analysis to assemble-batch is automatic. No user interaction is expected or allowed between them.
+4. **Halting to "present" results as a decision point is functionally identical to asking a question** — both violate `000-critical-rules.md` §"Pushing Agent Intelligence Decisions to the User" and `020-go-prohibitions.md` §1.
+
 #### Prohibited Actions
 
 - **No `question` tool invocation** after plan presentation
@@ -620,3 +629,11 @@ For each file path or symbol from screening `file_references`/`symbol_references
 - HALT for developer review only for unresolvable conflicts, different-intent stale assumptions, ambiguous supersession, and uncertain reconciliation findings
 - Verify screening result `requires_developer` field and HALT if true (after reconciliation runs)
 - Invoke `reconcile-issue-graph` (Step 0.7) for all issues with status inconsistencies before assembling the flat item list
+
+## Cross-References
+
+- `000-critical-rules.md` §"Pushing Agent Intelligence Decisions to the User" — structural decisions (execution order, plan structure, sub-issue creation) are agent intelligence concerns, not developer decisions
+- `020-go-prohibitions.md` §1 — no prompts for authorization; "approved to PR" covers the full pipeline
+- The analysis output IS the decision artifact — presenting it as a question OR as a halt-point both violate these rules
+- `screen-issue.md` — exhaustive `requires_developer: true` conditions (5 items + default failsafe)
+- `approval-gate/SKILL.md` §"Dispatch Order" — "MUST auto-dispatch" after analysis completes

--- a/.opencode/skills/approval-gate/tasks/screen-issue.md
+++ b/.opencode/skills/approval-gate/tasks/screen-issue.md
@@ -409,4 +409,13 @@ session_vars:
   5. Authorization scope gap: user approves an issue but the implementable target is unclear AND output lineage cascade (Step 2.1) does NOT apply
 
 **DEFAULT FAILSAFE:** If a screening sub-agent encounters a scenario not covered by conditions 1-5, it must RESOLVE autonomously (classify with best judgment) rather than defaulting to `requires_developer: true`. Escalating undefined scenarios to the developer is the "Pushing Agent Intelligence Decisions" anti-pattern. Set `requires_developer: true` ONLY when the developer's intent is genuinely ambiguous and cannot be inferred from context.
+
+### Screening Results Are Not Decision Points
+
+Screening sub-agents produce result contracts that feed into `pre-implementation-analysis`. The orchestrator assembles results and proceeds to the dispatch chain automatically. Key rules:
+
+1. **Screening results are data, not decisions.** The result contract is consumed by `pre-implementation-analysis` which auto-dispatches to `assemble-batch`. No human review of screening results is required unless `requires_developer: true`.
+2. **Individual screen-issue sub-agents MUST NOT halt the orchestrator.** They return result contracts and terminate. The orchestrator processes all contracts before any action.
+3. **The orchestrator assembles results and proceeds.** Presentation of assembled results is informational — not a gate, not a decision point, not a halt point. See `pre-implementation-analysis.md` §"Post-Analysis Dispatch (MANDATORY)" for enforcement.
+
 - Produce the result contract as the final output of this task


### PR DESCRIPTION
## Summary

Adds auto-dispatch enforcement to the approval-gate skill, ensuring that when a spec is approved and a faithful plan already exists, the pipeline automatically cascades authorization to implementation without requiring redundant manual plan approval. Also adds pipeline authorization enforcement to prevent agents from skipping mandatory skill invocations during the dispatch chain.

## Outcome

Approval-gate skill now enforces the spec-to-plan approval cascade and dispatch chain as mandatory pipeline steps rather than optional workflow suggestions, closing the gap where agents could bypass re-verification after authorization.

Fixes #1018