### PR TITLE
fix(approval-gate): remove inline screening threshold and add autonomous classification resolution

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -642,11 +642,14 @@ Structural decisions — single-task vs multi-task classification, phase decompo
 - 🚫 FORBIDDEN: "Should this be a single-task spec or broken into phases?" — the agent decides
 - 🚫 FORBIDDEN: "Is this a small change or a big one?" — the agent assesses
 - 🚫 FORBIDDEN: "Do you want this as one spec or multiple?" — the agent classifies
+- 🚫 FORBIDDEN: "How should we handle this partially-implemented issue?" — scope-reduce and continue
+- 🚫 FORBIDDEN: "Should we re-plan?" — yes, if authorization says "re-plan as needed"
+- 🚫 FORBIDDEN: "How should we close this already-implemented issue?" — via verify-already-implemented or via referenced spec-fix
 - 🚫 FORBIDDEN: Any question where the answer is determinable from context, codebase, or request analysis
 - ✅ REQUIRED: Classify autonomously and state the classification as part of the design proposal
 - ✅ REQUIRED: Only ask when multiple valid structures exist with genuinely ambiguous trade-offs (e.g., 3+ subsystems with unclear boundaries)
 
-**See `brainstorming` skill → `explore` task → "Autonomous Structural Classification" for the complete criteria.**
+**See `brainstorming` skill → `explore` task → "Autonomous Structural Classification" for the complete criteria. See `approval-gate/tasks/pre-implementation-analysis.md` Step 0.15 for the classification decision table that maps screening results to autonomous actions. See `approval-gate/tasks/screen-issue.md` §"Autonomous Resolution" for the exhaustive `requires_developer: true` conditions.**
 
 ## Critical Violation: Process Gaps Are Bugs — Completed Issues Not Auto-Closed
 
@@ -665,17 +668,26 @@ Structural decisions — single-task vs multi-task classification, phase decompo
 
 ## Critical Violation: Inline Screening of Authorization Sets
 
-**⚠️ When more than 3 issues are approved at once, the agent MUST dispatch `screen-issue` sub-agents for per-issue screening. Loading all issue bodies into the orchestrator's own context is a CRITICAL GUIDELINE VIOLATION.**
+**⚠️ The agent MUST ALWAYS dispatch `screen-issue` sub-agents for per-issue screening, regardless of approval set size. Loading issue bodies into the orchestrator's own context is a CRITICAL GUIDELINE VIOLATION.**
 
-- 🚫 FORBIDDEN: Fetching all approved issue bodies into orchestrator context before sub-agent dispatch
-- 🚫 FORBIDDEN: Running screening logic inline when approval set size > 3
-- ✅ REQUIRED: Dispatch one `screen-issue` sub-agent per approved issue
+- 🚫 FORBIDDEN: Fetching approved issue bodies into orchestrator context before sub-agent dispatch
+- 🚫 FORBIDDEN: Running screening logic inline for ANY approval set size
+- ✅ REQUIRED: Dispatch one `screen-issue` sub-agent for EVERY approved issue — no count threshold
 - ✅ REQUIRED: Orchestrator receives only compact result contracts (≈100-500 words each)
 - ✅ REQUIRED: Cross-issue merge and dependency graph built from result contracts, not raw issue bodies
 
-**Why 3 as the threshold:** Single approvals and pairs can reasonably be screened inline. Three or more issues risk context exhaustion and require sub-agent isolation. The `screen-issue` sub-agent architecture exists precisely to prevent the orchestrator from blowing out its context window on authorization sets.
-
 **AUTHORITY:** `approval-gate/tasks/pre-implementation-analysis.md` Step -1
