### PR TITLE
Enforce post-merge cleanup and root cause fix-spec discipline

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -151,6 +151,16 @@ Content generation — producing specs, plans, runbooks, documentation, or corre
 - 🚫 FORBIDDEN: Marking complete without commit/push/URL; skipping review-prep for any reason; proceeding without URL in chat
 - ✅ REQUIRED: See `git-workflow` skill `--task review-prep` for mandatory commit, push, compare URL, and HALT protocol
 
+## Critical Violation: Skipping Post-Merge Cleanup
+
+**⚠️ Failing to invoke `git-workflow --task cleanup` after confirming PR merge is a CRITICAL GUIDELINE VIOLATION.** The cleanup task is the sole mechanism for deleting merged branches, closing issues, and syncing the local dev branch. Skipping it leaves stale branches and open issues.
+
+- 🚫 FORBIDDEN: Assuming cleanup is optional after PR merge; manually closing issues without running cleanup; leaving merged branches undeleted; skipping cleanup because "the work is done"
+- ✅ REQUIRED: Invoke `git-workflow --task cleanup` after every confirmed PR merge; verify branch deletion and issue closure via cleanup task result; ensure local dev HEAD matches origin/dev before proceeding
+- ✅ REQUIRED: `git-workflow --task cleanup` Step 2.7 performs hierarchical issue closure — this is the ONLY authorized closure mechanism when PRs merge to `dev` (GitHub autoclose is inert for non-main targets)
+
+**See `git-workflow` skill → `cleanup` task for the complete post-merge workflow.** **AUTHORITY: `git-workflow/tasks/cleanup.md`**
+
 ## Critical Violation: Wrong Chat Output at Halt Points
 
 **⚠️ Producing casual summaries at halt points instead of the mandatory format (exec summary → outcome → URL → byline) is a CRITICAL GUIDELINE VIOLATION.**
@@ -519,6 +529,27 @@ Trigger words: "audit this spec", "review this issue", "revisit this task", "che
 
 - 🚫 FORBIDDEN: Editing source code after discovering a bug; creating branches without approved spec; treating discovery as authorization
 - ✅ REQUIRED: Create bug report issue (permitted without auth); invoke `issue-review --task analyze-and-spec` for root cause analysis; perform read-only analysis; HALT and wait for authorization
+
+## Critical Violation: Symptom-Only Fix-Specs — Patches Without Root Cause Analysis
+
+**⚠️ Creating fix-specs that address only the observed symptom without identifying and targeting the root cause is a CRITICAL GUIDELINE VIOLATION.**
+
+Fix-specs exist to ensure bugs are fixed at their source, not patched at their surface. A symptom-only fix-spec proposes changes that mask the bug's effects without eliminating its cause — the bug will recur or manifest differently.
+
+**See `issue-review` skill → `analyze-and-spec` task for the complete root cause analysis and fix spec creation workflow.** **AUTHORITY: `issue-review/tasks/analyze-and-spec.md`**
+
+| Anti-Pattern | Root Cause Fix | Symptom-Only Patch (FORBIDDEN) |
+| -- | -- | -- |
+| Process gap: "just add the missing close call" | Add enforcement rule + enforcement test mandate | Add one line of code that closes the issue |
+| Data corruption: query returns wrong results | Fix the query logic producing bad data | Filter out wrong results in the UI |
+| State mismatch: stale cache serves old values | Invalidate cache on state change | Increase cache timeout |
+| Missing validation: invalid input causes crash | Add input validation at the entry point | Catch the exception and return empty result |
+| Missing step: workflow skips cleanup | Add mandatory cleanup step to the workflow | Close the issue manually without fixing the workflow |
+
+- 🚫 FORBIDDEN: Creating fix-specs that patch symptoms without root cause analysis; closing bug reports with "add close call" patches that don't prevent recurrence; proposing tactical fixes that mask effects instead of eliminating causes
+- ✅ REQUIRED: Use `issue-review --task analyze-and-spec` for root cause analysis before creating any fix spec; every fix spec MUST include a "Root Cause" section identifying the underlying cause; the "Fix Approach" section MUST target the root cause, not just the symptom; if root cause is unclear, HALT and request developer input per the smart checkpoint in `analyze-and-spec`
+
+**Why this matters:** The entire purpose of the fix-spec workflow is to prevent recurring bugs. A symptom-only fix is the opposite — it closes the issue while leaving the root cause active, guaranteeing the bug will resurface. The `analyze-and-spec` task enforces root cause analysis as MANDATORY before any fix spec creation.
 
 ## Critical Violation: Conflating Issue References with Authorization Cascade
 

--- a/.opencode/skills/finishing-a-development-branch/SKILL.md
+++ b/.opencode/skills/finishing-a-development-branch/SKILL.md
@@ -152,7 +152,7 @@ Before invoking any cross-referenced skill:
 
 ## Cross-References
 
