### PR TITLE
fix: relocate gitbucket_api.py to CLI tool + fix PEP 723 invocations

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -757,10 +757,10 @@ Any API mutation (PR creation, issue creation, branch creation) MUST be idempote
 
 **⚠️ API calls that mutate state (POST, PUT, PATCH) inlined in `python -c '...'` strings are a CRITICAL GUIDELINE VIOLATION.**
 
-API calls that mutate state must use the platform's dedicated API client (e.g., `GitBucketAPI`, GitHub MCP). If the client lacks the method, HALT — do NOT work around it with inline scripts. Shell interpolation corrupts inline Python, POST calls succeed but parsing crashes, and agents retry the entire call creating duplicates.
+API calls that mutate state must use the platform's dedicated API client (e.g., `gitbucket-api` CLI tool, GitHub MCP). If the client lacks the method, HALT — do NOT work around it with inline scripts. Shell interpolation corrupts inline Python, POST calls succeed but parsing crashes, and agents retry the entire call creating duplicates.
 
 - 🚫 FORBIDDEN: `uv run python -c '...'` for any POST/PUT/PATCH operation; raw `requests.post()` / `requests.put()` / `requests.patch()` outside the dedicated API client; any inline script containing a mutation HTTP method
-- ✅ REQUIRED: Use `GitBucketAPI.create_pull_request()`, `GitBucketAPI.create_issue()`, etc. for all mutations; if the client lacks a needed method, HALT and report the gap; use the API client's built-in error handling and response parsing
+- ✅ REQUIRED: Use `./.opencode/tools/gitbucket-api create-pr`, `./.opencode/tools/gitbucket-api create-issue`, etc. for all GitBucket mutations; use GitHub MCP for GitHub mutations; if a needed command is missing, HALT and report the gap; use the tool's built-in error handling and response parsing
 
 ## Sub-Agent Extraction Pattern
 

