### PR TITLE
feat: add sub-issue linkage verification and post-merge cleanup enforcement (#1050)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -695,6 +695,18 @@ Structural decisions — single-task vs multi-task classification, phase decompo
 
 **See `approval-gate` skill → `verify-already-implemented` task → "Auto-Close Procedure" for the post-merge issue closure workflow. See `finishing-a-development-branch` skill → `checklist` task for issue-closure verification steps.**
 
+## Critical Violation: Sub-issue Linkage Verification — Phase Count Mismatch
+
+**⚠️ `get_sub_issues` count MUST match plan body phase count before implementation proceeds. If counts don't match, block implementation and offer remediation via `issue-operations --task link-sub-issue`.**
+
+**This enforcement point is `approval-gate --task verify-authorization` Step 5, specifically the phase-count cross-reference check (Step 5.2.1).** **AUTHORITY: `approval-gate/tasks/verify-authorization.md` Step 5.2.1** (this line is a reference only)
+
+- 🚫 FORBIDDEN: Proceeding with implementation when a multi-task plan has fewer formal sub-issues than phases in its body; treating markdown headings as equivalent to formal sub-issue linkage; skipping the phase-count cross-reference check
+- ✅ REQUIRED: Parse plan body for `### Phase N:` or `#### Task N:` heading patterns to count expected phases; compare count against `github_issue_read(method=get_sub_issues)` result count; if plan body has N > 1 phases and `get_sub_issues` returns fewer than N sub-issues, report STRUCTURE-VIOLATION and block implementation with a remediation offer to run `issue-operations --task link-sub-issue`
+- ✅ REQUIRED: Single-task plans (0 or 1 phases expected) skip the count check and pass automatically
+
+**See `020-go-prohibitions.md` §5 for multi-task plan sub-issue requirements.** **AUTHORITY: `020-go-prohibitions.md` §5** (this line is a reference only)
+
 ## Critical Violation: Inline Screening of Authorization Sets
 
 **⚠️ The agent MUST ALWAYS dispatch `screen-issue` sub-agents for per-issue screening, regardless of approval set size. Loading issue bodies into the orchestrator's own context is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -214,6 +214,56 @@ for sub_issue in sub_issues:
         pass
 ```
 
+#### 5.2.1 Phase-Count Cross-Reference Check
+
+**For multi-task plans, verify that the number of sub-issues matches the number of phases in the plan body.** A mismatch indicates incomplete sub-issue linkage — phases exist in the plan but lack corresponding formal GitHub sub-issues.
+
+```python
+import re
+
+def count_plan_phases(plan_body: str) -> int:
+    heading_patterns = [
+        r"^###\s+Phase\s+\d+",
+        r"^####\s+Task\s+\d+",
+        r"^##\s+Phase\s+\d+",
+    ]
+    phase_count = 0
+    for line in plan_body.splitlines():
+        for pattern in heading_patterns:
+            if re.match(pattern, line.strip()):
+                phase_count += 1
+                break
+    return phase_count
+
+expected_phases = count_plan_phases(plan_body)
+actual_sub_issues = github_issue_read(method="get_sub_issues", issue_number=plan_issue)
+actual_count = len(actual_sub_issues)
+
+if expected_phases > 1 and actual_count < expected_phases:
+    # STRUCTURE-VIOLATION: Plan has N phases but fewer than N sub-issues
+    # Block implementation and offer remediation
+    findings.append({
+        "finding": f"Plan has {expected_phases} phases but only {actual_count} sub-issues",
+        "problem_class": "STRUCTURE-VIOLATION",
+        "classification": "auto-fix",
+        "action": "block_implementation",
+        "remediation": "issue-operations --task link-sub-issue"
+    })
+elif expected_phases <= 1:
+    # Single-task plan — skip count check, pass
+    pass
+```
+
+**Finding Classification:**
+
+| Finding | Problem Class | Classification | Action |
+|---------|---------------|----------------|--------|
+| Plan has N > 1 phases, sub-issues < N | STRUCTURE-VIOLATION | auto-fix | Block implementation; offer `issue-operations --task link-sub-issue` to create missing linkages |
+| Plan has N > 1 phases, sub-issues >= N | VERIFIED | auto-proceed | Phase count matches; continue verification |
+| Plan has 0 or 1 phases | VERIFIED | auto-proceed | Single-task plan; count check skipped |
+
+**Evidence artifact:** `count_plan_phases()` result and `github_issue_read(method=get_sub_issues)` count MUST be recorded in the verification report.
+
 #### 5.3 Adversarial Verification of Sub-Issue State
 
 **Before trusting any sub-issue claim, verify against actual GitHub API state.**

--- a/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
@@ -72,6 +72,9 @@ Run the completion checklist to verify a branch is fully ready for PR creation.
 ### Issue Closure Verification
 - [ ] Verify all issues referenced by the merged PR are closed on GitHub
 - [ ] If issues remain open after verified merge, close them with a comment referencing the merged PR
+
+### Sub-Issue Linkage Verification
+- [ ] If the plan has multiple phases, verify that `get_sub_issues` count on the plan issue matches the number of phases in the plan body. If counts don't match, run `issue-operations --task link-sub-issue` to create missing linkages before proceeding to review-prep
 ```
 
 ## What Skills MUST Check

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -363,6 +363,58 @@ Total nodes visited: <N>
 
 **If orphaned sub-issues remain:** Do NOT close them. Report them as verification gaps requiring developer attention.
 
+### Step 2.7.8: Orphaned Task Issues (Unlinked Sub-issues)
+
+For issues with `[Task: #N]` or `Phase N:` patterns in their title that reference the parent plan but are not formal sub-issues (i.e., not returned by `get_sub_issues`), include them in closure candidates by searching the issue body and PR body for these references.
+
+```python
+def find_orphaned_task_issues(parent_issue_number, pr_body, pr_files):
+    """
+    Find issues that reference a parent plan in their title but
+    are not linked via formal sub-issue relationships.
+    """
+    sub_issues = github_issue_read(
+        method="get_sub_issues", issue_number=parent_issue_number
+    )
+    linked_numbers = {sub["number"] for sub in sub_issues}
+
+    title_patterns = [
+        r"\[Task:\s*#(\d+)\]",
+        r"Phase\s+\d+",
+    ]
+
+    orphaned_candidates = []
+
+    search_sources = [pr_body]
+    parent_issue = github_issue_read(method="get", issue_number=parent_issue_number)
+    if parent_issue.get("body"):
+        search_sources.append(parent_issue["body"])
+
+    for source in search_sources:
+        for match in re.finditer(r"#(\d+)", source):
+            ref_num = int(match.group(1))
+            if ref_num == parent_issue_number:
+                continue
+            if ref_num in linked_numbers:
+                continue
+
+            ref_issue = github_issue_read(method="get", issue_number=ref_num)
+            ref_title = ref_issue.get("title", "")
+
+            for pattern in title_patterns:
+                if re.search(pattern, ref_title):
+                    orphaned_candidates.append({
+                        "number": ref_num,
+                        "title": ref_title,
+                        "state": ref_issue.get("state"),
+                    })
+                    break
+
+    return orphaned_candidates
+```
+
+For each orphaned task issue found, apply the same closure verification logic as formal sub-issues (check deliverables against PR file list, verify merged PR evidence). Orphaned issues with verified deliverables should be closed; those without should be flagged for developer review.
+
 ### Step 3: Switch to Dev and Sync (Fast-Forward Only)
 
 **Three-Branch Workflow:** After feature PR merge, switch to `dev` (not `main`) and sync with remote.

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -447,6 +447,17 @@ After a PR has been created, the chat output MUST use **"PR URL"** with the `pul
 - Wait for developer's next explicit instruction
 - If developer says "approved" or "go" again → STILL WAIT for "create a PR"
 
+### ⚠️ Post-Merge Reminder (MANDATORY)
+
+**After PR merge confirmation, run `git-workflow --task cleanup` to close issues, clean branches, and verify sub-issue closure.**
+
+This reminder is part of the review-prep HALT output to ensure the cleanup workflow is not skipped after merge. The cleanup task handles:
+
+- Verifying PR merge via GitHub API
+- Closing sub-issues and parent issues with proper verification
+- Deleting merged branches (local and remote)
+- Running transitive graph reconciliation for orphaned sub-issues
+
 ### ⚠️ CRITICAL: Implementation Must Push Before Review-Prep
 
 **If review-prep is invoked but branch is NOT pushed:**


### PR DESCRIPTION
## Summary

Add enforcement checkpoints to prevent sub-issues from being orphaned after plan implementation, and add post-merge cleanup reminders to the review-prep workflow.

## Outcome

Sub-issues that are created during plan setup but never linked to the parent plan via `github_sub_issue_write` will now be caught by a phase-count cross-reference check in `approval-gate --task verify-authorization` Step 5. Post-merge cleanup is reinforced with a mandatory reminder in `review-prep` output. The cleanup task now handles orphaned task issues that reference a parent plan by title pattern but lack formal sub-issue linkage.

Remediated the immediate gap: closed orphaned task issues #1005-#1008 (all completed in PRs #1038 and #1048), removed stale `needs-approval` label from #1004.

Fixes #1049

Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)