### PR TITLE
feat(skills): add completion tasks to 16 state-modifying skills

### DIFF
--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -26,12 +26,14 @@ You are a Requirements Explorer. Your focus is understanding what the user wants
 | -- | -- | -- |
 | `explore` | Full conversational exploration workflow (default) | ~1000 |
 | `enforcement` | Enforcement rules, protocol-compliance verification, and investigation completion criteria | ~600 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
 - `/skill brainstorming` — Start exploration workflow
 - `/skill brainstorming --task explore` — Same as above
 - `/skill brainstorming --task enforcement` — Enforcement rules and completion criteria
+- `/skill brainstorming --task completion` — Invoke when workflow halts at any point
 
 ## Operating Protocol
 
@@ -131,3 +133,5 @@ Findings from authorization verification follow the three-tier model:
 - Related guidelines: `140-planning-spec-creation.md` (spec workflow), `045-open-questions.md` (Q&A protocol), `065-verification-honesty.md` (evidence artifacts)
 - Related subtask: `spec-auditor --task ground-truth` (adversarial metadata verification model)
 - Source: Adapted from [obra/superpowers brainstorming](https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md)
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/brainstorming/tasks/completion.md
+++ b/.opencode/skills/brainstorming/tasks/completion.md
@@ -1,0 +1,60 @@
+# Task: completion
+
+Idempotent completion subtask for brainstorming. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Terminal-state dispatch:** Verify spec-creation/writing-plans dispatch occurred (Path A or Path B), or FAILURE documented (Path C)
+2. **Chat output format:** Verify chat output follows exec summary format (summary → outcome → URL → byline)
+
+## Skill-Specific Completion
+
+1. **Terminal-state dispatch** (if not already performed):
+   - Check evidence for spec-creation or writing-plans dispatch
+   - If missing: invoke appropriate skill as remediation (spec-creation for Path A, writing-plans for Path B), or document FAILURE for Path C
+
+2. **Chat output** (if not already produced):
+   - Verify exec summary was posted to chat
+   - If missing: generate and post exec summary now
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO brainstorming workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/changelog-generator/SKILL.md
+++ b/.opencode/skills/changelog-generator/SKILL.md
@@ -23,12 +23,14 @@ This skill transforms technical git commits into polished, user-friendly changel
 | `since-last-release` | Generate changelog for commits since last CHANGELOG.md update | ~170 |
 | `date-range` | Generate changelog for commits within specific date range | ~90 |
 | `backfill` | One-time historical backfill of missing changelog entries | ~120 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
 - `/skill changelog-generator --task since-last-release` - Normal PR workflow (after PR creation)
 - `/skill changelog-generator --task date-range --from DATE --to DATE` - Weekly/monthly updates
 - `/skill changelog-generator --task backfill` - One-time historical catchup
+- `/skill changelog-generator --task completion` - Invoke when workflow halts at any point
 - `/skill changelog-generator` - Overview only
 
 ## When to Use This Skill
@@ -238,3 +240,5 @@ Before invoking any cross-referenced skill:
 - Writing app store update descriptions
 - Generating email updates for users
 - Creating social media announcement posts
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/changelog-generator/tasks/completion.md
+++ b/.opencode/skills/changelog-generator/tasks/completion.md
@@ -1,0 +1,71 @@
+# Task: completion
+
+Idempotent completion subtask for changelog-generator. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **CHANGELOG.md update:** Changelog file updated with new entries
+2. **No duplicate entries:** No duplicate entries introduced
+3. **Categorization consistency:** Branch headers and categories applied consistently
+4. **Correct location:** Changes written to correct path (worktree if WORKTREE_PATH set)
+
+## Skill-Specific Completion
+
+1. **CHANGELOG.md update verification** (if not already performed):
+   - Check evidence that CHANGELOG.md was modified with new entries
+   - If missing: invoke appropriate task (`since-last-release`, `date-range`, or `backfill`) as remediation
+
+2. **Duplicate entry check** (if not already performed):
+   - Scan CHANGELOG.md for duplicate entries matching newly added content
+   - If duplicates found: remove duplicates, keep single canonical entry
+
+3. **Categorization verification** (if not already performed):
+   - Check that branch-header-based categorization follows prefix mapping rules
+   - If inconsistent: re-categorize per branch prefix table in SKILL.md
+
+4. **Location verification** (if not already performed):
+   - If WORKTREE_PATH is set: confirm changes written to `${WORKTREE_PATH}/CHANGELOG.md`
+   - If WORKTREE_PATH not set: confirm changes written to project root `CHANGELOG.md`
+   - If wrong location: move changes to correct path
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO changelog-generator workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/conflict-resolution/SKILL.md
+++ b/.opencode/skills/conflict-resolution/SKILL.md
@@ -18,12 +18,14 @@ You are a Conflict Resolution Specialist. Your focus is ensuring no committed wo
 - **Automatic**: Invoked by `git-workflow` tasks when conflicts are detected during rebase/merge
 - **Manual**: `/skill conflict-resolution` — Overview only
 - **Manual**: `/skill conflict-resolution --task classify-and-resolve` — Full classification and resolution procedure
+- **Manual**: `/skill conflict-resolution --task completion` — Invoke when workflow halts at any point
 
 ## Tasks
 
 | Task | Purpose | Words |
 |------|---------|-------|
 | `classify-and-resolve` | Detect, classify, and resolve conflicts by tier | ~550 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Conflict Classification Tiers
 
