### PR TITLE
fix: enforce ff-only dev sync and align LLM-facing variable names

### DIFF
--- a/.opencode/scripts/session_context.py
+++ b/.opencode/scripts/session_context.py
@@ -9,7 +9,7 @@ Called after session_init.py. Probes git state, validates credentials,
 and conditionally emits a reply injection for trigger states.
 
 Identity section (always-emit):
-  GIT_OWNER, GIT_REPO, GIT_PLATFORM, _CREDENTIALS=
+  github.owner, github.repo, github.platform, _CREDENTIALS=
 
 Trigger conditions (appended when detected):
   on_main_branch, protected_branch_with_changes, pair_mode_resume,
@@ -328,9 +328,9 @@ def has_orphaned_worktrees() -> list[str]:
 def build_identity_section(owner: str, repo: str, platform: str, credential_status: str) -> str:
     lines = [
         "## Repository Identity",
-        f"- GIT_OWNER={owner}",
-        f"- GIT_REPO={repo}",
-        f"- GIT_PLATFORM={platform}",
+        f"- github.owner={owner}",
+        f"- github.repo={repo}",
+        f"- github.platform={platform}",
     ]
     cred_key = f"{platform.upper()}_CREDENTIALS" if platform != "unknown" else "CREDENTIALS"
     lines.append(f"- {cred_key}={credential_status}")

--- a/.opencode/skills/finishing-a-development-branch/tasks/prepare.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/prepare.md
@@ -22,6 +22,32 @@ If `worktree.path` is not set or empty: **FATAL ERROR → FLAG DEV → HALT.** D
 4. `git rev-parse --show-toplevel` MUST return the worktree path
 5. NEVER operate in the main working directory during implementation
 
+## Step 0: Sync Dev Branch (Fast-Forward Only)
+
+**Before running quality checks, ensure local dev is current.** If dev has been updated by other merges since this branch was created, running checks on a stale base produces incorrect results.
+
+```bash
+git fetch origin dev
+git pull origin dev --ff-only
+```
+
+**The `--ff-only` flag is MANDATORY.** A plain `git pull origin dev` can silently succeed with a merge commit, hiding divergence. The `--ff-only` flag ensures dev fast-forwards cleanly.
+
+**If `--ff-only` pull fails (diverged history):**
+
+```bash
+# HALT and report. Suggest manual resolution:
+echo "ERROR: local dev has diverged from origin/dev"
+echo "Suggest: git pull --rebase origin dev"
+echo "Or manual resolution required"
+# HALT — do NOT proceed with stale codebase
+# Do NOT create merge commits on dev
+```
+
+**If dev is already up to date:** The ff-only pull is a no-op and proceeds instantly.
+
+**Worktree context:** If running from a worktree, `git pull` must target the main working tree's dev, not the worktree. Use `git -C /path/to/main/repo pull origin dev --ff-only` to ensure operations target the main tree.
+
 ## Prepare Branch Workflow
 
 ### Step 1: Verify All Changes Committed

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -412,7 +412,7 @@ The `pair-` prefix IS the mode signal. No state files needed — branch name car
 ### Pair Mode Session Start
 
 The `session_context.py` plugin detects pair mode at session start and injects context:
-- Identity section (always): GIT_OWNER, GIT_REPO, GIT_PLATFORM, credential status
+- Identity section (always): github.owner, github.repo, github.platform, credential status
 - Pair mode resume context: branch name, related issue, diff summary
 - Trigger warnings: on_main_branch, protected_branch_with_changes, uncommitted_work
 

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -363,24 +363,41 @@ Total nodes visited: <N>
 
 **If orphaned sub-issues remain:** Do NOT close them. Report them as verification gaps requiring developer attention.
 
-### Step 3: Switch to Dev and Sync
+### Step 3: Switch to Dev and Sync (Fast-Forward Only)
 
 **Three-Branch Workflow:** After feature PR merge, switch to `dev` (not `main`) and sync with remote.
 
 ```bash
 git checkout dev
-git pull origin dev
+git pull origin dev --ff-only
 ```
+
+**🚫 CRITICAL: The `--ff-only` flag is MANDATORY.** A plain `git pull origin dev` can silently succeed with a merge commit, hiding divergence issues. The `--ff-only` flag ensures dev fast-forwards to the remote tip without creating merge commits.
+
+**If `--ff-only` pull fails (diverged history):**
+
+```bash
+# HALT and report. Suggest manual resolution:
+echo "ERROR: local dev has diverged from origin/dev"
+echo "Suggest: git pull --rebase origin dev"
+echo "Or manual resolution required"
+# HALT — do NOT proceed with stale codebase
+```
+
+**⚠️ DO NOT create merge commits on dev.** If ff-only fails, HALT and report to the developer. Suggest `git pull --rebase origin dev` or manual resolution.
 
 **Verify local dev matches the merge commit:**
 
 ```bash
-git log --oneline -5
+git log --oneline -1 origin/dev
+git log --oneline -1 dev
 ```
 
