### PR TITLE
feat: Rename session-init output to scoped parameter names

### DIFF
--- a/.opencode/.guidelines/branch-first-protocol.md
+++ b/.opencode/.guidelines/branch-first-protocol.md
@@ -45,8 +45,8 @@ This is the FIRST and MOST CRITICAL rule. Before writing any code, editing any f
 # 1. Sync dev: git checkout dev && git pull origin dev
 # 2. Create worktree: git worktree add .worktrees/spec-my-change -b spec/my-change dev
 # 3. Work in .worktrees/spec-my-change/ (using workdir parameter on bash commands)
-# IMPORTANT: For read/edit/write/glob/grep tools, prefix filePath with WORKTREE_PATH:
-#   read(filePath=f"{WORKTREE_PATH}/src/main.py")  — NOT read(filePath="src/main.py")
+# IMPORTANT: For read/edit/write/glob/grep tools, prefix filePath with worktree.path:
+#   read(filePath=f"{worktree.path}/src/main.py")  — NOT read(filePath="src/main.py")
 ```
 
 ### 🚫 NEVER DO
@@ -66,7 +66,7 @@ git checkout -b spec/my-change dev
 
 Worktrees provide complete isolation — no stash is needed. Each worktree has its own working directory, so main tree changes are never affected.
 
-**If `WORKTREE_PATH` is not set or empty after worktree creation: FATAL ERROR → FLAG DEV → HALT.**
+**If `worktree.path` is not set or empty after worktree creation: FATAL ERROR → FLAG DEV → HALT.**
 
 <!--
 Fragment ID: branch-first-protocol

--- a/.opencode/.guidelines/commit-workflow.md
+++ b/.opencode/.guidelines/commit-workflow.md
@@ -24,7 +24,7 @@ The developer will say "commit" or "create a PR" when they want git operations. 
 - **Re-run discovery** (`git status`, `git diff`) before any commit workflow
 - **If `pyproject.toml` changed, include `uv.lock`** — this is an application/CI repo
 - **Use dynamic AI identity** — the AI knows its own name and email
-- **Use cached human identity** — from session start values (`DEV_NAME`, `DEV_EMAIL`)
+- **Use cached human identity** — from session start values (`dev.name`, `dev.email`)
 
 <!--
 Fragment ID: commit-workflow

--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -20,7 +20,7 @@ These mandates protect the integrity of the codebase and repository. They **NEVE
 | Human-only merge | Agents must never merge PRs |
 | No `/tmp/` usage — `./tmp/` only | Prevents system-level temp file leakage |
 | Path rules in worktree context | Prevents silent file operation errors across worktrees |
-| Sub-agents must receive `WORKTREE_PATH` | Prevents sub-agents from mutating main repo |
+| Sub-agents must receive `worktree.path` | Prevents sub-agents from mutating main repo |
 | Human-only branch deletion | Unmerged branches must never be force-deleted by agents |
 | Agents must never self-authorize | Authorization comes from developers, never from agent reasoning |
 
@@ -57,8 +57,8 @@ When developer authorization conflicts with a mandate:
 
 Worktrees are ALWAYS mandatory for feature branch creation. **See `using-git-worktrees` skill for the complete worktree creation procedure. See `060-tool-usage.md` §1-2 for tool priority hierarchy and path resolution rules.** **AUTHORITY: `060-tool-usage.md` §1-2** (this line is a reference only)
 
-- 🚫 FORBIDDEN: `git checkout -b`, `stash + checkout`, operating in main working directory, ignoring `WORKTREE_FATAL=1`
-- ✅ REQUIRED: `using-git-worktrees` skill for every feature branch; HALT if `WORKTREE_FATAL=1` or `WORKTREE_PATH` empty
+- 🚫 FORBIDDEN: `git checkout -b`, `stash + checkout`, operating in main working directory, ignoring `worktree.fatal=1`
+- ✅ REQUIRED: `using-git-worktrees` skill for every feature branch; HALT if `worktree.fatal=1` or `worktree.path` empty
 
 ## Critical Violation: Skipping Git Pre-Check Before ANY Work
 
@@ -69,21 +69,21 @@ Worktrees are ALWAYS mandatory for feature branch creation. **See `using-git-wor
 
 ## Critical Violation: Relative File Paths in Worktree Context
 
-**⚠️ Using relative paths with `read`/`edit`/`write`/`glob`/`grep` tools when `WORKTREE_PATH` is set is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ Using relative paths with `read`/`edit`/`write`/`glob`/`grep` tools when `worktree.path` is set is a CRITICAL GUIDELINE VIOLATION.**
 
 **See `060-tool-usage.md` §2 "Path Rules (ZERO TOLERANCE)" for the complete tool-by-tool table showing wrong vs correct path resolution, and the `using-git-worktrees` skill → "Tool Usage Compliance" section for worktree-specific guidance.** **AUTHORITY: `060-tool-usage.md` §2** (this line is a reference only)
 
-- 🚫 FORBIDDEN: Relative paths with file operation tools when `WORKTREE_PATH` is set; assuming tools respect `workdir`
-- ✅ REQUIRED: Prefix ALL paths with `WORKTREE_PATH` when in worktree context
+- 🚫 FORBIDDEN: Relative paths with file operation tools when `worktree.path` is set; assuming tools respect `workdir`
+- ✅ REQUIRED: Prefix ALL paths with `worktree.path` when in worktree context
 
 ## Critical Violation: Sub-Agents Ignoring Worktree Context
 
 **⚠️ Sub-agents that modify the main repo instead of the worktree are a CRITICAL GUIDELINE VIOLATION.**
 
-When a main agent is operating in a worktree and dispatches a sub-agent, the sub-agent MUST receive `WORKTREE_PATH` in its dispatch context and use it as the base directory for ALL file operations and git commands.
+When a main agent is operating in a worktree and dispatches a sub-agent, the sub-agent MUST receive `worktree.path` in its dispatch context and use it as the base directory for ALL file operations and git commands.
 
-- 🚫 FORBIDDEN: Spawning sub-agents without `WORKTREE_PATH` when operating in a worktree; sub-agents that stage/commit to the main repo's working directory; skills that perform git or file operations without a "Worktree Mode" section
-- ✅ REQUIRED: Pass `WORKTREE_PATH` in ALL sub-agent dispatch prompts when set; sub-agents verify `git rev-parse --show-toplevel` matches `WORKTREE_PATH` before mutating state; all new skills MUST include worktree awareness per `skill-creator` skill requirements
+- 🚫 FORBIDDEN: Spawning sub-agents without `worktree.path` when operating in a worktree; sub-agents that stage/commit to the main repo's working directory; skills that perform git or file operations without a "Worktree Mode" section
+- ✅ REQUIRED: Pass `worktree.path` in ALL sub-agent dispatch prompts when set; sub-agents verify `git rev-parse --show-toplevel` matches `worktree.path` before mutating state; all new skills MUST include worktree awareness per `skill-creator` skill requirements
 
 ## Critical Violation: Implementing Without Verifying Against Live Documentation
 
@@ -239,14 +239,14 @@ Feature branches target `dev`. Compare URLs: `compare/dev...<branch-name>`. Only
 **⚠️ Generating URLs from memory, guesswork, or hardcoded patterns is a CRITICAL GUIDELINE VIOLATION.** All URLs must be constructed from session-enforcement plugin output. No exceptions.
 
 - 🚫 FORBIDDEN: Hard-coding domains; using "known correct" URLs from previous sessions; guessing from git remotes; caching URL bases across sessions
-- ✅ REQUIRED: Extract `<GitBucketHtmlUrl>` from session init; construct all URLs from that value; HALT if session init missing
+- ✅ REQUIRED: Extract `<gitbucket.html_url>` from session init; construct all URLs from that value; HALT if session init missing
 
 ## Critical Violation: Inferring GitHub Owner from File Paths/Usernames
 
 **⚠️ Inferring GitHub owner from file paths or usernames is a CRITICAL GUIDELINE VIOLATION.**
 
 - 🚫 FORBIDDEN: Inferring owner from file paths, `$USER`, `git config user.name`, cached values; making GitHub MCP calls without session init values
-- ✅ REQUIRED: Use `GIT_OWNER` and `GIT_REPO` from session init for EVERY GitHub MCP call
+- ✅ REQUIRED: Use `github.owner` and `github.repo` from session init for EVERY GitHub MCP call
 
 ## Critical Violation: Missing AI Co-Authored Attribution
 
@@ -283,13 +283,13 @@ All identity values MUST use placeholder tokens that are resolved at runtime fro
 - 🚫 FORBIDDEN: `<specific-model-id>` (e.g., `ollama-cloud/glm-5`, `claude-3-5-sonnet`) in skill files, guidelines, or task files
 - 🚫 FORBIDDEN: `example-developer`, `example-dev-alias`, or any specific developer name/email in skill files, guidelines, or task files
 - 🚫 FORBIDDEN: `example-org`, `example-repo`, or any specific org/repo name in skill files, guidelines, or task files
