### PR TITLE
feat: add sub-agent result validation gate

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -597,6 +597,26 @@ No feature creep: implement ONLY what is in the approved spec. No unapproved wor
 - 🚫 FORBIDDEN: Producing zero output before stopping; silently failing without error message; context overflow without reporting the overflow; tool failure without reporting the failure; ending a session with no summary of work done
 - ✅ REQUIRED: Every HALT MUST be preceded by a status message; every failure MUST be reported with the specific error; every context overflow MUST be reported with the specific cause; every completed task MUST produce an executive summary
 
+### Post-Dispatch Output Guarantee
+
+After EVERY `task(subagent_type="general")` dispatch, the agent MUST produce output — never transition directly from dispatch to halt without output.
+
+| After Dispatch | Agent MUST |
+|----------------|-----------|
+| Sub-agent returned valid result | Report result or proceed to next step (existing behavior, no change) |
+| Sub-agent returned empty result | FALLBACK to inline execution + report warning in chat |
+| Sub-agent returned error | FALLBACK to inline execution + report error in chat |
+| Inline fallback also failed | Report double-failure + invoke `--task completion` + HALT with status message + byline |
+
+| Violation Pattern | Classification |
+|-------------------|----------------|
+| Empty sub-agent result → zero output → silent halt | Critical: Silent Agent Termination |
+| Empty sub-agent result → fallback attempt → status message in chat | Acceptable: self-corrected |
+| Empty sub-agent result → inline succeeds → chain continues | Acceptable: self-corrected |
+| Error sub-agent result → zero output → silent halt | Critical: Silent Agent Termination |
+
+**This guarantee supplements the existing Silent Agent Termination rule by specifying the post-dispatch scenario explicitly.** The existing rule covers general halts; this adds the specific case where the agent dispatches a sub-agent, gets an empty result, and has no code path to recovery or reporting.
+
 **See `020-go-prohibitions.md` for the complete halt requirements and `finishing-a-development-branch` skill for completion guarantees.** **AUTHORITY: `020-go-prohibitions.md`** (this line is a reference only)
 
 ## Critical Violation: Skipping Interdependency Analysis for Batch Approvals

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -18,6 +18,30 @@ Check for explicit authorization and needs-approval label status before implemen
 
 ## Procedure
 
+### Step 0: Sub-Agent Result Guard
+
+When `verify-authorization` is executed inline after a sub-agent dispatch returns an empty result, this step provides the fallback path.
+
+**Trigger condition:** After dispatching a `screen-issue` or other sub-agent via `task()`, if the result is empty or whitespace-only:
+
+```python
+if not result or not result.strip():
+    # Sub-agent returned empty — perform inline verification
+    report_warning("Sub-agent for verify-authorization returned empty result, performing inline")
+    # Execute Steps 1-6 of this verify-authorization procedure inline
+    # Continue the dispatch chain as if verify-authorization completed normally
+```
+
+**Fallback execution:** When this guard activates, the agent executes the full verify-authorization procedure (Steps 1-6) inline using direct tool calls rather than dispatching another sub-agent. The inline execution follows the same steps and produces the same result contract format.
+
+**Double-failure protocol:** If inline verification also fails:
+
+1. Report: `"Sub-agent and inline verification both failed for verify-authorization"`
+2. Invoke `--task completion` on the `approval-gate` skill
+3. HALT with status message + byline
+
+**No regression:** When sub-agent returns a valid result, this guard is not triggered — Steps 1-6 execute normally from the sub-agent's result.
+
 ### Step 1: Verify Git State (MANDATORY FIRST)
 
 **🚫 CRITICAL: This check MUST happen BEFORE any other work.**

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -24,6 +24,7 @@ Enforces context window safety by mandating pre-flight assessment before non-tri
 | `decompose` | Split a task into sub-tasks with dispatch context, preserve spec boundaries | ≈300 |
 | `dispatch` | Spawn sub-agent with scoped instructions and collect structured result | ≈250 |
 | `completion-checkpoint` | Post-dispatch verification: detect abnormal termination, assess work, recover | ≈300 |
+| `result-validation` | Post-dispatch result validation: empty/malformed result detection and fallback | ≈200 |
 | `overflow-signal` | Structured OVERFLOW response protocol for sub-agents that can't fit the work | ≈200 |
 | `merge` | Combine sub-agent results into final output, pure aggregation | ≈150 |
 | `context-passing` | Reference for dispatch context shapes between orchestrator and sub-agents | ≈200 |