@@ -91,3 +93,5 @@ Chat notification plus persistent GitHub Issue with `conflict-resolution` label 
 
 - Related skills: `git-workflow` (branch management, rebase operations)
 - Related guidelines: `000-critical-rules.md` → "Critical Violation: Blind Conflict Resolution"
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/conflict-resolution/tasks/completion.md
+++ b/.opencode/skills/conflict-resolution/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for conflict-resolution. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Conflict classification:** All conflicts classified into tiers
+2. **Tier resolution:** Tier 1 and Tier 2 conflicts fully resolved
+3. **Tier 3 safety:** No Tier 3 conflicts resolved without developer review
+4. **Rebase state:** Git rebase/merge state is clean (no lingering conflicts)
+
+## Skill-Specific Completion
+
+1. **Classification completeness** (if not already performed):
+   - Check evidence for all detected conflicts having tier classification
+   - If missing: invoke `classify-and-resolve` task as remediation
+
+2. **Tier 1/2 resolution verification** (if not already performed):
+   - Check evidence that all Tier 1 and Tier 2 conflicts were resolved
+   - If unresolved: resolve and document in chat per notification format
+
+3. **Tier 3 developer review guard** (if not already performed):
+   - Confirm no Tier 3 conflict was resolved without explicit developer approval
+   - If Tier 3 was auto-resolved: flag as critical violation, HALT for developer review
+
+4. **Rebase state verification** (if not already performed):
+   - Run `git status` to confirm no unresolved conflicts remain
+   - If conflicts remain: invoke `classify-and-resolve` as remediation
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO conflict-resolution workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -44,6 +44,7 @@ phase_progress:
 | `step` | Legacy — redirects to divide-and-conquer/orchestrate | ~100 |
 | `progress` | Legacy — redirects to divide-and-conquer/orchestrate | ~100 |
 | `verify` | Redirects to verification-before-completion | ~100 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
@@ -52,6 +53,7 @@ phase_progress:
 - `/skill executing-plans --task step` — Redirects to divide-and-conquer/orchestrate
 - `/skill executing-plans --task progress` — Redirects to divide-and-conquer/orchestrate
 - `/skill executing-plans --task verify` — Redirects to verification-before-completion
+- `/skill executing-plans --task completion` — Invoke when workflow halts at any point
 
 ## Operating Protocol
 