-- ✅ REQUIRED: Use `<AgentName>`, `<ModelId>`, `<DevName>`, `<DevEmail>`, `<GitOwner>`, `<GitRepo>`, `<GitBucketHtmlUrl>` placeholders everywhere
+- ✅ REQUIRED: Use `<AgentName>`, `<ModelId>`, `<dev.name>`, `<dev.email>`, `<github.owner>`, `<github.repo>`, `<gitbucket.html_url>` placeholders everywhere
 - ✅ REQUIRED: Skill-creator MUST validate that no hardcoded identity values appear in generated skill files
 - ✅ REQUIRED: Spec-auditor MUST flag hardcoded identity values as STRUCTURE-VIOLATION auto-fix findings
 
 **Applies to:** SKILL.md files, task/*.md files, guideline files, agent configuration files, code comments that serve as templates or examples.
 
-**Exempt from placeholders (concrete values are OK):** Python source code runtime strings, test fixtures, historical changelog entries, repository URLs in examples that use `<GitOwner>/<GitRepo>` pattern.
+**Exempt from placeholders (concrete values are OK):** Python source code runtime strings, test fixtures, historical changelog entries, repository URLs in examples that use `<github.owner>/<github.repo>` pattern.
 
 **See `080-code-standards.md` for the complete placeholder reference and `skill-creator/SKILL.md` for the validation gate.** **AUTHORITY: `080-code-standards.md`** (this line is a reference only)
 
@@ -435,7 +435,7 @@ If you think something ELSE should be changed: 1) STOP, 2) Comment on the issue,
 
 The approval-gate dispatch chain defines a mandatory sequence after plan approval:
 
-1. `git-workflow --task pre-work` — Create worktree, set `WORKTREE_PATH`, verify branch state
+1. `git-workflow --task pre-work` — Create worktree, set `worktree.path`, verify branch state
 2. `divide-and-conquer --task assemble-work` — Dispatch sub-agents for implementation
 3. `verification-before-completion` — Verify success criteria before marking complete
 4. `finishing-a-development-branch --task checklist` — Final branch readiness check
@@ -450,7 +450,7 @@ The approval-gate dispatch chain defines a mandatory sequence after plan approva
 - 🚫 FORBIDDEN: Generating compare URL without invoking `git-workflow --task review-prep`
 - ✅ REQUIRED: Follow the approval-gate dispatch chain in order after plan approval
 - ✅ REQUIRED: Invoke each mandatory skill in sequence
-- ✅ REQUIRED: Verify `WORKTREE_PATH` is set before any file modification
+- ✅ REQUIRED: Verify `worktree.path` is set before any file modification
 - ✅ REQUIRED: Use `divide-and-conquer` to dispatch sub-agents for all file modifications on multi-task plans
 
 **See `approval-gate/SKILL.md` → "Dispatch Order" for the complete mandatory sequence. See `using-git-worktrees` skill → `create-worktree` task for worktree creation procedure.**
@@ -716,7 +716,7 @@ Skill task files exceeding 1,000 words are extracted into sub-agent execution pe
 - Tasks >1,000 words → sub-agent dispatch via `task(subagent_type="general")`
 - Tasks ≤1,000 words → inline execution (spawning overhead exceeds inline cost)
 - Result contracts reference task files as source of truth (no duplication)
-- Dispatch context MUST include `WORKTREE_PATH`, `GIT_OWNER`, `GIT_REPO`, `DEV_NAME`, `DEV_EMAIL`
+- Dispatch context MUST include `worktree.path`, `github.owner`, `github.repo`, `dev.name`, `dev.email`
 
 **See each skill's SKILL.md → "Sub-Agent Tasks" section for execution mode tables and result contract schemas.**
 

--- a/.opencode/guidelines/016-srclight-preference.md
+++ b/.opencode/guidelines/016-srclight-preference.md
@@ -205,11 +205,11 @@ pycharm_rename_refactoring(pathInProject="src/main.py", symbolName="foo", newNam
 
 ### Worktree Path Resolution
 
-When `WORKTREE_PATH` is set (working in a git worktree), all file operation tools must prefix paths with the worktree path. See `060-tool-usage.md` for the complete tool-by-tool table.
+When `worktree.path` is set (working in a git worktree), all file operation tools must prefix paths with the worktree path. See `060-tool-usage.md` for the complete tool-by-tool table.
 
 ```
-# ✅ CORRECT: In worktree context, prefix with WORKTREE_PATH
-edit(filePath=f"{WORKTREE_PATH}/src/main.py", oldString="foo", newString="bar")
+# ✅ CORRECT: In worktree context, prefix with worktree.path
+edit(filePath=f"{worktree.path}/src/main.py", oldString="foo", newString="bar")
 
 # ❌ WRONG: Relative path in worktree context resolves to main repo
 edit(filePath="src/main.py", oldString="foo", newString="bar")

--- a/.opencode/guidelines/060-tool-usage.md
+++ b/.opencode/guidelines/060-tool-usage.md
@@ -66,17 +66,17 @@ When a platform has a dedicated API client (e.g., `GitBucketAPI`, GitHub MCP), t
 
 ### ⚠️ Worktree Path Resolution for File Operation Tools (CRITICAL)
 
-When working in a git worktree (`WORKTREE_PATH` is set), TIER 1 file operation tools (`read`, `edit`, `write`, `glob`, `grep`) do **NOT** have a `workdir` parameter. Relative paths like `src/main.py` resolve to the **main repo**, not the worktree. This causes silent file operation errors — edits go to the wrong file.
+When working in a git worktree (`worktree.path` is set), TIER 1 file operation tools (`read`, `edit`, `write`, `glob`, `grep`) do **NOT** have a `workdir` parameter. Relative paths like `src/main.py` resolve to the **main repo**, not the worktree. This causes silent file operation errors — edits go to the wrong file.
 
-**When `WORKTREE_PATH` is set, ALL file operations MUST prefix paths with the worktree path:**
+**When `worktree.path` is set, ALL file operations MUST prefix paths with the worktree path:**
 
 | Tool | Wrong (operates on main repo) | Correct (targets worktree) |
 | -- | -- | -- |
-| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{WORKTREE_PATH}/src/main.py")` |
-| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)` |
-| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)` |
-| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` |
-| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` |
+| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{worktree.path}/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{worktree.path}/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{worktree.path}/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=worktree.path)` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{worktree.path}/src/")` |
 
 **When NOT in a worktree** (working in main repo): Relative paths are correct and function as expected.
 

--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -280,3 +280,20 @@ See `guidelines.md:150` for the rule.
 See `process_data()` in `file.py` for the function definition.
 See `"Cross-Reference Standards"` section in `guidelines.md` for the rule.
 ```
+
+## Parameter Naming Convention
+
+Session-init and env-loader are two independent pipelines with separate naming conventions:
+
+| Pipeline | Source | Output Format | Consumer | Example |
+|----------|--------|---------------|----------|---------|
+| LLM context | session-init (Python) | Dotted `scope.param` | Agent system prompt | `github.owner` |
+| Bash environment | env-loader.ts (TypeScript) | UPPER_CASE | Shell commands, Python scripts | `GIT_OWNER` |
+
+**Session-init dotted names** (use in skill files, guidelines, dispatch contexts):
+`github.owner`, `github.repo`, `github.platform`, `github.html_url`, `gitbucket.owner`, `gitbucket.repo`, `gitbucket.html_url`, `gitbucket.ssh_url`, `gitbucket.has_credentials`, `srclight.project`, `dev.name`, `dev.email`, `branch`, `worktree.path`, `worktree.fatal`
+
+**Env-loader UPPER_CASE names** (use in bash scripts, Python env reads):
+`GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`
+
+These pipelines are independent. Changing session-init output names does NOT require changes to env-loader, and vice versa.

--- a/.opencode/guidelines/115-branch-naming.md
+++ b/.opencode/guidelines/115-branch-naming.md
@@ -59,9 +59,9 @@ git checkout dev && git pull origin dev
 git worktree add .worktrees/spec-my-feature -b spec/my-feature dev
 
 # 3. Work in the worktree (use workdir parameter on all bash commands)
-# IMPORTANT: For read/edit/write/glob/grep tools, prefix filePath with WORKTREE_PATH
-#   read(filePath=f"{WORKTREE_PATH}/src/main.py")  — NOT read(filePath="src/main.py")
-#   edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)  — NOT edit(filePath="src/main.py", ...)
+# IMPORTANT: For read/edit/write/glob/grep tools, prefix filePath with worktree.path
+#   read(filePath=f"{worktree.path}/src/main.py")  — NOT read(filePath="src/main.py")
+#   edit(filePath=f"{worktree.path}/src/main.py", ...)  — NOT edit(filePath="src/main.py", ...)
 # ... make changes, commit inside .worktrees/spec-my-feature ...
 
 # 4. Push feature branch from worktree

--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -82,7 +82,7 @@ ______________________________________________________________________
 
 ### Platform Routing
 
-| `GIT_PLATFORM` | Platform Sub-Skill |
+| `github.platform` | Platform Sub-Skill |
 |----------------|-------------------|
 | `github` | `issue-operations/platforms/github-mcp/` |
 | `gitbucket` | `issue-operations/platforms/gitbucket-api/` |

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -180,7 +180,7 @@ function buildWorktreeBlock(input: PluginInput): string {
   const worktreeDir = input?.worktree || "";
 
   if (worktreeDir && worktreeDir !== mainRepoDir) {
-    return `WORKTREE_PATH: ${worktreeDir}\nAll file operations (read, edit, write, glob, grep) MUST use paths prefixed with WORKTREE_PATH. Relative paths resolve to the main repo, not the worktree.`;
+    return `worktree.path: ${worktreeDir}\nAll file operations (read, edit, write, glob, grep) MUST use paths prefixed with worktree.path. Relative paths resolve to the main repo, not the worktree.`;
   }
 
   return "";

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -108,7 +108,7 @@ Already implemented
 - Plan approval: Issue has `plan` label or `[PLAN]` prefix in title
 - See `verify-authorization.md` Step 5 for full procedure
 
-**⚠️ MANDATORY WORKTREE STEP:** `git-workflow --task pre-work` MUST be invoked between plan approval and any implementation. This step creates the feature branch worktree, sets `WORKTREE_PATH`, and verifies branch state. Skipping this step is a CRITICAL GUIDELINE VIOLATION (see `000-critical-rules.md`).
+**⚠️ MANDATORY WORKTREE STEP:** `git-workflow --task pre-work` MUST be invoked between plan approval and any implementation. This step creates the feature branch worktree, sets `worktree.path`, and verifies branch state. Skipping this step is a CRITICAL GUIDELINE VIOLATION (see `000-critical-rules.md`).
 
 **Circular dispatch prevention:** Spec approval dispatches to `writing-plans`, which creates a plan. Plan approval dispatches to `executing-plans`. The plan requires its own approval before `executing-plans` can run.
 
@@ -331,11 +331,11 @@ nodes_visited: <N>
 issue_number: <N>
 work_peers: [<N>]  # screen-issue only
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```
 
 ## Adversarial Verification Requirements

--- a/.opencode/skills/approval-gate/tasks/completion.md
+++ b/.opencode/skills/approval-gate/tasks/completion.md
@@ -44,7 +44,7 @@ Generate executive summary in chat:
 
 **Outcome:** <What the result means for stakeholders>
 
-Issue URL: <GitBucketHtmlUrl><GitOwner>/<GitRepo>/issues/<number>
+Issue URL: <gitbucket.html_url><github.owner>/<github.repo>/issues/<number>
 
 🤖 <AgentName> (<ModelId>) <status>
 ```

--- a/.opencode/skills/approval-gate/tasks/post-implementation.md
+++ b/.opencode/skills/approval-gate/tasks/post-implementation.md
@@ -71,10 +71,10 @@ This pushes the branch WITHOUT creating a PR.
 
 ### Step 3: Generate Compare URL
 
-Using session values (<GitOwner>, <GitRepo>):
+Using session values (<github.owner>, <github.repo>):
 
 ```
-https://github.com/<GitOwner>/<GitRepo>/compare/dev...<branch-name>
+https://github.com/<github.owner>/<github.repo>/compare/dev...<branch-name>
 ```
 
 ### Step 4: Report Completion
@@ -177,7 +177,7 @@ git log origin/dev..HEAD --oneline
 ```
 After generating compare URL:
   - Verify URL uses correct base branch (dev, not main)
-  - Verify URL uses session init values for <GitOwner> and <GitRepo> (not hardcoded)
+  - Verify URL uses session init values for <github.owner> and <github.repo> (not hardcoded)
   - If URL contains wrong base → STRUCTURE-VIOLATION (auto-fix: regenerate with correct base)
 ```
 
@@ -208,7 +208,7 @@ Before sending chat message in Step 4:
 
 ## Context Required
 
-- Session values: <GitOwner>, <GitRepo>, branch name
+- Session values: <github.owner>, <github.repo>, branch name
 - Related tasks: `pr-creation` (PR)
 
 ## Why This Task Is Critical

--- a/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
@@ -54,11 +54,11 @@ For each approved issue:
 issue_number: <N>
 work_peers: [<list of all approved issue numbers except this one>]
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```
 
 **After all sub-agents return**, assemble screening results.
@@ -347,12 +347,12 @@ branch: "spec/<short-name>"
 worktree_path: ".worktrees/spec-<short-name>"
 dev_base_hash: "<7-char-sha>"
 env_vars:
-  WORKTREE_PATH: ".worktrees/spec-<short-name>"
-  BRANCH_NAME: "spec/<short-name>"
-  GitOwner: "<from-session>"
-  GitRepo: "<from-session>"
-  DevName: "<from-session>"
-  DevEmail: "<from-session>"
+  worktree.path: ".worktrees/spec-<short-name>"
+  branch: "spec/<short-name>"
+  github.owner: "<from-session>"
+  github.repo: "<from-session>"
+  dev.name: "<from-session>"
+  dev.email: "<from-session>"
 ```
 
 The `worktree_path` is derived from the branch name by replacing `/` with `-`:

--- a/.opencode/skills/approval-gate/tasks/reconcile-issue-graph.md
+++ b/.opencode/skills/approval-gate/tasks/reconcile-issue-graph.md
@@ -6,7 +6,7 @@ Act on findings from the issue graph traversal performed by `verify-authorizatio
 
 - Graph traversal complete via `verify-authorization` §5.5
 - Findings list available from traversal output
-- `<GitOwner>` and `<GitRepo>` from session context
+- `<github.owner>` and `<github.repo>` from session context
 
 ## Entry Criteria
 
@@ -38,9 +38,9 @@ For each finding from the traversal list, classify into one of six categories:
 
 For each sub-issue finding in the traversal list:
 
-1. **Identify the parent plan** — call `github_issue_read(method=get_sub_issues, owner=<GitOwner>, repo=<GitRepo>, issue_number=<N>)` on each finding's parent to confirm the plan relationship. Record the parent plan issue number.
-2. **Read the parent plan body** — call `github_issue_read(method=get, owner=<GitOwner>, repo=<GitRepo>, issue_number=<plan_N>)` and extract the spec reference using the pattern `Spec: #N`.
-3. **Search for other plans referencing the same spec** — call `github_search_issues(query="label:plan \"Spec: #<spec_N>\" in:body repo:<GitOwner>/<GitRepo>", owner=<GitOwner>, repo=<GitRepo>)`. Collect all plan issue numbers returned.
+1. **Identify the parent plan** — call `github_issue_read(method=get_sub_issues, owner=<github.owner>, repo=<github.repo>, issue_number=<N>)` on each finding's parent to confirm the plan relationship. Record the parent plan issue number.
+2. **Read the parent plan body** — call `github_issue_read(method=get, owner=<github.owner>, repo=<github.repo>, issue_number=<plan_N>)` and extract the spec reference using the pattern `Spec: #N`.
+3. **Search for other plans referencing the same spec** — call `github_search_issues(query="label:plan \"Spec: #<spec_N>\" in:body repo:<github.owner>/<github.repo>", owner=<github.owner>, repo=<github.repo>)`. Collect all plan issue numbers returned.
 4. **Compare plan scopes for overlap** — for each additional plan found, call `github_issue_read(method=get)` to read its body. Extract phase titles and compare with the current plan's phases. Record overlapping phase titles.
 5. **If overlap exists**: Add a finding to the `uncertain` classification with reason `"duplicate plan track — requires dev action to determine which plan owns deliverables"`. Record: spec number, all plan numbers referencing that spec, and the overlapping phase titles.
 
@@ -65,7 +65,7 @@ Candidates without evidence artifacts are reclassified as `uncertain` with reaso
 
 For each `auto-close` candidate, scan all comments on the issue for conflicting signals that would prevent confident auto-closure.
 
-1. Call `github_issue_read(method=get_comments, owner=<GitOwner>, repo=<GitRepo>, issue_number=<N>)` for each candidate.
+1. Call `github_issue_read(method=get_comments, owner=<github.owner>, repo=<github.repo>, issue_number=<N>)` for each candidate.
 2. For each comment, check for conflict phrases within 24 hours of the reconciliation run timestamp: `"needs work"`, `"verification gap"`, `"not complete"`, `"partial"`, `"⚠️"`.
 3. If any comment posted within the 24-hour window contains a conflict phrase, reclassify the candidate from `auto-close` to `uncertain` with reason `"comment-content conflict: issue comments flag incomplete work"`. Record the conflicting comment ID and phrase.
 4. If no conflicting comments are found within the 24-hour window, the candidate passes this gate.
@@ -165,9 +165,9 @@ Every action MUST produce a live tool-call artifact:
 root_issue_number: <N>
 findings: [{issue: <N>, state: <str>, classification: <str>, evidence_summary: <str>}]
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```

--- a/.opencode/skills/approval-gate/tasks/screen-issue.md
+++ b/.opencode/skills/approval-gate/tasks/screen-issue.md
@@ -9,7 +9,7 @@ Per-issue screening for pre-implementation analysis. Screen a single approved is
 - Single issue number to screen (passed via dispatch context)
 - Issue has been verified by `verify-authorization`
 - User has explicitly authorized implementation
-- `<GitOwner>` and `<GitRepo>` available from dispatch context
+- `<github.owner>` and `<github.repo>` available from dispatch context
 
 ## Exit Criteria
 
@@ -130,7 +130,7 @@ This gate ensures the agent cannot skip the sub-issue traversal. The section bel
 
 1. **ENUMERATE:** Call `github_issue_read(method=get_sub_issues, issue_number=<candidate>)` — no exceptions, no shortcuts
 2. **VERIFY EACH CHILD:** For EVERY sub-issue returned, call `github_issue_read(method=get, issue_number=<sub_issue_number>)` — do NOT trust cached state; verify against live GitHub API
-3. **CHECK CLOSURE LEGITIMACY:** For each closed sub-issue, search for merged PR evidence via `github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{<GitOwner>}/{<GitRepo>}")`. If closed without merged PR and `state_reason != "not_planned"` → DOWNGRADE to "partially-implemented"
+3. **CHECK CLOSURE LEGITIMACY:** For each closed sub-issue, search for merged PR evidence via `github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{<github.owner>}/{<github.repo>}")`. If closed without merged PR and `state_reason != "not_planned"` → DOWNGRADE to "partially-implemented"
 4. **CHECK OPEN SUB-ISSUES:** If ANY sub-issue is open → the parent CANNOT be "already-implemented" — DOWNGRADE to "partially-implemented"
 5. **PRODUCE EVIDENCE:** Each sub-issue MUST produce a tool-call artifact showing its state was verified. Blanket assertions ("all sub-issues checked") WITHOUT per-sub-issue tool-call evidence are VERIFICATION-GAP findings
 
@@ -142,10 +142,10 @@ For each sub-issue of the candidate "already implemented" issue:
 
   if child.state == "closed":
     state_reason = child.get("state_reason", "")
-    prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{<GitOwner>}/{<GitRepo>}")
+    prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{<github.owner>}/{<github.repo>}")
     merged_pr_found = False
     for pr in prs:
-      pr_detail = github_pull_request_read(method="get", owner=<GitOwner>, repo=<GitRepo>, pullNumber=pr["number"])
+      pr_detail = github_pull_request_read(method="get", owner=<github.owner>, repo=<github.repo>, pullNumber=pr["number"])
       if pr_detail.get("merged_at") is not None:
         merged_pr_found = True
         break
@@ -371,11 +371,11 @@ concerns:
 issue_number: <N>
 work_peers: [<list of other issue numbers in work set>]
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```
 
 ## Red Flags

--- a/.opencode/skills/approval-gate/tasks/verify-already-implemented.md
+++ b/.opencode/skills/approval-gate/tasks/verify-already-implemented.md
@@ -168,10 +168,10 @@ For each sub-issue:
 
     elif state_reason == "completed":
       # Verify a merged PR exists for this sub-issue
-      prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{<GitOwner>}/{<GitRepo>}")
+      prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{<github.owner>}/{<github.repo>}")
       merged_pr_found = False
       for pr in prs:
-        pr_detail = github_pull_request_read(method="get", owner=<GitOwner>, repo=<GitRepo>, pullNumber=pr["number"])
+        pr_detail = github_pull_request_read(method="get", owner=<github.owner>, repo=<github.repo>, pullNumber=pr["number"])
         if pr_detail.get("merged_at") is not None:
           merged_pr_found = True
           break

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -29,7 +29,7 @@ git status
 
 **If on `main` or `dev`:** This is expected — feature branches are created in worktrees, not by switching branches in the main tree. Proceed to Step 2.
 
-**If on a feature branch already:** Verify you're in the correct worktree. Check `WORKTREE_PATH` environment variable.
+**If on a feature branch already:** Verify you're in the correct worktree. Check `worktree.path` environment variable.
 
 **🚫 CRITICAL: Do NOT create branches directly in verify-authorization.**
 
@@ -176,10 +176,10 @@ For each closed issue encountered during verification:
 
     # Check 1: Was it closed via merged PR?
     # Search for PRs referencing this issue
-    prs = github_search_pull_requests(query=f"Fixes #{closed_issue_number} repo:{<GitOwner>}/{<GitRepo>}")
+    prs = github_search_pull_requests(query=f"Fixes #{closed_issue_number} repo:{<github.owner>}/{<github.repo>}")
     merged_pr_found = False
     for pr in prs:
-      pr_detail = github_pull_request_read(method="get", owner=<GitOwner>, repo=<GitRepo>, pullNumber=pr["number"])
+      pr_detail = github_pull_request_read(method="get", owner=<github.owner>, repo=<github.repo>, pullNumber=pr["number"])
       if pr_detail.get("merged_at") is not None:
         merged_pr_found = True
         break
@@ -388,7 +388,7 @@ if not is_spec:
 # Search for plans referencing this spec
 spec_number = issue["number"]
 plan_issues = github_search_issues(
-    query=f"open label:plan Spec: #{spec_number} repo:{<GitOwner>}/{<GitRepo>}"
+    query=f"open label:plan Spec: #{spec_number} repo:{<github.owner>}/{<github.repo>}"
 )
 ```
 
@@ -470,12 +470,12 @@ elif not plan_issues:
 **Before any sub-agent dispatch or file modification, the agent MUST invoke `git-workflow --task pre-work` to:**
 
 1. Create the feature branch in a worktree (`.worktrees/`)
-2. Set the `WORKTREE_PATH` environment variable
+2. Set the `worktree.path` environment variable
 3. Verify branch state and working tree cleanliness
 
 **This step is MANDATORY and CANNOT be skipped.** If the worktree already exists from a previous session, verify it and proceed. If worktree creation fails, HALT — do not proceed without a valid worktree.
 
-**Evidence requirement:** `git worktree list` must show the feature branch worktree, and `WORKTREE_PATH` must be set before any `divide-and-conquer` dispatch.
+**Evidence requirement:** `git worktree list` must show the feature branch worktree, and `worktree.path` must be set before any `divide-and-conquer` dispatch.
 
 After all verification gates pass, determine the approval context and auto-dispatch:
 
@@ -498,11 +498,11 @@ After all verification gates pass, determine the approval context and auto-dispa
    - Plan detection is via `plan` label or `[PLAN]` prefix in title (NOT via sub-issue relationship to spec)
 2. **If spec approval:** Invoke `writing-plans --task create` with context:
    - `spec_issue=#N` (the approved spec issue number)
-   - `<GitOwner>`, `<GitRepo>`, `<WorktreePath>` from session
+   - `<github.owner>`, `<github.repo>`, `<worktree.path>` from session
 5. **If plan approval:** Invoke `executing-plans --task start` with context:
    - `plan_issue=#N` (the approved plan issue number)
    - `spec_issue=#M` (extracted from plan body — the spec reference)
-   - `<GitOwner>`, `<GitRepo>`, `<WorktreePath>` from session
+   - `<github.owner>`, `<github.repo>`, `<worktree.path>` from session
 4. **Chat output:** Clearly indicate the transition:
    - Spec approval: "Verification passed → Creating implementation plan"
    - Plan approval: "Verification passed → Starting implementation"

--- a/.opencode/skills/approval-gate/tasks/verify-blockers.md
+++ b/.opencode/skills/approval-gate/tasks/verify-blockers.md
@@ -34,7 +34,7 @@ elif has_label and not explicit_authorization:
 
 ```python
 # Query for issues that may supersede current spec
-issues = github_list_issues(owner=<GitOwner>, repo=<GitRepo>, state="open")
+issues = github_list_issues(owner=<github.owner>, repo=<github.repo>, state="open")
 for issue in issues:
     if issue_supersedes_current(issue, current_spec):
         HALT("Superseding issue: #{}".format(issue["number"]))

--- a/.opencode/skills/approval-gate/tasks/verify-closed-issue.md
+++ b/.opencode/skills/approval-gate/tasks/verify-closed-issue.md
@@ -53,7 +53,7 @@ state_reason = issue.get("state_reason", "")
 ```python
 # Search for PRs that reference this issue
 prs = github_search_pull_requests(
-    query=f"Fixes #{N} repo:{<GitOwner>}/{<GitRepo>}"
+    query=f"Fixes #{N} repo:{<github.owner>}/{<github.repo>}"
 )
 
 merged_pr_found = False
@@ -61,7 +61,7 @@ merged_prs = []
 
 for pr in prs:
     pr_detail = github_pull_request_read(
-        method="get", owner=<GitOwner>, repo=<GitRepo>, pullNumber=pr["number"]
+        method="get", owner=<github.owner>, repo=<github.repo>, pullNumber=pr["number"]
     )
     if pr_detail.get("merged_at") is not None:
         merged_pr_found = True
@@ -318,7 +318,7 @@ This task now performs transitive graph traversal (Step 8). Callers should handl
 ## Context Required
 
 - Issue number to verify
-- `<GitOwner>` and `<GitRepo>` from session
+- `<github.owner>` and `<github.repo>` from session
 - Downstream callers should handle the result type to make appropriate decisions
 
 ## Cross-References

--- a/.opencode/skills/approval-gate/tasks/verify-codebase.md
+++ b/.opencode/skills/approval-gate/tasks/verify-codebase.md
@@ -34,7 +34,7 @@ For each code reference:
 
 ```python
 # Query for later issues that may supersede
-issues = github_list_issues(owner=<GitOwner>, repo=<GitRepo>, state="open")
+issues = github_list_issues(owner=<github.owner>, repo=<github.repo>, state="open")
 for issue in issues:
     if "[SPEC]" in issue["title"] and issue["number"] > current_spec:
         # Check if superseding
@@ -67,7 +67,7 @@ If staleness detected:
 ```
 For each file mentioned in the spec:
   - Use glob or read tool to verify the file actually exists at the specified path
-  - If file path includes WORKTREE_PATH prefix → verify in worktree
+  - If file path includes worktree.path prefix → verify in worktree
   - If file does not exist → VERIFICATION-GAP (flag-for-review: may be planned but not created, or path may have changed)
   - If file path has changed since spec was written → MISSING-TRACEABILITY (conditional: update spec with correct path)
 ```

--- a/.opencode/skills/approval-gate/tasks/verify-fix-spec.md
+++ b/.opencode/skills/approval-gate/tasks/verify-fix-spec.md
@@ -83,10 +83,10 @@ if bug_report.state == "closed":
 
     elif state_reason == "completed":
         # Verify a merged PR exists that fixes this bug
-        prs = github_search_pull_requests(query=f"Fixes #{bug_issue_number} repo:{<GitOwner>}/{<GitRepo>}")
+        prs = github_search_pull_requests(query=f"Fixes #{bug_issue_number} repo:{<github.owner>}/{<github.repo>}")
         merged_pr_found = False
         for pr in prs:
-            pr_detail = github_pull_request_read(method="get", owner=<GitOwner>, repo=<GitRepo>, pullNumber=pr["number"])
+            pr_detail = github_pull_request_read(method="get", owner=<github.owner>, repo=<github.repo>, pullNumber=pr["number"])
             if pr_detail.get("merged_at") is not None:
                 merged_pr_found = True
                 break

--- a/.opencode/skills/changelog-generator/SKILL.md
+++ b/.opencode/skills/changelog-generator/SKILL.md
@@ -178,20 +178,20 @@ guidelines from CHANGELOG_STYLE.md
 
 ## Worktree Mode
 
-When invoked from a worktree context (`WORKTREE_PATH` is set):
+When invoked from a worktree context (`worktree.path` is set):
 
-- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
-- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
+- ALL `bash` tool calls MUST use `workdir` parameter set to `worktree.path`
+- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `worktree.path/`
 - `git` commands run from the worktree directory, NOT the main repo
-- `CHANGELOG.md` path MUST be prefixed with `WORKTREE_PATH/`
+- `CHANGELOG.md` path MUST be prefixed with `worktree.path/`
 
 **Verification guard:** Before any git operation, run:
 ```bash
 git rev-parse --show-toplevel
 ```
-If the output does NOT match `WORKTREE_PATH`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
+If the output does NOT match `worktree.path`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
 
-If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+If `worktree.path` is NOT set, operate normally from the project root.
 
 ## Cross-Reference Verification (MANDATORY)
 

--- a/.opencode/skills/changelog-generator/tasks/completion.md
+++ b/.opencode/skills/changelog-generator/tasks/completion.md
@@ -7,7 +7,7 @@ Idempotent completion subtask for changelog-generator. Ensures mandatory steps r
 1. **CHANGELOG.md update:** Changelog file updated with new entries
 2. **No duplicate entries:** No duplicate entries introduced
 3. **Categorization consistency:** Branch headers and categories applied consistently
-4. **Correct location:** Changes written to correct path (worktree if WORKTREE_PATH set)
+4. **Correct location:** Changes written to correct path (worktree if worktree.path set)
 
 ## Skill-Specific Completion
 
@@ -24,8 +24,8 @@ Idempotent completion subtask for changelog-generator. Ensures mandatory steps r
    - If inconsistent: re-categorize per branch prefix table in SKILL.md
 
 4. **Location verification** (if not already performed):
-   - If WORKTREE_PATH is set: confirm changes written to `${WORKTREE_PATH}/CHANGELOG.md`
-   - If WORKTREE_PATH not set: confirm changes written to project root `CHANGELOG.md`
+   - If worktree.path is set: confirm changes written to `${WORKTREE_PATH}/CHANGELOG.md`
+   - If worktree.path not set: confirm changes written to project root `CHANGELOG.md`
    - If wrong location: move changes to correct path
 
 ## Shared Completion Delegation

--- a/.opencode/skills/coherence-auditor/SKILL.md
+++ b/.opencode/skills/coherence-auditor/SKILL.md
@@ -59,7 +59,7 @@ LLM Coherence Auditor ensuring guidelines, skills, and AI agent behavior work to
 
 When running in maintenance mode, the coherence auditor SHOULD verify:
 
-1. All session-init variable names referenced in `.opencode/guidelines/` and `.opencode/skills/` (e.g., `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`) appear as `KEY:` prefixes in `.opencode/tools/session-init` stdout output
+1. All session-init variable names referenced in `.opencode/guidelines/` and `.opencode/skills/` (e.g., `github.owner`, `github.repo`, `github.platform`, `dev.name`, `dev.email`, `branch`, `worktree.path`, `worktree.fatal`, `github.html_url`, `gitbucket.html_url`, `gitbucket.ssh_url`, `gitbucket.has_credentials`) appear as `KEY:` prefixes in `.opencode/tools/session-init` stdout output
 2. `.opencode/tools/session-init` does NOT output prose-only labels (e.g., `Owner:`, `Repository:`) for variables referenced by canonical names in guidelines
 3. `env-loader.ts` `output.env` keys match the same canonical names
 

--- a/.opencode/skills/coherence-auditor/tasks/create-report.md
+++ b/.opencode/skills/coherence-auditor/tasks/create-report.md
@@ -54,5 +54,5 @@ Retain the audit log in `./tmp/` for session reference. Do NOT delete — it may
 
 ## Context Required
 
-- Session values: <GitOwner>, <GitRepo>
+- Session values: <github.owner>, <github.repo>
 - Related tasks: All tasks feed into this report

--- a/.opencode/skills/completion-core/completion-core.md
+++ b/.opencode/skills/completion-core/completion-core.md
@@ -41,7 +41,7 @@ Before posting, evaluate whether the comment is substantive per the `issue-opera
 ```python
 # ONLY post if the comment conveys stakeholder-meaningful information
 if is_substantive:
-    github_add_issue_comment(owner=<GitOwner>, repo=<GitRepo>, issue_number=N, body="...")
+    github_add_issue_comment(owner=<github.owner>, repo=<github.repo>, issue_number=N, body="...")
 else:
     # Skip posting — progress goes to chat only
     pass

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -72,13 +72,13 @@ Enforces context window safety by mandating pre-flight assessment before non-tri
 **Before dispatching any sub-agent, the main agent MUST verify:**
 
 1. **Worktree exists:** `git worktree list` shows the feature branch worktree
-2. **WORKTREE_PATH is set:** `echo $WORKTREE_PATH` returns a non-empty path inside the repository (`.worktrees/`)
+2. **worktree.path is set:** `echo $WORKTREE_PATH` returns a non-empty path inside the repository (`.worktrees/`)
 3. **git-workflow --task pre-work was invoked:** The worktree was created by the mandatory skill, not manually
 4. **Feature branch is checked out:** The worktree shows the correct branch name
 
 **If ANY check fails:** HALT and invoke `git-workflow --task pre-work` before proceeding.
 
-**Evidence requirement:** Record `git worktree list` output and `WORKTREE_PATH` value before dispatching any sub-agent.
+**Evidence requirement:** Record `git worktree list` output and `worktree.path` value before dispatching any sub-agent.
 
 ## Overflow Signal Contract
 
@@ -125,17 +125,17 @@ sub_task:
   scope: "<files, modules, functions>"
   boundaries: "<what is OUT of scope>"
 env_vars:
-  WorktreePath: "<worktree path>"
-  BRANCH_NAME: "<branch name>"
-  GitOwner: "<from-session>"
-  GitRepo: "<from-session>"
-  DevName: "<from-session>"
-  DevEmail: "<from-session>"
+  worktree.path: "<worktree path>"
+  branch: "<branch name>"
+  github.owner: "<from-session>"
+  github.repo: "<from-session>"
+  dev.name: "<from-session>"
+  dev.email: "<from-session>"
 ```
 
 **Phase progress is prose-driven.** The `phase_progress` section communicates what information must travel between phases — completed phases should be named by the concern they address, concern boundaries should describe the architectural transition point, and verification evidence should summarize what was confirmed and the outcome. The agent composing the context decides how to encode this; the requirement is the information, not the format.
 
-**Invariants:** `WORKTREE_PATH` is MANDATORY — no exceptions. If empty: FATAL ERROR → HALT. `plan_issue` is set when dispatched from plan approval flow. `phase_progress` is composed by the orchestrator from prior sub-agent results and the Plan STATUS marker — it accumulates across the work set as each issue completes.
+**Invariants:** `worktree.path` is MANDATORY — no exceptions. If empty: FATAL ERROR → HALT. `plan_issue` is set when dispatched from plan approval flow. `phase_progress` is composed by the orchestrator from prior sub-agent results and the Plan STATUS marker — it accumulates across the work set as each issue completes.
 
 ## Sub-Agent Completion Checkpoint
 
@@ -242,12 +242,12 @@ When the orchestrating agent detects abnormal termination via the Sub-Agent Comp
 
 ## Worktree Mode
 
-When `WORKTREE_PATH` is set:
-- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
-- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
+When `worktree.path` is set:
+- ALL `bash` tool calls MUST use `workdir` parameter set to `worktree.path`
+- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `worktree.path/`
 - `git` commands run from the worktree directory, NOT the main repo
 
-If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+If `worktree.path` is NOT set, operate normally from the project root.
 
 ## Sub-Agent Tasks
 
@@ -290,11 +290,11 @@ results: [{issue: <N>, status: <str>, summary: <str>}]
 ```yaml
 work_state_file: <path>
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```
 
 ## Sub-Agent Spawning
@@ -308,7 +308,7 @@ This skill is a **heavy skill** — its orchestration logic can run in isolation
 5. Sub-agent returns structured result per Sub-agent Result Contract
 6. Main agent receives result — no orchestration detail in main context
 
-**Sub-agent context parameters:** Pass `<WorktreePath>`, `BRANCH_NAME`, `<GitOwner>`, `<GitRepo>`, `<DevName>`, `<DevEmail>` from session init.
+**Sub-agent context parameters:** Pass `<worktree.path>`, `branch`, `<github.owner>`, `<github.repo>`, `<dev.name>`, `<dev.email>` from session init.
 
 ## Live Verification: Work State (MANDATORY)
 

--- a/.opencode/skills/divide-and-conquer/tasks/assemble-work.md
+++ b/.opencode/skills/divide-and-conquer/tasks/assemble-work.md
@@ -89,12 +89,12 @@ For each issue in execution order:
        verification_evidence: "<prose summary of what was verified in prior phases and the outcomes>"
      dependency_branches: ["spec/<prior-branch>"]
      env_vars:
-        WorktreePath: ".worktrees/spec-<name>"
-        BRANCH_NAME: "spec/<name>"
-        GitOwner: "<from-session>"
-        GitRepo: "<from-session>"
-        DevName: "<from-session>"
-        DevEmail: "<from-session>"
+         worktree.path: ".worktrees/spec-<name>"
+         branch: "spec/<name>"
+        github.owner: "<from-session>"
+        github.repo: "<from-session>"
+        dev.name: "<from-session>"
+        dev.email: "<from-session>"
      ```
 
 3. **Spawn sub-agent** via `task(subagent_type="general", prompt=...)`

--- a/.opencode/skills/divide-and-conquer/tasks/code-quality-reviewer-prompt.md
+++ b/.opencode/skills/divide-and-conquer/tasks/code-quality-reviewer-prompt.md
@@ -18,9 +18,9 @@ Task tool (general-purpose):
 
     ## Worktree Context
 
-    WORKTREE_PATH: <WORKTREE_PATH value or 'not set'>
+    worktree.path: <worktree.path value or 'not set'>
 
-    If WORKTREE_PATH is set, ALL file reads MUST prefix paths with WORKTREE_PATH/. ALL bash commands MUST use workdir=WORKTREE_PATH. If WORKTREE_PATH is not set, use project root.
+    If worktree.path is set, ALL file reads MUST prefix paths with worktree.path/. ALL bash commands MUST use workdir=worktree.path. If worktree.path is not set, use project root.
 
     ## What Was Requested
 

--- a/.opencode/skills/divide-and-conquer/tasks/completion.md
+++ b/.opencode/skills/divide-and-conquer/tasks/completion.md
@@ -48,7 +48,7 @@ Generate executive summary in chat:
 
 **Outcome:** <What changed for stakeholders>
 
-Compare URL: <GitBucketHtmlUrl><GitOwner>/<GitRepo>/compare/dev...<branch>
+Compare URL: <gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch>
 ```
 
 URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/divide-and-conquer/tasks/context-passing.md
+++ b/.opencode/skills/divide-and-conquer/tasks/context-passing.md
@@ -119,7 +119,7 @@ Co-authored with AI: <AgentName> (<ModelId>)
 
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|-------------------|-----------|---------------|
-| "WORKTREE_PATH correct" | Verify path exists | `ls -d <path>` | STRUCTURE-VIOLATION |
+| "worktree.path correct" | Verify path exists | `ls -d <path>` | STRUCTURE-VIOLATION |
 | "Session vars current" | Verify vars match session init | Check against session values | VERIFICATION-GAP |
 | "Prior results accurate" | Verify result contracts from prior sub-agents | Read work state file | VERIFICATION-GAP |
 
@@ -129,6 +129,6 @@ Co-authored with AI: <AgentName> (<ModelId>)
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
-| WORKTREE_PATH invalid | STRUCTURE-VIOLATION | auto-fix | HALT — cannot safely dispatch |
+| worktree.path invalid | STRUCTURE-VIOLATION | auto-fix | HALT — cannot safely dispatch |
 | Stale session vars | VERIFICATION-GAP | conditional | Refresh from session init |
 | Prior results contradicted | VERIFICATION-GAP | conditional | Re-verify prior sub-agent output |

--- a/.opencode/skills/divide-and-conquer/tasks/dispatch.md
+++ b/.opencode/skills/divide-and-conquer/tasks/dispatch.md
@@ -33,17 +33,17 @@ sub_task:
   scope: "<files, modules, functions>"
   boundaries: "<what is OUT of scope>"
 env_vars:
-  WorktreePath: "<worktree path>"
-  BRANCH_NAME: "<branch name>"
-  GitOwner: "<from-session>"
-  GitRepo: "<from-session>"
-  DevName: "<from-session>"
-  DevEmail: "<from-session>"
+  worktree.path: "<worktree path>"
+  branch: "<branch name>"
+  github.owner: "<from-session>"
+  github.repo: "<from-session>"
+  dev.name: "<from-session>"
+  dev.email: "<from-session>"
 ```
 
 **MANDATORY verification items before dispatch:**
-- `WORKTREE_PATH` is non-empty — FATAL if missing
-- `BRANCH_NAME` matches the feature branch for this sub-task
+- `worktree.path` is non-empty — FATAL if missing
+- `branch` matches the feature branch for this sub-task
 - `depth` is less than `max_depth`
 
 ### Step 2: Spawn Sub-agent
@@ -54,8 +54,8 @@ task(
     prompt="""
 Use divide-and-conquer skill with context:
 
-WORKTREE_PATH: <value>
-If WORKTREE_PATH is set, all file operations and git commands MUST use it as the base directory.
+worktree.path: <value>
+If worktree.path is set, all file operations and git commands MUST use it as the base directory.
 
 Sub-task: <description from dispatch context>
 Scope: <scope>
@@ -105,7 +105,7 @@ After collecting the sub-agent result, the orchestrator MUST perform a completio
    - `BLOCKED` → HALT and report blocker
 
 2. **If sub-agent returned NO result** (timeout, crash, empty response) — this is **ABNORMAL TERMINATION**:
-   a. Run `git status` in the worktree (`workdir=WORKTREE_PATH`)
+   a. Run `git status` in the worktree (`workdir=worktree.path`)
    b. If working tree is clean → sub-agent didn't start → re-dispatch (return to Step 2)
    c. If working tree has uncommitted changes → assess the changes:
       - `git diff` and `git diff --cached` to see what was modified
@@ -160,7 +160,7 @@ Sub-agent reports bug as finding (read-only), HALTs implementation for its sub-t
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|-------------------|-----------|---------------|
 | "Sub-agent completed" | Verify result contract returned | Check for result contract in context | VERIFICATION-GAP |
-| "WORKTREE_PATH passed" | Verify worktree path in dispatch context | Check dispatch prompt for WORKTREE_PATH | STRUCTURE-VIOLATION |
+| "worktree.path passed" | Verify worktree path in dispatch context | Check dispatch prompt for worktree.path | STRUCTURE-VIOLATION |
 | "Sub-agent stayed in worktree" | Verify sub-agent didn't modify main repo | `git -C <main-repo> status --porcelain` | CONFLICTING |
 
 **Evidence artifact:** Result contract presence and main repo cleanliness check.

--- a/.opencode/skills/divide-and-conquer/tasks/implementer-prompt.md
+++ b/.opencode/skills/divide-and-conquer/tasks/implementer-prompt.md
@@ -44,26 +44,26 @@ Task tool (general-purpose):
 
     All feature branches operate in worktrees. There is no alternative — worktree is the only method.
 
-    If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+    If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
-    1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
-2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{WORKTREE_PATH}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
-       - `read(filePath=f"{{WORKTREE_PATH}}/src/main.py")` — NOT `read(filePath="src/main.py")`
-       - `edit(filePath=f"{{WORKTREE_PATH}}/src/main.py", ...)` — NOT `edit(filePath="src/main.py", ...)`
-       - `write(filePath=f"{{WORKTREE_PATH}}/src/new.py", ...)` — NOT `write(filePath="src/new.py", ...)`
-       - `glob(pattern="src/**/*.py", path="{{WORKTREE_PATH}}")` — NOT `glob(pattern="src/**/*.py")`
-       - `grep(pattern="TODO", path=f"{{WORKTREE_PATH}}/src/")` — NOT `grep(pattern="TODO", path="src/")`
+    1. All `bash` tool calls MUST use `workdir="{{worktree.path}}"`
+2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{worktree.path}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
+       - `read(filePath=f"{{worktree.path}}/src/main.py")` — NOT `read(filePath="src/main.py")`
+       - `edit(filePath=f"{{worktree.path}}/src/main.py", ...)` — NOT `edit(filePath="src/main.py", ...)`
+       - `write(filePath=f"{{worktree.path}}/src/new.py", ...)` — NOT `write(filePath="src/new.py", ...)`
+       - `glob(pattern="src/**/*.py", path="{{worktree.path}}")` — NOT `glob(pattern="src/**/*.py")`
+       - `grep(pattern="TODO", path=f"{{worktree.path}}/src/")` — NOT `grep(pattern="TODO", path="src/")`
      3. Before any push/squash/rebase operation, verify:
        ```
        git branch --show-current
-       # MUST match BRANCH_NAME
+       # MUST match branch
        ```
     3. `git rev-parse --show-toplevel` MUST return the worktree path
     4. NEVER operate in the main working directory during implementation
 
     **Environment variables available:**