@@ -46,6 +47,7 @@ Enforces context window safety by mandating pre-flight assessment before non-tri
 - `/skill divide-and-conquer --task context-passing` - Reference dispatch context shapes
 - `/skill divide-and-conquer --task purification-and-enforcement` - Reference boundaries
 - `/skill divide-and-conquer --task completion` - Invoke when workflow halts
+- `/skill divide-and-conquer --task result-validation` - Post-dispatch result validation and fallback
 - `/skill divide-and-conquer --task orchestrate` - Full workflow
 - `/skill divide-and-conquer --task assemble-work` - Work set branch assembly
 - `/skill divide-and-conquer --task two-stage-review` - Optional two-stage review pipeline (spec + code quality)
@@ -243,6 +245,50 @@ When the orchestrating agent detects abnormal termination via the Sub-Agent Comp
 
 **Cross-reference:** See `000-critical-rules.md` → "Pushing Agent Intelligence Decisions to the User" for the rule that structural decisions (including recovery strategy) are agent intelligence concerns, not user decisions.
 
+## Sub-Agent Result Validation (MANDATORY)
+
+After every `task(subagent_type="general")` dispatch, the agent MUST validate the result before acting on it. This gate prevents silent agent termination when a sub-agent returns an empty or malformed result.
+
+### Validation Rules
+
+| Condition | Action |
+|-----------|--------|
+| Result is empty string or whitespace-only | FALLBACK: perform task inline; report warning in chat |
+| Result is non-empty but not valid result contract | TRY: parse available content; FALLBACK if unparseable |
+| Result is valid result contract with `status: DONE` | PROCEED to next step (existing behavior) |
+| Result is valid result contract with `status: DONE_WITH_CONCERNS` | Review concerns, proceed if scope OK (existing behavior) |
+| Result is valid result contract with `status: BLOCKED` | HALT with status message (existing behavior) |
+| Result is valid result contract with `status: OVERFLOW` | Re-dispatch with reduced scope per `overflow-signal` task (existing behavior) |
+| Result contains error/exception trace | FALLBACK: perform task inline; report error in chat |
+
+### FALLBACK Procedure
+
+When a sub-agent result triggers the FALLBACK action:
+
+1. Report warning in chat: `⚠️ Sub-agent for <task_name> returned empty/invalid result, performing inline`
+2. Perform the task inline using direct tool calls (the orchestrator executes the sub-agent's intended work itself)
+3. Continue the dispatch chain from the inline result — do not re-dispatch the same sub-agent
+
+### Double-Failure Protocol
+
+If the inline fallback also fails:
+
+1. Report in chat: `❌ Sub-agent and inline fallback both failed for <task_name>. Unable to continue.`
+2. Invoke `--task completion` on the current skill (idempotent, safe)
+3. HALT with status message + byline (per chat output format rules)
+4. NEVER produce zero output before halting
+
+### Integration with Completion Checkpoint
+
+This validation gate runs BEFORE the Sub-Agent Completion Checkpoint. The sequence is:
+
+1. Dispatch sub-agent via `task()`
+2. **Result Validation (this gate)** — check for empty/malformed result
+3. Completion Checkpoint — check for abnormal termination (existing)
+4. If both pass: accept result, proceed
+
+If the Result Validation gate triggers FALLBACK and inline succeeds, the Completion Checkpoint is skipped (inline execution produces its own result). If inline fails, the Double-Failure Protocol runs instead.
+
 ## Worktree Mode
 
 When `worktree.path` is set:
@@ -264,6 +310,7 @@ If `worktree.path` is NOT set, operate normally from the project root.
 | `decompose` | ≈300 |
 | `dispatch` | ≈250 |
 | `completion-checkpoint` | ≈300 |
+| `result-validation` | ≈200 |
 | `overflow-signal` | ≈200 |
 | `merge` | ≈150 |
 | `context-passing` | ≈200 |


### PR DESCRIPTION
## Summary

Added sub-agent result validation gate to prevent silent agent termination when a sub-agent dispatch returns an empty or malformed result. Three files modified with additive sections that supplement existing error handling without changing current behavior.

## Outcome

- divide-and-conquer/SKILL.md: New `Sub-Agent Result Validation (MANDATORY)` section with validation rules table, FALLBACK procedure, and double-failure protocol
- verify-authorization.md: New `Step 0: Sub-Agent Result Guard` for empty-result fallback with inline verification path
- 000-critical-rules.md: New `Post-Dispatch Output Guarantee` subsection under Silent Agent Termination rule with violation classification table

Fixes #1060