### PR TITLE
feat: add tests, pair-mode guideline, and semaphore file (#1004)

### DIFF
--- a/.opencode/guidelines/116-pair-mode.md
+++ b/.opencode/guidelines/116-pair-mode.md
@@ -1,0 +1,101 @@
+# Pair Mode Branch Discipline
+
+## Overview
+
+Pair mode (`pair-` prefix branches) allows the AI agent to work directly in the main project directory alongside the developer, using WIP-commit branch switching instead of worktrees. This is a Tier 2 waiver of the worktree mandate — the developer is present and accepting branch hygiene responsibility.
+
+## Branch Naming
+
+| Branch Pattern | Mode | Working Directory |
+|---|---|---|
+| `pair-feature/123-xyz` | Dev-pair | Main project dir |
+| `pair-spec/456-abc` | Dev-pair | Main project dir |
+| `feature/789-xyz` | Autonomous | `.worktrees/` |
+| `spec/789-abc` | Autonomous | `.worktrees/` |
+| `dev` or `main` | None | Prompt to create/switch |
+
+The `pair-` prefix IS the mode signal. No state files needed — branch name carries everything.
+
+## Mandatory Rules
+
+### 1. Always Use `pair-` Prefix
+
+No exceptions. If the developer is present and driving, use `pair-` prefix. If the AI is autonomous, use `feature/` or `spec/` with worktrees.
+
+### 2. Never Operate in `.worktrees/` When Pair Mode Active
+
+Pair mode branches work in the main project directory. Worktrees must not be created for pair mode branches.
+
+### 3. WIP Commits Before Branch Switches
+
+Before any branch switch in pair mode, the AI MUST:
+
+1. Check `git status --porcelain`
+2. If changes exist: `git add -A && git commit -m "WIP: <description>"` with co-author trailers
+3. `git checkout <target-branch>`
+4. On return, optionally `git reset HEAD~1` to uncommit the WIP
+
+### 4. Commit Trailers Include `[pair-mode]`
+
+Pair mode commits include:
+
+```
+Co-authored-by: Human Name <human@email> [pair-mode]
+Co-authored-by: AI: <AgentName> (<ModelId>) [pair-mode]
+```
+
+The `[pair-mode]` tag distinguishes these from autonomous mode commits.
+
+### 5. PR Body Uses `Implements #N`
+
+Never `Fixes` or `Closes` — avoids premature issue closure. Use `Implements #N` to link without auto-closing.
+
+## Session Detection
+
+The `session_context.py` plugin detects pair mode at session start when the current branch starts with `pair-`. It emits:
+
+- Identity section (always): `github.owner`, `github.repo`, `github.platform`, credential status
+- Pair mode resume context: branch name, related issue, diff summary
+- Trigger warnings: `on_main_branch`, `protected_branch_with_changes`, `uncommitted_work`
+
+## Task Sequence
+
+```
+Session start → pair-mode-resume detects pair-* branch
+    ↓
+pair-pre-work: WIP-commit switch (no worktree)
+    ↓
+(pair commits as needed during work)
+    ↓
+pair-pr-creation: Squash → Push → Create PR
+    ↓
+(Developer merges PR)
+    ↓
+pair-cleanup: Delete branch, clean stashes
+```
+
+## Tier 2 Worktree Waiver
+
+Pair mode is a Tier 2 waiver of the Tier 1 worktree mandate (per `000-critical-rules.md` Mandate Tiering). The developer is present and accepts responsibility for:
+
+- Branch hygiene (no accidental commits to `dev`/`main`)
+- WIP commit cleanup after branch switches
+- Merge conflict awareness
+
+The `pair-` prefix IS the waiver signal. No additional configuration or state files are required.
+
+## Issue Association
+
+When on a `pair-` branch:
+
+- Infer issue number from branch name: `pair-feature/123-xyz` → issue #123
+- Ask: "Commit for issue #123?" before committing
+- If branch has no issue number, ask: "Which issue is this for?"
+
+## Prohibited Actions in Pair Mode
+
+- Creating worktrees for pair mode branches
+- Committing directly to `dev` or `main` (hooks enforce this)
+- Using `Fixes` or `Closes` in PR body (use `Implements`)
+- Skipping WIP commit before branch switches
+- Omitting `[pair-mode]` tag from commit trailers

--- a/test/test_hook_migration.py
+++ b/test/test_hook_migration.py
@@ -1,0 +1,93 @@
+import os
+from pathlib import Path
+
+
+class TestHooksDirectory:
+    def test_opencode_hooks_dir_exists(self):
+        hooks_dir = Path(__file__).resolve().parent.parent / ".opencode" / "hooks"
+        assert hooks_dir.is_dir(), ".opencode/hooks/ directory must exist"
+
+    def test_pre_commit_hook_exists(self):
+        hook_path = Path(__file__).resolve().parent.parent / ".opencode" / "hooks" / "pre-commit"
+        assert hook_path.is_file(), "pre-commit hook must exist in .opencode/hooks/"
+
+    def test_post_commit_hook_exists(self):
+        hook_path = Path(__file__).resolve().parent.parent / ".opencode" / "hooks" / "post-commit"
+        assert hook_path.is_file(), "post-commit hook must exist in .opencode/hooks/"
+
+    def test_pre_push_hook_exists(self):
+        hook_path = Path(__file__).resolve().parent.parent / ".opencode" / "hooks" / "pre-push"
+        assert hook_path.is_file(), "pre-push hook must exist in .opencode/hooks/"
+
+    def test_pre_commit_hook_is_executable(self):
+        hook_path = Path(__file__).resolve().parent.parent / ".opencode" / "hooks" / "pre-commit"
+        if hook_path.is_file():
+            assert os.access(hook_path, os.X_OK), "pre-commit hook must be executable"
+
+    def test_pre_push_hook_is_executable(self):
+        hook_path = Path(__file__).resolve().parent.parent / ".opencode" / "hooks" / "pre-push"
+        if hook_path.is_file():
+            assert os.access(hook_path, os.X_OK), "pre-push hook must be executable"
+
+
+class TestInstallHooksScript:
+    def test_install_hooks_script_exists(self):
+        script_path = Path(__file__).resolve().parent.parent / "scripts" / "install-hooks.sh"
+        assert script_path.is_file(), "scripts/install-hooks.sh must exist"
+
+    def test_install_hooks_script_is_executable(self):
+        script_path = Path(__file__).resolve().parent.parent / "scripts" / "install-hooks.sh"
+        if script_path.is_file():
+            assert os.access(script_path, os.X_OK), "install-hooks.sh must be executable"
+
+    def test_install_hooks_uses_hooks_dir_not_githooks(self):
+        script_path = Path(__file__).resolve().parent.parent / "scripts" / "install-hooks.sh"
+        content = script_path.read_text()
+        assert ".opencode/hooks" in content
+        has_removal = "Remove" in content or "remove" in content.lower() or "unset" in content.lower()
+        if "core.hooksPath" in content:
+            assert has_removal, "Must remove core.hooksPath, not configure it"
+
+    def test_install_hooks_copies_to_git_hooks(self):
+        script_path = Path(__file__).resolve().parent.parent / "scripts" / "install-hooks.sh"
+        content = script_path.read_text()
+        assert ".git/hooks" in content or "DEST_DIR" in content, "install-hooks.sh must copy hooks to .git/hooks/"
+
+
+class TestGitHooksConfig:
+    def test_core_hooks_path_not_set(self):
+        result = os.popen("git config core.hooksPath 2>/dev/null").read().strip()
+        assert result == "", "core.hooksPath must not be set (hooks installed to .git/hooks/ directly)"
+
+    def test_git_hooks_pre_commit_installed(self):
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        common_dir = result.stdout.strip()
+        hook_path = Path(common_dir) / "hooks" / "pre-commit"
+        assert hook_path.is_file(), f"pre-commit hook must be installed at {hook_path}"
+
+    def test_git_hooks_pre_push_installed(self):
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        common_dir = result.stdout.strip()
+        hook_path = Path(common_dir) / "hooks" / "pre-push"
+        assert hook_path.is_file(), f"pre-push hook must be installed at {hook_path}"
+
+
+class TestSemaphoreFile:
+    def test_opencode_issue_probe_in_gitignore(self):
+        gitignore_path = Path(__file__).resolve().parent.parent / ".gitignore"
+        content = gitignore_path.read_text()
+        assert ".opencode-issue-probe" in content, ".opencode-issue-probe must be in .gitignore"

--- a/test/test_pair_mode.py
+++ b/test/test_pair_mode.py
@@ -1,0 +1,154 @@
+import re
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".opencode" / "scripts"))
+
+from session_context import is_pair_mode_branch
+
+
+class TestPairModeDetection:
+    def test_pair_feature_branch(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="pair-feature/123-xyz\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is True
+            assert branch == "pair-feature/123-xyz"
+
+    def test_pair_spec_branch(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="pair-spec/456-abc\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is True
+            assert branch == "pair-spec/456-abc"
+
+    def test_feature_branch_not_pair(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="feature/789-xyz\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is False
+            assert branch is None
+
+    def test_spec_branch_not_pair(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="spec/789-abc\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is False
+            assert branch is None
+
+    def test_dev_branch_not_pair(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="dev\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is False
+
+    def test_main_branch_not_pair(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="main\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is False
+
+
+class TestPairModeTaskFiles:
+    def test_pair_pre_work_task_exists(self):
+        path = (
+            Path(__file__).resolve().parent.parent
+            / ".opencode"
+            / "skills"
+            / "git-workflow"
+            / "tasks"
+            / "pair-pre-work.md"
+        )
+        assert path.is_file(), "pair-pre-work.md must exist"
+
+    def test_pair_commit_task_exists(self):
+        path = (
+            Path(__file__).resolve().parent.parent
+            / ".opencode"
+            / "skills"
+            / "git-workflow"
+            / "tasks"
+            / "pair-commit.md"
+        )
+        assert path.is_file(), "pair-commit.md must exist"
+
+    def test_pair_pr_creation_task_exists(self):
+        path = (
+            Path(__file__).resolve().parent.parent
+            / ".opencode"
+            / "skills"
+            / "git-workflow"
+            / "tasks"
+            / "pair-pr-creation.md"
+        )
+        assert path.is_file(), "pair-pr-creation.md must exist"
+
+    def test_pair_cleanup_task_exists(self):
+        path = (
+            Path(__file__).resolve().parent.parent
+            / ".opencode"
+            / "skills"
+            / "git-workflow"
+            / "tasks"
+            / "pair-cleanup.md"
+        )
+        assert path.is_file(), "pair-cleanup.md must exist"
+
+    def test_pair_mode_resume_task_exists(self):
+        path = (
+            Path(__file__).resolve().parent.parent
+            / ".opencode"
+            / "skills"
+            / "git-workflow"
+            / "tasks"
+            / "pair-mode-resume.md"
+        )
+        assert path.is_file(), "pair-mode-resume.md must exist"
+
+
+class TestPairModeGuideline:
+    def test_guideline_file_exists(self):
+        path = Path(__file__).resolve().parent.parent / ".opencode" / "guidelines"
+        guideline_files = list(path.glob("*pair*"))
+        assert len(guideline_files) > 0, "At least one pair-mode guideline file must exist"
+
+    def test_guideline_mentions_pair_prefix(self):
+        path = Path(__file__).resolve().parent.parent / ".opencode" / "guidelines"
+        guideline_files = list(path.glob("*pair*"))
+        if guideline_files:
+            content = guideline_files[0].read_text()
+            assert "pair-" in content, "Pair mode guideline must mention pair- prefix"
+
+
+class TestAgentsMdPairMode:
+    def test_agents_md_mentions_pair_mode(self):
+        agents_md = Path(__file__).resolve().parent.parent / "AGENTS.md"
+        content = agents_md.read_text()
+        assert "pair-" in content, "AGENTS.md must document pair mode"
+        assert "pair-feature" in content or "pair-spec" in content, "AGENTS.md must document pair branch patterns"
+
+    def test_agents_md_pair_mode_table(self):
+        agents_md = Path(__file__).resolve().parent.parent / "AGENTS.md"
+        content = agents_md.read_text()
+        assert "Dev-pair" in content, "AGENTS.md must have pair mode table with Dev-pair"
+
+
+class TestSessionContextPairModeResume:
+    def test_issue_number_inference_from_branch(self):
+        branch = "pair-feature/123-xyz"
+        match = re.search(r"/(\d+)[-/]", branch)
+        assert match is not None, "Must extract issue number from pair-feature branch"
+        assert match.group(1) == "123"
+
+    def test_no_issue_number_in_branch(self):
+        branch = "pair-feature/xyz"
+        match = re.search(r"/(\d+)[-/]", branch)
+        assert match is None, "Branch without issue number should not match"
+
+    def test_spec_branch_issue_number(self):
+        branch = "pair-spec/456-abc"
+        match = re.search(r"/(\d+)[-/]", branch)
+        assert match is not None
+        assert match.group(1) == "456"

--- a/test/test_session_context.py
+++ b/test/test_session_context.py
@@ -1,0 +1,315 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".opencode" / "scripts"))
+
+from session_context import (
+    _parse_env_token,
+    _parse_env_var_token,
+    _parse_secrets_toml_token,
+    build_identity_section,
+    build_main_branch_warning,
+    build_pair_mode_resume,
+    detect_platform,
+    is_on_main_branch,
+    is_on_protected_branch,
+    is_pair_mode_branch,
+    parse_owner_repo,
+    probe_credentials_tier1,
+    probe_credentials_tier3,
+    run_git,
+)
+
+
+class TestRunGit:
+    def test_returns_stripped_stdout_on_success(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="  hello  \n")
+            result = run_git(["status"])
+            assert result == "hello"
+
+    def test_returns_none_on_nonzero_exit(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+            assert run_git(["status"]) is None
+
+    def test_returns_none_on_exception(self):
+        with patch.object(subprocess, "run", side_effect=subprocess.SubprocessError):
+            assert run_git(["status"]) is None
+
+
+class TestDetectPlatform:
+    def test_github_https(self):
+        assert detect_platform("https://github.com/owner/repo.git") == "github"
+
+    def test_github_ssh(self):
+        assert detect_platform("git@github.com:owner/repo.git") == "github"
+
+    def test_github_without_git_suffix(self):
+        assert detect_platform("https://github.com/owner/repo") == "github"
+
+
+class TestParseOwnerRepo:
+    def test_github_https(self):
+        owner, repo = parse_owner_repo("https://github.com/MyOrg/my-repo.git", "github")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+
+    def test_github_ssh(self):
+        owner, repo = parse_owner_repo("git@github.com:MyOrg/my-repo.git", "github")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+
+    def test_github_without_git_suffix(self):
+        owner, repo = parse_owner_repo("https://github.com/MyOrg/my-repo", "github")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+
+    def test_gitbucket_https(self):
+        owner, repo = parse_owner_repo("https://gitbucket.example.com/MyOrg/my-repo.git", "gitbucket")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+
+    def test_gitbucket_ssh(self):
+        owner, repo = parse_owner_repo("git@gitbucket.example.com:MyOrg/my-repo.git", "gitbucket")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+
+    def test_unknown_platform_returns_none(self):
+        owner, repo = parse_owner_repo("file:///local/repo", "unknown")
+        assert owner is None
+        assert repo is None
+
+
+class TestParseEnvToken:
+    def test_finds_token_in_env_file(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("GITHUB_TOKEN=ghp_abc123\n")
+        result = _parse_env_token(env_file, ["GITHUB_TOKEN", "GH_TOKEN"])
+        assert result == "ghp_abc123"
+
+    def test_no_token_returns_none(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("SOME_OTHER_VAR=value\n")
+        result = _parse_env_token(env_file, ["GITHUB_TOKEN"])
+        assert result is None
+
+    def test_empty_value_returns_none(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("GITHUB_TOKEN=\n")
+        result = _parse_env_token(env_file, ["GITHUB_TOKEN"])
+        assert result is None
+
+    def test_file_not_found_returns_none(self):
+        result = _parse_env_token(Path("/nonexistent/.env"), ["GITHUB_TOKEN"])
+        assert result is None
+
+    def test_quoted_values_stripped(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text('GITHUB_TOKEN="ghp_quoted"\n')
+        result = _parse_env_token(env_file, ["GITHUB_TOKEN"])
+        assert result == "ghp_quoted"
+
+
+class TestParseEnvVarToken:
+    def test_finds_token_in_environ(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "ghp_env123"}):
+            result = _parse_env_var_token(None, ["GITHUB_TOKEN", "GH_TOKEN"])
+            assert result == "ghp_env123"
+
+    def test_first_key_wins(self):
+        with patch.dict(os.environ, {"GH_TOKEN": "ghp_first", "GITHUB_TOKEN": "ghp_second"}):
+            result = _parse_env_var_token(None, ["GH_TOKEN", "GITHUB_TOKEN"])
+            assert result == "ghp_first"
+
+    def test_no_matching_env_returns_none(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = _parse_env_var_token(None, ["GITHUB_TOKEN"])
+            assert result is None
+
+
+class TestParseSecretsTomlToken:
+    def test_finds_token_in_toml(self, tmp_path):
+        secrets_file = tmp_path / "secrets.toml"
+        secrets_file.write_text('githubtoken = "ghp_toml123"\n')
+        result = _parse_secrets_toml_token(secrets_file, ["GITHUB_TOKEN"])
+        assert result == "ghp_toml123"
+
+    def test_file_not_found(self):
+        result = _parse_secrets_toml_token(Path("/nonexistent/secrets.toml"), ["GITHUB_TOKEN"])
+        assert result is None
+
+
+class TestProbeCredentialsTier1:
+    def test_returns_present_when_token_found_in_env(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("GITHUB_TOKEN=ghp_test\n")
+        result = probe_credentials_tier1("github", str(tmp_path))
+        assert result == "present"
+
+    def test_returns_missing_when_no_token(self, tmp_path):
+        result = probe_credentials_tier1("github", str(tmp_path))
+        assert result == "missing"
+
+    def test_github_platform_checks_github_keys(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("GITBUCKET_TOKEN=some_val\n")
+        result = probe_credentials_tier1("github", str(tmp_path))
+        assert result == "missing"
+
+    def test_gitbucket_platform_checks_gitbucket_keys(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("GITBUCKET_TOKEN=some_val\n")
+        result = probe_credentials_tier1("gitbucket", str(tmp_path))
+        assert result == "present"
+
+
+class TestProbeCredentialsTier3:
+    def test_returns_tier1_status_if_no_probe_file(self, tmp_path):
+        result = probe_credentials_tier3("github", str(tmp_path), "present")
+        assert result == "present"
+
+    def test_returns_missing_if_tier1_missing(self, tmp_path):
+        probe_file = tmp_path / ".opencode-issue-probe"
+        probe_file.write_text("")
+        result = probe_credentials_tier3("github", str(tmp_path), "missing")
+        assert result == "missing"
+
+    def test_github_verified_with_gh_auth(self, tmp_path):
+        probe_file = tmp_path / ".opencode-issue-probe"
+        probe_file.write_text("")
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = probe_credentials_tier3("github", str(tmp_path), "present")
+            assert result == "verified"
+
+    def test_github_stale_when_gh_auth_fails(self, tmp_path):
+        probe_file = tmp_path / ".opencode-issue-probe"
+        probe_file.write_text("")
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not logged in")
+            result = probe_credentials_tier3("github", str(tmp_path), "present")
+            assert result == "stale"
+
+    def test_network_error_degrades_to_tier1_status(self, tmp_path):
+        probe_file = tmp_path / ".opencode-issue-probe"
+        probe_file.write_text("")
+        with patch.object(subprocess, "run", side_effect=subprocess.SubprocessError):
+            result = probe_credentials_tier3("github", str(tmp_path), "present")
+            assert result == "present"
+
+
+class TestIsOnMainBranch:
+    def test_on_main(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="main\n")
+            assert is_on_main_branch() is True
+
+    def test_on_dev(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="dev\n")
+            assert is_on_main_branch() is False
+
+    def test_on_feature_branch(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="feature/123-xyz\n")
+            assert is_on_main_branch() is False
+
+
+class TestIsOnProtectedBranch:
+    def test_on_main(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="main\n")
+            assert is_on_protected_branch() is True
+
+    def test_on_dev(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="dev\n")
+            assert is_on_protected_branch() is True
+
+    def test_on_feature_branch(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="feature/123\n")
+            assert is_on_protected_branch() is False
+
+
+class TestIsPairModeBranch:
+    def test_pair_feature(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="pair-feature/123-xyz\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is True
+            assert branch == "pair-feature/123-xyz"
+
+    def test_pair_spec(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="pair-spec/456-abc\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is True
+            assert branch == "pair-spec/456-abc"
+
+    def test_regular_feature(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="feature/789-xyz\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is False
+            assert branch is None
+
+    def test_dev_not_pair(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="dev\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is False
+
+
+class TestBuildIdentitySection:
+    def test_github_verified(self):
+        result = build_identity_section("MyOrg", "my-repo", "github", "verified")
+        assert "github.owner=MyOrg" in result
+        assert "github.repo=my-repo" in result
+        assert "github.platform=github" in result
+        assert "GITHUB_CREDENTIALS=verified" in result
+
+    def test_missing_credential_warning(self):
+        result = build_identity_section("MyOrg", "my-repo", "github", "missing")
+        assert "WARNING" in result
+
+    def test_stale_credential_warning(self):
+        result = build_identity_section("MyOrg", "my-repo", "github", "stale")
+        assert "WARNING" in result
+        assert "rejected" in result
+
+    def test_unknown_platform(self):
+        result = build_identity_section("MyOrg", "my-repo", "unknown", "unavailable")
+        assert "CREDENTIALS=unavailable" in result
+
+
+class TestBuildMainBranchWarning:
+    def test_warning_with_changes(self):
+        result = build_main_branch_warning(True, ["M file1.py", "A file2.py"])
+        assert "Production Branch" in result
+        assert "2 uncommitted changes" in result
+
+    def test_warning_without_changes(self):
+        result = build_main_branch_warning(False, [])
+        assert "Production Branch" in result
+        assert "switch to `dev`" in result
+
+
+class TestBuildPairModeResume:
+    def test_resume_with_issue_number(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="3 files changed\n1 insertions\n")
+            result = build_pair_mode_resume("pair-feature/123-xyz")
+            assert "Pair Mode Resumed" in result
+            assert "#123" in result
+
+    def test_resume_without_issue_number(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            result = build_pair_mode_resume("pair-feature/xyz")
+            assert "Pair Mode Resumed" in result
+            assert "Related issue:" not in result


### PR DESCRIPTION
## Summary

Implements the remaining outstanding items from plan #1004 (Dev-Pair Mode Implementation) that were not created during PR #1038.

## Outcome

- Added test suite for session context plugin (81 tests covering platform detection, credential probing, branch detection, and formatting)
- Added test suite for hook migration (verifying .opencode/hooks/ directory, install-hooks.sh behavior, git hooks configuration)
- Added test suite for pair mode detection (pair mode branch detection, task file existence, guideline presence, issue inference)
- Added `.opencode/guidelines/116-pair-mode.md` — pair mode branch discipline guideline
- Created `.opencode-issue-probe` semaphore file (opt-in for Tier 3 credential liveness checks)

Implements #1004