### PR TITLE
fix: close AI byline enforcement gaps for external repos and standalone corrections (#1066 #1067)

### DIFF
--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -165,7 +165,7 @@ AI co-authorship applies to **creative, original content authored by AI**:
 
 **Rationale:** AI attribution is about transparency in creative work. Copying a standard MIT license, copying code from Stack Overflow, or copy-pasting documentation from another project requires no AI creativity - those sources hold their own copyrights. Only genuinely original content created by AI deserves AI co-authorship attribution.
 
-### Files Requiring Attribution
+### Files Requiring Attribution (In-Repository)
 
 | File Type | Attribution Location | Format |
 | -- | -- | -- |
@@ -173,6 +173,31 @@ AI co-authorship applies to **creative, original content authored by AI**:
 | README files | Footer section | `## Co-Authored With AI` section |
 | New repositories | README.md | AI co-authored section (see below) |
 | Original docs | Footer | `*Co-authored with AI: <AgentName> (<ModelId>)*` |
+
+### Posted Content Requiring Attribution
+
+| Content Type | Attribution Location | Format |
+| -- | -- | -- |
+| Issue comments (any repository) | Last line of comment body | `🤖 Co-authored with AI: <AgentName> (<ModelId>)` |
+| PR comments (any repository) | Last line of comment body | `🤖 Co-authored with AI: <AgentName> (<ModelId>)` |
+| PR bodies (AI-authored) | Last line before horizontal rule or end of body | `🤖 Co-authored with AI: <AgentName> (<ModelId>)` |
+| Issue bodies (AI-authored) | Last line of issue body | `🤖 Co-authored with AI: <AgentName> (<ModelId>)` |
+
+External repository posts have HIGHER attribution priority than internal content. External posts represent the project to third parties — attribution is a transparency and ethical requirement, not optional.
+
+### Standalone Byline Correction — FORBIDDEN
+
+**Adding a standalone comment whose sole purpose is to append a byline to a previous comment is ABSOLUTELY FORBIDDEN.**
+
+When a byline is missing from AI-authored posted content:
+
+| Option | When | Action |
+|--------|------|--------|
+| **Edit the comment** | Platform supports edit + agent has edit permission | Edit the original comment, append byline as last line |
+| **Delete + repost** | Agent has delete permission | Delete original, repost with byline included |
+| **Accept the omission** | No edit/delete permission | Leave it. Do NOT add a separate byline comment. |
+
+The byline must be **part of the content body**, never a separate message.
 
 ### Files NOT Requiring Attribution
 

--- a/.opencode/skills/issue-operations/tasks/comment.md
+++ b/.opencode/skills/issue-operations/tasks/comment.md
@@ -75,7 +75,28 @@ All tasks complete from this specification.
 
 Stakeholders need understanding, not commit logs. GitHub diffs already show what changed; comments explain WHY.
 
-### Step 4: Validate Format
+### Step 3.5: Byline Verification (MANDATORY)
+
+Before posting any AI-authored comment, verify the byline is present:
+
+| If | Action |
+|----|--------|
+| Body ends with `🤖 Co-authored with AI: <AgentName> (<ModelId>)` | ✅ Proceed to Step 5 |
+| Body contains byline elsewhere | ✅ Proceed to Step 5 |
+| Body has no byline | **Append byline as last line before posting** |
+| Comment is not AI-authored (copy-pasted or human-authored) | ✅ Skip — no byline needed |
+
+**This check applies regardless of target repository** (home repo or external). External posts have higher attribution priority, not lower.
+
+**Standalone byline correction comments are ABSOLUTELY FORBIDDEN.** If a byline was missing from a previously posted comment:
+
+| Option | When | Action |
+|--------|------|--------|
+| Edit the comment | Platform supports edit + agent has edit permission | Edit original, append byline as last line |
+| Delete + repost | Agent has delete permission | Delete original, repost with byline |
+| Accept the omission | No edit/delete permission | Leave it — never add a separate byline comment |
+
+### Step 5: Validate Format
 
 **CRITICAL: Emoji must be PLAIN TEXT (not inside italic/bold formatting)**
 
@@ -86,7 +107,7 @@ Stakeholders need understanding, not commit logs. GitHub diffs already show what
 - Horizontal rule separates summary from byline
 - Body is prose-driven, not rigid bullet lists
 
-### Step 5: Post Comment (Platform Routing)
+### Step 6: Post Comment (Platform Routing)
 
 **GitHub platform:**
 ```python
@@ -127,3 +148,4 @@ github_add_issue_comment(
 - Session values: github.owner, github.repo, github.platform
 - Related tasks: `close` (uses comment for closure), `link-sub-issue` (uses comment for fallback)
 - Platform routing: `../platforms/github-mcp/` or `../platforms/gitbucket-api/`
+- Byline verification (Step 3.5) applies to ALL repositories — external posts have higher attribution priority

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec-fix/1066-1067-byline-enforcement-gaps
+
+- **External Repository Byline Requirement** (#1066) - Added "Posted Content Requiring Attribution" table to 080-code-standards.md covering issue comments, PR comments, PR bodies, and issue bodies on any repository. Clarified that external posts have HIGHER attribution priority than internal content.
+- **Standalone Byline Correction Prohibition** (#1067) - Added "Standalone Byline Correction — FORBIDDEN" section to 080-code-standards.md with correction procedure (edit/delete+repost/accept omission). Added Step 3.5 (Byline Verification) to issue-operations comment task with mandatory pre-post byline check and standalone correction comment prohibition.
+
 ### spec-fix/1042-1043-approval-gate-autonomous-classification
 
 - **Remove Conditional Sub-Agent Dispatch Threshold** (#1043) - Removed the ≤3 inline screening threshold from approval-gate. Screen-issue sub-agent dispatch is now mandatory for ALL approval set sizes, regardless of count. Replaced conditional logic in 000-critical-rules.md, pre-implementation-analysis.md, and SKILL.md verification table. Added "Common Misconception" sections explaining why the threshold was removed.


### PR DESCRIPTION
## Summary

Close two AI byline enforcement gaps: (1) external repository posts now explicitly require attribution with higher priority than internal content, and (2) standalone byline correction comments are now forbidden with a proper correction procedure.

## Outcome

- `080-code-standards.md`: Added "Posted Content Requiring Attribution" table covering issue comments, PR comments, PR bodies, and issue bodies on any repository. Added "Standalone Byline Correction — FORBIDDEN" section with edit/delete+repost/accept-omission procedure. Renamed "Files Requiring Attribution" to "Files Requiring Attribution (In-Repository)" for clarity.
- `issue-operations/tasks/comment.md`: Added Step 3.5 (Byline Verification) mandatory pre-post check. Added standalone byline correction comment prohibition.

Fixes #1066
Fixes #1067