@@ -94,6 +96,7 @@ Plan approved (approval-gate)
 | Task table entry `step` | File exists at `.opencode/skills/executing-plans/tasks/step.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `progress` | File exists at `.opencode/skills/executing-plans/tasks/progress.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `verify` | File exists at `.opencode/skills/executing-plans/tasks/verify.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `completion` | File exists at `.opencode/skills/executing-plans/tasks/completion.md` | MISSING-TRACEABILITY if missing |
 | `divide-and-conquer` dispatch behavior | Matches actual SKILL.md: `assemble-batch` task handles implementation | CONFLICTING if mismatched |
 | `approval-gate` dispatch behavior | Matches actual SKILL.md: `verify-authorization` dispatches to `executing-plans` | CONFLICTING if mismatched |
 | `verification-before-completion` redirect | Matches actual SKILL.md: `verify` task exists and redirects | CONFLICTING if mismatched |
@@ -119,3 +122,5 @@ Before invoking any cross-referenced skill:
 - Related skills: `divide-and-conquer` (implementation orchestration), `approval-gate` (authorization), `verification-before-completion` (evidence), `finishing-a-development-branch` (branch readiness), `git-workflow` (branch/PR/cleanup), `writing-plans` (plan creation)
 
 Co-authored with AI: <AI-Name> (<model-id>)
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/executing-plans/tasks/completion.md
+++ b/.opencode/skills/executing-plans/tasks/completion.md
@@ -1,0 +1,65 @@
+# Task: completion
+
+Idempotent completion subtask for executing-plans. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **assemble-batch dispatch:** Verify divide-and-conquer/assemble-batch dispatch was attempted
+2. **Plan issue STATUS:** Verify plan issue STATUS reflects actual outcome (completed, partial, failed)
+3. **Chat exec summary:** Verify chat output follows exec summary format (summary → outcome → URL → byline)
+
+## Skill-Specific Completion
+
+1. **assemble-batch dispatch** (if not already performed):
+   - Check evidence for assemble-batch invocation
+   - If missing: invoke `divide-and-conquer --task assemble-batch` as remediation
+
+2. **Plan issue STATUS** (if not already updated):
+   - Check plan issue STATUS marker against actual completion state
+   - If mismatched: update STATUS to reflect current state
+
+3. **Chat executive summary** (if not already produced):
+   - Verify exec summary was posted to chat
+   - If missing: generate and post exec summary now
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (plan issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO executing-plans workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/fragment-manager/SKILL.md
+++ b/.opencode/skills/fragment-manager/SKILL.md
@@ -44,6 +44,7 @@ Fragment Manager handles duplicate text blocks (fragments) that appear in multip
 | `check-drift` | Detect drift between masters and copies | Periodic validation, before syncs |
 | `status-report` | Show sync status for all fragments | Overview of fragment health |
 | `resolve-conflict` | Handle merge conflicts | When drift is detected |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
@@ -51,6 +52,7 @@ Fragment Manager handles duplicate text blocks (fragments) that appear in multip
 - `/skill fragment-manager --task sync-fragment` - Sync master to destinations
 - `/skill fragment-manager --task check-drift` - Detect drift
 - `/skill fragment-manager --task status-report` - Overview
+- `/skill fragment-manager --task completion` - Invoke when workflow halts at any point
 - `/skill fragment-manager` - Skill overview only
 
 ## Operating Protocol
@@ -130,3 +132,5 @@ fragments:
 ## Edge Cases
 
 See individual task files for edge case handling protocols.
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/fragment-manager/tasks/completion.md
+++ b/.opencode/skills/fragment-manager/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for fragment-manager. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Registry update:** Fragment registry (`.opencode/.guidelines/registry.yaml`) updated after operation
+2. **Destination synchronization:** All destinations synchronized from master
+3. **No drift remaining:** Master and destination hashes match
+4. **Backup preservation:** Backup preserved before destructive operations
+
+## Skill-Specific Completion
+
+1. **Registry update verification** (if not already performed):
+   - Check evidence that `.opencode/.guidelines/registry.yaml` was modified with correct entries
+   - If missing: update registry with current operation details as remediation
+
+2. **Destination sync verification** (if not already performed):
+   - Verify all destinations listed in registry have been synchronized
+   - If any destination not synced: invoke `sync-fragment` task as remediation
+
+3. **Drift check** (if not already performed):
+   - Run `check-drift` to confirm zero drift between masters and destinations
+   - If drift found: invoke `resolve-conflict` or `sync-fragment` as remediation
+
+4. **Backup verification** (if not already performed):
+   - Check `.opencode/.backups/` exists and contains expected backup files
+   - If missing from destructive operation: flag for developer, cannot recreate
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO fragment-manager workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/issue-review/SKILL.md
+++ b/.opencode/skills/issue-review/SKILL.md
@@ -25,6 +25,7 @@ You are an Issue Review Orchestrator. Your focus is gathering all issue context,
 | `audit` | Delegate to `spec-auditor` with triage hints | ~350 |
 | `qa` | Ask clarifying questions one at a time for non-bug, non-spec issues | ~500 |
 | `analyze-and-spec` | Root cause analysis → fix spec auto-creation for bug reports | ~600 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
@@ -34,6 +35,7 @@ You are an Issue Review Orchestrator. Your focus is gathering all issue context,
 - `/skill issue-review --issue N --task audit` — Audit delegation only (requires prior triage)
 - `/skill issue-review --issue N --task qa` — Q/A mode for non-bug, non-spec issues
 - `/skill issue-review --issue N --task analyze-and-spec` — Root cause analysis + fix spec for bug reports
+- `/skill issue-review --issue N --task completion` — Invoke when workflow halts at any point
 - `/skill issue-review` — Overview only
 
 ## Operating Protocol
@@ -234,3 +236,5 @@ Action: [auto-fix|conditional|flag-for-review]
 - `065-verification-honesty.md` (metadata verification extension): Extended "don't trust — verify" principle covering issue metadata
 
 Base directory for this skill: `.opencode/skills/issue-review/`
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/issue-review/tasks/completion.md
+++ b/.opencode/skills/issue-review/tasks/completion.md
@@ -1,0 +1,71 @@
+# Task: completion
+
+Idempotent completion subtask for issue-review. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Full workflow completion:** Gather → triage → dispatch completed for target issue
+2. **Fix spec sub-issue:** If analyze-and-spec path, fix spec sub-issue was created
+3. **Spec-auditor invocation:** If audit path, spec-auditor was invoked
+4. **Executive summary channel:** Output routed to correct channel (chat for audit, issue for qa)
+
+## Skill-Specific Completion
+
+1. **Workflow completeness** (if not already performed):
+   - Check evidence that gather, triage, and dispatch all ran
+   - If incomplete: invoke missing task as remediation
+
+2. **Fix spec sub-issue verification** (if analyze-and-spec path was taken):
+   - Check evidence for fix spec sub-issue linked to bug report parent
+   - If missing: invoke `analyze-and-spec` task as remediation
+
+3. **Spec-auditor invocation verification** (if audit path was taken):
+   - Check evidence that spec-auditor was invoked for the issue
+   - If missing: invoke `audit` task as remediation
+
+4. **Executive summary channel verification** (if not already performed):
+   - Audit path: summary went to chat only (not GitHub comments)
+   - QA path: durable outcomes posted to issue
+   - If wrong channel: repost to correct channel
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO issue-review workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -18,11 +18,13 @@ PR creation is a DISTINCT phase requiring EXPLICIT instruction — it is NOT aut
 |------|---------|-------|
 | `pre-pr-checklist` | Mandatory checks before PR creation (squash, changelog, branch state) | ~500 |
 | `sub-issue-collection` | Fetch and include sub-issues in PR body for autoclose | ~300 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
 - `/skill pr-creation-workflow --task pre-pr-checklist` - Run mandatory pre-PR checks
 - `/skill pr-creation-workflow --task sub-issue-collection` - Collect sub-issues for PR body
+- `/skill pr-creation-workflow --task completion` - Invoke when workflow halts at any point
 - `/skill pr-creation-workflow` - Overview only
 
 ## Authorization Boundary (CRITICAL)
@@ -152,3 +154,5 @@ Before invoking any cross-referenced skill:
 | `git-workflow` skill | Post-merge workflow including issue closure |
 | `spec-auditor` (ground-truth subtask) | Adversarial verification of authorization and PR state claims |
 | `065-verification-honesty.md` | Metadata verification extension for PR readiness claims |
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/pr-creation-workflow/tasks/completion.md
+++ b/.opencode/skills/pr-creation-workflow/tasks/completion.md
@@ -1,0 +1,71 @@
+# Task: completion
+
+Idempotent completion subtask for pr-creation-workflow. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Pre-PR checklist:** All checks passed before PR creation
+2. **PR creation outcome:** PR was created or not created with documented reason
+3. **URL reporting:** PR URL or compare URL reported in chat
+4. **Issue closure safety:** No issues prematurely closed before PR merge
+
+## Skill-Specific Completion
+
+1. **Pre-PR checklist verification** (if not already performed):
+   - Check evidence for squash, changelog, branch state, co-author trailers
+   - If missing: invoke `pre-pr-checklist` task as remediation
+
+2. **PR creation status** (if not already determined):
+   - Check whether PR was created via `github_list_pull_requests` for branch
+   - If PR exists: verify URL was reported in chat
+   - If PR not created: verify reason was documented (e.g., no explicit instruction)
+
+3. **URL reporting verification** (if not already performed):
+   - Confirm PR URL or compare URL appears in chat output
+   - If missing: report URL now
+
+4. **Issue closure guard** (if not already performed):
+   - Confirm no issues were closed before PR merge confirmation
+   - If premature closure found: reopen issue, flag for developer
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO pr-creation-workflow workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/receiving-code-review/SKILL.md
+++ b/.opencode/skills/receiving-code-review/SKILL.md
@@ -20,12 +20,14 @@ Workflow for responding to code review feedback on pull requests. Ensures all re
 |------|---------|-------|
 | `address` | Address all review comments | ~350 |
 | `respond` | Reply to review comments | ~250 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
 - `/skill receiving-code-review` — Overview only
 - `/skill receiving-code-review --task address` — Address review feedback
 - `/skill receiving-code-review --task respond` — Reply to comments
+- `/skill receiving-code-review --task completion` — Invoke when workflow halts at any point
 
 ## Operating Protocol
 
@@ -105,3 +107,5 @@ Before invoking any cross-referenced skill:
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Use Python client from gitbucket-api skill
 - **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/receiving-code-review/tasks/completion.md
+++ b/.opencode/skills/receiving-code-review/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for receiving-code-review. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Comment addressance:** All reviewer comments addressed or replied
+2. **Scope integrity:** No changes beyond what reviewer requested
+3. **Branch state:** Changes pushed to remote branch
+4. **Test health:** All tests still pass after review changes
+
+## Skill-Specific Completion
+
+1. **Comment addressance verification** (if not already performed):
+   - Check evidence for all review comments having response or code change
+   - If missing: invoke `address` or `respond` task as remediation
+
+2. **Scope creep check** (if not already performed):
+   - Check diff against review request — no changes beyond what was asked
+   - If scope creep detected: revert extraneous changes, invoke `address` task
+
+3. **Branch push verification** (if not already performed):
+   - Check `git status` for uncommitted changes and `git log origin/<branch>..HEAD` for unpushed commits
+   - If missing: commit and push as remediation
+
+4. **Test verification** (if not already performed):
+   - Run `uv run pytest test/` in worktree
+   - If failing: report failures, do not push broken tests
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO receiving-code-review workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -41,6 +41,7 @@ You are a Content-Aware Audit Orchestrator. Your focus is determining document t
 | `sub-issue-fidelity` | Verify sub-issue alignment with Plan phases (delegated from plan-fidelity-auditor) | ~350 |
 | `concern-coverage` | Verify sub-issue concern boundaries match Plan phases (delegated from concern-separation-auditor) | ~350 |
 | `prose-structure` | Anti-prose drift detection — flag rigid structure where prose is expected | ~250 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
@@ -56,6 +57,7 @@ You are a Content-Aware Audit Orchestrator. Your focus is determining document t
 - `/skill spec-auditor --issue N --task sub-issue-fidelity` — Sub-issue alignment with Plan phases only
 - `/skill spec-auditor --issue N --task concern-coverage` — Sub-issue concern boundary checks only
 - `/skill spec-auditor --issue N --task prose-structure` — Anti-prose drift checks only
+- `/skill spec-auditor --task completion` — Invoke when workflow halts at any point
 - `/skill spec-auditor --file path --type plan` — Audit with manual type override
 - `/skill spec-auditor --url URL --type runbook` — Audit with manual type override
 - `/skill spec-auditor` — Overview only
@@ -408,6 +410,7 @@ When auditing a plan, runbook, process flow, checklist, or reference document, u
 | `concern-coverage` | ~350 | inline |
 | `prose-structure` | ~250 | inline |
 | `fresh-start` | ~400 | inline |
+| `completion` | ~200 | inline |
 
 **Note:** Individual subtasks are lightweight. Sub-agent dispatch is recommended for the full audit (all subtasks per document type) when running 3+ subtasks together, not for individual subtasks.
 
@@ -478,6 +481,7 @@ This skill is a **heavy skill** — quality audits with all subtasks consume sig
 | Task table entry `sub-issue-fidelity` | File exists at `.opencode/skills/spec-auditor/tasks/sub-issue-fidelity.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `concern-coverage` | File exists at `.opencode/skills/spec-auditor/tasks/concern-coverage.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `prose-structure` | File exists at `.opencode/skills/spec-auditor/tasks/prose-structure.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `completion` | File exists at `.opencode/skills/spec-auditor/tasks/completion.md` | MISSING-TRACEABILITY if missing |
 | Described behavior of `issue-review` | Matches actual SKILL.md: `audit` task delegates to spec-auditor | CONFLICTING if mismatched |
 | Described behavior of `writing-plans` | Matches actual SKILL.md: `clean-room` task generates plans | CONFLICTING if mismatched |
 | Described behavior of `programming-principles` | Matches actual SKILL.md: defines engineering principles | CONFLICTING if mismatched |
