### PR TITLE
Fix: Scope-gate plan auto-approval and enforce dev sync gate

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -141,7 +141,8 @@ Content generation — producing specs, plans, runbooks, documentation, or corre
 **⚠️ Failing to invoke `verification-before-completion` and `finishing-a-development-branch` after implementation is a CRITICAL GUIDELINE VIOLATION.**
 
 - 🚫 FORBIDDEN: Claiming complete without invoking verification skills; manually executing skill steps; skipping verification because "changes look correct"
-- ✅ REQUIRED: See `verification-before-completion` skill `--task verify` for evidence requirements; `finishing-a-development-branch` skill `--task checklist` for branch readiness; `git-workflow` skill `--task review-prep` for post-implementation workflow
+- ✅ REQUIRED: See `verification-before-completion` skill `--task verify` for evidence requirements; `finishing-a-development-branch` skill `--task checklist` for branch readiness; `git-workflow` skill `--task review-prep` for post-implementation workflow; `git-workflow --task cleanup` Step 3.5 for dev sync verification gate before any branch deletion, worktree removal, or issue closure
+- **`git-workflow --task cleanup` Step 3.5** — Dev sync verification gate before any branch deletion, worktree removal, or issue closure. Local dev HEAD MUST match origin/dev HEAD before proceeding.
 
 ## Critical Violation: Skipping review-prep After Implementation
 

--- a/.opencode/skills/git-workflow/tasks/cleanup.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup.md
@@ -451,6 +451,29 @@ The two commit hashes MUST match. If they differ, the pull did not succeed — r
 
 **Worktree context:** If running from a worktree, `git checkout dev` and `git pull` must operate on the main working tree, not the worktree. Use `git -C /path/to/main/repo checkout dev && git -C /path/to/main/repo pull origin dev --ff-only` to ensure operations target the main tree.
 
+### Step 3.5: Dev Sync Verification Gate (MANDATORY — ZERO TOLERANCE)
+
+**After Step 3 (merge verification) and BEFORE any branch deletion, worktree removal, or issue closure:**
+
+This gate is a HARD BLOCK, not a checklist item. No downstream operation may proceed until local dev HEAD matches origin/dev HEAD.
+
+**Procedure:**
+
+1. Run: `git checkout dev && git pull origin dev --ff-only`
+2. Capture local hash: `git log --oneline -1 dev`
+3. Capture remote hash: `git log --oneline -1 origin/dev`
+4. Compare hashes — they MUST match exactly
+5. If hashes differ → re-pull and verify again (maximum 3 attempts)
+6. If still different after 3 attempts → HALT and report to developer
+
+**Evidence artifact (MANDATORY):** The tool-call output showing matching hashes MUST be present in chat before proceeding. This is a verification gate, not a checklist item.
+
+**Why this is a hard gate:** Without confirming local dev is synced, the next session starts with a stale local branch. This causes `git pull` failures from untracked files and merge conflicts when creating new feature branches. The `--ff-only` flag prevents silent merge commits that obscure divergence.
+
+**🚫 FORBIDDEN:** Proceeding past this gate without matching hash evidence. Branch deletion, worktree removal, and issue closure ALL require this gate to pass first.
+
+**Worktree context:** If running from a worktree, the dev sync MUST operate on the main working tree. Use absolute paths: `git -C /path/to/main/repo checkout dev && git -C /path/to/main/repo pull origin dev --ff-only`. The worktree has already been removed in some flows — the main tree must be synced before proceeding.
+
 ### Step 4: Remove Feature Worktree
 
 Feature worktrees must be cleaned up after PR merge.
@@ -1084,6 +1107,7 @@ This parent issue cannot be closed because the following sub-issue(s) remain inc
 | PR merge status | `github_pull_request_read(method=get, ...)` | `merged_at` is not None | CONFLICTING → HALT, do not close issues |
 | Merged by | `github_pull_request_read(method=get, ...)` | `merged_by` populated | VERIFICATION-GAP → investigate |
 | Branch merged into dev | `git branch --merged dev` | Feature branch listed | VERIFICATION-GAP → may need manual merge |
+| Local dev synced | `git log --oneline -1 dev` equals `git log --oneline -1 origin/dev` | Hashes match exactly | VERIFICATION-GAP → re-pull and re-verify |
 | Dev has merge commit | `git log --oneline -5 dev` | Merge commit visible | MISSING-ELEMENT → sync dev first |
 | Sub-issues closed | `github_issue_read(method=get_sub_issues, ...)` | All sub-issues state=closed | VERIFICATION-GAP → close remaining or investigate |
 

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -92,11 +92,11 @@ When combined, the spec issue body has this structure:
 
 ### Approval Cascade
 