-- Related skills: `git-workflow` (branch management), `verification-before-completion` (evidence), `pr-creation-workflow` (PR timing), `spec-auditor` (ground-truth adversarial verification)
+- Related skills: `git-workflow` (branch management, mandatory post-merge cleanup), `verification-before-completion` (evidence), `pr-creation-workflow` (PR timing), `spec-auditor` (ground-truth adversarial verification)
 - Related guidelines: `000-critical-rules.md` (review-prep required), `060-tool-usage.md` (build/lint commands), `065-verification-honesty.md` (metadata verification extension)
 - Authorization classification: See `010-approval-gate.md` §Action Authorization Classification
 

--- a/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
@@ -73,6 +73,12 @@ Run the completion checklist to verify a branch is fully ready for PR creation.
 - [ ] Verify all issues referenced by the merged PR are closed on GitHub
 - [ ] If issues remain open after verified merge, close them with a comment referencing the merged PR
 
+### Post-Merge Cleanup Verification
+- [ ] `git-workflow --task cleanup` invoked after PR merge confirmation (CRITICAL — skipping is a guideline violation)
+- [ ] Local dev branch synced with origin/dev (dev HEAD matches origin/dev HEAD)
+- [ ] Merged feature branch deleted (local and remote)
+- [ ] No stale worktrees remaining from the merged branch
+
 ### Sub-Issue Linkage Verification
 - [ ] If the plan has multiple phases, verify that `get_sub_issues` count on the plan issue matches the number of phases in the plan body. If counts don't match, run `issue-operations --task link-sub-issue` to create missing linkages before proceeding to review-prep
 ```

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -67,6 +67,7 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
 6. **Compare URLs use `dev` as base:** Feature branches target `dev`, not `main`.
 7. **Squash to single commit before any PR:** No exceptions.
 8. **Never merge PRs:** Human-only operation.
+9. **Post-merge cleanup is MANDATORY:** Skipping `git-workflow --task cleanup` after confirming PR merge is a CRITICAL GUIDELINE VIOLATION. The cleanup task is the sole mechanism for branch deletion, issue closure, and dev sync. Every merged PR MUST be followed by `cleanup`.
 
 ### PR Body Keyword Discipline
 
@@ -102,7 +103,7 @@ pr-creation: Squash → Push → Create PR → HALT
     ↓
 Developer confirms "PR merged"
     ↓
-cleanup: Verify merge via API → Close issues
+cleanup: Verify merge via API → Close issues (MANDATORY — Skipping is a CRITICAL VIOLATION)
 ```
 
 ## Sub-Agent Tasks

--- a/.opencode/skills/issue-review/SKILL.md
+++ b/.opencode/skills/issue-review/SKILL.md
@@ -96,9 +96,13 @@ Hints inform but do not override — `spec-auditor` retains its own subtask sele
 
 Invoke `analyze-and-spec` task for root cause analysis and fix spec auto-creation. See `tasks/analyze-and-spec.md` for full procedure.
 
+**CRITICAL: Symptom-only fix-specs are a CRITICAL GUIDELINE VIOLATION.** Every fix spec created through this path MUST include a "Root Cause" section identifying the underlying cause, and the "Fix Approach" section MUST target the root cause — not just the observed symptom. See `000-critical-rules.md` → "Symptom-Only Fix-Specs" for the complete rule and anti-pattern table.
+
 **Key behavior:**
 - Bug language triggers this path (NOT `qa` anymore)
-- Root cause analysis is read-only
+- Root cause analysis is read-only and MANDATORY — never skip to a quick fix
+- Fix spec MUST include "Root Cause" and "Fix Approach" sections targeting the root cause
+- Symptom-only patches (e.g., "just add the missing close call" without enforcement) are FORBIDDEN
 - Fix spec sub-issue created and linked to bug report parent
 - Smart checkpoint: auto-proceed if clear, HALT if ambiguous
 - Fix spec still requires explicit authorization before code changes

--- a/.opencode/skills/issue-review/tasks/analyze-and-spec.md
+++ b/.opencode/skills/issue-review/tasks/analyze-and-spec.md
@@ -69,11 +69,21 @@ Create a fix spec using the `issue-operations` skill. The fix spec must include:
 
 1. **Title**: `[SPEC] Fix: <brief bug description>`
 2. **Body** (minimum required sections):
-   - **Root Cause**: Prose description of the identified root cause
-   - **Fix Approach**: Minimal targeted fix targeting root cause (not symptoms)
+   - **Root Cause**: Prose description of the identified root cause. This section is MANDATORY — a fix spec without a "Root Cause" section that identifies the underlying cause is a CRITICAL GUIDELINE VIOLATION (see `000-critical-rules.md` → "Symptom-Only Fix-Specs"). The root cause must explain WHY the bug occurs, not just WHAT the bug is.
+   - **Fix Approach**: Minimal targeted fix targeting root cause (not symptoms). If the fix approach only masks the symptom without eliminating the root cause, it is a symptom-only patch and a CRITICAL GUIDELINE VIOLATION. Every fix approach MUST explain how it eliminates the root cause, not just how it hides the symptom.
    - **Success Criteria**: Testable conditions confirming the fix works
    - **Affected Files**: Files that need modification
    - **Risk Assessment**: Potential regression areas