-    - `WORKTREE_PATH`: Path to worktree directory (e.g., `.worktrees/spec-feature`)
-    - `BRANCH_NAME`: Name of feature branch (e.g., `spec/feature`)
+    - `worktree.path`: Path to worktree directory (e.g., `.worktrees/spec-feature`)
+    - `branch`: Name of feature branch (e.g., `spec/feature`)
     - `DEV_BASE_HASH`: Hash of dev branch at dispatch time
 
     **While you work:** If you encounter something unexpected or unclear, **ask questions**.

--- a/.opencode/skills/divide-and-conquer/tasks/orchestrate.md
+++ b/.opencode/skills/divide-and-conquer/tasks/orchestrate.md
@@ -313,7 +313,7 @@ Co-authored with AI: <AgentName> (<ModelId>)
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|-------------------|-----------|---------------|
 | "Workflow step completed" | Verify step was actually executed | Check for step output in context | VERIFICATION-GAP |
-| "Sub-agent dispatch correct" | Verify dispatch context includes WORKTREE_PATH | Review dispatch prompt | STRUCTURE-VIOLATION |
+| "Sub-agent dispatch correct" | Verify dispatch context includes worktree.path | Review dispatch prompt | STRUCTURE-VIOLATION |
 | "Work state current" | Verify work state file reflects latest state | `glob(pattern="./tmp/work-*.md")` | VERIFICATION-GAP |
 | "No skipped steps" | Verify all mandatory steps were invoked | Check for tool-call artifacts per step | MISSING-ELEMENT |
 