@@ -528,6 +532,8 @@ Before invoking any cross-referenced skill:
 | Spec-only auditing | Spec-only auditing | Spec-only auditing | Multi-type: spec, plan, process-flow, runbook, checklist, reference-doc |
 
 Co-authored with AI: <AI-Name> (<model-id>)
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.
 
 ## Symbolic Engine Integration
 

--- a/.opencode/skills/spec-auditor/tasks/completion.md
+++ b/.opencode/skills/spec-auditor/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for spec-auditor. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **All selected subtasks completed:** Verify all baseline and conditional subtasks ran to completion
+2. **Auto-fixes documented:** Verify all auto-fix findings were applied and documented
+3. **Flag-for-review findings in exec summary:** Verify all flag-for-review findings are reported in executive summary
+4. **Chat exec summary posted:** Verify chat executive summary was posted
+
+## Skill-Specific Completion
+
+1. **Subtask completion** (if not all completed):
+   - Check evidence for each selected subtask execution
+   - If any missing: invoke missing subtask as remediation
+
+2. **Auto-fix documentation** (if not fully documented):
+   - Check evidence for auto-fix application and documentation
+   - If missing: document what was applied during this session
+
+3. **Flag-for-review in exec summary** (if not included):
+   - Check exec summary includes all flag-for-review findings
+   - If missing: regenerate exec summary with all findings
+
+4. **Chat executive summary** (if not already posted):
+   - Verify exec summary was posted to chat
+   - If missing: generate and post exec summary now
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (audited issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO spec-auditor workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/spec-creation/SKILL.md
+++ b/.opencode/skills/spec-creation/SKILL.md
@@ -30,6 +30,7 @@ You are a Spec Architect. Your focus is structuring investigation results into a
 | `risk` | Analyze risk, blast radius, failure propagation, operational needs | #8, #9 | Only for simple bug fixes with no deployment impact |
 | `write` | Assemble spec, create GitHub Issue, output exec summary + URL + byline | #4, #6, #10 | No — mandatory assembly step |
 | `change-control` | Version spec, document rationale and impact analysis for changes | #12 | Only for initial spec creation (not revisions) |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | — | No — mandatory completion |
 
 ## Invocation
 
@@ -37,6 +38,7 @@ You are a Spec Architect. Your focus is structuring investigation results into a
 - `/skill spec-creation --task requirements` — Requirements extraction only
 - `/skill spec-creation --task write` — Assemble spec from structured outputs only
 - `/skill spec-creation --task change-control` — Version/reason a spec revision
+- `/skill spec-creation --task completion` — Invoke when workflow halts at any point
 
 ## Operating Protocol
 
@@ -228,3 +230,5 @@ session_vars:
 - **Related subtask:** `spec-auditor --task ground-truth` (adversarial metadata verification model)
 
 Co-authored with AI: <AI-Name> (<model-id>)
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/spec-creation/tasks/completion.md
+++ b/.opencode/skills/spec-creation/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for spec-creation. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Spec issue created:** Verify spec issue exists with [SPEC] prefix and `needs-approval` label
+2. **spec-auditor invoked:** Verify spec-auditor was invoked after spec creation
+3. **Self-review evidence:** Verify self-review was performed (placeholder scan, consistency check, ambiguity check)
+4. **Chat exec summary + URL:** Verify chat output includes exec summary format with spec URL
+
+## Skill-Specific Completion
+
+1. **Spec issue** (if not already created):
+   - Check evidence for spec issue creation with [SPEC] prefix
+   - If missing: invoke `spec-creation --task write` as remediation
+
+2. **spec-auditor** (if not already invoked):
+   - Check evidence for spec-auditor invocation
+   - If missing: invoke `spec-auditor --issue N` as remediation
+
+3. **Self-review** (if not already performed):
+   - Check evidence for self-review completion
+   - If missing: perform self-review (placeholder scan, consistency check)
+
+4. **Chat executive summary** (if not already produced):
+   - Verify exec summary was posted to chat with spec URL
+   - If missing: generate and post exec summary now
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (spec issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO spec-creation workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/sre-runbook/SKILL.md
+++ b/.opencode/skills/sre-runbook/SKILL.md
@@ -24,12 +24,14 @@ You are an SRE-oriented operator writing runbooks for sysops under pressure. You
 |------|---------|-------|
 | `generate` | Generate an operational runbook for a given domain and scenario | ~900 |
 | `track` | Track an incident or change via GitHub Issue with structured labels | ~450 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
 - `/skill sre-runbook` — Overview only
 - `/skill sre-runbook --task generate` — Generate an operational runbook
 - `/skill sre-runbook --task track` — Track an incident or change via GitHub Issue
+- `/skill sre-runbook --task completion` — Invoke when workflow halts at any point
 
 ## Operating Protocol
 
@@ -180,6 +182,7 @@ Action: [auto-fix|conditional|flag-for-review]
 | `065-verification-honesty.md` metadata extension | Guideline contains "Metadata Verification Extension" section | CONFLICTING if missing |
 | Task table entry `generate` | File exists at `.opencode/skills/sre-runbook/tasks/generate.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `track` | File exists at `.opencode/skills/sre-runbook/tasks/track.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `completion` | File exists at `.opencode/skills/sre-runbook/tasks/completion.md` | MISSING-TRACEABILITY if missing |
 
 **Verification Procedure:**
 

--- a/.opencode/skills/sre-runbook/tasks/completion.md
+++ b/.opencode/skills/sre-runbook/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for sre-runbook. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Runbook produced:** Verify runbook was produced (file or issue body) with dual-output contract (AI-parseable + human-readable)
+2. **Incident issue created:** If `track` was invoked, verify incident GitHub Issue was created with structured labels
+3. **Verification documented:** Verify runbook claims were verified against live documentation (evidence artifacts produced)
+4. **Chat exec summary:** Verify chat executive summary was posted
+
+## Skill-Specific Completion
+
+1. **Runbook output** (if not already produced):
+   - Check evidence for runbook generation
+   - If missing: invoke `sre-runbook --task generate` as remediation
+
+2. **Incident issue** (if track was invoked and issue not created):
+   - Check evidence for incident issue creation
+   - If missing: invoke `sre-runbook --task track` as remediation
+
+3. **Verification** (if not already documented):
+   - Check evidence for live verification of runbook claims
+   - If missing: flag in completion report that verification was skipped
+
+4. **Chat executive summary** (if not already produced):
+   - Verify exec summary was posted to chat
+   - If missing: generate and post exec summary now
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (incident issue URL if created, or runbook file path) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO sre-runbook workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/subagent-driven-development/SKILL.md
+++ b/.opencode/skills/subagent-driven-development/SKILL.md
@@ -23,11 +23,13 @@ Execute an approved implementation plan by dispatching fresh subagents per task,
 | `spec-reviewer-prompt` | Dispatch spec compliance reviewer subagent | ~300 |
 | `code-quality-reviewer-prompt` | Dispatch code quality reviewer subagent | ~300 |
 | `batch-execution` | Accept batch execution plans with branch-per-issue and merge-based dependency resolution | ~500 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
 - `/skill subagent-driven-development` - Overview only
 - `/skill subagent-driven-development --task batch-execution` - For batch approval plans
+- `/skill subagent-driven-development --task completion` — Invoke when workflow halts at any point
 
 ## When to Use This Skill vs Divide-and-Conquer
 
@@ -137,3 +139,5 @@ This skill is a **heavy skill** — task dispatching and orchestration can run i
 - Related skills: `approval-gate` (authorization), `git-workflow` (git ops), `divide-and-conquer` (primary orchestration, context window safety), `verification-before-completion` (evidence), `finishing-a-development-branch` (branch readiness), `using-git-worktrees` (worktree creation with BASE_BRANCH)
 
 Co-authored with AI: <AI-Name> (<model-id>)
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/subagent-driven-development/tasks/completion.md
+++ b/.opencode/skills/subagent-driven-development/tasks/completion.md
@@ -1,0 +1,72 @@
+# Task: completion
+
+Idempotent completion subtask for subagent-driven-development. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **All tasks dispatched:** Verify all plan tasks were dispatched to sub-agent implementers
+2. **Post-implementation skills invoked:** Verify verification-before-completion and finishing-a-development-branch were invoked
+3. **No BLOCKED/NEEDS_CONTEXT unresolved:** Verify no sub-agent returned unresolved BLOCKED or NEEDS_CONTEXT status
+4. **Chat exec summary:** Verify chat executive summary was posted
+
+## Skill-Specific Completion
+
+1. **Task dispatch** (if not all dispatched):
+   - Check evidence for each task's implementer dispatch
+   - If any missing: dispatch missing tasks as remediation
+
+2. **Post-implementation skills** (if not already invoked):
+   - Check evidence for verification-before-completion invocation
+   - If missing: invoke `verification-before-completion --task verify` as remediation
+   - Check evidence for finishing-a-development-branch invocation
+   - If missing: invoke `finishing-a-development-branch --task checklist` as remediation
+
+3. **Unresolved statuses** (if any remain):
+   - Check for any BLOCKED or NEEDS_CONTEXT sub-agent results
+   - If found: report in completion report; escalate to developer if unresolvable
+
+4. **Chat executive summary** (if not already produced):
+   - Verify exec summary was posted to chat
+   - If missing: generate and post exec summary now
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (compare URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO subagent-driven-development workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/sync-guidelines/SKILL.md
+++ b/.opencode/skills/sync-guidelines/SKILL.md
@@ -20,6 +20,7 @@ Intelligently synchronizes guidelines, skills, and tools between repositories th
 | `sync-push` | Push core changes to target repository | ~300 |
 | `sync-pull` | Pull core changes into local repository | ~300 |
 | `issue-format` | Template for sync issue content | ~350 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
@@ -28,6 +29,7 @@ Intelligently synchronizes guidelines, skills, and tools between repositories th
 - `/skill sync-guidelines --task sync-push` — Push changes to target repo
 - `/skill sync-guidelines --task sync-pull` — Pull changes from source repo
 - `/skill sync-guidelines --task issue-format` — Get issue template
+- `/skill sync-guidelines --task completion` — Invoke when workflow halts at any point
 
 ## Operating Protocol
 
@@ -141,3 +143,5 @@ Before invoking any cross-referenced skill:
 
 - Related skills: `git-workflow` (branch management, commit workflow), `coherence-auditor` (drift detection and verification after sync)
 - Related guidelines: `000-critical-rules.md` (no vibe coding, scope autonomy)
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/sync-guidelines/tasks/completion.md
+++ b/.opencode/skills/sync-guidelines/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for sync-guidelines. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Classification completion:** All files classified as core or project-specific
+2. **Sync issue creation:** Sync issues created for core changes (not direct file edits)
+3. **Sync state file:** `.opencode/sync-state.yml` updated after sync operation
+4. **No direct modifications:** No target repository files modified directly
+
+## Skill-Specific Completion
+
+1. **Classification verification** (if not already performed):
+   - Check evidence that all relevant files were read and classified
+   - If missing: invoke `classify` task as remediation
+
+2. **Sync issue creation verification** (if not already performed):
+   - Check evidence that sync issues exist in target repository for core changes
+   - If missing: invoke `sync-push` or `sync-pull` task as remediation
+
+3. **Sync state file verification** (if not already performed):
+   - Check `.opencode/sync-state.yml` has updated timestamp and file list
+   - If stale: update sync state with current operation details
+
+4. **No direct modification guard** (if not already performed):
+   - Verify no files were directly edited in target repository
+   - If direct edits found: create sync issue to propose those changes formally
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO sync-guidelines workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/systematic-debugging/SKILL.md
+++ b/.opencode/skills/systematic-debugging/SKILL.md
@@ -20,12 +20,14 @@ Systematic debugging process that enforces root cause analysis, hypothesis testi
 |------|---------|-------|
 | `diagnose` | Systematic bug diagnosis workflow | ~400 |
 | `fix` | Minimal targeted fix after diagnosis | ~350 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
 - `/skill systematic-debugging` — Overview only
 - `/skill systematic-debugging --task diagnose` — Diagnose a bug
 - `/skill systematic-debugging --task fix` — Apply minimal fix
+- `/skill systematic-debugging --task completion` — Invoke when workflow halts at any point
 
 ## Operating Protocol
 
@@ -114,6 +116,7 @@ Action: [auto-fix|conditional|flag-for-review]
 | `065-verification-honesty.md` metadata extension | Guideline contains "Metadata Verification Extension" section | CONFLICTING if missing |
 | Task table entry `diagnose` | File exists at `.opencode/skills/systematic-debugging/tasks/diagnose.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `fix` | File exists at `.opencode/skills/systematic-debugging/tasks/fix.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `completion` | File exists at `.opencode/skills/systematic-debugging/tasks/completion.md` | MISSING-TRACEABILITY if missing |
 
 **Verification Procedure:**
 
@@ -143,3 +146,5 @@ Before invoking any cross-referenced skill:
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Use Python client from gitbucket-api skill
 - **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/systematic-debugging/tasks/completion.md
+++ b/.opencode/skills/systematic-debugging/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for systematic-debugging. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Bug report created:** If diagnosis completed, verify bug report issue was created
+2. **analyze-and-spec invoked:** If bug report created, verify `issue-review --task analyze-and-spec` was invoked
+3. **Fix verified:** If fix was applied, verify fix resolves the issue and no new issues introduced
+4. **Unauthorized fix flagged:** Verify no code changes were made without authorization
+
+## Skill-Specific Completion
+
+1. **Bug report** (if diagnosis completed but no bug report):
+   - Check evidence for bug report issue creation
+   - If missing: create bug report issue as remediation
+
+2. **analyze-and-spec** (if bug report created but analyze-and-spec not invoked):
+   - Check evidence for analyze-and-spec invocation
+   - If missing: invoke `issue-review --issue N --task analyze-and-spec` as remediation
+
+3. **Fix verification** (if fix applied but not verified):
+   - Check evidence for test execution confirming fix works
+   - If missing: run tests and verify fix resolves issue
+
+4. **Unauthorized fix detection** (if code was changed without authorization):
+   - Check for unapproved code changes
+   - If found: `git checkout -- <affected-files>` and report in completion output
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (bug report issue URL if created) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO systematic-debugging workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -28,6 +28,7 @@ You are a Worktree Setup Specialist. Your focus is creating safe, isolated git w
 | `create-worktree` | Full worktree creation workflow: sync, verify, setup, export env | ~600 |
 | `tool-usage` | File operation and bash tool compliance rules for worktrees | ~250 |
 | `reference` | Quick reference, common mistakes, fatal errors, integration | ~450 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
@@ -35,6 +36,7 @@ You are a Worktree Setup Specialist. Your focus is creating safe, isolated git w
 - `/skill using-git-worktrees --task create-worktree` — Create a new worktree
 - `/skill using-git-worktrees --task tool-usage` — Tool usage compliance rules
 - `/skill using-git-worktrees --task reference` — Quick reference and troubleshooting
+- `/skill using-git-worktrees --task completion` — Invoke when workflow halts at any point
 
 ## Operating Protocol
 
@@ -67,3 +69,5 @@ Branch naming: `spec/<short-name>` for spec-driven work, `feature/<description>`
 - **Called by:** `brainstorming` (Phase 4), `subagent-driven-development`, `executing-plans`
 - **Pairs with:** `finishing-a-development-branch` (cleanup), `git-workflow` (branch/PR management)
 - **Related guidelines:** `000-critical-rules.md` (worktree bypass violation), `060-tool-usage.md` (path rules)
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/using-git-worktrees/tasks/completion.md
+++ b/.opencode/skills/using-git-worktrees/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for using-git-worktrees. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Worktree creation:** Worktree was created and verified to exist
+2. **Environment export:** WORKTREE_PATH, BRANCH_NAME, DEV_BASE_HASH exported
+3. **Gitignore:** `.worktrees/` directory is gitignored
+4. **Test baseline:** Clean test baseline established after setup
+
+## Skill-Specific Completion
+
+1. **Worktree existence verification** (if not already performed):
+   - Check evidence that worktree directory exists at expected path
+   - If missing: invoke `create-worktree` task as remediation
+
+2. **Environment variable verification** (if not already performed):
+   - Check evidence for WORKTREE_PATH, BRANCH_NAME, DEV_BASE_HASH being set/output
+   - If missing: re-export from worktree state as remediation
+
+3. **Gitignore verification** (if not already performed):
+   - Check `.gitignore` for `.worktrees/` entry
+   - If missing: add entry and commit as remediation
+
+4. **Test baseline verification** (if not already performed):
+   - Run `uv run pytest test/` from worktree directory
+   - If failing: report failures, flag for developer decision on proceeding
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO using-git-worktrees workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -107,6 +107,7 @@ The spec-to-plan approval cascade still applies to combined plans:
 | `validate` | Check for placeholders and completeness | ~500 |
 | `retroactive` | Create plan for existing spec | ~600 |
 | `clean-room` | Generate independent plan from problem statement only | ~500 |
+| `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ~200 |
 
 ## Invocation
 
@@ -115,6 +116,7 @@ The spec-to-plan approval cascade still applies to combined plans:
 - `/skill writing-plans --task validate` — Validate existing plan
 - `/skill writing-plans --task retroactive` — Create plan for existing spec
 - `/skill writing-plans --task clean-room` — Generate clean-room plan (for comparison by spec-auditor)
+- `/skill writing-plans --task completion` — Invoke when workflow halts at any point
 
 ## Hybrid Structure: Phases + TDD Steps
 
@@ -286,6 +288,7 @@ session_vars:
 | Task table entry `validate` | File exists at `.opencode/skills/writing-plans/tasks/validate.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `retroactive` | File exists at `.opencode/skills/writing-plans/tasks/retroactive.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `clean-room` | File exists at `.opencode/skills/writing-plans/tasks/clean-room.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `completion` | File exists at `.opencode/skills/writing-plans/tasks/completion.md` | MISSING-TRACEABILITY if missing |
 | `approval-gate` auto-dispatch behavior | Matches actual SKILL.md: `verify-authorization` dispatches to `writing-plans` | CONFLICTING if mismatched |
 | `issue-operations` dispatch behavior | Matches actual SKILL.md: `link-sub-issue` task for sub-issue linking | CONFLICTING if mismatched |
 | `spec-auditor` clean-room invocation | Matches actual SKILL.md: `fidelity` subtask invokes `writing-plans --task clean-room` | CONFLICTING if mismatched |
@@ -340,3 +343,5 @@ Action: [auto-fix|conditional|flag-for-review]
 
 - Related skills: `brainstorming` (pre-spec), `approval-gate` (authorization), `executing-plans` (implementation), `spec-auditor` (fidelity subtask uses clean-room), `issue-operations` (sub-issue creation via `link-sub-issue` task), `spec-creation` (spec creation discipline)
 - Source: adapted from [obra/superpowers `writing-plans`](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md)
+
+**⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/writing-plans/tasks/completion.md
+++ b/.opencode/skills/writing-plans/tasks/completion.md
@@ -1,0 +1,70 @@
+# Task: completion
+
+Idempotent completion subtask for writing-plans. Ensures mandatory steps ran regardless of where the workflow halted.
+
+## State Check Phase
+
+1. **Plan issue created:** Verify plan issue exists with [PLAN] prefix and `needs-approval` label (separate), or combined spec+plan has `## Implementation Plan` section
+2. **Sub-issues created:** For multi-task plans, verify sub-issues created under the plan
+3. **Self-review completed:** Verify self-review checklist was run (coverage, placeholders, type consistency)
+4. **Chat exec summary + URL:** Verify chat output includes exec summary format with plan URL
+
+## Skill-Specific Completion
+
+1. **Plan issue** (if not already created):
+   - Check evidence for plan issue creation (separate or combined)
+   - If missing: invoke `writing-plans --task create` as remediation
+
+2. **Sub-issues** (if multi-task and not already created):
+   - Check evidence for sub-issue creation under the plan
+   - If missing: invoke `issue-operations --task link-sub-issue` as remediation
+
+3. **Self-review** (if not already performed):
+   - Check evidence for self-review checklist completion
+   - If missing: invoke `writing-plans --task validate` as remediation
+
+4. **Chat executive summary** (if not already produced):
+   - Verify exec summary was posted to chat with plan URL
+   - If missing: generate and post exec summary now
+
+## Shared Completion Delegation
+
+Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
+
+1. Report executive summary in chat (always runs)
+2. Action URL (plan issue URL) as the URL (ALWAYS last)
+
+## Completion Guarantee
+
+**MANDATORY:** Regardless of workflow outcome (success, partial, error), produce a status message containing:
+1. What was completed
+2. What was attempted but not completed
+3. Why the halt occurred
+
+This is the completion guarantee: NO writing-plans workflow ends without a status message.
+
+## Report Phase
+
+Generate executive summary in chat:
+
+```
+**Summary:**
+
+<1-2 sentences describing impact>
+
+**Outcome:** <What the result means for stakeholders>
+
+<URL if applicable, ALWAYS LAST>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+### Format Verification Before Halt (MANDATORY)
+
+**Idempotent — safe to invoke multiple times. This verification runs before EVERY halt, regardless of path.**
+
+- [ ] Executive summary present as **first** element
+- [ ] Outcome line present after summary
+- [ ] URL present IF relevant (after outcome, before byline)
+- [ ] AI byline present as **LAST** element
+- [ ] No stale todowrite items remain (all cleared or N/A)


### PR DESCRIPTION
## Summary

Adds `--task completion` to all 16 state-modifying skills that lacked it, closing the process gap that enabled Silent Agent Termination and Skipping Completion Guarantee violations.

## Outcome

- 16 new `tasks/completion.md` files created, each referencing `completion-core` for shared operations
- 16 SKILL.md files updated with completion task rows, invocation lines, and COMPLETION GUARANTEE paragraphs
- `sre-runbook` bug fixed: created missing `tasks/completion.md` that SKILL.md already referenced
- All 23 state-modifying skills now deliver the completion guarantee mandated by `000-critical-rules.md`

Fixes #1016