+
+**Root Cause Anti-Patterns (FORBIDDEN):**
+
+| Anti-Pattern | Root Cause Fix (REQUIRED) | Symptom-Only Patch (FORBIDDEN) |
+| -- | -- | -- |
+| Process gap | Add enforcement rule + enforcement test | Add one line of code |
+| Data corruption | Fix the query/data logic producing bad data | Filter out bad results in the UI |
+| State mismatch | Invalidate cache on state change | Increase cache timeout |
+| Missing validation | Add input validation at entry point | Catch the exception and return empty |
+| Missing workflow step | Add mandatory step to workflow | Manual close without fixing workflow |
 
 ### Step 5: Smart Checkpoint
 
@@ -186,4 +196,4 @@ Before classifying a closed bug report as `already-handled` or `stale`:
 - `systematic-debugging`: Root cause analysis overlaps with `diagnose` task; this task is for issue-review context, not active debugging
 - `approval-gate`: Fix spec requires authorization before code changes proceed
 - `067-context-completeness.md`: All comments read before analysis
-- `000-critical-rules.md`: Bug reports must have fix spec before closure
+- `000-critical-rules.md`: Bug reports must have fix spec before closure; symptom-only fix-specs are a CRITICAL GUIDELINE VIOLATION

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -35,6 +35,8 @@ SCENARIOS["bug-report"]="I have a bug - my database query returns wrong results"
 SCENARIOS["create-spec"]="I want to create a new feature spec for user authentication"
 SCENARIOS["simple-question"]="What does the session-enforcement plugin do?"
 SCENARIOS["implement-request"]="implement the skill invocation enforcement plugin"
+SCENARIOS["post-merge-cleanup"]="PR merged, the work is done"
+SCENARIOS["symptom-patch"]="I found a bug where the cleanup step was skipped, let me just add a close-issue call to fix it"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -42,6 +44,8 @@ EXPECTED_SKILLS["bug-report"]="systematic-debugging"
 EXPECTED_SKILLS["create-spec"]="brainstorming"
 EXPECTED_SKILLS["simple-question"]=""
 EXPECTED_SKILLS["implement-request"]="approval-gate"
+EXPECTED_SKILLS["post-merge-cleanup"]="git-workflow"
+EXPECTED_SKILLS["symptom-patch"]="issue-review"
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -54,7 +58,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -93,7 +97,7 @@ for scenario_name in bug-report create-spec simple-question implement-request; d
     fi
     # Fallback: check stdout for skill names
     if [ -z "$SKILL_INVOKED" ] && [ -f "$SCENARIO_OUT" ]; then
-        SKILL_INVOKED=$(grep -oiE "(systematic-debugging|brainstorming|approval-gate|git-workflow|spec-auditor|writing-plans)" "$SCENARIO_OUT" 2>/dev/null | sort -u | tr '\n' ',' | sed 's/,$//' || echo "")
+        SKILL_INVOKED=$(grep -oiE "(systematic-debugging|brainstorming|approval-gate|git-workflow|spec-auditor|writing-plans|issue-review)" "$SCENARIO_OUT" 2>/dev/null | sort -u | tr '\n' ',' | sed 's/,$//' || echo "")
     fi
 
     echo "**Results:**" >> "$RESULTS_FILE"


### PR DESCRIPTION
## Summary

Adds two critical violations and supporting enforcement to close process gaps discovered after PR #1074:

1. **#1075 — Post-merge cleanup enforcement**: Skipping `git-workflow --task cleanup` after PR merge is now a CRITICAL GUIDELINE VIOLATION. The cleanup task is the sole mechanism for branch deletion, issue closure, and dev sync. Adds enforcement checkpoint to `git-workflow/SKILL.md` and verification items to `finishing-a-development-branch/tasks/checklist.md`.

2. **#1076 — Root cause fix-spec discipline**: Creating fix-specs that patch symptoms without identifying the root cause is now a CRITICAL GUIDELINE VIOLATION. Adds anti-pattern table and MANDATORY root cause analysis enforcement to `issue-review/tasks/analyze-and-spec.md`. Every fix spec must include a "Root Cause" section targeting the underlying cause.

Both changes follow the enforcement test mandate from #1074: RED (test scenarios added to `test-enforcement.sh`) → GREEN (guideline/skill changes) → COMMIT.

## Outcome

- `000-critical-rules.md`: Two new critical violation sections (post-merge cleanup skip, symptom-only fix-specs)
- `git-workflow/SKILL.md`: Mandatory post-merge cleanup checkpoint in operating protocol and workflow diagram
- `finishing-a-development-branch/SKILL.md`: Updated cross-reference
- `finishing-a-development-branch/tasks/checklist.md`: Post-merge cleanup verification items
- `issue-review/SKILL.md`: Root cause enforcement in analyze-and-spec path
- `issue-review/tasks/analyze-and-spec.md`: Anti-pattern table, MANDATORY root cause sections
- `test-enforcement.sh`: Two new test scenarios (`post-merge-cleanup`, `symptom-patch`)

Implements #1075
Implements #1076