### PR TITLE
feat: enforcement test mandate for guideline and skill changes

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -274,6 +274,25 @@ When the agent identifies a problem and the fix is clear, the ONLY permitted nex
 
 **Why this matters:** The offer-to-edit pattern is a rationalization bypass. The agent reasons: "I'm not *doing* the edit, I'm just *offering* — so I'm not violating the rule." But the offer normalizes direct edits and creates social pressure to authorize without a spec. The spec-first workflow exists precisely to prevent this.
 
+## Critical Violation: Enforcement Test Updates — Guideline and Skill Changes Without Test Scenarios
+
+**⚠️ Modifying guideline files or skill files without adding or updating corresponding enforcement test scenarios is a CRITICAL GUIDELINE VIOLATION.**
+
+Guideline files (`.opencode/guidelines/*.md`) and skill files (`.opencode/skills/*/SKILL.md`, `.opencode/skills/*/tasks/*.md`) are enforcement-critical documents. A guideline without a test is a suggestion, not a rule. A skill without a test is documentation, not enforcement.
+
+- 🚫 FORBIDDEN: Adding a critical violation section without an enforcement test that checks for it
+- 🚫 FORBIDDEN: Adding a verification step to a skill without an enforcement test that validates it
+- 🚫 FORBIDDEN: Creating a new guideline without an enforcement test that confirms its key sections exist
+- 🚫 FORBIDDEN: Modifying a guideline or skill without updating the corresponding enforcement test
+- 🚫 FORBIDDEN: Running `opencode-cli run` directly without the `with-test-home` wrapper
+- ✅ REQUIRED: Every guideline/skill change comes with an enforcement test scenario
+- ✅ REQUIRED: Add the test scenario FIRST (RED), then make the change (GREEN) — TDD for rules
+- ✅ REQUIRED: Run `bash .opencode/tests/test-enforcement.sh` to verify
+- ✅ REQUIRED: Use `bash .opencode/tests/with-test-home opencode-cli run '<message>'` for all opencode-cli testing
+- ✅ REQUIRED: Clean up test homes after testing: `bash .opencode/tests/with-test-home --clean-all`
+
+**See `080-code-standards.md` → "Enforcement Test Mandate" for the complete per-change TDD pattern. See `.opencode/tests/README.md` for the enforcement test template and usage guide.**
+
 ## Critical Violation: Hardcoded Identity Values in Skills and Guidelines
 
 **⚠️ Hardcoding agent names, model IDs, developer names, developer emails, org names, repo names, or platform names in skill files, guideline files, task files, or any AI agent configuration is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -259,6 +259,41 @@ AI co-authored attribution:
 4. Helps identify AI-generated content for review
 5. **Respects copyright** - only claims co-authorship on genuinely original AI work
 
