### PR TITLE
fix: PEP 723 script invocation compliance

### DIFF
--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -40,7 +40,7 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
   }
 
   try {
-    const result = await $.nothrow()`uv run .opencode/tools/session-init`;
+    const result = await $.nothrow()`uv run --script .opencode/tools/session-init`;
     const stdout = result.text();
 
     if (!stdout || stdout.trim().length === 0) {
@@ -73,7 +73,7 @@ async function runSessionContext($: PluginInput["$"]): Promise<string> {
   }
 
   try {
-    const result = await $.nothrow()`uv run .opencode/scripts/session_context.py`;
+    const result = await $.nothrow()`uv run --script .opencode/scripts/session_context.py`;
     const stdout = result.text();
 
     if (result.exitCode !== 0) {

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/test_api_deficiencies.py
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/test_api_deficiencies.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """GitBucket API Deficiencies Test Suite.
 
 Tests the documented API deficiencies to verify if they persist after GitBucket upgrades.

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/test_pr_idempotency.py
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/test_pr_idempotency.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 import json
 import os
 import tempfile

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
 """GitBucket API Verification Tests.
 
 This script verifies that the documented GitBucket API endpoints match

--- a/.opencode/tests/test-pep723-tools.sh
+++ b/.opencode/tests/test-pep723-tools.sh
@@ -57,6 +57,13 @@ check_no_old_references() {
     fi
 }
 
+check_python_script() {
+    local file="$1"
+    check_shebang "$file"
+    check_pep723_metadata "$file"
+    check_python_version_pinned "$file"
+}
+
 ENTRY_POINTS=(
     guidelines memory md py jupyter help file-exists
     schema-version jupyter-start jupyter-stop symbolic session-init
@@ -70,7 +77,45 @@ for tool in "${ENTRY_POINTS[@]}"; do
     check_python_version_pinned "$file"
 done
 
+IMPL_DIR=".opencode/tools/impl"
+for impl_file in "$IMPL_DIR"/*; do
+    [ -f "$impl_file" ] || continue
+    check_python_script "$impl_file"
+done
+
+SCRIPTS_DIR=".opencode/scripts"
+for script_file in "$SCRIPTS_DIR"/*.py; do
+    [ -f "$script_file" ] || continue
+    check_python_script "$script_file"
+done
+
+SKILL_SCRIPTS_DIR=".opencode/skills"
+find "$SKILL_SCRIPTS_DIR" -name '*.py' -not -path '*/tests/*' | while read -r skill_py; do
+    check_python_script "$skill_py"
+done
+
 check_no_old_references
+
+check_plugin_invocations() {
+    local plugin_failures=0
+    local plugin_files
+    plugin_files=$(find .opencode/plugins -name '*.ts' -o -name '*.js' 2>/dev/null || true)
+    for pf in $plugin_files; do
+        local bare_matches
+        bare_matches=$(grep -n 'uv run [^ ]*\.opencode/' "$pf" 2>/dev/null | grep -v '\-\-script' || true)
+        if [ -n "$bare_matches" ]; then
+            echo "FAIL: $pf has bare 'uv run' without --script:"
+            echo "$bare_matches"
+            FAIL=$((FAIL + 1))
+            plugin_failures=$((plugin_failures + 1))
+        fi
+    done
+    if [ "$plugin_failures" -eq 0 ]; then
+        PASS=$((PASS + 1))
+    fi
+}
+
+check_plugin_invocations
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Plugin invocations used bare `uv run` instead of `uv run --script`, forcing project venv dependency sync (including PyTorch ~2GB) for lightweight tool scripts. This is the root cause of session-init output never reaching the LLM system prompt.

## Outcome

- **Critical fix**: `session-enforcement.ts` now invokes `uv run --script` for both `session-init` and `session_context.py`, enabling PEP 723 standalone execution
- **Compliance**: 3 gitbucket-api test files now have PEP 723 shebangs + inline metadata
- **Test coverage**: `test-pep723-tools.sh` extended to check impl/, scripts/, skills/*.py, and plugin invocation patterns
- **Verified**: `uv run --script .opencode/tools/session-init` produces `github.owner: Brothertown-Language` output correctly

Fixes #1055

🤖 OpenCode (ollama-cloud/glm-5.1) completed