-The merge commit from the merged PR MUST be visible in the recent log. If the merge commit is NOT visible, `git pull origin dev` may have failed silently — re-run `git pull origin dev` and verify again.
+The two commit hashes MUST match. If they differ, the pull did not succeed — re-run `git pull origin dev --ff-only` and verify again.
 
-**Why this verification matters:** Without confirming local `dev` is synced, the next session starts with a stale local branch, causing `git pull` failures from untracked files and merge conflicts when creating new feature branches.
+**Why this verification matters:** Without confirming local `dev` is synced, the next session starts with a stale local branch, causing `git pull` failures from untracked files and merge conflicts when creating new feature branches. The `--ff-only` flag prevents silent merge commits that obscure divergence.
+
+**Worktree context:** If running from a worktree, `git checkout dev` and `git pull` must operate on the main working tree, not the worktree. Use `git -C /path/to/main/repo checkout dev && git -C /path/to/main/repo pull origin dev --ff-only` to ensure operations target the main tree.
 
 ### Step 4: Remove Feature Worktree
 

--- a/.opencode/skills/git-workflow/tasks/pair-commit.md
+++ b/.opencode/skills/git-workflow/tasks/pair-commit.md
@@ -11,7 +11,7 @@ Pair mode commits include `[pair-mode]` tag in co-author trailers:
 
 <optional body>
 
-Co-authored-by: <DEV_NAME> <<DEV_EMAIL>> [pair-mode]
+Co-authored-by: <dev.name> <<dev.email>> [pair-mode]
 Co-authored-by: AI: <AGENT_NAME> (<MODEL_ID>) [pair-mode]
 ```
 
@@ -40,7 +40,7 @@ When branch has no issue number or ambiguous:
 
    <body if needed>
 
-   Co-authored-by: <DEV_NAME> <<DEV_EMAIL>> [pair-mode]
+   Co-authored-by: <dev.name> <<dev.email>> [pair-mode]
    Co-authored-by: AI: <AGENT_NAME> (<MODEL_ID>) [pair-mode]"
    ```
 
@@ -50,7 +50,7 @@ When branch has no issue number or ambiguous:
 
    Implements #<issue>
 
-   Co-authored-by: <DEV_NAME> <<DEV_EMAIL>> [pair-mode]
+   Co-authored-by: <dev.name> <<dev.email>> [pair-mode]
    Co-authored-by: AI: <AGENT_NAME> (<MODEL_ID>) [pair-mode]"
    ```
 

--- a/.opencode/skills/git-workflow/tasks/pair-pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pair-pr-creation.md
@@ -19,7 +19,7 @@ Pair mode uses the same squash workflow as autonomous mode:
 
    Implements #<issue>
 
-   Co-authored-by: <DEV_NAME> <<DEV_EMAIL>> [pair-mode]
+   Co-authored-by: <dev.name> <<dev.email>> [pair-mode]
    Co-authored-by: AI: <AGENT_NAME> (<MODEL_ID>) [pair-mode]"
    ```
 
@@ -45,7 +45,7 @@ Pair mode uses the same squash workflow as autonomous mode:
 
      Implements #<issue>
 
-     Co-authored-by: <DEV_NAME> <<DEV_EMAIL>> [pair-mode]
+     Co-authored-by: <dev.name> <<dev.email>> [pair-mode]
      Co-authored-by: AI: <AGENT_NAME> (<MODEL_ID>) [pair-mode]
    ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Two plugins run at session start:
 
 Session context output includes:
 
-- **Identity section** (always): `GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, credential status
+- **Identity section** (always): `github.owner`, `github.repo`, `github.platform`, credential status
 - **Trigger alerts** (when detected): `on_main_branch`, `protected_branch_with_changes`, `pair_mode_resume`, `uncommitted_work`, `stale_stash`, `merge_conflict`, `unpushed_commits`, `orphaned_worktrees`
 - **Tier 3 probes** (opt-in via `.opencode-issue-probe`): `open_pr_on_branch`, `ci_failure`, `stale_pr`
 


### PR DESCRIPTION
## Summary

- Strengthen dev sync step in `cleanup.md` to use `--ff-only` flag with explicit HALT on divergence (prevents silent merge commits on dev)
- Add mandatory dev sync step (Step 0) to `prepare.md` before quality checks, ensuring checks run against current codebase
- Migrate all LLM-facing variable names from legacy `UPPER_CASE` (`GIT_OWNER`, `GIT_REPO`, `GIT_PLATFORM`, `DEV_NAME`, `DEV_EMAIL`) to canonical `dotted.notation` (`github.owner`, `github.repo`, `github.platform`, `dev.name`, `dev.email`) matching `session-init` output format

## Outcome

Agents will no longer see conflicting variable naming conventions in LLM context — `session_context.py` now emits `github.owner=Brothertown-Language` matching `session-init`'s `github.owner: Brothertown-Language`. The diverged naming was the root cause of agents inferring `owner` from filesystem paths (`muksihs`) instead of consuming session-init values. Dev sync after PR merge is now enforced with `--ff-only` to prevent silent merge commits.

Implements #1039, Implements #1040

Co-authored-by: Michael Conrad <m.conrad.202@gmail.com>