+## Enforcement Test Mandate for Guideline and Skill Changes
+
+Guideline files (`.opencode/guidelines/*.md`) and skill files (`.opencode/skills/*/SKILL.md`, `.opencode/skills/*/tasks/*.md`) are enforcement-critical documents that control AI agent behavior. Changes to these files MUST be accompanied by corresponding enforcement test updates.
+
+### 🚫 PROHIBITED
+
+- Adding a critical violation section without an enforcement test that checks for it
+- Adding a verification step to a skill without an enforcement test that validates it
+- Creating a new guideline without an enforcement test that confirms its key sections exist
+- Modifying a guideline or skill without updating the corresponding enforcement test
+- Running `opencode-cli run` directly without the `with-test-home` wrapper
+
+### ✅ REQUIRED
+
+- Every guideline/skill change comes with an enforcement test scenario
+- Add the test scenario FIRST (RED), then make the change (GREEN) — TDD for rules
+- Run the enforcement suite: `bash .opencode/tests/test-enforcement.sh`
+- Use `bash .opencode/tests/with-test-home opencode-cli run '<message>'` for all opencode-cli testing — never run bare `opencode-cli run`
+- Clean up test homes after testing: `bash .opencode/tests/with-test-home --clean-all`
+
+### Per-Change TDD Pattern
+
+| TDD Phase | Action |
+|-----------|--------|
+| **RED** | Add enforcement test scenario to `test-enforcement.sh` that checks for the change (expect failure — change doesn't exist yet) |
+| **GREEN** | Make the guideline/skill change that makes the test pass |
+| **REFACTOR** | Clean up test scenario, add cross-reference checks |
+| **COMMIT** | Both the test addition and the guideline change committed together |
+
+### Why This Matters
+
+Enforcement tests are the verification layer that proves agent guidelines are actually enforceable. A guideline without a test is a suggestion, not a rule. A skill without a test is documentation, not enforcement. The `with-test-home` wrapper prevents SQLite session conflicts between the desktop app and CLI tests.
+
+**See `090-incremental-build.md` for the incremental implementation discipline that governs HOW these changes are delivered.** **See `.opencode/tests/README.md` for the enforcement test template and usage guide.**
+
 ## Cross-Reference Standards
 
 **Cross-references in specs, issues, and documentation MUST use stable anchors, NOT line numbers.**

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -52,6 +52,28 @@ Applies to NEW skills AND EDITS to existing skills. No exceptions — not for "s
 2. **GREEN:** Write minimal skill addressing those rationalizations. Run same scenarios WITH skill. Agent should comply.
 3. **REFACTOR:** Close loopholes. Agent found new rationalization? Add explicit counter. Re-test until bulletproof.
 
+### Enforcement Test Step (MANDATORY)
+
+After creating or updating a skill, add or update the corresponding enforcement test scenario in `.opencode/tests/test-enforcement.sh`. This is not optional — it is a critical violation to modify a skill without updating its enforcement test.
+
+**Test scenario pattern:**
+
+```bash
+# In test-enforcement.sh, add to SCENARIOS:
+SCENARIOS["your-scenario-name"]="prompt message that should trigger the skill/guideline"
+
+# Add to EXPECTED_SKILLS:
+EXPECTED_SKILLS["your-scenario-name"]="expected-skill-name"
+```
+
+**Run via the XDG-isolated wrapper (never bare `opencode-cli run`):**
+
+```bash
+bash .opencode/tests/with-test-home opencode-cli run '<test message>'
+```
+
+**See `.opencode/tests/README.md` for the complete template and per-change TDD pattern.**
+
 ## CSO Checklist (Claude Search Optimization)
 
 1. **Description field:** "Use when..." format, triggering conditions only, NO workflow summaries

--- a/.opencode/tests/README.md
+++ b/.opencode/tests/README.md
@@ -1,0 +1,115 @@
+# Enforcement Tests
+
+Tests that verify AI agent guidelines and skills are enforced by the LLM during opencode-cli sessions.
+
+## Test Infrastructure
+
+### `with-test-home` — XDG-Isolated Test Runner
+
+**MUST be used for ALL opencode-cli testing.** Never run `opencode-cli run` directly — it causes SQLite session conflicts with the desktop app.
+
+```bash
+# Run a single test message
+bash .opencode/tests/with-test-home opencode-cli run '<message>'
+
+# Run the full enforcement suite
+bash .opencode/tests/test-enforcement.sh
+
+# Clean up the most recent test home
+bash .opencode/tests/with-test-home --clean
+
+# Clean up ALL test homes
+bash .opencode/tests/with-test-home --clean-all
+```
+
+The wrapper creates an isolated temporary home directory (`.opencode/tmp/test-home-<timestamp>`) with clean XDG state, preventing SQLite conflicts between the desktop app and CLI sessions.
+
+### `test-enforcement.sh` — Full Enforcement Test Suite
+
+Runs opencode-cli sequentially for each test scenario, verifying that the LLM invokes appropriate skills based on user prompts. Produces a results file at `.opencode/tmp/enforcement-test-<timestamp>/results.md`.
+
+### `test-pep723-tools.sh` — Tool Infrastructure Tests
+
+Tests that `.opencode/tools/` scripts work correctly.
+
+## Per-Change TDD Pattern for Guideline and Skill Changes
+
+Every change to a guideline or skill file MUST be accompanied by an enforcement test scenario. Follow this TDD cycle:
+
+### RED — Add the test first
+
+Add a new scenario to the `SCENARIOS` and `EXPECTED_SKILLS` associative arrays in `test-enforcement.sh`:
+
+```bash
+# In test-enforcement.sh, add to SCENARIOS:
+SCENARIOS["your-scenario-name"]="a prompt message that should trigger the skill/guideline"
+
+# In test-enforcement.sh, add to EXPECTED_SKILLS:
+EXPECTED_SKILLS["your-scenario-name"]="expected-skill-name"
+# Use empty string "" if no specific skill invocation is expected
+```
+
+Then run the test and confirm it **fails** (the change doesn't exist yet):
+
+```bash
+bash .opencode/tests/with-test-home opencode-cli run '<your test message>'
+# Expected: behavior indicates the rule/guideline is missing or not enforced
+```
+
+### GREEN — Make the guideline or skill change
+
+Create or modify the guideline/skill file that makes the test pass.
+
+### REFACTOR — Clean up
+
+- Review the test scenario for clarity
+- Add cross-reference checks if needed
+- Run the full suite: `bash .opencode/tests/test-enforcement.sh`
+
+### COMMIT — Working slice
+
+Commit both the test addition and the guideline/skill change together.
+
+## Test Scenario Template
+
+When adding a new enforcement test scenario for a guideline or skill change, use this pattern:
+
+```bash
+# 1. Scenario name: descriptive-kebab-case
+# 2. Prompt message: natural language that should trigger the rule/skill
+# 3. Expected skill: the skill that should be invoked, or "" for no specific skill
+
+# Example: enforcing item decomposition in plans
+SCENARIOS["plan-item-decomposition"]="create a plan for adding user authentication without decomposing it into items"
+EXPECTED_SKILLS["plan-item-decomposition"]="writing-plans"
+
+# Example: enforcing enforcement test mandate
+SCENARIOS["enforcement-test-mandate"]="update the skill-creator skill without adding an enforcement test"
+EXPECTED_SKILLS["enforcement-test-mandate"]="skill-creator"
+```
+
+## What to Test
+
+| Change Type | Test Scenario Focus |
+|-------------|-------------------|
+| New critical violation in `000-critical-rules.md` | Verify the violation is referenced and the LLM recognizes it |
+| New guideline section | Verify the section exists and is cross-referenced |
+| New skill task | Verify the task is listed in the SKILL.md task table |
+| Modified skill behavior | Verify the LLM follows the updated behavior |
+| New enforcement rule | Verify the LLM enforces the new rule when prompted |
+
+## Cleanup
+
+After testing, always clean up test home directories:
+
+```bash
+# Remove the most recent test home
+bash .opencode/tests/with-test-home --clean
+
+# Remove ALL test homes (thorough cleanup)
+bash .opencode/tests/with-test-home --clean-all
+```
+
+## Critical Rule
+
+**Skipping enforcement test updates when modifying guidelines or skills is a CRITICAL GUIDELINE VIOLATION.** See `080-code-standards.md` → "Enforcement Test Mandate" and `000-critical-rules.md` → "Enforcement Test Updates" for the complete rule.


### PR DESCRIPTION
## Summary

Adds a critical violation rule requiring enforcement test updates whenever guideline or skill files are modified, following a TDD pattern (RED → GREEN → COMMIT).

## Outcome

All guideline and skill changes must now be accompanied by corresponding enforcement test scenarios. A new `.opencode/tests/README.md` documents the test template, TDD pattern, and `with-test-home` usage.

## Changes

- **`080-code-standards.md`**: New "Enforcement Test Mandate" section with forbidden/required patterns and per-change TDD table
- **`000-critical-rules.md`**: New critical violation for enforcement test updates, cross-referencing `080-code-standards.md` and `.opencode/tests/README.md`
- **`.opencode/tests/README.md`**: Enforcement test template, `with-test-home` usage guide, per-change TDD pattern, scenario template, and cleanup commands
- **`skill-creator/SKILL.md`**: Mandatory enforcement test step added to TDD cycle section

Fixes #1073