@@ -324,6 +324,6 @@ Co-authored with AI: <AgentName> (<ModelId>)
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
 | Step claimed but no artifact | VERIFICATION-GAP | conditional | Re-execute step |
-| WORKTREE_PATH missing from dispatch | STRUCTURE-VIOLATION | auto-fix | Re-dispatch with correct context |
+| worktree.path missing from dispatch | STRUCTURE-VIOLATION | auto-fix | Re-dispatch with correct context |
 | Work state stale | VERIFICATION-GAP | auto-fix | Re-read and verify |
 | Mandatory step skipped | MISSING-ELEMENT | conditional | Execute skipped step now |

--- a/.opencode/skills/divide-and-conquer/tasks/spec-reviewer-prompt.md
+++ b/.opencode/skills/divide-and-conquer/tasks/spec-reviewer-prompt.md
@@ -14,9 +14,9 @@ Task tool (general-purpose):
 
     ## Worktree Context
 
-    WORKTREE_PATH: <WORKTREE_PATH value or 'not set'>
+    worktree.path: <worktree.path value or 'not set'>
 
-    If WORKTREE_PATH is set, ALL file reads MUST prefix paths with WORKTREE_PATH/. ALL bash commands MUST use workdir=WORKTREE_PATH. If WORKTREE_PATH is not set, use project root.
+    If worktree.path is set, ALL file reads MUST prefix paths with worktree.path/. ALL bash commands MUST use workdir=worktree.path. If worktree.path is not set, use project root.
 
     ## What Was Requested
 

--- a/.opencode/skills/engineering-approach/tasks/SKILL.md
+++ b/.opencode/skills/engineering-approach/tasks/SKILL.md
@@ -70,7 +70,7 @@ Execute implementation after design is approved, following established design de
 
 ## Context Required
 
-- Session values: <GitOwner>, <GitRepo>, <DevName>, <DevEmail>
+- Session values: <github.owner>, <github.repo>, <dev.name>, <dev.email>
 - Related tasks: `verify-understanding`, `verify-design`
 
 ## Live Verification: Engineering Claims (MANDATORY)

--- a/.opencode/skills/engineering-approach/tasks/verify-understanding.md
+++ b/.opencode/skills/engineering-approach/tasks/verify-understanding.md
@@ -110,7 +110,7 @@ Report understanding verification to chat (NOT as GitHub Issue comment). The und
 
 ## Context Required
 
-- Session values: <GitOwner>, <GitRepo>
+- Session values: <github.owner>, <github.repo>
 - Related tasks: `verify-design` (next step), `verify-implementation` (final step)
 
 ## Live Verification: Understanding Claims (MANDATORY)

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -23,9 +23,9 @@ When dispatched from `approval-gate` after plan approval, the following context 
 ```yaml
 plan_issue: <number>
 spec_issue: <number, extracted from plan body>
-GitOwner: "<from-session>"
-GitRepo: "<from-session>"
-WorktreePath: "<worktree path>"
+github.owner: "<from-session>"
+github.repo: "<from-session>"
+worktree.path: "<worktree path>"
 phase_progress:
   completed_phases: "<prose listing of completed phases by concern name, from Plan STATUS>"
   concern_boundaries_crossed: "<prose description of architectural concern transitions from plan>"

--- a/.opencode/skills/executing-plans/tasks/start.md
+++ b/.opencode/skills/executing-plans/tasks/start.md
@@ -19,7 +19,7 @@ This task dispatches plan execution to `divide-and-conquer --task assemble-work`
 /skill divide-and-conquer --task assemble-work
 ```
 
-When dispatching, the `executing-plans` skill passes `phase_progress` alongside `plan_issue`, `spec_issue`, `<GitOwner>`, `<GitRepo>`, and `<WorktreePath>`. The `assemble-work` task then maintains and extends phase progress as each sub-agent completes, feeding it forward into subsequent dispatch contexts.
+When dispatching, the `executing-plans` skill passes `phase_progress` alongside `plan_issue`, `spec_issue`, `<github.owner>`, `<github.repo>`, and `<worktree.path>`. The `assemble-work` task then maintains and extends phase progress as each sub-agent completes, feeding it forward into subsequent dispatch contexts.
 
 The phase progress information comes from two sources:
 - The Plan STATUS marker (which phases are marked complete with ☑)

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -36,14 +36,14 @@ Branch completion workflow that ensures a feature branch is fully ready for PR c
 1. **Mandatory invocation (no decision point):** The agent MUST invoke this skill when implementation completes on a feature branch, when the user says "done" or "finished" or "ready for PR", or before review-prep task in git-workflow.
 2. **Verification-first approach:** All changes must be committed. All tests must pass. All lint/typecheck must pass. Branch must be pushed to remote.
 3. **Exit conditions:** Branch is READY when all checklist items pass, compare URL is generated, and agent HALTs to report readiness.
-4. **Worktree mandatory:** All feature branches operate in worktrees. If `WORKTREE_PATH` is not set: FATAL ERROR → FLAG DEV → HALT.
+4. **Worktree mandatory:** All feature branches operate in worktrees. If `worktree.path` is not set: FATAL ERROR → FLAG DEV → HALT.
 
 ## Worktree Mode (MANDATORY)
 
-If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
-- All `bash` tool calls use `workdir="{{WORKTREE_PATH}}"`
-- All `read`/`edit`/`write`/`glob`/`grep` tool calls prefix paths with `{{WORKTREE_PATH}}/`
+- All `bash` tool calls use `workdir="{{worktree.path}}"`
+- All `read`/`edit`/`write`/`glob`/`grep` tool calls prefix paths with `{{worktree.path}}/`
 - NEVER operate in the main working directory during implementation
 
 ## Lazy-Loaded Guidelines
@@ -86,7 +86,7 @@ Implementation tracks against **plan sub-issues**, not spec sub-issues. The hier
 | "Tests pass" | Verify by running tests | `bash` to run `uv run pytest test/` → confirm exit code 0 | VERIFICATION-GAP |
 | "Lint passes" | Verify by running linter | `bash` to run `uvx ruff check src/ test/` → confirm no errors | VERIFICATION-GAP |
 | "Branch pushed to remote" | Verify remote branch exists | `bash` to run `git log origin/<branch>..HEAD` → confirm empty | MISSING-ELEMENT |
-| "All files in worktree" | Verify all changed files are under WORKTREE_PATH | `bash` to run `git diff --name-only HEAD~1` → check paths | STRUCTURE-VIOLATION |
+| "All files in worktree" | Verify all changed files are under worktree.path | `bash` to run `git diff --name-only HEAD~1` → check paths | STRUCTURE-VIOLATION |
 
 **Evidence format:**
 
@@ -152,4 +152,4 @@ Before invoking any cross-referenced skill:
 
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Fully supported — uses GitBucket compare URL format
-- **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+- **Platform Detection:** Uses `github.platform` environment variable

--- a/.opencode/skills/finishing-a-development-branch/tasks/completion.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/completion.md
@@ -46,7 +46,7 @@ Generate executive summary in chat:
 
 **Outcome:** <What stakeholders get — branch is ready/not ready for PR>
 
-Compare URL: <GitBucketHtmlUrl><GitOwner>/<GitRepo>/compare/dev...<branch>
+Compare URL: <gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch>
 ```
 
 URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/finishing-a-development-branch/tasks/prepare.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/prepare.md
@@ -14,11 +14,11 @@ Prepare a feature branch for PR creation by ensuring all changes are committed, 
 
 All feature branches operate in worktrees. There is no alternative.
 
-If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
-1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
-2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{WORKTREE_PATH}}/`
-3. Before any push/squash/rebase: `git branch --show-current` MUST match BRANCH_NAME
+1. All `bash` tool calls MUST use `workdir="{{worktree.path}}"`
+2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{worktree.path}}/`
+3. Before any push/squash/rebase: `git branch --show-current` MUST match branch
 4. `git rev-parse --show-toplevel` MUST return the worktree path
 5. NEVER operate in the main working directory during implementation
 

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -195,11 +195,11 @@ conflicts_resolved: [<N>]
 branch_name: <str>
 worktree_path: <path>
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```
 
 ## Sub-Agent Spawning
@@ -213,9 +213,9 @@ This skill is a **heavy skill** — its task files contain significant detail th
 5. Sub-agent executes task in isolation, returns structured result
 6. Main agent receives result summary — no full git-workflow content in main context
 
-**Sub-agent context parameters:** Pass `<WorktreePath>`, `BRANCH_NAME`, `<GitOwner>`, `<GitRepo>`, `<DevName>`, `<DevEmail>` from session init.
+**Sub-agent context parameters:** Pass `<worktree.path>`, `branch`, `<github.owner>`, `<github.repo>`, `<dev.name>`, `<dev.email>` from session init.
 