-The spec-to-plan approval cascade still applies to combined plans:
+The spec-to-plan approval cascade applies differently based on authorization scope:
 
-- If the spec was already approved when the plan is appended, the combined plan inherits the spec's approval
-- No separate plan approval is needed — the plan content is part of the already-approved spec
-- If the spec has not been approved, the combined plan requires the spec to be approved (single approval covers both)
+- `standard` scope: The combined plan section requires separate plan approval, even though the spec was already approved. The cascade does NOT apply to newly created plans in standard scope — it only applies to EXISTING plans (per approval-gate Step 5b).
+- Pipeline scope (`for_plan` or higher): The combined plan inherits the spec's approval. No separate plan approval needed — the pipeline authorization covers plan creation and approval.
+- If the spec has not been approved, the combined plan requires the spec to be approved (single approval covers both, but only when scope >= for_plan)
 - Spec revision invalidates the `## Implementation Plan` section — see Spec Revision Revocation below
 
 ## Tasks
@@ -167,7 +167,12 @@ approval-gate --task verify-authorization (all gates pass for spec approval)
 | `<github.repo>` | Session init | Repository name for API calls |
 | `worktree.path` | Session / worktree setup | Base directory for file operations |
 
-**Spec-to-plan approval cascade:** When `writing-plans --task create` is invoked for a spec that is already approved, the newly created plan inherits the spec's approval status. The `needs-approval` label is removed from the plan and a comment documents the cascade — see Step 11 in `tasks/create.md` for the complete post-creation cascade procedure. This handles the case where plan creation happens AFTER spec approval in the same session.
+**Spec-to-plan approval cascade (scope-aware):** When `writing-plans --task create` is invoked for a spec that is already approved, the cascade behavior depends on authorization scope:
+
+- `standard` scope: The newly created plan RETAINS the `needs-approval` label. Spec approval authorizes plan creation (first gate), but plan approval requires separate authorization (second gate). The cascade does NOT apply to newly created plans — it only applies to EXISTING plans per approval-gate Step 5b.
+- Pipeline scope (`for_plan` or higher): The newly created plan inherits the spec's approval. The `needs-approval` label is removed and a comment documents the cascade — see Step 11 in `tasks/create.md` for the complete post-creation cascade procedure.
+
+This scope-aware distinction prevents the gateway bypass where a newly created plan is auto-approved in standard scope, skipping the second gate of the two-gate authorization model.
 
 **Manual invocation still works:** `writing-plans --task create` can be invoked directly at any time. Auto-dispatch is additive — it eliminates the silent gap between approval and plan creation, but does not replace manual invocation.
 
@@ -233,7 +238,8 @@ The spec itself is the stable reference. Whether the plan is combined or separat
 - Plan approved but has placeholders → REJECT plan
 - Plan approved but missing TDD steps → REJECT plan
 - Plan approved and complete → PROCEED to implementation
-- Combined spec+plan → plan inherits spec approval status; no separate plan approval needed
+- Combined spec+plan (scope >= for_plan) → plan inherits spec approval status; no separate plan approval needed
+- Combined spec+plan (standard scope) → plan requires separate approval; cascade does NOT apply to newly created plans
 
 ## Sub-Agent Tasks
 
@@ -264,6 +270,7 @@ self_review_passed: bool
 spec_issue: <N>
 single_task: bool
 single_task_determination: <str>