+
+### Common Misconception: "Small approval sets can be screened inline"
+
+**This is INCORRECT.** There is no inline screening path. Every approved issue — whether 1, 2, or 20 — MUST be screened by a `screen-issue` sub-agent dispatched via `task(subagent_type="general")`. The count threshold was removed because:
+
+1. Inline screening creates a forked code path that agents exploit to skip sub-agents
+2. Even a single issue can consume significant context (long spec, many comments, sub-issues)
+3. Sub-agent dispatch has near-zero cost but guarantees consistent execution
+4. The "context savings" of inline screening for ≤3 issues never materialized in practice
+
+**DO NOT re-introduce a count threshold.** This is a structural invariant, not a performance optimization.
 
 ## Critical Violation: Silent Halt Without Prompt — No Spec/Plan Search Before Stopping
 

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -353,7 +353,7 @@ Every task in this skill that reads a metadata claim (label, comment, STATUS mar
 | Authorization currency | Verify spec has not been revised after most recent authorization comment | `github_issue_read(method=get_comments)` → compare revision timestamps | STRUCTURE-VIOLATION |
 | Sub-issue state (open/closed) | Verify sub-issue state via GitHub API, not from cached or claimed state | `github_issue_read(method=get, issue_number=N)` → check `state` field | VERIFICATION-GAP |
 | Fix spec existence | Verify fix spec sub-issue exists and has correct labels/STATUS for its maturity | `github_issue_read(method=get_sub_issues)` → verify each child | MISSING-TRACEABILITY |
-| Work screening dispatch (>3 issues) | Verify `screen-issue` sub-agents were dispatched (not inline screening) when work set size > 3 | Check for `task(subagent_type="general")` dispatch calls per issue | STRUCTURE-VIOLATION |
+| Work screening dispatch | Verify `screen-issue` sub-agents were dispatched for EVERY approved issue — no count threshold | Check for `task(subagent_type="general")` dispatch calls per issue | STRUCTURE-VIOLATION |
 
 ### Evidence Artifacts
 

--- a/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
+++ b/.opencode/skills/approval-gate/tasks/pre-implementation-analysis.md
@@ -11,7 +11,7 @@ Analyze interdependencies and determine execution order for all approved issues 
 - One or more issues approved (e.g., `Approved: #660`, `Approved: #660, #662, #621`)
 - Each issue has been verified by `verify-authorization`
 - User has explicitly authorized implementation
-- **Per-issue screening results available** (from `screen-issue` sub-agents or inline execution)
+- **Per-issue screening results available** (from `screen-issue` sub-agents — mandatory parallel dispatch)
 
 ## Exit Criteria
 
@@ -26,27 +26,30 @@ Analyze interdependencies and determine execution order for all approved issues 
 
 ## Procedure
 
-### Step -1: Work Set Size Check and Dispatch Decision (MANDATORY FIRST)
+### Step -1: Mandatory Sub-Agent Dispatch (MANDATORY FIRST)
 
 Before reading ANY issue body:
 
-1. COUNT the number of approved issues
-2. If count ≤ 3: inline screening is PERMITTED (proceed to Step 0)
-3. If count > 3: sub-agent dispatch is MANDATORY — do NOT read any issue body into orchestrator context
+1. Dispatch `screen-issue` sub-agents for EVERY approved issue — no count check, no inline path
+2. Do NOT read any issue body into orchestrator context
 
-**⚠️ CRITICAL VIOLATION:** Reading issue bodies for >3 issues into orchestrator context before sub-agent dispatch is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Inline Screening of Authorization Sets. The orchestrator's context window must stay clean for cross-issue merge and dependency graph building — not consumed by raw issue bodies.
+**⚠️ CRITICAL VIOLATION:** Reading issue bodies into orchestrator context before sub-agent dispatch is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md` §Inline Screening of Authorization Sets. The orchestrator's context window must stay clean for cross-issue merge and dependency graph building — not consumed by raw issue bodies.
+
+**There is no inline screening path.** Every approved issue — whether 1, 2, or 20 — MUST be screened by a `screen-issue` sub-agent dispatched via `task(subagent_type="general")`. The count threshold was removed because inline screening creates a forked code path that agents exploit to skip sub-agents. See `000-critical-rules.md` §"Common Misconception: Small approval sets can be screened inline" for the rationale.
 
 ### Step 0: Collect Screening Results
 
-Collect per-issue screening results from `screen-issue` sub-agents (parallel) or inline execution.
+Collect per-issue screening results from `screen-issue` sub-agents (mandatory parallel dispatch).
 
-If screening results are NOT already available from sub-agent dispatch, dispatch `screen-issue` sub-agents:
+All approved issues have been dispatched to `screen-issue` sub-agents in Step -1. Collect the result contracts:
 
 ```
 For each approved issue:
-  Dispatch sub-agent: task(subagent_type="general", prompt="Use screen-issue task for issue #N with dispatch context: ...")
-  Collect result contract
+  Collect result contract from dispatched screen-issue sub-agent
+  Assemble into screening results
 ```
+
+**If screening results are NOT available** (e.g., sub-agent dispatch failed), HALT and report the failure — do NOT fall back to inline screening.
 
 **Dispatch context per sub-agent:**
 
@@ -73,6 +76,52 @@ If the agent encounters a scenario not covered by existing rules:
 1. Apply the closest applicable rule by analogy
 2. If no analogy exists, resolve with best judgment and document the reasoning in the execution plan
 3. Do NOT escalate to the developer unless the scenario matches one of the five `requires_developer: true` conditions from `screen-issue`
+
+### Step 0.15: Autonomous Classification Resolution (MANDATORY)
+
+When screening results return classifications, the orchestrator MUST resolve them autonomously using the decision table below. These are deterministic mappings — not judgment calls requiring developer input.
+
+#### Classification Decision Table
+
+| Screening Classification | Autonomous Action | Rationale |
+|---|---|---|
+| `already-implemented` | Exclude from work set; add to auto-close list via `verify-already-implemented` | All success criteria met; no work remaining |
+| `partially-implemented` | Scope-reduce to remaining phases; continue with gap work only | Completed phases require no action; remaining gaps are the scope |
+| `scope-reduced` | Continue with remaining phases only | Same as partially-implemented — the completed phases are done |
+| `null` (fresh spec) | Include fully in work set | No prior implementation exists |
+| `superseded` | Exclude from work set; flag in execution plan report | Another spec fully encompasses this one |
+| `moot` | Exclude from work set; flag in execution plan report | Problem no longer exists or references restructured/removed code |
+
+#### Re-Planning Decision
+
+When the authorization text contains phrases like "re-plan as needed" or "revise as needed":
+
+| Authorization Phrase | Autonomous Action |
+|---|---|
+| "re-plan as needed" | Re-plan the spec against the current codebase before implementing |
+| "revise as needed" | Re-plan the spec against the current codebase before implementing |
+| "update the spec" | Re-plan the spec against the current codebase before implementing |
+| No re-planning phrase | Implement the spec as written, even if partially implemented |
+
+#### Already-Implemented Closure Decision
+
+| Scenario | Autonomous Action |
+|---|---|
+| Already-implemented issue referenced by another spec-fix | Close via the spec-fix's procedure (e.g., #1037 Phase 2 closes #1025) |
+| Already-implemented with no referencing spec-fix | Close via `verify-already-implemented` auto-close procedure |
+| Partially-implemented issue | Scope-reduce, do NOT close |
+
+#### `requires_developer: true` Escalation Criteria
+
+The ONLY conditions where screening results warrant developer escalation:
+
+1. **Multiple valid structures with genuinely ambiguous trade-offs** (3+ subsystems with unclear boundaries — not a preference between two equivalent approaches)
+2. **Legal/compliance concerns** requiring human judgment
+3. **Developer must choose between mutually exclusive approaches** (not a choice between equivalent options)
+4. **Unresolvable conflicts** between issues in the authorization set (contradictory success criteria)
+5. **Different-intent stale assumptions** (Issue A references code that Issue B deletes, and their intents conflict)
+
+All other scenarios — including classification decisions, re-planning, scope-reducing, and closure — are resolved autonomously per this decision table.
 
 ### Step 0.5: Assemble Gate Evidence Audit Table
 
@@ -488,6 +537,17 @@ This handoff ensures:
 - Each sub-agent gets isolated context
 - The orchestrator stays clean — no implementation pollution
 - Work state survives context turnover
+
+## Common Misconception: "Small approval sets can be screened inline"
+
+**This is INCORRECT.** There is no inline screening path. Every approved issue — whether 1, 2, or 20 — MUST be screened by a `screen-issue` sub-agent dispatched via `task(subagent_type="general")`. The count threshold was removed because:
+
+1. Inline screening creates a forked code path that agents exploit to skip sub-agents
+2. Even a single issue can consume significant context (long spec, many comments, sub-issues)
+3. Sub-agent dispatch has near-zero cost but guarantees consistent execution
+4. The "context savings" of inline screening for ≤3 issues never materialized in practice
+
+**DO NOT re-introduce a count threshold.** This is a structural invariant, not a performance optimization.
 
 ## Classification Detail
 

--- a/.opencode/skills/approval-gate/tasks/screen-issue.md
+++ b/.opencode/skills/approval-gate/tasks/screen-issue.md
@@ -425,6 +425,31 @@ session_vars:
 
 **DEFAULT FAILSAFE:** If a screening sub-agent encounters a scenario not covered by conditions 1-5, it must RESOLVE autonomously (classify with best judgment) rather than defaulting to `requires_developer: true`. Escalating undefined scenarios to the developer is the "Pushing Agent Intelligence Decisions" anti-pattern. Set `requires_developer: true` ONLY when the developer's intent is genuinely ambiguous and cannot be inferred from context.
 
+### Autonomous Resolution
+
+**Reference: `000-critical-rules.md` §"Pushing Agent Intelligence Decisions to the User"**
+
+Screening classification decisions are agent intelligence concerns, not developer judgment calls. The `requires_developer: true` field in the result contract MUST be set to `true` ONLY for the exhaustive conditions listed in the Red Flags section (conditions 1-5). All other scenarios are resolved autonomously.
+
+**PROHIBITED questions (agent MUST decide, never ask):**
+
+- "Should this be single-task or multi-task?" → agent decides based on scope
+- "Is this a small change or a big one?" → agent assesses from screening
+- "Do you want this as one spec or multiple?" → agent classifies
+- "How should we handle this partially-implemented issue?" → scope-reduce and continue
+- "Should we re-plan?" → yes, if authorization says "re-plan as needed"
+- "How should we close this already-implemented issue?" → via verify-already-implemented or via referenced spec-fix
+
+**When `requires_developer: true` is genuinely needed (exhaustive list):**
+
+1. **Unresolvable conflicts:** Contradictory success criteria between issues in the authorization set
+2. **Different-intent stale assumptions:** Issue A references code Issue B deletes, with different goals
+3. **Ambiguous supersession:** Partial scope overlap where it is unclear which spec is canonical
+4. **Uncertain reconciliation findings:** `reconcile-issue-graph` produced `requires_dev_action` with conflicting signals
+5. **Authorization scope gap:** User approves an issue but the implementable target is unclear AND output lineage cascade does NOT apply
+
+**DEFAULT FAILSAFE:** If a scenario is NOT covered by conditions 1-5, RESOLVE autonomously (classify with best judgment) rather than defaulting to `requires_developer: true`. Per `000-critical-rules.md` §"Pushing Agent Intelligence Decisions to the User," structural decisions are agent intelligence concerns.
+
 ### Screening Results Are Not Decision Points
 
 Screening sub-agents produce result contracts that feed into `pre-implementation-analysis`. The orchestrator assembles results and proceeds to the dispatch chain automatically. Key rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec-fix/1042-1043-approval-gate-autonomous-classification
+
+- **Remove Conditional Sub-Agent Dispatch Threshold** (#1043) - Removed the ≤3 inline screening threshold from approval-gate. Screen-issue sub-agent dispatch is now mandatory for ALL approval set sizes, regardless of count. Replaced conditional logic in 000-critical-rules.md, pre-implementation-analysis.md, and SKILL.md verification table. Added "Common Misconception" sections explaining why the threshold was removed.
+- **Add Autonomous Classification Resolution** (#1042) - Added classification decision table to pre-implementation-analysis.md (Step 0.15) mapping screening results to autonomous actions. Added "Autonomous Resolution" section to screen-issue.md with prohibited questions and genuine escalation criteria. Added pre-implementation-analysis classification decisions as prohibited questions in 000-critical-rules.md §Pushing Agent Intelligence Decisions to the User.
+
 ### spec/sub-agent-extraction
 
 - **Sub-Agent Extraction for Heavy Skill Tasks** (#984, #985, #986, #987, #988) - Extracted task files over 1,000 words into sub-agent execution pattern, reducing main agent context consumption by ~88%. Created `screen-issue` task for per-issue screening, revised `pre-implementation-analysis` from 5,635w to 3,137w, and added Sub-Agent Tasks sections with execution mode tables and result contracts to 7 SKILL.md files.


### PR DESCRIPTION
## Summary

Remove the conditional ≤3 inline screening threshold from approval-gate, making screen-issue sub-agent dispatch mandatory for ALL approval set sizes. Add autonomous classification resolution decision tables to pre-implementation-analysis and screen-issue so agents resolve deterministic screening classifications without developer input.

## Outcome

- Inline screening path eliminated — no count threshold, no "or inline" alternative, unconditional sub-agent dispatch for every approved issue
- Classification decisions (already-implemented, partially-implemented, scope-reduced, superseded, moot) are now resolved autonomously via decision table, not presented as developer questions
- "Re-plan as needed" in authorization text now triggers re-planning without asking
- Already-implemented closure follows existing workflows without developer input
- Prohibited question list expanded with pre-implementation-analysis specific examples
- Common Misconception sections added to 000-critical-rules.md and pre-implementation-analysis.md

Fixes #1043
Fixes #1042