--- a/.opencode/guidelines/060-tool-usage.md
+++ b/.opencode/guidelines/060-tool-usage.md
@@ -32,7 +32,7 @@ ABSOLUTE EXCEPTION: .ipynb files → the-notebook-mcp MANDATORY (zero tolerance,
 
 ### API Client Mandatory (ZERO TOLERANCE)
 
-When a platform has a dedicated API client (e.g., `GitBucketAPI`, GitHub MCP), the agent MUST use it for ALL operations. If the client lacks a needed method:
+When a platform has a dedicated API client (e.g., `gitbucket-api` CLI tool at `.opencode/tools/gitbucket-api`, GitHub MCP), the agent MUST use it for ALL operations. If the client lacks a needed method:
 
 1. HALT
 2. Report: executive summary of what was needed, the missing method name, possible resolution

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -40,7 +40,7 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
   }
 
   try {
-    const result = await $.nothrow()`uv run --script .opencode/tools/session-init`;
+    const result = await $.nothrow()`./.opencode/tools/session-init`;
     const stdout = result.text();
 
     if (!stdout || stdout.trim().length === 0) {
@@ -73,7 +73,7 @@ async function runSessionContext($: PluginInput["$"]): Promise<string> {
   }
 
   try {
-    const result = await $.nothrow()`uv run --script .opencode/scripts/session_context.py`;
+    const result = await $.nothrow()`./.opencode/scripts/session_context.py`;
     const stdout = result.text();
 
     if (result.exitCode !== 0) {

--- a/.opencode/skills/fragment-manager/tasks/status-report.md
+++ b/.opencode/skills/fragment-manager/tasks/status-report.md
@@ -96,19 +96,10 @@ Include last modified dates, hash values, line ranges.
 ### JSON Export
 
 ```bash
-uv run python -c "
-import yaml
-import json
-
-with open('.opencode/.guidelines/registry.yaml') as f:
-    registry = yaml.safe_load(f)
-
-print(json.dumps({
-    'total': len(registry['fragments']),
-    'synchronized': sum(1 for f in registry['fragments'] if f.get('sync_status') == 'synchronized'),
-    'drifted': sum(1 for f in registry['fragments'] if f.get('sync_status') == 'drifted'),
-}, indent=2))
-"
+# Use the registry tool for structured output, or parse YAML directly:
+./.opencode/tools/guidelines search fragment-status
+# For programmatic access, write a script to ./tmp/ and run it:
+./tmp/registry-export.py
 ```
 
 ## Edge Cases

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -770,28 +770,8 @@ Fixes #<child2>
 
 #### GitBucket (github.platform=gitbucket)
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-pr = api.create_pull_request(
-    owner=<github.owner>,
-    repo=<github.repo>,
-    title="[SPEC] <description>",
-    body="""**Summary:**
-
-<1-2 sentences describing the impact and stakeholder value>
-
-**Outcome:** <What changed for stakeholders>
-
-Fixes #<parent>
-Fixes #<child1>
-Fixes #<child2>
-...
-""",
-    head=branch_name,
-    base="dev"
-)
+```bash
+./.opencode/tools/gitbucket-api create-pr <github.owner> <github.repo> "[SPEC] <description>" <branch-name> dev --body "<PR body>"
 ```
 
 **PR Body Requirements:**

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/API-DEFICIENCIES.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/API-DEFICIENCIES.md
@@ -16,7 +16,7 @@ This document records discovered API deficiencies between the OpenAPI specificat
 
 **How to Retest:**
 ```bash
-uv run python .opencode/skills/gitbucket-api/tests/verify_api.py
+./.opencode/skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py
 ```
 
 ## Deficiencies Discovered (Post-Upgrade Status)

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/SKILL.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/SKILL.md
@@ -61,16 +61,33 @@ GitBucket platform implementation using Python client. Implements a GitHub-compa
 
 Token authentication ONLY. Basic auth is broken in GitBucket (returns "Bad credentials" for all requests).
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-api = GitBucketAPI()  # Reads GITBUCKET_HTML_URL and GITBUCKET_TOKEN from .env
+```bash
+./.opencode/tools/gitbucket-api check-auth
 ```
 
-## Python Client
+## CLI Tool
 
-**Use `from skills.gitbucket_api.tools import GitBucketAPI` for all operations.** The client handles both array and object responses correctly. See task files for endpoint-specific patterns.
+**Use `./.opencode/tools/gitbucket-api <command>` for all GitBucket operations.** The CLI tool handles authentication, response parsing, and error handling. See task files for command-specific patterns.
 
-**CRITICAL: Agent MUST use `GitBucketAPI` for ALL API calls on GitBucket platform. If a needed method is missing, the agent MUST HALT and report: executive summary, exact error/missing method, possible resolution, byline. NEVER fall back to inline `requests` scripts or `python -c` strings.**
+**CRITICAL: Agent MUST use the `gitbucket-api` CLI tool for ALL API calls on GitBucket platform. If a needed command is missing, the agent MUST HALT and report: executive summary, exact error/missing command, possible resolution, byline. NEVER fall back to inline `requests` scripts or `python -c` strings.**
+
+### Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `me` | Get current user |
+| `issues <owner> <repo> [--state open\|closed\|all]` | List issues |
+| `issue <owner> <repo> <number>` | Get single issue |
+| `create-issue <owner> <repo> <title> [--body ...] [--labels ...]` | Create issue |
+| `add-comment <owner> <repo> <number> <body>` | Add comment |
+| `prs <owner> <repo> [--state ...] [--head ...]` | List pull requests |
+| `create-pr <owner> <repo> <title> <head> <base> [--body ...]` | Create pull request |
+| `labels <owner> <repo>` | List labels |
+| `branches <owner> <repo>` | List branches |
+| `repos [--user ...]` | List repositories |
+| `repo <owner> <repo>` | Get repository |
+| `init-config [--path ...]` | Initialize configuration |
+| `check-auth` | Validate authentication |
 
 ## Response Schema
 

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/error-recovery.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/error-recovery.md
@@ -84,22 +84,9 @@ gitbucket.has_credentials: true
 
 ## Token Validation
 
-```python
-def validate_token():
-    """Verify GitBucket token works."""
-    response = requests.get(
-        f"{GITBUCKET_URL}api/v3/user",
-        headers={"Authorization": f"token {GITBUCKET_TOKEN}"}
-    )
-    if response.status_code == 200:
-        print("Token valid")
-        return True
-    if response.status_code == 401:
-        print("Token invalid or expired")
-        return False
-    if response.status_code == 404:
-        print("Wrong endpoint or GitBucket URL")
-        return False
+```bash
+./.opencode/tools/gitbucket-api check-auth
+# Outputs: authentication status and user info if valid
 ```
 
 ## Fallback Strategy

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/issue-operations.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/issue-operations.md
@@ -2,66 +2,44 @@
 
 ## Overview
 
-Issue CRUD operations using GitBucket Python API client.
+Issue CRUD operations using the `gitbucket-api` CLI tool at `.opencode/tools/gitbucket-api`.
 
-**Primary Tool: Python client from `.opencode/skills/gitbucket-api/tools/gitbucket_api.py`**
+**Primary Tool: CLI tool at `.opencode/tools/gitbucket-api`**
 
-**CRITICAL: The `gitbucket_*` MCP tools have been REMOVED. The Python client is the ONLY option. Use `from skills.gitbucket_api.tools import GitBucketAPI` for all operations.**
+**CRITICAL: The `gitbucket_*` MCP tools have been REMOVED. The Python import pattern has been REPLACED by the CLI tool. Use `./.opencode/tools/gitbucket-api <command>` for all operations.**
 
 ## Response Types
 
-**ALL `list_*` methods return arrays:**
-- `list_issues()` → `list[dict]`
-- `get_issue()` → `dict`
+**ALL `list` commands return JSON arrays:**
+- `issues` → JSON array
+- `issue` → JSON object
 
 **Always check type before iterating:**
-```python
-issues = api.list_issues(owner="org", repo="project")
-# type: list[dict]
+```bash
+# List returns JSON array
+./.opencode/tools/gitbucket-api issues org project --state open
 
-issue = api.get_issue(owner="org", repo="project", issue_number=14)
-# type: dict
+# Get single issue returns JSON object
+./.opencode/tools/gitbucket-api issue org project 14
 ```
 
 ## Basic Operations
 
 ### Create Issue
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-issue = api.create_issue(
-    owner="org",
-    repo="project",
-    title="Issue title",
-    body="Issue body",
-    labels=["enhancement", "bug"],  # ✅ Auto-creates labels
-    assignees=["username"],
-    milestone=5
-)
-# Returns: single Issue object (dict)
-print(f"Created issue #{issue['number']}")
+```bash
+./.opencode/tools/gitbucket-api create-issue org project "Issue title" --body "Issue body" --labels enhancement,bug
 ```
 
 **Fields supported:**
-- `title` (required) - Issue title
-- `body` (optional) - Issue description
-- `labels` (optional) - Array of label names (auto-created)
-- `assignees` (optional) - Array of usernames
-- `milestone` (optional) - Milestone number
+- `<title>` (required positional) - Issue title
+- `--body` (optional) - Issue description
+- `--labels` (optional, comma-separated) - Label names (auto-created)
 
 ### Get Issue
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-issue = api.get_issue(owner="org", repo="project", issue_number=14)
-# Returns: single Issue object (dict)
-print(f"Issue title: {issue['title']}")
-print(f"State: {issue['state']}")
-print(f"Labels: {[l['name'] for l in issue['labels']]}")
+```bash
+./.opencode/tools/gitbucket-api issue org project 14
 ```
 
 ### Update Issue
@@ -70,187 +48,64 @@ print(f"Labels: {[l['name'] for l in issue['labels']]}")
 
 GitBucket does NOT implement `PATCH /repos/{owner}/{repo}/issues/{issue_number}`.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
+```bash
 # ❌ THIS DOES NOT WORK - Returns 404
-api = GitBucketAPI()
-issue = api.update_issue(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    title="New title",
-    body="New body"
-)
-# Raises NotFoundError: 404 Not Found
+# No update-issue CLI command available
 ```
 
 **Workaround:** Use GitBucket web UI to update issue title, body, or state. There is no API for updating existing issues.
 
 ### List Issues
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-issues = api.list_issues(
-    owner="org",
-    repo="project",
-    state="open",      # "open", "closed", or "all"
-    labels="bug,enhancement"  # Comma-separated label names
-)
-# Returns: array of Issue objects (list[dict])
-for issue in issues:
-    print(f"#{issue['number']}: {issue['title']}")
+```bash
+./.opencode/tools/gitbucket-api issues org project --state open
 ```
 
 ### Add Comment
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-comment = api.add_issue_comment(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    body="Comment text"
-)
-# Returns: Comment object (dict)
+```bash
+./.opencode/tools/gitbucket-api add-comment org project 14 "Comment text"
 ```
 
 ## Chained Operations
 
 ### Workflow 1: Create Issue with Labels and Comments
 
-**Scenario:** Create issue, add labels, assign user, add welcome comment.
+**Scenario:** Create issue, add welcome comment.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
+```bash
 # Step 1: Create issue with labels
-issue = api.create_issue(
-    owner="org",
-    repo="project",
-    title="Bug: Login fails on mobile",
-    body="## Description\n\nLogin fails on mobile devices.\n\n## Steps to Reproduce\n\n1. Open mobile browser\n2. Navigate to login page\n3. Enter credentials\n4. Click login\n\n## Expected Behavior\n\nShould authenticate successfully.",
-    labels=["bug", "priority:high"]
-)
-print(f"Created issue #{issue['number']}")
+./.opencode/tools/gitbucket-api create-issue org project "Bug: Login fails on mobile" --body "## Description\n\nLogin fails on mobile devices." --labels bug,priority:high
 
 # Step 2: Add welcome comment
-api.add_issue_comment(
-    owner="org",
-    repo="project",
-    issue_number=issue['number'],
-    body="**Status:** Issue created and under investigation.\n\nWe'll look into this shortly."
-)
-
-# Step 3: Update issue (add assignee)
-api.update_issue(
-    owner="org",
-    repo="project",
-    issue_number=issue['number'],
-    assignees=["developer-name"]
-)
-
-print(f"Issue #{issue['number']} created with labels and assigned")
+./.opencode/tools/gitbucket-api add-comment org project <issue-number> "**Status:** Issue created and under investigation.\n\nWe'll look into this shortly."
 ```
 
 ### Workflow 2: Parent/Child Issue Management
 
 **Scenario:** Create parent spec issue and child task issues, link via comments.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
+```bash
 # Step 1: Create parent spec issue
-parent_issue = api.create_issue(
-    owner="org",
-    repo="project",
-    title="[SPEC] Add OAuth2 Authentication",
-    body="#" Spec: OAuth2 Authentication\n\n## Objective\n\nImplement OAuth2 authentication for the application.\n\n## Phases\n\n1. OAuth2 Client Setup\n2. Token Management\n3. Session Handling\n4. UI Integration\n\n## Success Criteria\n\n- Users can authenticate via OAuth2\n- Tokens refresh automatically\n- Sessions persist across page reloads",
-    labels=["enhancement", "spec"]
-)
-print(f"Parent issue #{parent_issue['number']} created")
+./.opencode/tools/gitbucket-api create-issue org project "[SPEC] Add OAuth2 Authentication" --body "## Objective\n\nImplement OAuth2 authentication." --labels enhancement,spec
 
-# Step 2: Create child task issues
-phases = [
-    "OAuth2 Client Setup",
-    "Token Management",
-    "Session Handling",
-    "UI Integration"
-]
-
-child_issues = []
-for i, phase in enumerate(phases, 1):
-    child = api.create_issue(
-        owner="org",
-        repo="project",
-        title=f"[Task: #{parent_issue['number']}] Phase {i}: {phase}",
-        body=f"Parent Issue: #{parent_issue['number']}\n\n**Scope:**\n\nImplement {phase.lower()} for OAuth2 authentication.\n\nSee parent issue for full details.",
-        labels=["task"]
-    )
-    child_issues.append(child)
-    print(f"Child issue #{child['number']} created")
+# Step 2: Create child task issues (repeat for each phase)
+./.opencode/tools/gitbucket-api create-issue org project "[Task: #<parent>] Phase 1: OAuth2 Client Setup" --body "Parent Issue: #<parent>\n\nImplement OAuth2 client setup." --labels task
 
 # Step 3: Add comment to parent listing children
-child_list = "\n".join([f"- #{c['number']}: {phases[i]}" for i, c in enumerate(child_issues)])
-api.add_issue_comment(
-    owner="org",
-    repo="project",
-    issue_number=parent_issue['number'],
-    body=f"**Sub-issues created:**\n\n{child_list}"
-)
-
-print(f"Parent #{parent_issue['number']} with {len(child_issues)} child issues created")
+./.opencode/tools/gitbucket-api add-comment org project <parent-number> "**Sub-issues created:**\n\n- #<child1>: OAuth2 Client Setup\n- #<child2>: Token Management"
 ```
 
 ### Workflow 3: Close Issue with Summary Comment
 
 **Scenario:** Close issue after completion, add summary comment.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
+```bash
 # Step 1: Add completion comment
-api.add_issue_comment(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    body="""🤖 <AgentName> (<ModelId>) ✅ completed
+./.opencode/tools/gitbucket-api add-comment org project 14 "🤖 <AgentName> (<ModelId>) ✅ completed\n\n**Summary:**\n\nImplemented OAuth2 authentication with automatic token refresh.\n\n**Outcome:**\n\nUsers can now authenticate via OAuth2, and tokens refresh automatically without user intervention."
 
-**Summary:**
-
-Implemented OAuth2 authentication with automatic token refresh.
-
-**Outcome:**
-
-Users can now authenticate via OAuth2, and tokens refresh automatically without user intervention.
-
-**Verification:**
-
-- OAuth2 client configured
-- Token management implemented
-- Session handling tested
-- UI integration complete"""
-)
-
-# Step 2: Close issue
-api.update_issue(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    state="closed"
-)
-
-print("Issue #14 closed with summary comment")
+# Step 2: Close issue (requires web UI — PATCH is broken on GitBucket)
+# Use GitBucket web UI to close the issue
 ```
 
 ### Workflow 4: Batch Label Operations
@@ -263,24 +118,12 @@ print("Issue #14 closed with summary comment")
 
 **Labels can ONLY be set during `create_issue()`.** There is no working API for changing labels after issue creation.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
+```bash
 # ✅ WORKS: Set labels during issue creation
-issue = api.create_issue(
-    owner="org",
-    repo="project",
-    title="Bug report",
-    body="Description",
-    labels=["bug", "priority:high", "needs-review"]
-)
+./.opencode/tools/gitbucket-api create-issue org project "Bug report" --body "Description" --labels bug,priority:high,needs-review
 
 # ❌ BROKEN: Cannot change labels after creation
-# api.add_labels_to_issue(...) → returns []
-# api.replace_issue_labels(...) → returns []
-# api.update_issue(labels=[...]) → returns 404
+# No CLI command available — post-creation label operations are broken
 ```
 
 **Workaround:** Delete and recreate the issue if labels need to change.
@@ -289,105 +132,51 @@ issue = api.create_issue(
 
 **Scenario:** Find duplicate issues and close them with reference to original.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
+```bash
 # Step 1: Get the canonical issue
-canonical_issue = api.get_issue(
-    owner="org",
-    repo="project",
-    issue_number=14
-)
+./.opencode/tools/gitbucket-api issue org project 14
 
 # Step 2: List all open issues
-all_issues = api.list_issues(
-    owner="org",
-    repo="project",
-    state="open"
-)
+./.opencode/tools/gitbucket-api issues org project --state open
 
-# Step 3: Find duplicates (same title)
-duplicates = [
-    issue for issue in all_issues
-    if issue['title'] == canonical_issue['title'] and issue['number'] != canonical_issue['number']
-]
+# Step 3: Identify duplicates from the list
 
-print(f"Found {len(duplicates)} duplicates")
-
-# Step 4: Close each duplicate with comment
-for dup in duplicates:
-    # Add comment
-    api.add_issue_comment(
-        owner="org",
-        repo="project",
-        issue_number=dup['number'],
-        body=f"**Closing as duplicate of #{canonical_issue['number']}**\n\nThis issue is a duplicate and is being closed. Please continue discussion on #{canonical_issue['number']}."
-    )
-    
-    # Close issue
-    api.update_issue(
-        owner="org",
-        repo="project",
-        issue_number=dup['number'],
-        state="closed",
-        labels=["duplicate"]
-    )
-    
-    print(f"Closed duplicate #{dup['number']}")
-
-print(f"All {len(duplicates)} duplicates closed")
+# Step 4: Close each duplicate with comment (requires web UI for closing)
+./.opencode/tools/gitbucket-api add-comment org project <dup-number> "**Closing as duplicate of #14**\n\nThis issue is a duplicate and is being closed. Please continue discussion on #14."
 ```
 
 ## Error Handling
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-from skills.gitbucket_api.tools.exceptions import (
-    AuthenticationError,
-    NotFoundError,
-    ValidationError,
-    GitBucketError
-)
+The CLI tool outputs structured error information:
 
-api = GitBucketAPI()
+```bash
+# 401 - Authentication error
+./.opencode/tools/gitbucket-api check-auth
 
-try:
-    issue = api.create_issue(
-        owner="org",
-        repo="nonexistent",
-        title="Test"
-    )
-except AuthenticationError as e:
-    # 401 - Check GITBUCKET_TOKEN
-    print(f"Auth failed: {e.message}")
-except NotFoundError as e:
-    # 404 - Repo doesn't exist
-    print(f"Not found: {e.endpoint}")
-except ValidationError as e:
-    # 422 - Invalid input
-    print(f"Validation error: {e.message}")
-except GitBucketError as e:
-    # Other HTTP errors
-    print(f"API error: {e.status_code} - {e.message}")
+# 404 - Repo doesn't exist
+./.opencode/tools/gitbucket-api create-issue org nonexistent "Test"
+# Error: 404 Not Found
+
+# 422 - Invalid input
+./.opencode/tools/gitbucket-api create-issue org project "Test" --labels "invalid label!"
+# Error: 422 Unprocessable Entity
 ```
 
 ## Complete API Reference
 
-| Operation | Method | Returns |
-|-----------|--------|---------|
-| Create issue | `create_issue()` | `dict` |
-| Get issue | `get_issue()` | `dict` |
-| Update issue | `update_issue()` | `dict` ⚠️ BROKEN (404) |
-| List issues | `list_issues()` | `list[dict]` |
-| Add comment | `add_issue_comment()` | `dict` |
-| Add labels | `add_labels_to_issue()` | `list[dict]` |
-| Replace labels | `replace_issue_labels()` | `list[dict]` |
-| Remove label | `remove_label_from_issue()` | `None` |
-| Remove all labels | `remove_all_labels_from_issue()` | `None` |
+| Operation | CLI Command | Status |
+|-----------|------------|--------|
+| Create issue | `create-issue <owner> <repo> <title> [--body ...] [--labels ...]` | ✅ |
+| Get issue | `issue <owner> <repo> <number>` | ✅ |
+| Update issue | N/A | ❌ BROKEN (404) |
+| List issues | `issues <owner> <repo> [--state ...]` | ✅ |
+| Add comment | `add-comment <owner> <repo> <number> <body>` | ✅ |
+| Add labels | N/A | ❌ BROKEN (returns `[]`) |
+| Replace labels | N/A | ❌ BROKEN (returns `[]`) |
+| Remove label | N/A | Available via Python API |
+| Remove all labels | N/A | Available via Python API |
 
 ## Source Code
 
-- `tools/gitbucket_api.py` - All issue methods
-- `tools/exceptions.py` - Exception classes
+- `.opencode/tools/gitbucket-api` - CLI entry point
+- `.opencode/skills/issue-operations/platforms/gitbucket-api/tools/impl/` - Python implementation

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/label-operations.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/label-operations.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-GitBucket label operations using Python API tools.
+GitBucket label operations using the `gitbucket-api` CLI tool at `.opencode/tools/gitbucket-api`.
 
 ## Add Labels to Issue
 
@@ -10,32 +10,15 @@ GitBucket label operations using Python API tools.
 
 The GitBucket API endpoint `POST /repos/{owner}/{repo}/issues/{number}/labels` returns HTTP 200 with an empty array but does NOT add labels to the issue.
 
-**Workaround:** Add labels during issue creation with `create_issue(labels=[...])`.
+**Workaround:** Add labels during issue creation with `create-issue --labels`.
 
-### Python API (Only Option)
+### CLI (Only Option)
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
-# ❌ BROKEN: Labels NOT added, returns empty array
-labels = api.add_labels_to_issue(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    labels=["bug", "enhancement"]
-)
-# Returns: [] — labels are NOT added to the issue
+```bash
+# ❌ BROKEN: No CLI command for post-creation label addition
 
 # ✅ WORKAROUND: Add labels during issue creation
-issue = api.create_issue(
-    owner="org",
-    repo="project",
-    title="Bug report",
-    body="Description",
-    labels=["bug", "enhancement"]  # ✅ Auto-creates and attaches labels
-)
+./.opencode/tools/gitbucket-api create-issue org project "Bug report" --body "Description" --labels bug,enhancement
 ```
 
 ## Replace All Labels
@@ -44,122 +27,63 @@ issue = api.create_issue(
 
 The GitBucket API endpoint `PUT /repos/{owner}/{repo}/issues/{number}/labels` returns HTTP 200 with an empty array but does NOT set labels on the issue.
 
-**Workaround:** Add labels during issue creation with `create_issue(labels=[...])`.
+**Workaround:** Add labels during issue creation with `create-issue --labels`.
 
-### Python API (Only Option)
+### CLI (Only Option)
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
-# ❌ BROKEN: Labels NOT set, returns empty array
-labels = api.replace_issue_labels(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    labels=["priority", "review"]
-)
-# Returns: [] — labels are NOT set on the issue
+```bash
+# ❌ BROKEN: No CLI command for label replacement
 
 # ✅ WORKAROUND: Add labels during issue creation
-issue = api.create_issue(
-    owner="org",
-    repo="project",
-    title="Bug report",
-    body="Description",
-    labels=["priority", "review"]  # ✅ Works, auto-creates labels
-)
+./.opencode/tools/gitbucket-api create-issue org project "Bug report" --body "Description" --labels priority,review
 ```
 
 ## Remove Specific Label
 
-### Python API (Only Option)
+### Python API (Only Option — not available via CLI)
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
-# Remove one label
-api.remove_label_from_issue(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    label_name="bug"
-)
-```
+Post-creation label removal is available via the Python API but not exposed as a CLI command.
 
 ## Remove All Labels
 
-### Python API (Only Option)
+### Python API (Only Option — not available via CLI)
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
-# Remove all labels
-api.remove_all_labels_from_issue(
-    owner="org",
-    repo="project",
-    issue_number=14
-)
-```
+All-labels removal is available via the Python API but not exposed as a CLI command.
 
 ## Repository Labels
 
 ### List Labels
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-labels = api.list_labels(owner="org", repo="project")
+```bash
+./.opencode/tools/gitbucket-api labels org project
 ```
 
 ### Create Label
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-label = api.create_label(
-    owner="org",
-    repo="project",
-    name="bug",
-    color="ff0000"
-)
-```
+Label creation happens automatically when labels are specified during `create-issue`. For explicit label creation, use the Python API directly.
 
 ## Tool Selection
 
-| Operation | Python API |
-|-----------|------------|
-| Add labels | `api.add_labels_to_issue()` | ⚠️ BROKEN (returns `[]`) |
-| Replace labels | `api.replace_issue_labels()` | ⚠️ BROKEN (returns `[]`) |
-| Remove label | `api.remove_label_from_issue()` |
-| Remove all labels | `api.remove_all_labels_from_issue()` |
-| List labels | `api.list_labels()` |
-| Create label | `api.create_label()` |
+| Operation | CLI Command | Status |
+|-----------|------------|--------|
+| Add labels | N/A | ⚠️ BROKEN (returns `[]`) |
+| Replace labels | N/A | ⚠️ BROKEN (returns `[]`) |
+| Remove label | N/A | Python API only |
+| Remove all labels | N/A | Python API only |
+| List labels | `gitbucket-api labels <owner> <repo>` | ✅ |
+| Create label | N/A | Auto-created via create-issue |
 
-**Note:** GitBucket Python API is the primary tool for all label operations.
+**Note:** The `gitbucket-api` CLI tool is the primary tool for label operations that work. Broken operations are not exposed via CLI.
 
 ## Error Handling
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-from skills.gitbucket_api.tools.exceptions import ValidationError
-
-api = GitBucketAPI()
-
-try:
-    api.add_labels_to_issue(...)
-except ValidationError as e:
-    # 422 - Invalid label name or format
-    print(f"Validation error: {e.message}")
+```bash
+# 422 - Invalid label name or format
+./.opencode/tools/gitbucket-api create-issue org project "Test" --labels "invalid label!"
+# Error output will indicate validation failure
 ```
 
 ## Source Code
 
-- `tools/gitbucket_api.py` - `add_labels_to_issue()`, `replace_issue_labels()`, `remove_label_from_issue()`, `remove_all_labels_from_issue()`, `list_labels()`, `create_label()`
+- `.opencode/tools/gitbucket-api` - CLI entry point
+- `.opencode/skills/issue-operations/platforms/gitbucket-api/tools/impl/` - Python implementation

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/mcp-operations.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/mcp-operations.md
@@ -1,180 +1,97 @@
-# GitBucket MCP Operations
+# GitBucket CLI Operations
 
 ## Overview
 
-GitBucket MCP tools are available for most operations. When MCP tools are unavailable, use Python tooling from `tools/` directory.
+GitBucket operations use the `gitbucket-api` CLI tool located at `.opencode/tools/gitbucket-api`. This replaces both MCP tools and the Python client for all operations.
 
-## MCP Tool Availability
+## CLI Tool Availability
 
-| Operation | MCP Tool | Fallback |
-|-----------|----------|----------|
-| Get issue | `gitbucket_get_issue` ✅ | Python API |
-| Create issue | `gitbucket_create_issue` ✅ | Python API |
-| Update issue | `gitbucket_update_issue` ✅ | Python API |
-| Add comment | `gitbucket_add_issue_comment` ✅ | Python API |
-| List issues | `gitbucket_list_issues` ✅ | Python API |
-| Get repository | `gitbucket_get_repository` ✅ | Python API |
-| List branches | `gitbucket_list_branches` ✅ | Python API |
-| Add labels | ❌ No MCP tool | **Python API only** |
-| Replace labels | ❌ No MCP tool | **Python API only** |
-| Remove labels | ❌ No MCP tool | **Python API only** |
-| Admin operations | ❌ No MCP tool | **Python API only** |
+| Operation | CLI Command | Status |
+|-----------|------------|--------|
+| Get issue | `gitbucket-api issue <owner> <repo> <number>` | ✅ |
+| Create issue | `gitbucket-api create-issue <owner> <repo> <title> [--body ...] [--labels ...]` | ✅ |
+| Add comment | `gitbucket-api add-comment <owner> <repo> <number> <body>` | ✅ |
+| List issues | `gitbucket-api issues <owner> <repo> [--state open\|closed\|all]` | ✅ |
+| Get repository | `gitbucket-api repo <owner> <repo>` | ✅ |
+| List branches | `gitbucket-api branches <owner> <repo>` | ✅ |
+| List PRs | `gitbucket-api prs <owner> <repo> [--state ...] [--head ...]` | ✅ |
+| Create PR | `gitbucket-api create-pr <owner> <repo> <title> <head> <base> [--body ...]` | ✅ |
+| List labels | `gitbucket-api labels <owner> <repo>` | ✅ |
+| Get current user | `gitbucket-api me` | ✅ |
+| Validate auth | `gitbucket-api check-auth` | ✅ |
+| Init config | `gitbucket-api init-config [--path ...]` | ✅ |
 
-## MCP-First Workflow
+## CLI-First Workflow
 
-**When MCP tools available:**
+**For all operations:**
 
-```python
-# Prefer MCP tool
-from tools import gitbucket_get_issue, gitbucket_create_issue
-
+```bash
 # Create issue
-issue = gitbucket_create_issue(
-    owner="org",
-    repo="project",
-    title="Bug fix",
-    body="Description",
-    labels=["bug", "enhancement"]
-)
-```
+./.opencode/tools/gitbucket-api create-issue org project "Bug fix" --body "Description" --labels bug,enhancement
 
-**When MCP tools unavailable:**
+# Get issue
+./.opencode/tools/gitbucket-api issue org project 14
 
-```python
-# Use Python tooling
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
-# Create issue
-issue = api.create_issue(
-    owner="org",
-    repo="project",
-    title="Bug fix",
-    body="Description",
-    labels=["bug", "enhancement"]
-)
+# List issues
+./.opencode/tools/gitbucket-api issues org project --state open
 ```
 
 ## Tool Selection Decision Tree
 
 ```
-Is operation in MCP table?
-    ├─ YES → Use MCP tool
+Is operation in CLI command table?
+    ├─ YES → Use CLI command
     │         ├─ Success → Return result
-    │         └─ Failure → Log MCPToolError, fallback to Python API
-    └─ NO → Use Python API directly
+    │         └─ Failure → Log error, check credentials with check-auth
+    └─ NO → Report missing command, HALT — do NOT fall back to inline scripts
 ```
 
 ## Error Classification
 
-### MCP Tool Error (Retry or Fallback)
+### CLI Error (Retry or Check Credentials)
 
-```python
-from skills.gitbucket_api.tools import MCPToolError
-
-try:
-    issue = gitbucket_get_issue(owner, repo, issue_number)
-except MCPToolError as e:
-    # MCP tool failed - can retry or fallback
-    logger.warning(f"MCP tool {e.tool} failed: {e.message}")
-    # Fallback to Python API
-    api = GitBucketAPI()
-    issue = api.get_issue(owner, repo, issue_number)
+```bash
+./.opencode/tools/gitbucket-api check-auth
+# If auth fails, check .env for GITBUCKET_TOKEN and GITBUCKET_HTML_URL
 ```
 
 ### API Error (Classified)
 
-```python
-from skills.gitbucket_api.tools import AuthenticationError, NotFoundError, ValidationError
+The CLI tool outputs structured error information:
 
-try:
-    api = GitBucketAPI()
-    issue = api.create_issue(...)
-except AuthenticationError as e:
-    # 401 - Check credentials
-    logger.error(f"Auth failed: {e.message}")
-    raise
-except NotFoundError as e:
-    # 404 - Check URL format
-    logger.error(f"Not found: {e.endpoint}")
-    raise
-except ValidationError as e:
-    # 422 - Check request body
-    logger.error(f"Validation error: {e.message}")
-    raise
+```bash
+./.opencode/tools/gitbucket-api create-issue org nonexistent "Test"
+# Error: 404 Not Found - Check owner/repo names
+
+./.opencode/tools/gitbucket-api create-issue org project "Test"
+# Error: 401 Unauthorized - Check GITBUCKET_TOKEN
+
+./.opencode/tools/gitbucket-api create-issue org project "Test"
+# Error: 422 Unprocessable Entity - Check request body format
 ```
 
-## Label Operations (Python API Only)
+## Label Operations (Labels Can ONLY Be Set During Creation)
 
-GitBucket MCP does **not** provide label tools. Use Python API:
+GitBucket does **not** support adding labels after issue creation. Use `--labels` during creation:
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
+```bash
+# ✅ WORKS: Set labels during issue creation
+./.opencode/tools/gitbucket-api create-issue org project "Bug report" --body "Description" --labels bug,enhancement
 
-api = GitBucketAPI()
-
-# Add labels (auto-creates missing labels)
-api.add_labels_to_issue(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    labels=["bug", "enhancement"]
-)
-
-# Replace all labels
-api.replace_issue_labels(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    labels=["priority", "review"]
-)
-
-# Remove specific label
-api.remove_label_from_issue(
-    owner="org",
-    repo="project",
-    issue_number=14,
-    label_name="bug"
-)
-
-# Remove all labels
-api.remove_all_labels_from_issue(
-    owner="org",
-    repo="project",
-    issue_number=14
-)
+# ❌ BROKEN: Cannot change labels after creation
+# No CLI command for post-creation label operations — they return empty arrays
 ```
 
 ## Admin Operations (Basic Auth Required)
 
 Admin operations require Basic authentication, not token:
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-# Initialize with Basic auth
-api = GitBucketAPI(
-    url="https://gitbucket.example.com/gitbucket/",
-    username="admin",
-    password="admin_password"
-)
-
-# Create user (admin only)
-user = api.create_user(
-    username="developer1",
-    password="secure_password",
-    email="developer1@example.com",
-    is_admin=False
-)
-
-# Create organization (admin only)
-org = api.create_organization(
-    name="my-team",
-    description="Development team"
-)
+```bash
+# Admin operations are not available via CLI
+# Uses Python API client directly for admin tasks
 ```
 
 ## Source Code
 
-- `tools/gitbucket_api.py` - Core client with all endpoints
+- `.opencode/tools/gitbucket-api` - CLI tool (entry point)
+- `.opencode/skills/issue-operations/platforms/gitbucket-api/tools/impl/` - Python implementation

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/repository-operations.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/repository-operations.md
@@ -2,76 +2,47 @@
 
 ## Overview
 
-Repository management operations using GitBucket Python API client.
+Repository management operations using the `gitbucket-api` CLI tool at `.opencode/tools/gitbucket-api`.
 
-**Primary Tool: Python client from `.opencode/skills/gitbucket-api/tools/gitbucket_api.py`**
+**Primary Tool: CLI tool at `.opencode/tools/gitbucket-api`**
 
-**CRITICAL: The `gitbucket_*` MCP tools have been REMOVED. The Python client is the ONLY option. Use `from skills.gitbucket_api.tools import GitBucketAPI` for all operations.**
+**CRITICAL: The `gitbucket_*` MCP tools have been REMOVED. The Python import pattern has been REPLACED by the CLI tool. Use `./.opencode/tools/gitbucket-api <command>` for all operations.**
 
 ## Basic Operations
 
 ### Get Repository
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-repo = api.get_repository(owner="org", repo="project")
-# Returns: Repository object (dict)
-print(f"Repo: {repo['full_name']}")
-print(f"Stars: {repo['stargazers_count']}")
-print(f"Forks: {repo['forks_count']}")
+```bash
+./.opencode/tools/gitbucket-api repo org project
 ```
 
 ### List User's Repositories
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
+```bash
+# List own repositories
+./.opencode/tools/gitbucket-api repos
 
-api = GitBucketAPI()
-repos = api.list_own_repositories()
-# Returns: array of Repository objects (list[dict])
-for repo in repos:
-    print(f"{repo['full_name']}: {repo.get('description', 'No description')}")
+# List repositories for a specific user
+./.opencode/tools/gitbucket-api repos --user username
 ```
 
 ### List Branches
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-branches = api.list_branches(owner="org", repo="project")
-# Returns: array of Branch objects (list[dict])
-for branch in branches:
-    print(f"{branch['name']}: {branch['commit']['sha'][:8]}")
+```bash
+./.opencode/tools/gitbucket-api branches org project
 ```
 
 ### List Pull Requests
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-prs = api.list_pull_requests(owner="org", repo="project", state="open")
-# Returns: array of PullRequest objects (list[dict])
-for pr in prs:
-    print(f"PR #{pr['number']}: {pr['title']} ({pr['state']})")
+```bash
+./.opencode/tools/gitbucket-api prs org project --state open
 ```
 
 ### Get Pull Request
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-pr = api.get_pull_request(owner="org", repo="project", pull_number=42)
-# Returns: PullRequest object (dict)
-print(f"PR #{pr['number']}: {pr['title']}")
-print(f"Head: {pr['head']['ref']}")
-print(f"Base: {pr['base']['ref']}")
-print(f"State: {pr['state']}")
-print(f"Mergeable: {pr.get('mergeable', 'unknown')}")
+```bash
+# List PRs and filter by number
+./.opencode/tools/gitbucket-api prs org project --state all | jq '.[] | select(.number == 42)'
 ```
 
 ## Chained Operations
@@ -80,246 +51,76 @@ print(f"Mergeable: {pr.get('mergeable', 'unknown')}")
 
 **Scenario:** Verify branch exists, check for open PRs, create PR if none exists.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
-branch_name = "feature/oauth2"
-base_branch = "dev"
-
+```bash
 # Step 1: Check if branch exists
-branches = api.list_branches(owner="org", repo="project")
-branch_exists = any(b['name'] == branch_name for b in branches)
-
-if not branch_exists:
-    print(f"Branch '{branch_name}' does not exist")
-    exit(1)
-
-print(f"✓ Branch '{branch_name}' exists")
+./.opencode/tools/gitbucket-api branches org project
 
 # Step 2: Check for existing PRs for this branch
-prs = api.list_pull_requests(owner="org", repo="project", state="open")
-existing_pr = None
-for pr in prs:
-    if pr['head']['ref'] == branch_name:
-        existing_pr = pr
-        break
+./.opencode/tools/gitbucket-api prs org project --state open
 
-if existing_pr:
-    print(f"✓ PR already exists: #{existing_pr['number']}")
-    print(f"  Title: {existing_pr['title']}")
-    print(f"  State: {existing_pr['state']}")
-    exit(0)
-
-# Step 3: Create new PR
-pr = api.create_pull_request(
-    owner="org",
-    repo="project",
-    title=f"Feature: {branch_name}",
-    head=branch_name,
-    base=base_branch,
-    body="## Description\n\nImplements OAuth2 authentication.\n\n## Changes\n\n- Added OAuth2 client\n- Implemented token management\n- Added session handling"
-)
-
-print(f"✓ Created PR #{pr['number']}")
-print(f"  URL: {pr['html_url']}")
+# Step 3: Create new PR (if no existing PR found)
+./.opencode/tools/gitbucket-api create-pr org project "Feature: feature/oauth2" feature/oauth2 dev --body "## Description\n\nImplements OAuth2 authentication."
 ```
 
 ### Workflow 2: Find Stale Branches
 
 **Scenario:** Find branches that haven't been updated recently.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-from datetime import datetime, timedelta
-
-api = GitBucketAPI()
-
-# Step 1: List all branches
-branches = api.list_branches(owner="org", repo="project")
-
-# Step 2: Check for stale branches (no activity in 30 days)
-stale_days = 30
-stale_threshold = datetime.now() - timedelta(days=stale_days)
-stale_branches = []
-
-for branch in branches:
-    # Get branch commit date (if available)
-    # GitBucket API may not include commit date in branch list
-    # You may need to call get_ref() or parse commit info separately
-    
-    # For now, filter out protected branches
-    if branch['name'] in ['main', 'master', 'dev']:
-        continue
-    
-    # Add to stale list (simplified - real logic needs commit date)
-    stale_branches.append(branch['name'])
-
-print(f"Found {len(stale_branches)} candidate stale branches:")
-for name in stale_branches:
-    print(f"  - {name}")
+```bash
+# List all branches
+./.opencode/tools/gitbucket-api branches org project
+# Then filter out protected branches (main, master, dev) and identify stale ones
 ```
 
 ### Workflow 3: Repository Health Check
 
 **Scenario:** Check repository for CI compliance, labels, milestones.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
+```bash
+# Check for required labels
+./.opencode/tools/gitbucket-api labels org project
 
-api = GitBucketAPI()
+# Check for open PRs
+./.opencode/tools/gitbucket-api prs org project --state open
 
-def check_repo_health(owner: str, repo: str):
-    """Check repository health."""
-    issues = []
-    
-    # Step 1: Check for required labels
-    labels = api.list_labels(owner=owner, repo=repo)
-    label_names = [l['name'] for l in labels]
-    
-    required_labels = ['bug', 'enhancement', 'documentation']
-    missing_labels = [l for l in required_labels if l not in label_names]
-    
-    if missing_labels:
-        issues.append(f"Missing labels: {', '.join(missing_labels)}")
-    else:
-        print("✓ All required labels present")
-    
-    # Step 2: Check for open PRs
-    prs = api.list_pull_requests(owner=owner, repo=repo, state="open")
-    if len(prs) > 10:
-        issues.append(f"Many open PRs ({len(prs)}) - consider reviewing")
-    else:
-        print(f"✓ Open PRs: {len(prs)}")
-    
-    # Step 3: Check for milestones
-    from skills.gitbucket_api.tools import GitBucketAPI
-    milestones = api.list_milestones(owner=owner, repo=repo)
-    if not milestones:
-        issues.append("No milestones defined")
-    else:
-        print(f"✓ Milestones: {len(milestones)}")
-    
-    # Step 4: Check branches
-    branches = api.list_branches(owner=owner, repo=repo)
-    protected = ['main', 'master', 'dev']
-    missing_protected = [b for b in protected if b not in [br['name'] for br in branches]]
-    
-    if missing_protected:
-        issues.append(f"Missing protected branches: {', '.join(missing_protected)}")
-    else:
-        print(f"✓ Protected branches present")
-    
-    # Report
-    if issues:
-        print("\n⚠️ Issues found:")
-        for issue in issues:
-            print(f"  - {issue}")
-        return False
-    else:
-        print("\n✓ Repository health check passed")
-        return True
+# Get repository info
+./.opencode/tools/gitbucket-api repo org project
 
-# Run health check
-check_repo_health(owner="<github.owner>", repo="<github.repo>")
+# Check branches
+./.opencode/tools/gitbucket-api branches org project
 ```
 
 ### Workflow 4: Sync Fork with Upstream
 
 **Scenario:** Check if fork is behind upstream and needs sync.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-import subprocess
-
-api = GitBucketAPI()
-
-# Step 1: Get repository info
-repo = api.get_repository(owner="org", repo="fork-repo")
-print(f"Repo: {repo['full_name']}")
-print(f"Default branch: {repo.get('default_branch', 'master')}")
-
-# Step 2: Check if this is a fork
-if not repo.get('fork'):
-    print("Not a fork - nothing to sync")
-    exit(0)
-
-# Step 3: Get upstream info
-parent = repo.get('parent')
-if parent:
-    print(f"Fork of: {parent['full_name']}")
-    print("To sync with upstream, use git commands:")
-    print("  git remote add upstream <upstream-url>")
-    print("  git fetch upstream")
-    print("  git merge upstream/main")
+```bash
+# Get repository info
+./.opencode/tools/gitbucket-api repo org fork-repo
+# Check if it's a fork and get upstream info from response
 ```
 
 ### Workflow 5: Create Release from Milestone
 
 **Scenario:** Create release when milestone is completed.
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
-# Step 1: Find milestone
-milestones = api.list_milestones(owner="org", repo="project")
-milestone_title = "v2.0.0"
-
-milestone = None
-for m in milestones:
-    if m['title'] == milestone_title:
-        milestone = m
-        break
-
-if not milestone:
-    print(f"Milestone '{milestone_title}' not found")
-    exit(1)
-
-print(f"Found milestone: {milestone['title']} (ID: {milestone['number']})")
-
-# Step 2: List issues in milestone (via search)
-issues = api.list_issues(owner="org", repo="project", state="all", milestone=str(milestone['number']))
-print(f"Issues in milestone: {len(issues)}")
-
-# Step 3: Create release
-release = api.create_release(
-    owner="org",
-    repo="project",
-    tag_name=milestone_title,
-    name=f"Release {milestone_title}",
-    body=f"## Release {milestone_title}\n\n{milestone.get('description', '')}\n\n## Issues Resolved\n\n" + 
-         "\n".join([f"- #{i['number']}: {i['title']}" for i in issues if i['state'] == 'closed']),
-    draft=False,
-    prerelease=False
-)
-
-print(f"✓ Created release: {release['html_url']}")
+```bash
+# Note: Release/milestone operations require direct Python API usage
+# Contact maintainers for milestone/release CLI commands if needed
 ```
 
 ## Complete API Reference
 
-| Operation | Method | Returns |
-|-----------|--------|---------|
-| Get repository | `get_repository()` | `dict` |
-| List own repos | `list_own_repositories()` | `list[dict]` |
-| List user repos | `list_user_repositories()` | `list[dict]` |
-| List branches | `list_branches()` | `list[dict]` |
-| List PRs | `list_pull_requests()` | `list[dict]` |
-| Get PR | `get_pull_request()` | `dict` |
-| Create PR | `create_pull_request()` | `dict` |
-| List releases | `list_releases()` | `list[dict]` |
-| Create release | `create_release()` | `dict` |
-| List milestones | `list_milestones()` | `list[dict]` |
-| Create milestone | `create_milestone()` | `dict` |
-| List labels | `list_labels()` | `list[dict]` |
-| Create label | `create_label()` | `dict` |
-| Get ref | `get_ref()` | `dict` |
-| Create status | `create_status()` | `dict` |
+| Operation | CLI Command | Returns |
+|-----------|------------|---------|
+| Get repository | `gitbucket-api repo <owner> <repo>` | JSON |
+| List own repos | `gitbucket-api repos` | JSON array |
+| List user repos | `gitbucket-api repos --user <user>` | JSON array |
+| List branches | `gitbucket-api branches <owner> <repo>` | JSON array |
+| List PRs | `gitbucket-api prs <owner> <repo> [--state ...] [--head ...]` | JSON array |
+| Create PR | `gitbucket-api create-pr <owner> <repo> <title> <head> <base> [--body ...]` | JSON |
 
 ## Source Code
 
-- `tools/gitbucket_api.py` - All repository methods
-- `tools/exceptions.py` - Exception classes
+- `.opencode/tools/gitbucket-api` - CLI entry point
+- `.opencode/skills/issue-operations/platforms/gitbucket-api/tools/impl/` - Python implementation

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/session-integration.md
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tasks/session-integration.md
@@ -8,21 +8,13 @@ Session init script (`.opencode/tools/session-init`) provides GitBucket credenti
 
 Credentials are loaded in this order:
 
-1. **Explicit parameters** - Highest priority
-   ```python
-   api = GitBucketAPI(
-       url="https://gitbucket.example.com/gitbucket/",
-       token="your-token"
-   )
-   ```
-
-2. **Environment variables**
+1. **Environment variables**
    ```bash
    export GITBUCKET_HTML_URL=https://gitbucket.example.com/gitbucket/
    export GITBUCKET_TOKEN=your-token
    ```
 
-3. **Project .env file** (`<project>/.env`)
+2. **Project .env file** (`<project>/.env`)
    ```bash
    # .env
    GITBUCKET_HTML_URL=https://gitbucket.example.com/gitbucket/
@@ -32,29 +24,18 @@ Credentials are loaded in this order:
    # GITBUCKET_PASSWORD=password
    ```
 
-4. **User config file** (platform-specific)
+3. **User config file** (platform-specific)
    - **Linux/macOS**: `~/.config/gitbucket/secrets.toml`
    - **Windows**: `%APPDATA%/gitbucket/secrets.toml`
 
 ## Create Config Template
 
-If `secrets.toml` doesn't exist, create it automatically:
+If `secrets.toml` doesn't exist, create it using the CLI:
 
-```python
-from skills.gitbucket_api.tools import create_config_file
-
-# Create platform-specific config file
-config_path = create_config_file()
-print(f"Config file created at: {config_path}")
-```
-
-**Or with API initialization:**
-
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-# Create config template if missing
-api = GitBucketAPI(create_config_if_missing=True)
+```bash
+./.opencode/tools/gitbucket-api init-config
+# Or specify a custom path:
+./.opencode/tools/gitbucket-api init-config --path /custom/path/secrets.toml
 ```
 
 **Template content:**
@@ -95,16 +76,9 @@ Note: Follows XDG Base Directory Specification. Respects `XDG_CONFIG_HOME` envir
 
 ## Extract Credentials
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-# Method 1: GitBucketAPI auto-detects
-api = GitBucketAPI()  # Reads from .env, secrets.toml, env
-
-# Method 2: Explicit create config
-from skills.gitbucket_api.tools import create_config_file
-config_path = create_config_file()
-# Prints: "Created config at /home/user/.config/gitbucket/secrets.toml"
+```bash
+# Validate credentials work
+./.opencode/tools/gitbucket-api check-auth
 ```
 
 ## Environment Variables
@@ -124,45 +98,16 @@ GITBUCKET_TOKEN=your-personal-access-token
 | Token | All operations | `GITBUCKET_TOKEN` | ✅ Working |
 | Basic | Admin endpoints | `GITBUCKET_USERNAME`, `GITBUCKET_PASSWORD` | ❌ Broken |
 
-## Error Handling
-
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-from skills.gitbucket_api.tools.exceptions import AuthenticationError
-
-try:
-    api = GitBucketAPI()  # Auto-detect from env/secrets.toml
-except ValueError as e:
-    # Missing GITBUCKET_URL
-    print(f"Error: {e}")
-    
-try:
-    api.get_current_user()
-except AuthenticationError as e:
-    # Invalid or expired token
-    print(f"Auth failed: {e.message}")
-```
-
 ## Credential Validation
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-
-api = GitBucketAPI()
-
+```bash
 # Validate token works
-try:
-    user = api.get_current_user()
-    print(f"Authenticated as {user['login']}")
-except AuthenticationError:
-    print("Token invalid or expired")
-except NotFoundError:
-    print("Wrong endpoint or GitBucket URL")
+./.opencode/tools/gitbucket-api check-auth
 ```
 
 ## Best Practices
 
-1. **Use config file** - Create `secrets.toml` with `create_config_file()` for persistent credentials
+1. **Use config file** - Run `init-config` to create `secrets.toml` for persistent credentials
 2. **Token auth ONLY** - Basic auth is broken in GitBucket, use token for all operations
-3. **Error handling** - Catch specific exceptions (AuthenticationError, NotFoundError, etc.)
+3. **Error handling** - Check `check-auth` output for specific error types
 4. **Cross-platform** - Config locations work on Linux, macOS, Windows

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/test_api_deficiencies.py
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/test_api_deficiencies.py
@@ -14,7 +14,7 @@ Test Coverage:
   - Deficiency #3: replace_issue_labels (returns empty array, labels NOT set)
 
 Usage:
-    uv run python .opencode/skills/gitbucket-api/tests/test_api_deficiencies.py
+    ./.opencode/skills/issue-operations/platforms/gitbucket-api/tests/test_api_deficiencies.py
 
 Requirements:
     - .env file with GITBUCKET_URL and GITBUCKET_TOKEN

--- a/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py
+++ b/.opencode/skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py
@@ -10,7 +10,7 @@ the actual API behavior. It tests authentication, endpoint availability,
 and response schemas.
 
 Usage:
-    uv run python .opencode/skills/gitbucket-api/tests/verify_api.py
+    ./.opencode/skills/issue-operations/platforms/gitbucket-api/tests/verify_api.py
 
 Requirements:
     - .env file with GITBUCKET_URL and GITBUCKET_TOKEN

--- a/.opencode/skills/issue-operations/tasks/close.md
+++ b/.opencode/skills/issue-operations/tasks/close.md
@@ -45,17 +45,10 @@ github_issue_write(
 ```
 
 **GitBucket platform (PATCH fallback):**
-```python
+```bash
 # PATCH /issues/:number returns 404 on GitBucket
 # Post closure comment instead
-from skills.gitbucket_api.tools import GitBucketAPI
-api = GitBucketAPI()
-api.add_issue_comment(
-    owner=<github.owner>,
-    repo=<github.repo>,
-    issue_number=N,
-    body="Closing: PR merged and implementation verified."
-)
+./.opencode/tools/gitbucket-api add-comment <github.owner> <github.repo> <issue-number> "Closing: PR merged and implementation verified."
 ```
 
 ### Step 4: Post Closure Comment (if substantive)

--- a/.opencode/skills/issue-operations/tasks/comment.md
+++ b/.opencode/skills/issue-operations/tasks/comment.md
@@ -99,15 +99,8 @@ github_add_issue_comment(
 ```
 
 **GitBucket platform:**
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-api = GitBucketAPI()
-api.add_issue_comment(
-    owner=<github.owner>,
-    repo=<github.repo>,
-    issue_number=N,
-    body=formatted_comment
-)
+```bash
+./.opencode/tools/gitbucket-api add-comment <github.owner> <github.repo> <issue-number> "<formatted_comment>"
 ```
 
 ## Live Verification: Comment Claims (MANDATORY)

--- a/.opencode/skills/issue-operations/tasks/creation.md
+++ b/.opencode/skills/issue-operations/tasks/creation.md
@@ -48,16 +48,8 @@ github_issue_write(
 ```
 
 **GitBucket platform:**
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-api = GitBucketAPI()
-api.create_issue(
-    owner=owner,
-    repo=repo,
-    title=title,
-    body=body,
-    labels=["needs-approval"]
-)
+```bash
+./.opencode/tools/gitbucket-api create-issue <github.owner> <github.repo> "<title>" --body "<body>" --labels needs-approval
 ```
 
 **Note (GitBucket):** Labels can ONLY be set during creation. Post-creation label changes do not work.

--- a/.opencode/skills/issue-operations/tasks/link-sub-issue.md
+++ b/.opencode/skills/issue-operations/tasks/link-sub-issue.md
@@ -56,16 +56,8 @@ sub_issue = github_issue_write(
 ```
 
 **GitBucket platform:**
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-api = GitBucketAPI()
-sub_issue = api.create_issue(
-    owner=<github.owner>,
-    repo=<github.repo>,
-    title=f"[Task: #{M}] {phase_description}",
-    body=f"**Parent Plan:** #{M}\n\n{phase_prose}",
-    labels=["task"]
-)
+```bash
+./.opencode/tools/gitbucket-api create-issue <github.owner> <github.repo> "[Task: #<M>] <phase_description>" --body "**Parent Plan:** #<M>\n\n<phase_prose>" --labels task
 ```
 
 ### Step 5: Link Sub-Issue to Parent
@@ -84,13 +76,8 @@ github_sub_issue_write(
 CRITICAL: Use database ID (`.id`), not issue number.
 
 **GitBucket platform (comment-based fallback):**
-```python
-api.add_issue_comment(
-    owner=<github.owner>,
-    repo=<github.repo>,
-    issue_number=M,
-    body=f"**Sub-issue linked:** #{sub_issue['number']} — {phase_description}"
-)
+```bash
+./.opencode/tools/gitbucket-api add-comment <github.owner> <github.repo> <M> "**Sub-issue linked:** #<sub_issue_number> — <phase_description>"
 ```
 
 The dispatcher records which method was used (formal link vs comment) for later closure operations.

--- a/.opencode/skills/issue-operations/tasks/verify-merge.md
+++ b/.opencode/skills/issue-operations/tasks/verify-merge.md
@@ -31,12 +31,9 @@ state = pr.get("state", "unknown")
 ```
 
 **GitBucket platform:**
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-api = GitBucketAPI()
-pr = api.get_pull_request(owner=<github.owner>, repo=<github.repo>, pull_number=N)
-merged = pr.get("merged", False)
-state = pr.get("state", "unknown")
+```bash
+# Get PR details and parse merged/state fields
+./.opencode/tools/gitbucket-api prs <github.owner> <github.repo> --state all | jq '.[] | select(.number == N)'
 ```
 
 ### Step 2: Verify Merge
@@ -56,15 +53,10 @@ When searching for a PR that fixes a specific issue on GitBucket (no search API)
 3. Stop on first match
 4. Paginate only if no match found on first page
 
-```python
-from skills.gitbucket_api.tools import GitBucketAPI
-api = GitBucketAPI()
-prs = api.list_pull_requests(owner=<github.owner>, repo=<github.repo>, state="closed")
-matching_pr = None
-for pr in prs:
-    if f"#{issue_number}" in pr.get("body", "") or f"Fixes #{issue_number}" in pr.get("body", ""):
-        matching_pr = pr
-        break
+```bash
+# List closed PRs and scan bodies for issue reference
+./.opencode/tools/gitbucket-api prs <github.owner> <github.repo> --state closed
+# Then check each PR body for the issue reference pattern
 ```
 
 ## Common Issues

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -25,9 +25,9 @@ Creating skills IS Test-Driven Development applied to process documentation. Wri
 ## Invocation
 
 - `/skill skill-creator` - Overview and skill creation process
-- `uv run python .opencode/skills/skill-creator/scripts/init_skill.py <skill-name> --path <output-directory>` - Initialize new skill
-- `uv run python .opencode/skills/skill-creator/scripts/package_skill.py <skill-folder> [output-dir]` - Package skill
-- `uv run python .opencode/skills/skill-creator/scripts/quick_validate.py <skill-folder>` - Validate skill
+- `./.opencode/skills/skill-creator/scripts/init_skill.py <skill-name> --path <output-directory>` - Initialize new skill
+- `./.opencode/skills/skill-creator/scripts/package_skill.py <skill-folder> [output-dir]` - Package skill
+- `./.opencode/skills/skill-creator/scripts/quick_validate.py <skill-folder>` - Validate skill
 
 ## Skill Type Taxonomy
 

--- a/.opencode/tests/test-pep723-tools.sh
+++ b/.opencode/tests/test-pep723-tools.sh
@@ -47,10 +47,20 @@ check_python_version_pinned() {
 
 check_no_old_references() {
     local matches
-    matches=$(grep -rn "uv run python .opencode/tools" .opencode/guidelines/ AGENTS.md .opencode/skills/ 2>/dev/null | grep -v "Do NOT use" || true)
+    matches=$(grep -rn "uv run python .opencode" .opencode/guidelines/ AGENTS.md .opencode/skills/ 2>/dev/null | grep -v "Do NOT use" || true)
     if [ -n "$matches" ]; then
-        echo "FAIL: Old 'uv run python .opencode/tools' references found:"
+        echo "FAIL: Old 'uv run python .opencode' references found:"
         echo "$matches"
+        FAIL=$((FAIL + 1))
+    else
+        PASS=$((PASS + 1))
+    fi
+
+    local md_matches
+    md_matches=$(grep -rn 'uv run python ' .opencode/ --include='*.md' 2>/dev/null | grep -v '# Do NOT use' | grep -v 'Do NOT use' | grep -v 'FORBIDDEN' | grep -v 'python -m unittest' || true)
+    if [ -n "$md_matches" ]; then
+        echo "FAIL: Old 'uv run python' references found in .md files:"
+        echo "$md_matches"
         FAIL=$((FAIL + 1))
     else
         PASS=$((PASS + 1))
@@ -67,6 +77,7 @@ check_python_script() {
 ENTRY_POINTS=(
     guidelines memory md py jupyter help file-exists
     schema-version jupyter-start jupyter-stop symbolic session-init
+    gitbucket-api
 )
 
 for tool in "${ENTRY_POINTS[@]}"; do
@@ -116,6 +127,20 @@ check_plugin_invocations() {
 }
 
 check_plugin_invocations
+
+check_no_python_imports() {
+    local import_matches
+    import_matches=$(grep -rn 'from skills.gitbucket_api' .opencode/ 2>/dev/null | grep -v 'test-pep723-tools.sh' || true)
+    if [ -n "$import_matches" ]; then
+        echo "FAIL: Old 'from skills.gitbucket_api' import references found (should use CLI tool):"
+        echo "$import_matches"
+        FAIL=$((FAIL + 1))
+    else
+        PASS=$((PASS + 1))
+    fi
+}
+
+check_no_python_imports
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/.opencode/tools/gitbucket-api
+++ b/.opencode/tools/gitbucket-api
@@ -1,0 +1,44 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
+"""
+DESCRIPTION: GitBucket API CLI client. Usage: ./.opencode/tools/gitbucket-api <command> [args...]
+Commands: me, issues, issue, create-issue, add-comment, prs, create-pr, labels, branches, repos, repo, init-config, check-auth
+Example: ./.opencode/tools/gitbucket-api issues Brothertown-Language snea-shoebox-editor --state open
+         ./.opencode/tools/gitbucket-api check-auth
+"""
+from __future__ import annotations
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+IMPL = BASE_DIR / ".opencode" / "tools" / "impl" / "gitbucket_api.py"
+
+
+def _get_description() -> str:
+    return "GitBucket API CLI client with 13 subcommands"
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if not args or args[0] in ("-h", "--help", "help"):
+        print(__doc__)
+        print(f"CWD: {os.getcwd()}")
+        print(f"Impl: {IMPL}")
+        print()
+        print("Run with --help to see subcommands, or pass any subcommand directly.")
+        sys.exit(0)
+
+    result = subprocess.run(
+        ["uv", "run", "--script", str(IMPL)] + args,
+        env={**os.environ, "OPENCODE_TOOLS_DISPATCHER": "1"},
+    )
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/.opencode/tools/impl/gitbucket_api.py
+++ b/.opencode/tools/impl/gitbucket_api.py
@@ -1,9 +1,7 @@
+#!/usr/bin/env -S uv run --script
 # /// script
-# requires-python = ">=3.12"
+# requires-python = "~=3.12"
 # dependencies = []
-#
-# [tool.uv]
-# exclude-newer = "2026-04-14T00:00:00Z"
 # ///
 
 import argparse


### PR DESCRIPTION
**Summary:**

Relocates `gitbucket_api.py` from a deeply nested skill directory to a proper CLI tool at `.opencode/tools/gitbucket-api`, and replaces all `uv run --script` invocations with direct `./` execution paths per PEP 723 self-contained script conventions.

**Outcome:** GitBucketAPI is now a proper CLI tool invoked via `./.opencode/tools/gitbucket-api <command>`, eliminating dead import paths and ensuring all `.opencode/` Python scripts use direct execution. 140/140 PEP 723 test checks pass.

Fixes #1057