+authorization_scope: <standard|for_spec|for_plan|for_implementation|for_code_review|for_pr|pr_only|review_only>
 session_vars:
   github.owner: <from-session>
   github.repo: <from-session>

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -57,7 +57,7 @@ Before reading the approved spec, invoke `verification-enforcement --task verify
    - The section contains the plan header, file structure, and TDD tasks
    - The issue retains its `[SPEC]` title prefix (not changed to `[PLAN]`)
    - No sub-issues needed (single-task by definition)
-   - Remove `needs-approval` label if the spec was already approved (plan inherits approval via spec-to-plan cascade)
+   - Remove `needs-approval` label only when `authorization_scope >= for_plan`. In `standard` scope, the combined plan section requires separate approval even though the spec was already approved.
    - Proceed to Step 2 (Map file structure) — plan content will be appended to spec body after all steps complete
 
    **If SEPARATE:**
@@ -210,7 +210,7 @@ Before mapping file structure, check whether existing plans already reference th
 
 11. **Post-creation approval cascade check and scope-aware auto-approval (MANDATORY):**
 
-     After the plan is created (either combined or separate), check whether the spec that triggered plan creation was already approved. If yes, the plan inherits the spec's approval status.
+     After the plan is created (either combined or separate), apply scope-aware approval logic. The cascade behavior depends on authorization scope — see success criteria for the complete matrix.
 
      **Scope-aware auto-approval:** When `authorization_scope >= for_plan` (from verify-authorization Step 2.0), the plan is auto-approved without requiring a separate approval gate. The user's pipeline authorization covers plan creation and approval. Remove `needs-approval` label and add cascade comment.
 
@@ -235,36 +235,27 @@ Before mapping file structure, check whether existing plans already reference th
 
      **If `halt_at == plan_created`:** After plan creation and auto-approval, HALT. Do NOT proceed to implementation. The scope horizon stops at plan creation.
 
-     **For combined spec+plan:** The spec issue already has the plan content appended. If the spec was already approved, no further approval action is needed — the combined document inherits the spec's approval. Do NOT remove `needs-approval` if it is still present on the spec (the spec itself may still be pending approval). If the spec was already approved AND `needs-approval` is absent, the combined plan is auto-approved.
+      **For combined spec+plan:** The spec issue already has the plan content appended. Do NOT remove `needs-approval` if `authorization_scope < for_plan`. The combined plan section requires separate plan approval in `standard` scope. Only auto-remove `needs-approval` when `scope_level >= SCOPE_LEVELS['for_plan']`.
 
-     **For separate plan:** Apply the existing cascade logic:
+      **For separate plan:** Apply scope-aware cascade logic:
 
-     ```python
-     spec_issue = github_issue_read(method="get", issue_number=spec_number)
-     spec_comments = github_issue_read(method="get_comments", issue_number=spec_number)
+      ```python
+       spec_labels = [l["name"] for l in spec_issue["labels"]]
 
-     has_approval = any(
-         "approved" in comment["body"].lower() or comment["body"].strip().lower() == "go"
-         for comment in spec_comments
-         if comment["author_association"] in ("MEMBER", "OWNER", "COLLABORATOR")
-     )
+       if scope_level >= SCOPE_LEVELS["for_plan"]:
+           # Pipeline authorization covers plan approval — auto-approve
+           github_issue_write(
+               method="update",
+               issue_number=plan_issue_number,
+               labels=[l for l in plan_labels if l != "needs-approval"],
+           )
+           github_add_issue_comment(
+               issue_number=plan_issue_number,
+               body=f"Plan auto-approved via pipeline scope (authorization_scope={scope}). Plan creation covered by '{scope}' authorization.",
+           )
+      ```
 
-     spec_labels = [l["name"] for l in spec_issue["labels"]]
-     label_already_removed = "needs-approval" not in spec_labels
-
-     if has_approval or label_already_removed or scope_level >= SCOPE_LEVELS["for_plan"]:
-         github_issue_write(
-             method="update",
-             issue_number=plan_issue_number,
-             labels=[l for l in plan_labels if l != "needs-approval"],
-         )
-         github_add_issue_comment(
-             issue_number=plan_issue_number,
-             body=f"Approval cascaded from spec #{spec_number}. Plan created for an already-approved spec — plan inherits approval status automatically.",
-         )
-     ```
-
-     This handles the case where plan creation happens AFTER spec approval in the same session. If the spec still has `needs-approval`, the new plan retains its `needs-approval` label and follows the standard flow (requires explicit plan approval) — unless `authorization_scope >= for_plan`, in which case the plan auto-approval applies regardless.
+      In `standard` scope, the newly created plan retains its `needs-approval` label and requires separate plan approval — the spec-to-plan cascade does NOT apply to newly created plans. In pipeline scope (`for_plan` or higher), the plan is auto-approved because the pipeline authorization covers plan creation and approval.
 
 ## Live Verification: Plan Creation Evidence (MANDATORY)
 


### PR DESCRIPTION
## Summary

Fixes two process bugs in approval gateway and git-workflow cleanup task.

## Outcome

- **#1065** — Removed `has_approval` and `label_already_removed` conditions from `writing-plans/tasks/create.md` Step 11, preventing newly created plans from inheriting spec approval in standard scope. Scope-aware cascade now requires pipeline scope (`>=for_plan`) for auto-approval. Updated SKILL.md cascade documentation and dispatch context schema to reflect scope-qualified behavior.
- **#1070** — Added Step 3.5 Dev Sync Verification Gate to `git-workflow/tasks/cleanup.md` as a hard block between merge verification (Step 3) and branch deletion (Step 4). Local dev HEAD must match origin/dev HEAD before proceeding. Added matching gate to `000-critical-rules.md` mandatory verification skills list and Live Verification table row.

Fixes #1065
Fixes #1070