### PR TITLE
feat: add simple work dispatch path for Tier 2 waived work

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -673,6 +673,46 @@ Every authorization follows the same pipeline regardless of issue count: `verify
 
 **See `approval-gate` skill → "Unified Dispatch Path (Work-of-1)" and `divide-and-conquer` skill → `assemble-work` task for the complete dispatch procedure.**
 
+## Simple Work Dispatch Path (Tier 2 Waiver)
+
+When ALL of the following conditions are met:
+- Developer has given explicit authorization (approved/go)
+- Work is "clearly simple" (see classification table below)
+- No spec or plan is required (Tier 2 waiver applies)
+- File modifications ARE needed (Tier 1 worktree mandate applies)
+
+The agent follows this REDUCED dispatch path:
+
+1. `git-workflow --task pre-work` — Create worktree (Tier 1, MANDATORY)
+2. Direct implementation in worktree — No sub-agent dispatch needed for single-file changes
+3. `verification-before-completion` — Verify success criteria exist and pass
+4. `finishing-a-development-branch --task checklist` — Branch readiness check
+5. `git-workflow --task review-prep` — Push, generate compare URL, HALT
+
+Steps SKIPPED for simple work:
+- `verify-authorization` (Tier 2 waiver replaces this — authorization IS the process)
+- `pre-implementation-analysis` (no plan to analyze)
+- `divide-and-conquer/assemble-work` (single implementer, single concern)
+- `verification-before-completion` can be simplified for documentation-only changes
+
+### Classification: "Clearly Simple Work"
+
+Work qualifies as "clearly simple" when ALL criteria are met:
+
+| Criterion | Qualifies | Does Not Qualify |
+|-----------|-----------|------------------|
+| File count | ≤2 files | 3+ files |
+| Behavioral change | None (docs, config, runbooks) | Any behavioral change |
+| Architectural impact | None | Any impact on architecture |
+| Existing code interaction | None (new files, minor edits) | Modified function signatures, APIs |
+| Risk level | Zero rollback risk | Data loss, security, deployment risk |
+
+When work does NOT qualify as "clearly simple", the full dispatch path applies regardless of developer authorization.
+
+### Key Principle
+
+"Simple" describes the PROCESS burden (no spec/plan needed), NOT the SAFETY mechanism. Worktrees protect repository integrity regardless of task complexity. The reduced dispatch path still enforces all Tier 1 mandates — it only skips Tier 2 process steps that are waived by developer authorization.
+
 **⚠️ Leaving stale or uncleared todowrite state after task completion is a CRITICAL GUIDELINE VIOLATION.**
 
 When the `todowrite` tool is used during a session, the agent MUST maintain the full lifecycle: create items with correct status, update status as work progresses, and clear all items before halting.

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -60,6 +60,17 @@ The interaction between developer authorization and process mandates follows the
 | Developer authorization + Tier 1 safety mandate | Safety mandate wins | Worktree and branch protection protect repository integrity regardless of authorization |
 | No developer authorization + any mandate | Mandate holds | Authorization is always required for implementation |
 
+#### Decision Table: Simple Work + File Modifications
+
+| Authorization | Work Type | File Mods? | Dispatch Path |
+|---------------|-----------|-------------|---------------|
+| Explicit (approved/go) | Clearly simple | Yes | `pre-work → implement → VbC → checklist → review-prep` (simple work dispatch path) |
+| Explicit (approved/go) | Clearly simple | No | Create issue only, no worktree needed |
+| Explicit (approved/go) | Complex | Yes | Full dispatch chain |
+| None | Any | Any | HALT — wait for authorization |
+
+Key insight: "Simple" describes the PROCESS burden (no spec/plan), not the SAFETY mechanism. Worktrees protect repository integrity regardless of task complexity.
+
 **For clearly simple work** (documentation, runbooks, minor configuration edits, single-file non-behavioral changes), developer authorization IS sufficient process — no separate spec/plan is required. The developer's explicit "approved" or "go" serves as both the authorization and the process justification.
 
 **For complex work** (new features, behavioral changes, multi-file modifications), developer authorization means "you may begin the process." The spec/plan workflow still produces value (traceability, review trail, edge case discovery) even when authorization exists. The agent should proceed through spec/plan creation as part of the authorized work.

--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -108,8 +108,18 @@ Plan approved
   → git-workflow --task review-prep
   ── VERIFICATION GATE ──────────────────────────────────────────────────
   → Confirm review-prep completed: compare URL generated and reported in correct format
-  → If skipped: INVOKE review-prep before proceeding (MANDATORY, no bypass)
-  ──────────────────────────────────────────────────────────────────────
+   → If skipped: INVOKE review-prep before proceeding (MANDATORY, no bypass)
+   ──────────────────────────────────────────────────────────────────────
+
+Clearly simple work (Tier 2 waiver)
+  → git-workflow --task pre-work (MANDATORY: worktree creation)
+  → Direct implementation in worktree (no sub-agent dispatch for single-file changes)
+  → verification-before-completion (simplified for docs/config)
+  → finishing-a-development-branch --task checklist
+  → git-workflow --task review-prep
+  → HALT (compare URL output)
+
+  **Classification check:** Before using this dispatch path, verify work meets ALL "clearly simple" criteria per `000-critical-rules.md` → "Simple Work Dispatch Path (Tier 2 Waiver)" → "Classification: Clearly Simple Work" table. If ANY criterion fails, use the full dispatch chain instead.
 
 Already implemented
   → verify-authorization (all gates pass)

--- a/.opencode/skills/using-git-worktrees/SKILL.md
+++ b/.opencode/skills/using-git-worktrees/SKILL.md
@@ -64,6 +64,28 @@ Branch naming: `spec/<short-name>` for spec-driven work, `feature/<description>`
 
 **BASE_BRANCH parameter:** The `create-worktree` task supports creating worktrees from branches other than `dev`. Defaults to `dev` for standalone branches. In work execution workflows, set to a prior feature branch (for dependency merge) or the work branch. Agent decides at creation time based on context.
 
+## Simple Work Worktree
+
+When the authorization qualifies as "clearly simple work" (per `000-critical-rules.md` → "Simple Work Dispatch Path (Tier 2 Waiver)"), a worktree is STILL MANDATORY for any file modification. The Tier 1 mandate for worktrees applies regardless of task simplicity.
+
+### Simple Work Procedure
+
+1. **Branch naming:** Use `docs/`, `runbook/`, or `config/` as the branch prefix for clearly simple work
+2. **Worktree creation:** Invoke `git-workflow --task pre-work` as normal — the worktree creation process is identical for simple and complex work
+3. **Direct implementation:** After worktree creation, implement directly in the worktree without sub-agent dispatch (no `divide-and-conquer` needed for single-file or two-file changes)
+4. **Completion steps:** Follow the simple work dispatch path: `verification-before-completion` → `finishing-a-development-branch --task checklist` → `git-workflow --task review-prep`
+
+### What Does NOT Change for Simple Work
+
+| Step | Simple Work | Complex Work |
+|------|-------------|--------------|
+| Worktree required? | YES (Tier 1) | YES (Tier 1) |
+| No commits to main/dev? | YES (Tier 1) | YES (Tier 1) |
+| Path rules apply? | YES (Tier 1) | YES (Tier 1) |
+| Spec/plan needed? | NO (Tier 2 waiver) | YES (Tier 2) |
+| Sub-agent dispatch? | NO (single concern) | YES (divide-and-conquer) |
+| Pre-implementation analysis? | NO (no plan) | YES (expand sub-issues) |
+
 ## Cross-References
 
 - **Called by:** `brainstorming` (Phase 4), `divide-and-conquer`, `executing-plans`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec-fix/1053-simple-work-dispatch-path
+
+- **Add Simple Work Dispatch Path** (#1053, #1063, #1064) - Added lightweight dispatch path for "clearly simple work" (docs, runbooks, minor config) that resolves agent contention between Tier 1 safety mandates and Tier 2 process waivers. Simple work now follows: pre-work → implement → VbC → checklist → review-prep, preserving worktree mandates while skipping spec/plan requirements. Added "Simple Work Dispatch Path (Tier 2 Waiver)" section to 000-critical-rules.md with classification table, "Decision Table: Simple Work + File Modifications" to 010-approval-gate.md, simple-work dispatch branch to approval-gate/SKILL.md, and "Simple Work Worktree" section to using-git-worktrees/SKILL.md.
+
 ### spec-fix/1042-1043-approval-gate-autonomous-classification
 
 - **Remove Conditional Sub-Agent Dispatch Threshold** (#1043) - Removed the ≤3 inline screening threshold from approval-gate. Screen-issue sub-agent dispatch is now mandatory for ALL approval set sizes, regardless of count. Replaced conditional logic in 000-critical-rules.md, pre-implementation-analysis.md, and SKILL.md verification table. Added "Common Misconception" sections explaining why the threshold was removed.


### PR DESCRIPTION
## Summary

Adds a lightweight "Simple Work Dispatch Path" that resolves agent contention between Tier 1 safety mandates (worktrees, never yield) and Tier 2 process waivers (no spec/plan for clearly simple work). Agents can now follow a reduced dispatch path — `pre-work → implement → VbC → checklist → review-prep` — for documentation, runbooks, and minor config changes, preserving all Tier 1 safety while waiving Tier 2 process steps.

## Outcome

Agents no longer loop between "authorized for simple work" and "need safety infrastructure" when file modifications are required. The decision table in `010-approval-gate.md` makes the Tier 1/Tier 2 interaction concrete, and the classification table in `000-critical-rules.md` provides unambiguous criteria for what qualifies as "clearly simple."

Fixes #1053
Fixes #1063
Fixes #1064