-**⚠️ Worktree pass-through is MANDATORY:** When spawning sub-agents from a worktree context, `WORKTREE_PATH` MUST be included in the dispatch prompt. Sub-agents that perform git operations without `WORKTREE_PATH` will silently modify the main repo — this is a CRITICAL GUIDELINE VIOLATION (see #741).
+**⚠️ Worktree pass-through is MANDATORY:** When spawning sub-agents from a worktree context, `worktree.path` MUST be included in the dispatch prompt. Sub-agents that perform git operations without `worktree.path` will silently modify the main repo — this is a CRITICAL GUIDELINE VIOLATION (see #741).
 
 ## Live Verification Requirements
 
@@ -254,7 +254,7 @@ This skill is a **heavy skill** — its task files contain significant detail th
 | `merged_at` is None (no merge) | CONFLICTING | flag-for-review | HALT — do not close issues |
 | Tracking branch missing | MISSING-ELEMENT | auto-fix | Push with `-u` to establish tracking |
 | Unpushed commits detected | VERIFICATION-GAP | conditional | Push before generating compare URL |
-| WORKTREE_PATH empty/not set | STRUCTURE-VIOLATION | auto-fix | HALT — fatal error, cannot proceed safely |
+| worktree.path empty/not set | STRUCTURE-VIOLATION | auto-fix | HALT — fatal error, cannot proceed safely |
 | Staged changes differ from expected | CONFLICTING | flag-for-review | Verify staging matches intent before commit |
 | Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Investigate closure reason, may need reopen |
 

--- a/.opencode/skills/git-workflow/tasks/check-pr.md
+++ b/.opencode/skills/git-workflow/tasks/check-pr.md
@@ -18,12 +18,12 @@ List all PRs (open and merged) for the repository. If merged PRs with uncleaned 
 ```python
 # List open PRs
 open_prs = github_list_pull_requests(
-    owner=<GitOwner>, repo=<GitRepo>, state="open", perPage=50
+    owner=<github.owner>, repo=<github.repo>, state="open", perPage=50
 )
 
 # List merged PRs
 merged_prs = github_list_pull_requests(
-    owner=<GitOwner>, repo=<GitRepo>, state="closed", perPage=50
+    owner=<github.owner>, repo=<github.repo>, state="closed", perPage=50
 )
 # Note: GitHub "closed" includes both merged and unmerged; filter by merged_at
 merged_prs = [pr for pr in merged_prs if pr.get("merged_at") is not None]

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -232,7 +232,7 @@ def plan_closure_path(plan_num, plan_issue, pr_files=None, merged_pr_number=None
 
 #### Step 2.7.4: Spec Closure Path
 
-1. Search `github_search_issues(query="Spec: #{spec_number} repo:{<GitOwner>}/{<GitRepo>}")` for plans referencing this spec
+1. Search `github_search_issues(query="Spec: #{spec_number} repo:{<github.owner>}/{<github.repo>}")` for plans referencing this spec
 2. For each plan found, verify it is closed
 3. If ALL plans for the spec are closed → close the spec
 4. If ANY plan is still open → do NOT close the spec
@@ -240,7 +240,7 @@ def plan_closure_path(plan_num, plan_issue, pr_files=None, merged_pr_number=None
 ```python
 def spec_closure_path(spec_num, spec_issue):
     plans = github_search_issues(
-        query=f"Spec: #{spec_num} repo:{<GitOwner>}/{<GitRepo>}"
+        query=f"Spec: #{spec_num} repo:{<github.owner>}/{<github.repo>}"
     )
 
     open_plans = []
@@ -873,10 +873,10 @@ For each sub-issue of the parent issue:
     state_reason = child.get("state_reason", "")
 
     # Verify closure is legitimate (not premature)
-    prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{<GitOwner>}/{<GitRepo>}")
+    prs = github_search_pull_requests(query=f"Fixes #{sub_issue_number} repo:{<github.owner>}/{<github.repo>}")
     merged_pr_found = False
     for pr in prs:
-      pr_detail = github_pull_request_read(method="get", owner=<GitOwner>, repo=<GitRepo>, pullNumber=pr["number"])
+      pr_detail = github_pull_request_read(method="get", owner=<github.owner>, repo=<github.repo>, pullNumber=pr["number"])
       if pr_detail.get("merged_at") is not None:
         merged_pr_found = True
         break
@@ -1024,7 +1024,7 @@ This parent issue cannot be closed because the following sub-issue(s) remain inc
 
 ```python
 # PR merge verification — MANDATORY, NOT OPTIONAL
-pr = github_pull_request_read(method="get", owner=<GitOwner>, repo=<GitRepo>, pullNumber=N)
+pr = github_pull_request_read(method="get", owner=<github.owner>, repo=<github.repo>, pullNumber=N)
 
 # Evidence artifacts:
 # EVIDENCE: merged_at = pr.get("merged_at")  # Must be non-None

--- a/.opencode/skills/git-workflow/tasks/commit-prep.md
+++ b/.opencode/skills/git-workflow/tasks/commit-prep.md
@@ -28,7 +28,7 @@ The developer will say "commit" or "create a PR" when they want git operations. 
 - **Re-run discovery** (`git status`, `git diff`) before any commit workflow
 - **If `pyproject.toml` changed, include `uv.lock`** — this is an application/CI repo
 - **Use dynamic AI identity** — the AI knows its own name and email
-- **Use cached human identity** — from session start values (`<DevName>`, `<DevEmail>`)
+- **Use cached human identity** — from session start values (`<dev.name>`, `<dev.email>`)
 
 ## Operating Protocol
 
@@ -113,13 +113,13 @@ Co-authored-by: <AgentName> (<ModelId>) <noreply@example.com>
 
 ### Human Collaborator Trailer
 
-- **Use cached values from session start** — `<DevName>` and `<DevEmail>`
+- **Use cached values from session start** — `<dev.name>` and `<dev.email>`
 - **Do NOT re-run `git config`** — use stored session values
 
 **Example:**
 
 ```
-Co-authored-by: <DevName> <DevEmail>
+Co-authored-by: <dev.name> <dev.email>
 ```
 
 ### Complete Example
@@ -127,7 +127,7 @@ Co-authored-by: <DevName> <DevEmail>
 ```bash
 git commit -m "feat: Add user authentication" \
     --trailer "Co-authored-by: <AgentName> (<ModelId>) <noreply@example.com>" \
-    --trailer "Co-authored-by: <DevName> <DevEmail>"
+    --trailer "Co-authored-by: <dev.name> <dev.email>"
 ```
 
 ## When Commits Happen

--- a/.opencode/skills/git-workflow/tasks/implementation.md
+++ b/.opencode/skills/git-workflow/tasks/implementation.md
@@ -37,15 +37,15 @@ git commit -m "WIP: <descriptive message>"
 
 ### ⚠️ CRITICAL: File Operation Tool Paths in Worktree
 
-When `WORKTREE_PATH` is set, ALL file operation tool calls (`read`, `edit`, `write`, `glob`, `grep`) MUST prefix paths with the worktree path. These tools have NO `workdir` parameter — relative paths resolve to the main repo, causing silent errors.
+When `worktree.path` is set, ALL file operation tool calls (`read`, `edit`, `write`, `glob`, `grep`) MUST prefix paths with the worktree path. These tools have NO `workdir` parameter — relative paths resolve to the main repo, causing silent errors.
 
 | Tool | Wrong (operates on main repo) | Correct (targets worktree) |
 | -- | -- | -- |
-| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{WORKTREE_PATH}/src/main.py")` |
-| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)` |
-| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)` |
-| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` |
-| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` |
+| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{worktree.path}/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{worktree.path}/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{worktree.path}/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=worktree.path)` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{worktree.path}/src/")` |
 
 **For `bash` tool:** Continue using `workdir` parameter as documented in `using-git-worktrees` skill.
 

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -236,10 +236,10 @@ branch_name = subprocess.check_output(['git', 'branch', '--show-current'], text=
 
 # List PRs for this branch
 prs = github_list_pull_requests(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     state="all",
-    head=f"{<GitOwner>}:{branch_name}"
+    head=f"{<github.owner>}:{branch_name}"
 )
 ```
 
@@ -359,7 +359,7 @@ For OPEN PRs, check the `mergeable` attribute from GitHub API:
 ```python
 # For existing open PRs
 if pr_state == "open":
-    pr_details = github_pull_request_read(method="get", owner=<GitOwner>, repo=<GitRepo>, pullNumber=pr_number)
+    pr_details = github_pull_request_read(method="get", owner=<github.owner>, repo=<github.repo>, pullNumber=pr_number)
     mergeable = pr_details.get("mergeable")  # True, False, or None
     mergeable_state = pr_details.get("mergeable_state")  # "clean", "dirty", "unknown", etc.
 ```
@@ -683,10 +683,10 @@ git rebase origin/dev
 
 All feature branches operate in worktrees. There is no alternative — worktree is the only method.
 
-If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
-1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
-2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{WORKTREE_PATH}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
+1. All `bash` tool calls MUST use `workdir="{{worktree.path}}"`
+2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{worktree.path}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
 3. Before any push/squash/rebase operation, verify:
    ```bash
    git branch --show-current
@@ -729,7 +729,7 @@ No sub-issues needed. Include only parent issue.
 
 ### Step 6: Create PR (Platform-Agnostic)
 
-**Detect platform from session init (`GIT_PLATFORM`) and use appropriate tool:**
+**Detect platform from session init (`github.platform`) and use appropriate tool:**
 
 **Three-Branch Workflow Target:**
 
@@ -737,12 +737,12 @@ No sub-issues needed. Include only parent issue.
 - Releases PR from `dev` to `main` (human-triggered, not by AI)
 - Hotfixes PR to both `dev` and `main` (paired issues)
 
-#### GitHub (GIT_PLATFORM=github)
+#### GitHub (github.platform=github)
 
 ```python
 github_create_pull_request(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     title="[SPEC] <description>",
     body="""**Summary:**
 
@@ -760,15 +760,15 @@ Fixes #<child2>
 )
 ```
 
-#### GitBucket (GIT_PLATFORM=gitbucket)
+#### GitBucket (github.platform=gitbucket)
 
 ```python
 from skills.gitbucket_api.tools import GitBucketAPI
 
 api = GitBucketAPI()
 pr = api.create_pull_request(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     title="[SPEC] <description>",
     body="""**Summary:**
 
@@ -843,7 +843,7 @@ Fixes #505
 
 **Outcome:** <What changed for stakeholders>
 
-**PR URL:** <GitBucketHtmlUrl><GitOwner>/<GitRepo>/pull/<number>
+**PR URL:** <gitbucket.html_url><github.owner>/<github.repo>/pull/<number>
 
 Wait for human to merge.
 ```
@@ -1038,8 +1038,8 @@ Every squash commit MUST include:
 **Human Trailer:**
 
 - Use session values from the session-enforcement plugin
-- `<DevName>`: Human's name
-- `<DevEmail>`: Human's email
+- `<dev.name>`: Human's name
+- `<dev.email>`: Human's email
 - Format: `Co-authored-by: <Human-Name> <human-email>`
 
 ## Sub-Issue Autoclose

--- a/.opencode/skills/git-workflow/tasks/pre-work.md
+++ b/.opencode/skills/git-workflow/tasks/pre-work.md
@@ -125,10 +125,10 @@ Invoke `using-git-worktrees` skill (ALWAYS, for ANY feature branch):
 
 1. Invoke `using-git-worktrees` skill
 2. The skill creates the worktree: `git worktree add .worktrees/spec-<name> -b spec/<name> dev`
-3. The skill exports `WORKTREE_PATH`, `BRANCH_NAME`, `DEV_BASE_HASH` as environment variables
-4. If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT**
+3. The skill exports `worktree.path`, `branch`, `DEV_BASE_HASH` as environment variables
+4. If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT**
 
-**If worktree creation fails or `WORKTREE_FATAL=1` is detected:**
+**If worktree creation fails or `worktree.fatal=1` is detected:**
 
 - HALT immediately
 - Report the fatal error to the developer
@@ -339,7 +339,7 @@ If found, report collision and HALT — do not reuse another branch's worktree.
 | Current branch | `git branch --show-current` | Feature branch name (not `main`, `dev`) | STRUCTURE-VIOLATION → HALT |
 | Working tree clean | `git status --porcelain` | Empty output | VERIFICATION-GAP → stash or commit first |
 | Worktree location | `git rev-parse --show-toplevel` | Worktree path (not main repo path) | STRUCTURE-VIOLATION → HALT |
-| WORKTREE_PATH set | `echo $WORKTREE_PATH` (or equivalent) | Non-empty, matches worktree dir | STRUCTURE-VIOLATION → HALT (fatal) |
+| worktree.path set | `echo $WORKTREE_PATH` (or equivalent) | Non-empty, matches worktree dir | STRUCTURE-VIOLATION → HALT (fatal) |
 | Dev base hash | `git rev-parse --short dev` | Valid 7-char SHA | MISSING-ELEMENT → sync dev first |
 
 ### Verification Procedure
@@ -350,7 +350,7 @@ If found, report collision and HALT — do not reuse another branch's worktree.
 1. git branch --show-current → EVIDENCE: <branch-name>
 2. git status --porcelain → EVIDENCE: <output or "(empty)">
 3. git rev-parse --show-toplevel → EVIDENCE: <path>
-4. WORKTREE_PATH → EVIDENCE: <path or "(empty)">
+4. worktree.path → EVIDENCE: <path or "(empty)">
 ```
 
 **Classification on failure:**
@@ -360,7 +360,7 @@ If found, report collision and HALT — do not reuse another branch's worktree.
 | On `main` or `dev` branch | CONFLICTING | flag-for-review | HALT — must create worktree first |
 | Dirty working tree in worktree | VERIFICATION-GAP | conditional | Stash or commit before implementation |
 | `rev-parse` returns main repo path | STRUCTURE-VIOLATION | auto-fix | Not in worktree — re-invoke using-git-worktrees |
-| WORKTREE_PATH empty | STRUCTURE-VIOLATION | auto-fix | FATAL — cannot safely do file operations |
+| worktree.path empty | STRUCTURE-VIOLATION | auto-fix | FATAL — cannot safely do file operations |
 | dev hash stale | MISSING-ELEMENT | conditional | Re-run `git pull origin dev` |
 
 **These verifications are MANDATORY. Skipping them is a CRITICAL GUIDELINE VIOLATION.**
@@ -376,7 +376,7 @@ If found, report collision and HALT — do not reuse another branch's worktree.
 
 - ✅ Authorization received (explicit `approved`, `go`, or `"#N approved"`)
 - ✅ Worktree created (not on `main` or `dev`)
-- ✅ `WORKTREE_PATH` environment variable is set and non-empty (FATAL ERROR if empty)
+- ✅ `worktree.path` environment variable is set and non-empty (FATAL ERROR if empty)
 - ✅ `git branch --show-current` in worktree shows feature branch
 - ✅ Feature branch created from `dev`
 

--- a/.opencode/skills/git-workflow/tasks/provenance.md
+++ b/.opencode/skills/git-workflow/tasks/provenance.md
@@ -348,7 +348,7 @@ Post a comment on the parent issue (<parent-issue>) in the parent repo:
   <AgentName> (<ModelId>)
 ```
 
-- For GitHub: github_add_issue_comment(owner=<GitOwner>, repo=<GitRepo>, issue_number=<parent-issue>, body=...)
+- For GitHub: github_add_issue_comment(owner=<github.owner>, repo=<github.repo>, issue_number=<parent-issue>, body=...)
 - For GitBucket: POST /api/v3/repos/<owner>/<repo>/issues/<number>/comments
 
 When Tier 3 is used, no parent issue comment is posted (no submodule issue exists to reference).
@@ -407,8 +407,8 @@ When invoking provenance from review-prep, pass these parameters:
 
 | Parameter | Source |
 | -- | -- |
-| parent_repo | `<GitOwner>/<GitRepo>` from session init |
-| parent_branch | Current feature branch name (BRANCH_NAME) |
+| parent_repo | `<github.owner>/<github.repo>` from session init |
+| parent_branch | Current feature branch name (branch) |
 | parent_issue | Issue number from the implementation spec |
 | submodule_path | Path of the pushed submodule within parent repo |
 | change_description | Brief description of what changed |
@@ -564,7 +564,7 @@ Post a comment on the parent issue (<parent-issue>) in the parent repo:
 
   <AgentName> (<ModelId>)
 
-- For GitHub: github_add_issue_comment(owner=<GitOwner>, repo=<GitRepo>, issue_number=<parent-issue>, body=...)
+- For GitHub: github_add_issue_comment(owner=<github.owner>, repo=<github.repo>, issue_number=<parent-issue>, body=...)
 - For GitBucket: POST /api/v3/repos/<owner>/<repo>/issues/<number>/comments
 ```
 
@@ -627,7 +627,7 @@ When invoking provenance for promotion, pass these parameters:
 
 | Parameter | Source |
 | -- | -- |
-| parent_repo | `<GitOwner>/<GitRepo>` from session init |
+| parent_repo | `<github.owner>/<github.repo>` from session init |
 | parent_branch | The branch being released (commonly `main` or `dev`) |
 | parent_issue | Issue number from the release spec |
 | submodule_path | Path of the promoted submodule within parent repo |
@@ -679,7 +679,7 @@ When Tier 1 or Tier 2 succeeds:
 
    <AgentName> (<ModelId>)
 
- 2. For GitHub: github_add_issue_comment(owner=<GitOwner>, repo=<GitRepo>, issue_number=<parent-issue>, body=...)
+ 2. For GitHub: github_add_issue_comment(owner=<github.owner>, repo=<github.repo>, issue_number=<parent-issue>, body=...)
 3. For GitBucket: POST /api/v3/repos/<owner>/<repo>/issues/<number>/comments
 ```
 
@@ -699,7 +699,7 @@ When Tier 1 or Tier 2 succeeds:
 
    <AgentName> (<ModelId>)
 
- 2. For GitHub: github_add_issue_comment(owner=<GitOwner>, repo=<GitRepo>, issue_number=<parent-issue>, body=...)
+ 2. For GitHub: github_add_issue_comment(owner=<github.owner>, repo=<github.repo>, issue_number=<parent-issue>, body=...)
 3. For GitBucket: POST /api/v3/repos/<owner>/<repo>/issues/<number>/comments
 ```
 

--- a/.opencode/skills/git-workflow/tasks/rebase-pending.md
+++ b/.opencode/skills/git-workflow/tasks/rebase-pending.md
@@ -43,8 +43,8 @@ List all open PRs and identify candidates for rebasing.
 ```python
 # List all open PRs on the repo
 open_prs = github_list_pull_requests(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     state="open"
 )
 
@@ -132,10 +132,10 @@ When a Tier 3 conflict is detected, perform spec-aware analysis:
 ```
 a. Read the conflicting file content (both sides of the conflict markers)
 b. Read the merged PR's issue/spec body:
-   github_issue_read(method="get", owner=<GitOwner>, repo=<GitRepo>, issue_number=<merged_pr_number>)
+   github_issue_read(method="get", owner=<github.owner>, repo=<github.repo>, issue_number=<merged_pr_number>)
    (Or locate the spec issue linked from the PR)
 c. Read the conflicting PR's issue/spec body:
-   github_issue_read(method="get", owner=<GitOwner>, repo=<GitRepo>, issue_number=<conflicting_pr_number>)
+   github_issue_read(method="get", owner=<github.owner>, repo=<github.repo>, issue_number=<conflicting_pr_number>)
    (Or locate the spec issue linked from the PR)
 d. Compare intent:
    - Same intent: Both PRs modify the same file for compatible purposes

--- a/.opencode/skills/git-workflow/tasks/release-promotion.md
+++ b/.opencode/skills/git-workflow/tasks/release-promotion.md
@@ -209,7 +209,7 @@ Invoke: /skill git-workflow --task provenance --mode=promotion
 
 | Parameter | Value |
 | -- | -- |
-| parent_repo | `<GitOwner>/<GitRepo>` from session init |
+| parent_repo | `<github.owner>/<github.repo>` from session init |
 | parent_branch | The branch being released (commonly `main` or `dev`) |
 | parent_issue | Issue number from the release spec |
 | submodule_path | Path of the promoted submodule |
@@ -337,7 +337,7 @@ git push origin main --tags
 Use GitHub MCP to create release:
 
 ```
-github_get_latest_release(owner=<GitOwner>, repo=<GitRepo>)
+github_get_latest_release(owner=<github.owner>, repo=<github.repo>)
 ```
 
 Then create release via GitHub API with:

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -204,8 +204,8 @@ For each submodule that was pushed in the Per-Submodule Push Sequence above:
 ```
 1. Invoke: /skill git-workflow --task provenance --mode=dev-push
    with parameters:
-     - parent_repo: <GitOwner>/<GitRepo>
-     - parent_branch: <BRANCH_NAME>
+     - parent_repo: <github.owner>/<github.repo>
+     - parent_branch: <branch>
      - parent_issue: <issue number from current implementation>
      - submodule_path: <path of the pushed submodule>
      - change_description: <brief description of what changed>
@@ -316,10 +316,10 @@ git rebase origin/dev
 
 All feature branches operate in worktrees. There is no alternative — worktree is the only method.
 
-If `WORKTREE_PATH` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
+If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** Do not proceed without a valid worktree path.
 
-1. All `bash` tool calls MUST use `workdir="{{WORKTREE_PATH}}"`
-2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{WORKTREE_PATH}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
+1. All `bash` tool calls MUST use `workdir="{{worktree.path}}"`
+2. All `read`/`edit`/`write`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `{{worktree.path}}/` — these tools have NO `workdir` parameter and resolve relative paths against the main repo
 3. Before any push/squash/rebase operation, verify:
    ```bash
    git branch --show-current
@@ -352,26 +352,26 @@ git push -u origin <branch-name>
 
 **⚠️ CRITICAL: URLs must be constructed from session init values ONLY. Never hardcode domains.**
 
-Using session values (<GitOwner>, <GitRepo>, GIT_PLATFORM, <GitBucketHtmlUrl>):
+Using session values (<github.owner>, <github.repo>, github.platform, <gitbucket.html_url>):
 
-**For GitBucket (GIT_PLATFORM=gitbucket):**
-
-```
-<GitBucketHtmlUrl><GitOwner>/<GitRepo>/compare/dev...<branch-name>
-```
-
-Where `<GitBucketHtmlUrl>` comes from session init (read from `.env`).
-
-**For GitHub (GIT_PLATFORM=github):**
+**For GitBucket (github.platform=gitbucket):**
 
 ```
-https://github.com/<GitOwner>/<GitRepo>/compare/dev...<branch-name>
+<gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch-name>
 ```
 
-**If <GitBucketHtmlUrl> is empty (not in .env):**
+Where `<gitbucket.html_url>` comes from session init (read from `.env`).
+
+**For GitHub (github.platform=github):**
+
+```
+https://github.com/<github.owner>/<github.repo>/compare/dev...<branch-name>
+```
+
+**If <gitbucket.html_url> is empty (not in .env):**
 
 1. REFUSE to generate any URL
-2. Report: "Cannot generate URL — <GitBucketHtmlUrl> not configured in .env"
+2. Report: "Cannot generate URL — <gitbucket.html_url> not configured in .env"
 3. HALT — do not guess or fabricate a URL
 
 ### Step 4: Report Completion (Chat Only)
@@ -387,12 +387,12 @@ Report to chat (exec summary + URL + AI byline):
 
 **Outcome:** <What changed for stakeholders>
 
-Compare URL: <GitBucketHtmlUrl><GitOwner>/<GitRepo>/compare/dev...<branch-name>
+Compare URL: <gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch-name>
 
 🤖 <AgentName> (<ModelId>) completed
 ```
 
-(GitBucket example — for GitHub use `https://github.com/<GitOwner>/<GitRepo>/compare/dev...<branch-name>`)
+(GitBucket example — for GitHub use `https://github.com/<github.owner>/<github.repo>/compare/dev...<branch-name>`)
 
 **URL Label Context:**
 
@@ -509,7 +509,7 @@ After generating the compare URL (Step 3) and before HALT (Step 5), verify ALL e
 | Executive summary present | Review chat output | First element is `**Summary:**` block | MISSING-ELEMENT → add before proceeding |
 | Outcome present | Review chat output | `**Outcome:**` line follows summary | MISSING-ELEMENT → add before proceeding |
 | URL label context-appropriate | Review chat output | Pre-PR: "Compare URL" with `compare/dev...`; Post-PR: "PR URL" with `pull/N`; label-format mismatch = critical violation | STRUCTURE-VIOLATION → fix label and format to match context |
-| URL present | Review chat output | URL starts with `https://github.com/` or `<GitBucketHtmlUrl>` | MISSING-ELEMENT → generate URL before proceeding |
+| URL present | Review chat output | URL starts with `https://github.com/` or `<gitbucket.html_url>` | MISSING-ELEMENT → generate URL before proceeding |
 | AI byline present | Review chat output | Ends with `🤖 <AgentName> (<ModelId>)` line | MISSING-ELEMENT → add before proceeding |
 | No URL before summary | Review chat output | URL appears AFTER summary, not before | STRUCTURE-VIOLATION → reorder output |
 | No byline before URL | Review chat output | Byline appears AFTER URL, not before | STRUCTURE-VIOLATION → reorder output |
@@ -525,7 +525,7 @@ After generating the compare URL (Step 3) and before HALT (Step 5), verify ALL e
 
 **Outcome:** <What changed for stakeholders>
 
-Compare URL: https://github.com/<GitOwner>/<GitRepo>/compare/dev...<branch-name>
+Compare URL: https://github.com/<github.owner>/<github.repo>/compare/dev...<branch-name>
 
 🤖 <AgentName> (<ModelId>) <status>
 ```
@@ -533,7 +533,7 @@ Compare URL: https://github.com/<GitOwner>/<GitRepo>/compare/dev...<branch-name>
 **After a PR has been created**, replace "Compare URL" with "PR URL" and use the `pull/N` format:
 
 ```
-PR URL: https://github.com/<GitOwner>/<GitRepo>/pull/<PR-number>
+PR URL: https://github.com/<github.owner>/<github.repo>/pull/<PR-number>
 
 🤖 <AgentName> (<ModelId>) <status>
 ```
@@ -742,7 +742,7 @@ Updated git-workflow skill to push feature branches after implementation and pro
 
 **Ready for Review:**
 
-<GitBucketHtmlUrl><GitOwner>/<GitRepo>/compare/dev...<branch-name>
+<gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch-name>
 
 ---
 🤖 <AgentName> (<ModelId>) completed

--- a/.opencode/skills/issue-operations/SKILL.md
+++ b/.opencode/skills/issue-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations
-description: Platform-agnostic issue operations dispatcher. Routes to GitHub MCP or GitBucket API based on GIT_PLATFORM. Triggers on: create issue, new issue, spec creation, submit issue, issue, bug report, comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator, sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue, close issue, verify merge.
+description: Platform-agnostic issue operations dispatcher. Routes to GitHub MCP or GitBucket API based on github.platform. Triggers on: create issue, new issue, spec creation, submit issue, issue, bug report, comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator, sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue, close issue, verify merge.
 type: technique
 license: MIT
 compatibility: opencode
@@ -10,7 +10,7 @@ compatibility: opencode
 
 ## Overview
 
-Platform-agnostic Issue Operations dispatcher. Detects `GIT_PLATFORM` from session init and routes all issue tracking operations to the appropriate platform sub-skill. Absorbs and replaces `github-issue-creation`, `github-comments`, and `github-sub-issues`.
+Platform-agnostic Issue Operations dispatcher. Detects `github.platform` from session init and routes all issue tracking operations to the appropriate platform sub-skill. Absorbs and replaces `github-issue-creation`, `github-comments`, and `github-sub-issues`.
 
 ## Persona
 
@@ -78,9 +78,9 @@ issue-operations/                     # Dispatcher — workflow logic, platform 
 
 ### Detection
 
-The dispatcher detects `GIT_PLATFORM` from session init output:
+The dispatcher detects `github.platform` from session init output:
 
-| `GIT_PLATFORM` | Platform Sub-Skill |
+| `github.platform` | Platform Sub-Skill |
 |----------------|-------------------|
 | `github` | `platforms/github-mcp/` |
 | `gitbucket` | `platforms/gitbucket-api/` |
@@ -92,7 +92,7 @@ The dispatcher detects `GIT_PLATFORM` from session init output:
 target:
   owner:     # overridden for submodules
   repo:        # overridden for submodules
-  platform:   # rarely overridden (defaults to session GIT_PLATFORM)
+  platform:   # rarely overridden (defaults to session github.platform)
 ```
 
 ### Capability Resolution (Hybrid)
@@ -328,7 +328,7 @@ All tasks are under 1,000 words — inline execution. No sub-agent dispatch need
 | "Issue has `needs-approval` label" | Verify label presence | `github_issue_read(method="get_labels", issue_number=N)` | VERIFICATION-GAP |
 | "All sub-issues closed" | Verify each sub-issue state | `github_issue_read(method="get_sub_issues", issue_number=N)` → check each closed | VERIFICATION-GAP |
 | "No conflicting spec exists" | Search for overlapping issues | `github_search_issues(query="label:spec <keyword>")` | CONFLICTING |
-| "Session init has <GitOwner>/<GitRepo>" | Verify session values | Check session init output | MISSING-ELEMENT |
+| "Session init has <github.owner>/<github.repo>" | Verify session values | Check session init output | MISSING-ELEMENT |
 
 **Evidence artifact:** Tool call results for each claim before the operation proceeds.
 

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/API-DEFICIENCIES.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/API-DEFICIENCIES.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document records discovered API deficiencies between the OpenAPI specification and actual GitBucket API behavior. These deficiencies were discovered through testing against `<GitOwner>/<GitRepo>` repository.
+This document records discovered API deficiencies between the OpenAPI specification and actual GitBucket API behavior. These deficiencies were discovered through testing against `<github.owner>/<github.repo>` repository.
 
 **Testing Date:** 2026-04-06
 **GitBucket Version:** v4.42.1 (per OpenAPI spec)
@@ -12,7 +12,7 @@ This document records discovered API deficiencies between the OpenAPI specificat
 
 **Test Script:** `.opencode/skills/gitbucket-api/tests/verify_api.py` (permanent test suite)
 
-**Test Repository:** `<GitOwner>/<GitRepo>`
+**Test Repository:** `<github.owner>/<github.repo>`
 
 **How to Retest:**
 ```bash
@@ -87,7 +87,7 @@ Response: 200 OK with empty array []
 
 **Post-Upgrade Test (2026-04-06):**
 ```bash
-Testing POST https://<GITBUCKET_HOST>/gitbucket/api/v3/repos/<GitOwner>/<GitRepo>/issues/6/labels
+Testing POST https://<GITBUCKET_HOST>/gitbucket/api/v3/repos/<github.owner>/<github.repo>/issues/6/labels
    Labels to add: ['test-label-1', 'test-label-2']
    Status: 200
    Response: []
@@ -98,7 +98,7 @@ Testing POST https://<GITBUCKET_HOST>/gitbucket/api/v3/repos/<GitOwner>/<GitRepo
 
 **Workaround FAILED:** `replace_issue_labels()` also returns empty array.
 ```
-Testing PUT https://<GITBUCKET_HOST>/gitbucket/api/v3/repos/<GitOwner>/<GitRepo>/issues/7/labels
+Testing PUT https://<GITBUCKET_HOST>/gitbucket/api/v3/repos/<github.owner>/<github.repo>/issues/7/labels
    Labels to set: ['replace-test-1', 'replace-test-2']
    Status: 200
    Response: []
@@ -144,7 +144,7 @@ These deficiencies are documented in `SKILL.md` under "API Deficiencies Document
 
 ## Testing Methodology
 
-**Test Repository:** `<GitOwner>/<GitRepo>`
+**Test Repository:** `<github.owner>/<github.repo>`
 
 **Test Script:** See `./tmp/test_gitbucket_api_operations.py` (temporary, deleted after testing)
 

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -10,7 +10,7 @@ compatibility: opencode
 
 ## Overview
 
-GitBucket platform implementation using Python client. Implements a GitHub-compatible API v3 with known deficiencies. This is a platform sub-skill under `issue-operations` — the dispatcher routes GitBucket operations here when `GIT_PLATFORM=gitbucket`.
+GitBucket platform implementation using Python client. Implements a GitHub-compatible API v3 with known deficiencies. This is a platform sub-skill under `issue-operations` — the dispatcher routes GitBucket operations here when `github.platform=gitbucket`.
 
 ## Capability Manifest (v4.46.0, empirically probed)
 

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/error-recovery.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/error-recovery.md
@@ -75,12 +75,12 @@ json=["bug", "enhancement"]  # ✅
 Session init script (`.opencode/tools/session-init`) detects GitBucket from remote URL and outputs:
 
 ```
-GIT_PLATFORM=gitbucket
-GITBUCKET_HTML_URL=https://gitbucket.example.com/gitbucket/
-GITBUCKET_HAS_CREDENTIALS=true
+github.platform: gitbucket
+gitbucket.html_url: https://gitbucket.example.com/gitbucket/
+gitbucket.has_credentials: true
 ```
 
-**If `GITBUCKET_HAS_CREDENTIALS=false`**, token is missing from `.env`.
+**If `gitbucket.has_credentials=false`**, token is missing from `.env`.
 
 ## Token Validation
 

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/repository-operations.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/repository-operations.md
@@ -222,7 +222,7 @@ def check_repo_health(owner: str, repo: str):
         return True
 
 # Run health check
-check_repo_health(owner="<GitOwner>", repo="<GitRepo>")
+check_repo_health(owner="<github.owner>", repo="<github.repo>")
 ```
 
 ### Workflow 4: Sync Fork with Upstream

--- a/.opencode/skills/issue-operations/tasks/capabilities.md
+++ b/.opencode/skills/issue-operations/tasks/capabilities.md
@@ -6,7 +6,7 @@ Probe platform capabilities at runtime. Determines what operations the current p
 
 ## Entry Criteria
 
-- `GIT_PLATFORM` detected from session init
+- `github.platform` detected from session init
 - Platform sub-skill available
 
 ## Exit Criteria
@@ -19,7 +19,7 @@ Probe platform capabilities at runtime. Determines what operations the current p
 ### Step 1: Detect Platform
 
 ```
-GIT_PLATFORM environment variable:
+github.platform session value:
   "github"    → platforms/github-mcp/
   "gitbucket"  → platforms/gitbucket-api/
   (unset)      → platforms/github-mcp/ (default)
@@ -82,7 +82,7 @@ When the GitBucket MCP plugin implements missing endpoints, the capability lands
 
 ## Context Required
 
-- Session values: GIT_PLATFORM
+- Session values: github.platform
 - Platform sub-skill: `../platforms/github-mcp/SKILL.md` or `../platforms/gitbucket-api/SKILL.md`
 
 ## Live Verification: Capabilities Evidence (MANDATORY)
@@ -91,7 +91,7 @@ When the GitBucket MCP plugin implements missing endpoints, the capability lands
 
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|-------------------|-----------|---------------|
-| "GIT_PLATFORM is X" | Verify session init value | Check session init output | MISSING-ELEMENT |
+| "github.platform is X" | Verify session init value | Check session init output | MISSING-ELEMENT |
 | "Platform supports operation Y" | Probe platform SKILL.md or MCP | `read(path=".opencode/skills/issue-operations/platforms/<platform>/SKILL.md")` | CONFLICTING |
 | "MCP plugin present" | Check for platform MCP tools | `grep(pattern="gitbucket_", path=".opencode/skills/issue-operations/platforms/")` | VERIFICATION-GAP |
 

--- a/.opencode/skills/issue-operations/tasks/close.md
+++ b/.opencode/skills/issue-operations/tasks/close.md
@@ -36,8 +36,8 @@ Invoke `verify-merge` task to confirm PR is actually merged before closing any i
 ```python
 github_issue_write(
     method="update",
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     issue_number=N,
     state="closed",
     state_reason="completed"
@@ -51,8 +51,8 @@ github_issue_write(
 from skills.gitbucket_api.tools import GitBucketAPI
 api = GitBucketAPI()
 api.add_issue_comment(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     issue_number=N,
     body="Closing: PR merged and implementation verified."
 )
@@ -86,7 +86,7 @@ All tasks complete from this specification.
 
 ## Context Required
 
-- Session values: GIT_OWNER, GIT_REPO, GIT_PLATFORM
+- Session values: github.owner, github.repo, github.platform
 - Related tasks: `verify-merge` (runs first), `comment` (format for closure comment)
 - Parent/child closure order per `010-approval-gate.md`
 

--- a/.opencode/skills/issue-operations/tasks/comment.md
+++ b/.opencode/skills/issue-operations/tasks/comment.md
@@ -91,8 +91,8 @@ Stakeholders need understanding, not commit logs. GitHub diffs already show what
 **GitHub platform:**
 ```python
 github_add_issue_comment(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     issue_number=N,
     body=formatted_comment
 )
@@ -103,8 +103,8 @@ github_add_issue_comment(
 from skills.gitbucket_api.tools import GitBucketAPI
 api = GitBucketAPI()
 api.add_issue_comment(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     issue_number=N,
     body=formatted_comment
 )
@@ -131,6 +131,6 @@ api.add_issue_comment(
 
 ## Context Required
 
-- Session values: GIT_OWNER, GIT_REPO, GIT_PLATFORM
+- Session values: github.owner, github.repo, github.platform
 - Related tasks: `close` (uses comment for closure), `link-sub-issue` (uses comment for fallback)
 - Platform routing: `../platforms/github-mcp/` or `../platforms/gitbucket-api/`

--- a/.opencode/skills/issue-operations/tasks/completion.md
+++ b/.opencode/skills/issue-operations/tasks/completion.md
@@ -47,7 +47,7 @@ Generate executive summary in chat:
 
 **Outcome:** <What stakeholders get from the new issue>
 
-Issue URL: <GitBucketHtmlUrl><GitOwner>/<GitRepo>/issues/<number>
+Issue URL: <gitbucket.html_url><github.owner>/<github.repo>/issues/<number>
 ```
 
 URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/issue-operations/tasks/link-sub-issue.md
+++ b/.opencode/skills/issue-operations/tasks/link-sub-issue.md
@@ -47,8 +47,8 @@ Read the full plan issue body and locate the section for the target phase. Extra
 ```python
 sub_issue = github_issue_write(
     method="create",
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     title=f"[Task: #{M}] {phase_description}",
     body=f"**Parent Plan:** #{M}\n\n{phase_prose}",
     labels=["task"]
@@ -60,8 +60,8 @@ sub_issue = github_issue_write(
 from skills.gitbucket_api.tools import GitBucketAPI
 api = GitBucketAPI()
 sub_issue = api.create_issue(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     title=f"[Task: #{M}] {phase_description}",
     body=f"**Parent Plan:** #{M}\n\n{phase_prose}",
     labels=["task"]
@@ -74,8 +74,8 @@ sub_issue = api.create_issue(
 ```python
 github_sub_issue_write(
     method="add",
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     issue_number=M,
     sub_issue_id=sub_issue["id"]
 )
@@ -86,8 +86,8 @@ CRITICAL: Use database ID (`.id`), not issue number.
 **GitBucket platform (comment-based fallback):**
 ```python
 api.add_issue_comment(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     issue_number=M,
     body=f"**Sub-issue linked:** #{sub_issue['number']} — {phase_description}"
 )
@@ -107,7 +107,7 @@ Title format: `[Task: #<plan-number>] <descriptive-title>`
 
 ## Context Required
 
-- Session values: GIT_OWNER, GIT_REPO, GIT_PLATFORM
+- Session values: github.owner, github.repo, github.platform
 - Related tasks: `close` (verifies sub-issue state), `track-hierarchy` (verifies structure)
 - Sub-issue closure queries parent comments when comment-based linking was used
 

--- a/.opencode/skills/issue-operations/tasks/pre-creation.md
+++ b/.opencode/skills/issue-operations/tasks/pre-creation.md
@@ -82,7 +82,7 @@ The check is content-coverage, not structural conformity. A spec that covers all
 
 1. Using `github_search_issues`, search for issues labeled `plan` in the repository:
    ```
-   github_search_issues(query="label:plan", owner=<GitOwner>, repo=<GitRepo>, state="open")
+   github_search_issues(query="label:plan", owner=<github.owner>, repo=<github.repo>, state="open")
    ```
 2. Filter results for those whose body contains `Spec: #<spec_number>` referencing the spec that will be planned.
 3. If one or more existing plans are found:

--- a/.opencode/skills/issue-operations/tasks/verify-merge.md
+++ b/.opencode/skills/issue-operations/tasks/verify-merge.md
@@ -22,8 +22,8 @@ Verify that a PR has actually been merged before closing associated issues. Prev
 ```python
 pr = github_pull_request_read(
     method="get",
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     pullNumber=N
 )
 merged = pr.get("merged", False)
@@ -34,7 +34,7 @@ state = pr.get("state", "unknown")
 ```python
 from skills.gitbucket_api.tools import GitBucketAPI
 api = GitBucketAPI()
-pr = api.get_pull_request(owner=<GitOwner>, repo=<GitRepo>, pull_number=N)
+pr = api.get_pull_request(owner=<github.owner>, repo=<github.repo>, pull_number=N)
 merged = pr.get("merged", False)
 state = pr.get("state", "unknown")
 ```
@@ -59,7 +59,7 @@ When searching for a PR that fixes a specific issue on GitBucket (no search API)
 ```python
 from skills.gitbucket_api.tools import GitBucketAPI
 api = GitBucketAPI()
-prs = api.list_pull_requests(owner=<GitOwner>, repo=<GitRepo>, state="closed")
+prs = api.list_pull_requests(owner=<github.owner>, repo=<github.repo>, state="closed")
 matching_pr = None
 for pr in prs:
     if f"#{issue_number}" in pr.get("body", "") or f"Fixes #{issue_number}" in pr.get("body", ""):
@@ -78,7 +78,7 @@ for pr in prs:
 
 ## Context Required
 
-- Session values: GIT_OWNER, GIT_REPO, GIT_PLATFORM
+- Session values: github.owner, github.repo, github.platform
 - Related tasks: `close` (uses merge verification before closing)
 
 ## Live Verification: Merge Evidence (MANDATORY)

--- a/.opencode/skills/issue-review/tasks/analyze-and-spec.md
+++ b/.opencode/skills/issue-review/tasks/analyze-and-spec.md
@@ -97,8 +97,8 @@ Invoke `issue-operations` skill to create the fix spec:
 ```
 github_issue_write(
     method="create",
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     title="[SPEC] Fix: <brief bug description>",
     body="<fix spec body from Step 4>",
     labels=["spec", "needs-approval"]
@@ -112,8 +112,8 @@ Link the newly created fix spec as a sub-issue of the bug report:
 ```
 github_sub_issue_write(
     method="add",
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     issue_number=<bug_report_number>,
     sub_issue_id=<fix_spec_database_id>
 )
@@ -127,8 +127,8 @@ Add a comment to the bug report summarizing the analysis and linking the fix spe
 
 ```
 github_add_issue_comment(
-    owner=<GitOwner>,
-    repo=<GitRepo>,
+    owner=<github.owner>,
+    repo=<github.repo>,
     issue_number=<bug_report_number>,
     body="Root cause analysis complete. Fix spec created: #<fix_spec_number>"
 )

--- a/.opencode/skills/mcp-tool-usage/SKILL.md
+++ b/.opencode/skills/mcp-tool-usage/SKILL.md
@@ -79,19 +79,19 @@ Bash/shell commands ONLY when no other tool covers the operation or it's inheren
 
 ## Owner Inference Prohibition (ZERO TOLERANCE)
 
-**DO NOT infer GitHub owner from file paths, usernames, or cached values.** Use ONLY values from session-enforcement plugin output (`<GitOwner>`, `<GitRepo>`).
+**DO NOT infer GitHub owner from file paths, usernames, or cached values.** Use ONLY values from session-enforcement plugin output (`<github.owner>`, `<github.repo>`).
 
 ## Worktree Path Resolution
 
-When `WORKTREE_PATH` is set, ALL file operations MUST prefix paths with the worktree path. TIER 1 tools (`read`, `edit`, `write`, `glob`, `grep`) resolve relative paths to the **main repo**, NOT the worktree.
+When `worktree.path` is set, ALL file operations MUST prefix paths with the worktree path. TIER 1 tools (`read`, `edit`, `write`, `glob`, `grep`) resolve relative paths to the **main repo**, NOT the worktree.
 
 | Tool | Wrong (main repo) | Correct (worktree) |
 |------|-------------------|---------------------|
-| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{WORKTREE_PATH}/src/main.py")` |
-| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)` |
-| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)` |
-| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` |
-| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` |
+| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{worktree.path}/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{worktree.path}/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{worktree.path}/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=worktree.path)` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{worktree.path}/src/")` |
 
 For `bash` tool calls, continue using the `workdir` parameter.
 

--- a/.opencode/skills/receiving-code-review/SKILL.md
+++ b/.opencode/skills/receiving-code-review/SKILL.md
@@ -106,6 +106,6 @@ Before invoking any cross-referenced skill:
 
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Use Python client from gitbucket-api skill
-- **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+- **Platform Detection:** Uses `github.platform` environment variable
 
 **⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/requesting-code-review/SKILL.md
+++ b/.opencode/skills/requesting-code-review/SKILL.md
@@ -99,4 +99,4 @@ Before invoking any cross-referenced skill:
 
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Use Python client from gitbucket-api skill
-- **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+- **Platform Detection:** Uses `github.platform` environment variable

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -95,9 +95,9 @@ Strongly encourage sub-agents and sub-tasks for skill operations that risk consu
 
 ### Required in every skill that:
 
-1. **Performs git operations** — Must include a "Worktree Mode" section explaining how to handle `WORKTREE_PATH`
-2. **Dispatches sub-agents** — Must pass `WORKTREE_PATH` in the dispatch context/prompt
-3. **Reads or writes files** — Must document path prefixing rules when `WORKTREE_PATH` is set
+1. **Performs git operations** — Must include a "Worktree Mode" section explaining how to handle `worktree.path`
+2. **Dispatches sub-agents** — Must pass `worktree.path` in the dispatch context/prompt
+3. **Reads or writes files** — Must document path prefixing rules when `worktree.path` is set
 
 ### Worktree Mode Template
 
@@ -106,12 +106,12 @@ Every skill SKILL.md should include (adapt as appropriate for the skill's operat
 ```markdown
 ## Worktree Mode
 
-When `WORKTREE_PATH` is set:
-- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
-- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
+When `worktree.path` is set:
+- ALL `bash` tool calls MUST use `workdir` parameter set to `worktree.path`
+- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `worktree.path/`
 - `git` commands run from the worktree directory, NOT the main repo
 
-If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+If `worktree.path` is NOT set, operate normally from the project root.
 ```
 
 ### Sub-Agent Dispatch Template
@@ -119,15 +119,15 @@ If `WORKTREE_PATH` is NOT set, operate normally from the project root.
 When a skill dispatches sub-agents, the prompt MUST include:
 
 ```
-WORKTREE_PATH: <value or 'not set'>
-If WORKTREE_PATH is set, all file operations and git commands MUST use it as the base directory.
+worktree.path: <value or 'not set'>
+If worktree.path is set, all file operations and git commands MUST use it as the base directory.
 ```
 
 ### Validation Gate
 
 The `validate` task (`quick_validate.py`) SHOULD check for:
 - Skills with `bash` or `git` operations that lack a "Worktree Mode" section
-- Skills that dispatch sub-agents but don't pass `WORKTREE_PATH` in context
+- Skills that dispatch sub-agents but don't pass `worktree.path` in context
 
 **Rationale:** Sub-agents that don't receive worktree context silently modify the main repo instead of the feature branch. This is a context window safety issue (see #741).
 
@@ -138,8 +138,8 @@ The `validate` task (`quick_validate.py`) SHOULD check for:
 ### Required in every skill that:
 
 1. **References AI agents** — MUST use `<AgentName>` and `<ModelId>` placeholders in byline contexts, never specific agent names or model IDs
-2. **References developers** — MUST use `<DevName>` and `<DevEmail>` placeholders in angle-bracket form, matching `DEV_NAME` and `DEV_EMAIL` from session init
-3. **References organizations/repos** — MUST use `<GitOwner>` and `<GitRepo>` placeholders in angle-bracket form, matching `GIT_OWNER` and `GIT_REPO` from session init
+2. **References developers** — MUST use `<dev.name>` and `<dev.email>` placeholders in angle-bracket form, matching `dev.name` and `dev.email` from session init
+3. **References organizations/repos** — MUST use `<github.owner>` and `<github.repo>` (or `<gitbucket.owner>` and `<gitbucket.repo>` for GitBucket contexts) placeholders in angle-bracket form, matching `github.owner` and `github.repo` from session init
 4. **Contains bylines or attribution** — MUST use `🤖 <AgentName> (<ModelId>) <status-icon> <status>` format, never specific agent/model combinations
 
 ### Validation Gate
@@ -148,7 +148,7 @@ The `validate` task (`quick_validate.py`) SHOULD check for and flag:
 - Specific agent names in SKILL.md or task files — must use `<AgentName>` placeholder token
 - Specific model IDs in SKILL.md or task files — must use `<ModelId>` placeholder token
 - Specific developer names or emails in SKILL.md or task files
-- Specific org/repo names in SKILL.md or task files (except in examples using the `<GitOwner>/<GitRepo>` pattern)
+- Specific org/repo names in SKILL.md or task files (except in examples using the `<github.owner>/<github.repo>` pattern)
 - Specific platform URLs in SKILL.md or task files (except in examples using session init variable references)
 
 ### Placeholder Reference
@@ -157,25 +157,35 @@ The `validate` task (`quick_validate.py`) SHOULD check for and flag:
 |-----------|-------------|--------|
 | AI agent name | `<AgentName>` | System prompt identity detection |
 | AI model ID | `<ModelId>` | System prompt identity detection |
-| Developer name | `<DevName>` | Session init (`DEV_NAME`) |
-| Developer email | `<DevEmail>` | Session init (`DEV_EMAIL`) |
-| Organization | `<GitOwner>` | Session init (`GIT_OWNER`) |
-| Repository | `<GitRepo>` | Session init (`GIT_REPO`) |
-| Platform | `GIT_PLATFORM` | Session init |
-| GitHub URL | `GITHUB_HTML_URL` | Session init |
-| GitBucket URL | `GITBUCKET_HTML_URL` | Session init |
+| Developer name | `<dev.name>` | Session init (`dev.name`) |
+| Developer email | `<dev.email>` | Session init (`dev.email`) |
+| Organization | `<github.owner>` or `<gitbucket.owner>` | Session init (dotted names) |
+| Repository | `<github.repo>` or `<gitbucket.repo>` | Session init (dotted names) |
+| Platform | `github.platform` or `gitbucket.platform` | Session init |
+| GitHub URL | `github.html_url` | Session init |
+| GitBucket URL | `gitbucket.html_url` | Session init |
+
+## Two Independent Pipelines
+
+Session-init and env-loader are **two independent pipelines with zero cross-coupling**:
+
+- **Session-init** (`.opencode/tools/session-init`): stdout → LLM system prompt. Uses dotted `scope.param` names. Agents read these values directly as MCP tool parameters.
+- **Env-loader** (`.opencode/plugins/env-loader.ts`): `output.env[]` → bash environment. Uses UPPER_CASE names. Shell commands and Python scripts read these from `os.environ`.
+
+Changing session-init output names does NOT require changes to env-loader. Adding a new LLM-facing variable goes in session-init only. Adding a new bash-facing variable goes in env-loader only. Add to the correct pipeline based on which consumers need the variable.
 
 ## Session Init Variable Alignment Requirement
 
-Skills and guidelines reference session-init variables by exact name (e.g., `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`). These names MUST match the `KEY: value` output of `.opencode/tools/session-init` exactly 1:1.
+Skills and guidelines reference session-init variables by exact dotted name (e.g., `github.owner`, `github.repo`, `gitbucket.html_url`). These names MUST match the `key: value` output of `.opencode/tools/session-init` exactly 1:1.
 
 **When creating or updating a skill that references session-init variables:**
 
-1. **Use canonical variable names only** — never invent new names or use prose labels (e.g., use `GIT_OWNER`, not `Owner:`)
-2. **Verify new variable references exist in session-init output** — if a skill needs a session-init variable that doesn't appear in `.opencode/tools/session-init`, the variable MUST be added to both `.opencode/tools/session-init` and `env-loader.ts` before the skill ships
-3. **The canonical variable list is:** `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`
+1. **Use canonical dotted variable names only** — never invent new names or use prose labels (e.g., use `github.owner`, not `Owner:`)
+2. **Verify new variable references exist in session-init output** — if a skill needs a session-init variable that doesn't appear in `.opencode/tools/session-init`, it MUST be added to session-init only (NOT env-loader, unless bash consumers also need it)
+3. **The canonical session-init variable list (dotted names, LLM context):** `github.owner`, `github.repo`, `github.platform`, `github.html_url`, `gitbucket.owner`, `gitbucket.repo`, `gitbucket.html_url`, `gitbucket.ssh_url`, `gitbucket.has_credentials`, `srclight.project`, `dev.name`, `dev.email`, `branch`, `worktree.path`, `worktree.fatal`, `AgentName`, `ModelId`
+4. **The canonical env-loader variable list (UPPER_CASE, bash environment — separate pipeline):** `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `GITHUB_HTML_URL`, `GITBUCKET_HTML_URL`, `GITBUCKET_SSH_URL`, `GITBUCKET_HAS_CREDENTIALS`, `DEV_NAME`, `DEV_EMAIL`, `BRANCH_NAME`, `WORKTREE_PATH`, `WORKTREE_FATAL`
 
-**Why:** Agents extract values from session init output by matching variable names. A name mismatch (e.g., guideline says `GIT_OWNER` but session-init outputs `Owner:`) causes agents to fall back to inferring values from git remotes, which is a critical rule violation.
+**Why:** Agents extract values from session-init output by matching variable names. A name mismatch (e.g., guideline says `GIT_OWNER` but session-init outputs `github.owner`) causes agents to fall back to inferring values from git remotes, which is a critical rule violation.
 
 ## Correctness-First Economics
 

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -359,7 +359,7 @@ After the audit session completes, findings are acted on per the auto-fix model:
 - Changes Made lists ALL auto-fix and conditional fix actions in summary form
 - Findings Not Acted On lists ALL flag-for-review findings with the specific reason they weren't auto-fixed
 - If audit finds zero issues, output: `## Content Audit: [source] — [title] — No findings. Type: [type] (confidence: [level]). Issue: [URL if applicable]`
-- Issue URL is constructed from session init values (`<GitOwner>`, `<GitRepo>`)
+- Issue URL is constructed from session init values (`<github.owner>`, `<github.repo>`)
 
 ## Mandatory Invocation
 
@@ -387,7 +387,7 @@ When auditing a plan, runbook, process flow, checklist, or reference document, u
 - Document type autodetection uses signal scoring; Low confidence requires user confirmation before proceeding
 - None confidence (empty/unparseable content) produces an error — cannot audit
 - **Backward compatibility:** `--issue N` produces identical results to previous behavior
-- **Worktree awareness check:** Skills that perform git operations, read/write files, or dispatch sub-agents MUST include a "Worktree Mode" section and pass `WORKTREE_PATH` in sub-agent dispatch contexts. Missing worktree awareness is a medium-severity finding.
+- **Worktree awareness check:** Skills that perform git operations, read/write files, or dispatch sub-agents MUST include a "Worktree Mode" section and pass `worktree.path` in sub-agent dispatch contexts. Missing worktree awareness is a medium-severity finding.
 
 ## Sub-Agent Tasks
 
@@ -421,11 +421,11 @@ source: {type: issue|file|url, identifier: <str>}
 document_type: <auto|spec|plan|process-flow|runbook|checklist|reference-doc>
 subtasks: [<task_name>]
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```
 
 ### Result Contract (Full Audit)
@@ -451,7 +451,7 @@ This skill is a **heavy skill** — quality audits with all subtasks consume sig
 5. Sub-agent executes audit in isolation, returns findings as structured report
 6. Main agent receives findings — no full audit content in main context
 
-**Sub-agent context parameters:** Pass issue number, `<WorktreePath>`, `<GitOwner>`, `<GitRepo>` from session init. When `<WorktreePath>` is set, sub-agents MUST receive it and use it as the base directory for all file operations and git commands.
+**Sub-agent context parameters:** Pass issue number, `<worktree.path>`, `<github.owner>`, `<github.repo>` from session init. When `<worktree.path>` is set, sub-agents MUST receive it and use it as the base directory for all file operations and git commands.
 
 ## Cross-Reference Verification (MANDATORY)
 

--- a/.opencode/skills/spec-auditor/tasks/fidelity.md
+++ b/.opencode/skills/spec-auditor/tasks/fidelity.md
@@ -26,7 +26,7 @@ Invoke `writing-plans --task clean-room` as a subtask:
 task(
   subagent_type="general",
   description="Generate clean-room plan for issue N",
-  prompt="Use the writing-plans skill --task clean-room to generate a plan from the problem statement in ./tmp/clean-room-input-N.md. WORKTREE_PATH: <WORKTREE_PATH value or 'not set'>. If WORKTREE_PATH is set, all file operations MUST use it as the base directory. Return the generated plan."
+  prompt="Use the writing-plans skill --task clean-room to generate a plan from the problem statement in ./tmp/clean-room-input-N.md. worktree.path: <worktree.path value or 'not set'>. If worktree.path is set, all file operations MUST use it as the base directory. Return the generated plan."
 )
 ```
 

--- a/.opencode/skills/spec-creation/SKILL.md
+++ b/.opencode/skills/spec-creation/SKILL.md
@@ -210,11 +210,11 @@ needs_approval_label_added: bool
 spec_content: <structured outputs from prerequisite tasks>
 exploration_results: <brainstorming output reference>
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```
 
 ## Cross-References

--- a/.opencode/skills/sre-runbook/SKILL.md
+++ b/.opencode/skills/sre-runbook/SKILL.md
@@ -119,20 +119,20 @@ The AI-parseable blocks provide structure for automation; the operational proced
 
 ## Worktree Mode
 
-When invoked from a worktree context (`WORKTREE_PATH` is set):
+When invoked from a worktree context (`worktree.path` is set):
 
-- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
-- ALL `read`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
-- ALL `write`/`edit` tool calls MUST prefix `filePath` with `WORKTREE_PATH/`
+- ALL `bash` tool calls MUST use `workdir` parameter set to `worktree.path`
+- ALL `read`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `worktree.path/`
+- ALL `write`/`edit` tool calls MUST prefix `filePath` with `worktree.path/`
 - Runbook output files MUST resolve within the worktree, not the main repo
 
 **Verification guard:** Before running any command, verify:
 ```bash
 git -C $WORKTREE_PATH rev-parse --show-toplevel
 ```
-If the result does NOT match `WORKTREE_PATH`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
+If the result does NOT match `worktree.path`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
 
-If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+If `worktree.path` is NOT set, operate normally from the project root.
 
 ## Live Verification: Runbook Claims (MANDATORY)
 
@@ -210,7 +210,7 @@ Before invoking any cross-referenced skill:
 
 - **GitHub:** Use GitHub MCP tools for issue tracking
 - **GitBucket:** Use Python client from gitbucket-api skill
-- **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+- **Platform Detection:** Uses `github.platform` environment variable
 
 ## Source Attribution
 

--- a/.opencode/skills/systematic-debugging/SKILL.md
+++ b/.opencode/skills/systematic-debugging/SKILL.md
@@ -145,6 +145,6 @@ Before invoking any cross-referenced skill:
 
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Use Python client from gitbucket-api skill
-- **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+- **Platform Detection:** Uses `github.platform` environment variable
 
 **⚠️ COMPLETION GUARANTEE:** If this workflow halts at ANY point — including error, failure, or early termination — you MUST invoke `--task completion` before halting. The completion subtask ensures mandatory steps are never skipped. It is idempotent and safe to invoke multiple times.

--- a/.opencode/skills/test-driven-development/SKILL.md
+++ b/.opencode/skills/test-driven-development/SKILL.md
@@ -78,4 +78,4 @@ TDD is invoked contextually — not mandatory for all development.
 
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Use Python client from gitbucket-api skill
-- **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+- **Platform Detection:** Uses `github.platform` environment variable

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: Use when creating a feature branch or worktree for implementation. Always invoke before git-workflow pre-work. Triggers on: branch, worktree, feature branch, create worktree, pre-work, WORKTREE_PATH.
+description: Use when creating a feature branch or worktree for implementation. Always invoke before git-workflow pre-work. Triggers on: branch, worktree, feature branch, create worktree, pre-work, worktree.path.
 type: discipline-enforcing
 license: MIT
 ---
@@ -45,9 +45,9 @@ You are a Worktree Setup Specialist. Your focus is creating safe, isolated git w
 1. **Always use `.worktrees/` directory** — stash+checkout is FORBIDDEN.
 1. **Verify `.worktrees/` is gitignored** before creating worktree. If not, add it and commit.
 1. **Check for name collisions** before creating — reuse existing worktree for same branch, HALT on mismatch.
-1. **Export `WORKTREE_PATH`, `BRANCH_NAME`, `DEV_BASE_HASH`** after creation — downstream skills require these.
-1. **If `WORKTREE_FATAL=1`** appears in session init: HALT immediately, report to developer, do NOT proceed.
-1. **If `WORKTREE_PATH` is empty after creation**: FATAL ERROR → FLAG DEV → HALT.
+1. **Export `worktree.path`, `branch`, `DEV_BASE_HASH`** after creation — downstream skills require these.
+1. **If `worktree.fatal=1`** appears in session init: HALT immediately, report to developer, do NOT proceed.
+1. **If `worktree.path` is empty after creation**: FATAL ERROR → FLAG DEV → HALT.
 1. **Verify clean test baseline** after setup — report failures, get explicit permission to proceed.
 1. **Cleanup** is handled by `finishing-a-development-branch`, not by this skill.
 

--- a/.opencode/skills/using-git-worktrees/tasks/completion.md
+++ b/.opencode/skills/using-git-worktrees/tasks/completion.md
@@ -5,7 +5,7 @@ Idempotent completion subtask for using-git-worktrees. Ensures mandatory steps r
 ## State Check Phase
 
 1. **Worktree creation:** Worktree was created and verified to exist
-2. **Environment export:** WORKTREE_PATH, BRANCH_NAME, DEV_BASE_HASH exported
+2. **Environment export:** worktree.path, branch, DEV_BASE_HASH exported
 3. **Gitignore:** `.worktrees/` directory is gitignored
 4. **Test baseline:** Clean test baseline established after setup
 
@@ -16,7 +16,7 @@ Idempotent completion subtask for using-git-worktrees. Ensures mandatory steps r
    - If missing: invoke `create-worktree` task as remediation
 
 2. **Environment variable verification** (if not already performed):
-   - Check evidence for WORKTREE_PATH, BRANCH_NAME, DEV_BASE_HASH being set/output
+   - Check evidence for worktree.path, branch, DEV_BASE_HASH being set/output
    - If missing: re-export from worktree state as remediation
 
 3. **Gitignore verification** (if not already performed):

--- a/.opencode/skills/using-git-worktrees/tasks/create-worktree.md
+++ b/.opencode/skills/using-git-worktrees/tasks/create-worktree.md
@@ -5,7 +5,7 @@ Create a git worktree for a feature branch, following the full creation workflow
 ## Prerequisites
 
 - Session init has been run
-- `WORKTREE_FATAL` is NOT `1` (if it is, HALT immediately)
+- `worktree.fatal` is NOT `1` (if it is, HALT immediately)
 - Authorization received for the feature branch
 
 ## Steps
@@ -141,7 +141,7 @@ export BASE_BRANCH="${BASE_BRANCH:-dev}"
 export DEV_BASE_HASH=$(git rev-parse --short 7 origin/dev)
 ```
 
-**If `WORKTREE_PATH` is not set or empty after this step: FATAL ERROR → FLAG DEV → HALT.** There is no alternative — worktree is the only method for feature branches.
+**If `worktree.path` is not set or empty after this step: FATAL ERROR → FLAG DEV → HALT.** There is no alternative — worktree is the only method for feature branches.
 
 These environment variables are consumed by:
 

--- a/.opencode/skills/using-git-worktrees/tasks/reference.md
+++ b/.opencode/skills/using-git-worktrees/tasks/reference.md
@@ -22,7 +22,7 @@ If NOT ignored:
 | `.worktrees/` exists | Use it |
 | `.worktrees/` not ignored | Add to `.gitignore` |
 | `.worktrees/` missing | Create it and add to `.gitignore` |
-| `WORKTREE_FATAL=1` in session init | HALT and report to developer |
+| `worktree.fatal=1` in session init | HALT and report to developer |
 | Tests fail during baseline | Report failures + ask |
 | No `pyproject.toml` | Skip dependency install |
 
@@ -37,7 +37,7 @@ If NOT ignored:
 
 ## Fatal Error Protocol
 
-If `WORKTREE_FATAL=1` appears in session init output or worktree creation fails:
+If `worktree.fatal=1` appears in session init output or worktree creation fails:
 
 1. HALT immediately — do NOT proceed with any implementation
 2. Report the fatal error to the developer
@@ -94,4 +94,4 @@ This cleanup happens as part of the standard `git-workflow --task cleanup` seque
 - Announce worktree creation at start
 - Create branch from `dev` (not `main`)
 - Verify clean test baseline
-- HALT immediately if `WORKTREE_FATAL=1` appears in session init
+- HALT immediately if `worktree.fatal=1` appears in session init

--- a/.opencode/skills/using-git-worktrees/tasks/tool-usage.md
+++ b/.opencode/skills/using-git-worktrees/tasks/tool-usage.md
@@ -14,16 +14,16 @@ Per AGENTS.md and `060-tool-usage.md`, `cd` commands are a zero-tolerance violat
 
 ## File Operation Tools (filePath parameter) — CRITICAL
 
-The `read`, `edit`, `write`, `glob`, and `grep` tools do NOT have a `workdir` parameter. When `WORKTREE_PATH` is set, relative paths resolve to the **main repo**, causing silent errors — edits go to the wrong file.
+The `read`, `edit`, `write`, `glob`, and `grep` tools do NOT have a `workdir` parameter. When `worktree.path` is set, relative paths resolve to the **main repo**, causing silent errors — edits go to the wrong file.
 
 | Tool | WRONG (main repo) | CORRECT (worktree) |
 |------|-------------------|---------------------|
-| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{WORKTREE_PATH}/src/main.py")` |
-| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{WORKTREE_PATH}/src/main.py", ...)` |
-| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{WORKTREE_PATH}/src/new.py", ...)` |
-| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=WORKTREE_PATH)` |
-| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{WORKTREE_PATH}/src/")` |
+| `read` | `read(filePath="src/main.py")` | `read(filePath=f"{worktree.path}/src/main.py")` |
+| `edit` | `edit(filePath="src/main.py", ...)` | `edit(filePath=f"{worktree.path}/src/main.py", ...)` |
+| `write` | `write(filePath="src/new.py", ...)` | `write(filePath=f"{worktree.path}/src/new.py", ...)` |
+| `glob` | `glob(pattern="src/**/*.py")` | `glob(pattern="src/**/*.py", path=worktree.path)` |
+| `grep` | `grep(pattern="TODO", path="src/")` | `grep(pattern="TODO", path=f"{worktree.path}/src/")` |
 
-**Rule:** When `WORKTREE_PATH` is set, every file operation tool call MUST prefix paths with the worktree path. No exceptions.
+**Rule:** When `worktree.path` is set, every file operation tool call MUST prefix paths with the worktree path. No exceptions.
 
 When NOT in a worktree (working in main repo), relative paths function correctly as-is.

--- a/.opencode/skills/verification-before-completion/SKILL.md
+++ b/.opencode/skills/verification-before-completion/SKILL.md
@@ -77,10 +77,10 @@ When invoked, this skill requires the following guidelines to be loaded on-deman
 
 ## Worktree Mode
 
-When invoked from a worktree context (`WORKTREE_PATH` is set):
+When invoked from a worktree context (`worktree.path` is set):
 
-- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
-- ALL `read`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
+- ALL `bash` tool calls MUST use `workdir` parameter set to `worktree.path`
+- ALL `read`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `worktree.path/`
 - Test/lint/typecheck commands MUST run from the worktree directory
 - `./tmp/` paths MUST resolve within the worktree, not the main repo
 
@@ -88,9 +88,9 @@ When invoked from a worktree context (`WORKTREE_PATH` is set):
 ```bash
 git -C $WORKTREE_PATH rev-parse --show-toplevel
 ```
-If the result does NOT match `WORKTREE_PATH`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
+If the result does NOT match `worktree.path`, HALT and report: "Worktree mismatch — skill is executing in the wrong directory."
 
-If `WORKTREE_PATH` is NOT set, operate normally from the project root.
+If `worktree.path` is NOT set, operate normally from the project root.
 
 ## Live Verification: Completion Claims (MANDATORY)
 
@@ -164,7 +164,7 @@ Before invoking any cross-referenced skill:
 
 - **GitHub:** Not applicable (this repository uses GitBucket)
 - **GitBucket:** Use Python client from gitbucket-api skill (MCP tools removed)
-- **Platform Detection:** Uses `GIT_PLATFORM` environment variable
+- **Platform Detection:** Uses `github.platform` environment variable
 
 ## Source Attribution
 

--- a/.opencode/skills/verification-before-completion/tasks/completion.md
+++ b/.opencode/skills/verification-before-completion/tasks/completion.md
@@ -28,7 +28,7 @@ Generate executive summary in chat:
 
 **Outcome:** <What stakeholders know — task is verified/not verified>
 
-Issue URL: <GitBucketHtmlUrl><GitOwner>/<GitRepo>/issues/<number>
+Issue URL: <gitbucket.html_url><github.owner>/<github.repo>/issues/<number>
 ```
 
 URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/verification-enforcement/SKILL.md
+++ b/.opencode/skills/verification-enforcement/SKILL.md
@@ -97,9 +97,9 @@ When the verification-enforcement workflow halts — whether after a successful 
 
 ## Worktree Mode
 
-When `WORKTREE_PATH` is set:
-- ALL `bash` tool calls MUST use `workdir` parameter set to `WORKTREE_PATH`
-- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `WORKTREE_PATH/`
-- Sub-agent dispatch prompts MUST include `WORKTREE_PATH: <value>`
+When `worktree.path` is set:
+- ALL `bash` tool calls MUST use `workdir` parameter set to `worktree.path`
+- ALL `read`/`write`/`edit`/`glob`/`grep` tool calls MUST prefix `filePath`/`path` with `worktree.path/`
+- Sub-agent dispatch prompts MUST include `worktree.path: <value>`
 
 Co-authored with AI: <AgentName> (<ModelId>)

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -163,9 +163,9 @@ approval-gate --task verify-authorization (all gates pass for spec approval)
 | `spec_issue` | Issue number from `verify-authorization` | Identifies the approved spec to plan from |
 | `single_task_determination` | From `issue-operations/tasks/post-creation` (via `single-task-check`) | Informs combined vs separate plan decision (`single-task` or `multi-task`) |
 | `single_task` | Boolean from `issue-operations/tasks/post-creation` (via `single-task-check`) | `true` for single-task, `false` for multi-task — shorthand for decision gate |
-| `<GitOwner>` | Session init | Repository owner for API calls |
-| `<GitRepo>` | Session init | Repository name for API calls |
-| `WORKTREE_PATH` | Session / worktree setup | Base directory for file operations |
+| `<github.owner>` | Session init | Repository owner for API calls |
+| `<github.repo>` | Session init | Repository name for API calls |
+| `worktree.path` | Session / worktree setup | Base directory for file operations |
 
 **Spec-to-plan approval cascade:** When `writing-plans --task create` is invoked for a spec that is already approved, the newly created plan inherits the spec's approval status. The `needs-approval` label is removed from the plan and a comment documents the cascade — see Step 11 in `tasks/create.md` for the complete post-creation cascade procedure. This handles the case where plan creation happens AFTER spec approval in the same session.
 
@@ -265,11 +265,11 @@ spec_issue: <N>
 single_task: bool
 single_task_determination: <str>
 session_vars:
-  GitOwner: <from-session>
-  GitRepo: <from-session>
-  DevName: <from-session>
-  DevEmail: <from-session>
-  WorktreePath: <from-session>
+  github.owner: <from-session>
+  github.repo: <from-session>
+  dev.name: <from-session>
+  dev.email: <from-session>
+  worktree.path: <from-session>
 ```
 
 ## Cross-Reference Verification (MANDATORY)

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -71,7 +71,7 @@ Before mapping file structure, check whether existing plans already reference th
 
 1. Using `github_search_issues`, search for issues labeled `plan` in the repository:
    ```
-   github_search_issues(query="label:plan", owner=<GitOwner>, repo=<GitRepo>, state="open")
+   github_search_issues(query="label:plan", owner=<github.owner>, repo=<github.repo>, state="open")
    ```
 2. Filter results for those whose body contains `Spec: #<spec_number>` referencing the current spec number.
 3. If one or more existing plans are found:
@@ -177,13 +177,13 @@ Before mapping file structure, check whether existing plans already reference th
       Example (separate plan):
 
       Created separate implementation plan for #771 (branch stacking prerequisite). 7 tasks across 6 files (3 skills + 3 guidelines).
-      https://github.com/<GitOwner>/<GitRepo>/issues/772
+      https://github.com/<github.owner>/<github.repo>/issues/772
       🤖 <AgentName> (<ModelId>)
 
       Example (combined spec+plan):
 
       Created combined spec+plan for #771 (simple configuration change). Plan appended under `## Implementation Plan`.
-      https://github.com/<GitOwner>/<GitRepo>/issues/771
+      https://github.com/<github.owner>/<github.repo>/issues/771
       🤖 <AgentName> (<ModelId>)
 
       Sub-issues are linked under the plan issue for separate plans, NOT under the spec. Combined plans have no sub-issues.

--- a/.opencode/tools/session-init
+++ b/.opencode/tools/session-init
@@ -5,13 +5,33 @@
 # ///
 """Session initialization script for AI agents.
 
-Outputs Key: value pairs for LLM consumption on stdout. Key names match
-the canonical PascalCase names referenced in guidelines and skills (GitOwner,
-GitRepo, GitPlatform, DevName, DevEmail, BranchName, WorktreePath, WorktreeFatal,
-GitHubHtmlUrl, GitBucketHtmlUrl, GitBucketSshUrl, GitBucketHasCredentials,
-AgentName, ModelId).
-Agents must use these key names directly — do NOT infer values from git
-remotes or other sources.
+Outputs key:value pairs for LLM consumption on stdout. Key names use
+the dotted scope.param convention where the prefix is the tool scope
+(github, gitbucket, srclight, dev, worktree) and the suffix is the
+exact parameter name the MCP tool or API expects. A convention comment
+at the top teaches the agent the rule.
+
+Session-init and env-loader are TWO INDEPENDENT PIPELINES:
+- Session-init (this script): stdout → LLM system prompt (dotted names)
+- env-loader.ts: output.env → bash environment (UPPER_CASE names, unchanged)
+
+Changing session-init output names does NOT require changes to env-loader.
+Agents read dotted names from session-init; bash scripts read UPPER_CASE
+names from env-loader. Never couple these pipelines.
+
+Canonical session-init variable names (dotted, LLM context):
+github.owner, github.repo, github.platform, github.html_url,
+gitbucket.owner, gitbucket.repo, gitbucket.html_url, gitbucket.ssh_url,
+gitbucket.has_credentials, srclight.project, dev.name, dev.email,
+branch, worktree.path, worktree.fatal, AgentName, ModelId
+
+Canonical env-loader variable names (UPPER_CASE, bash environment — separate pipeline):
+GIT_OWNER, GIT_REPO, GIT_PLATFORM, GITHUB_HTML_URL, GITBUCKET_HTML_URL,
+GITBUCKET_SSH_URL, GITBUCKET_HAS_CREDENTIALS, DEV_NAME, DEV_EMAIL,
+BRANCH_NAME, WORKTREE_PATH, WORKTREE_FATAL
+
+Agents must use dotted session-init names for MCP parameters — do NOT
+infer values from git remotes or other sources.
 
 Human-readable diagnostic lines (Remote:, Srclight:, Hooks path:) are preserved
 for developer diagnostics but are NOT referenced by guidelines as variables.
@@ -650,28 +670,31 @@ def main() -> int:
     wt_display = get_worktree_display()
     hooks_path = get_hooks_path()
 
-    print(f"GitOwner: {owner}")
-    print(f"GitRepo: {repo}")
-    print(f"GitPlatform: {platform}")
+    print("# Convention: dotted prefix = tool scope, suffix = MCP/API parameter name")
+    print("# Use scope.param directly as the tool parameter value.")
+    print("# Example: github_issue_read(owner=github.owner, repo=github.repo)")
+    print(f"github.owner: {owner}")
+    print(f"github.repo: {repo}")
+    print(f"github.platform: {platform}")
     print("AgentName: ")
     print("ModelId: ")
-    print(f"DevName: {user_name}")
-    print(f"DevEmail: {user_email}")
-    print(f"BranchName: {current_branch}")
+    print(f"dev.name: {user_name}")
+    print(f"dev.email: {user_email}")
+    print(f"branch: {current_branch}")
     print(f"Remote: {remote_url}")
 
     if platform == "github":
-        print("GitHubHtmlUrl: https://github.com/")
+        print("github.html_url: https://github.com/")
 
     if platform == "gitbucket":
         base_url, _, _ = parse_gitbucket_url(remote_url)
         if base_url:
-            print(f"GitBucketHtmlUrl: {base_url}")
+            print(f"gitbucket.html_url: {base_url}")
         else:
             print("GITBUCKET_HTML_URL not found in .env — URL generation unavailable", file=sys.stderr)
         ssh_url = extract_ssh_url(remote_url)
         if ssh_url:
-            print(f"GitBucketSshUrl: {ssh_url}")
+            print(f"gitbucket.ssh_url: {ssh_url}")
         has_credentials = False
         try:
             env_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
@@ -683,22 +706,23 @@ def main() -> int:
                     )
         except OSError:
             pass
-        print(f"GitBucketHasCredentials: {'true' if has_credentials else 'false'}")
+        print(f"gitbucket.has_credentials: {'true' if has_credentials else 'false'}")
 
     if in_wt and wt_path and main_repo:
-        print(f"WorktreePath: {wt_path}")
+        print(f"worktree.path: {wt_path}")
     elif worktree_ok:
         if wt_display:
             print(wt_display)
         else:
             print("Worktrees: available")
     else:
-        print("WorktreeFatal: 1")
+        print("worktree.fatal: 1")
 
     if hooks_path:
         print(f"Hooks path: {hooks_path}")
 
     if srclight_status == "indexed":
+        print(f"srclight.project: {repo}")
         print("Srclight: indexed")
     else:
         print("Srclight: NOT indexed — tell the developer to run: uvx srclight index --embed qwen3-embedding")


### PR DESCRIPTION
## Summary

Rename session-init output keys from PascalCase (`GitOwner`, `GitRepo`, etc.) to dotted `scope.param` format (`github.owner`, `github.repo`, etc.) so agents can use scoped names directly as MCP parameters with no mental mapping. Fix the false coupling rule in skill-creator that incorrectly mandated session-init and env-loader must be updated together — they are independent pipelines.

## Outcome

- 87 files modified: session-init script, session-enforcement plugin, skill-creator, mcp-tool-usage, all skill files with dispatch contexts, all guideline files with variable references
- env-loader.ts and bash environment variables remain UNCHANGED (UPPER_CASE format)
- Two-pipeline documentation added to skill-creator and 080-code-standards
- Convention comment added as first line of session-init output
- `srclight.project` added to session-init output (when indexed)

Fixes #1030