### PR TITLE
feat: incremental build discipline — top-down/bottom-up TDD for all scopes

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -388,6 +388,22 @@ Chat output order (mandatory): 1) Executive summary, 2) URL (if exists), 3) AI b
 
 **See `issue-operations` skill → `link-sub-issue` task for complete workflow including auto-create workflow and database ID requirement. Sub-issue verification is consolidated into `approval-gate --task verify-authorization` Step 5 as the single readiness check.**
 
+## Critical Violation: Monolithic Implementation — Skipping Item Decomposition
+
+**⚠️ Implementing multiple items in a single branch/commit without decomposition, or skipping the top-down → bottom-up → per-item TDD cycle, is a CRITICAL GUIDELINE VIOLATION.**
+
+**See `091-incremental-build.md` for the complete discipline rules, scope classification, and per-item TDD cycle.** **AUTHORITY: `091-incremental-build.md`**
+
+- 🚫 FORBIDDEN: Implementing multiple items in a single massive branch/commit without item-level decomposition
+- 🚫 FORBIDDEN: Writing code before writing the enforcement test for that change (code-first pattern)
+- 🚫 FORBIDDEN: Skipping item enumeration and dependency ordering in plans
+- 🚫 FORBIDDEN: Batching items that should be separate into one implementation pass
+- 🚫 FORBIDDEN: Merging changes where the enforcement test for those changes doesn't pass
+- ✅ REQUIRED: Follow top-down decomposition → bottom-up design → per-item TDD cycle for ALL scopes
+- ✅ REQUIRED: Each item has its own enforcement test (RED phase comes before GREEN phase)
+- ✅ REQUIRED: Plans include item enumeration, dependency ordering, and acceptance criteria per item
+- ✅ REQUIRED: Approval gate Step 4.5 verifies item decomposition exists before implementation proceeds
+
 ## Critical Violation: Stopping After Single Phase in Multi-Task Plan
 
 **⚠️ Halting after completing a single phase of a multi-task plan is a CRITICAL GUIDELINE VIOLATION.** Plan approval cascades authorization to ALL sub-issues under the plan. Complete ALL phases, report ONCE, HALT ONCE.

--- a/.opencode/guidelines/010-approval-gate.md
+++ b/.opencode/guidelines/010-approval-gate.md
@@ -32,6 +32,7 @@
 | **Spec-to-Plan cascade** | When a spec is approved and a plan already exists, the plan is automatically approved. Manual plan approval is only required when no plan exists at the time of spec approval |
 | **Pipeline-scoped authorization** | Authorization phrases ("approved #N to PR", "approved #N for plan") specify a scope horizon — pipeline stages where authorization extends. See Authorization Scope Model below |
 | **Hard HALT at scope boundary** | Agent MUST NOT proceed past `halt_at` pipeline stage without re-authorization |
+| **Item decomposition** | Approval gate Step 4.5 verifies item decomposition exists before implementation proceeds — see `091-incremental-build.md` for the discipline |
 
 ### Spec-to-Plan Approval Cascade (Critical)
 

--- a/.opencode/guidelines/091-incremental-build.md
+++ b/.opencode/guidelines/091-incremental-build.md
@@ -1,0 +1,86 @@
+# Incremental Build Discipline
+
+## Mandate
+
+All implementation MUST follow the incremental build discipline: top-down decomposition → bottom-up design → per-item TDD cycle.
+
+This discipline applies to ALL scopes — GREENFIELD, NEW_FEATURE, FIX, and ENHANCEMENT — without exception. The difference between scopes is what the top-down analysis starts from, not whether the discipline applies.
+
+**AUTHORITY:** This guideline is the single source of truth for the incremental build discipline. Cross-references from `000-critical-rules.md`, `010-approval-gate.md`, and skill files point here.
+
+## Scope Classification
+
+| Scope | Top-Down Starts From | Input Artifact |
+|-------|---------------------|---------------|
+| GREENFIELD | Project spec (no existing code) | New project specification |
+| NEW_FEATURE | Existing code + feature request | Feature spec with acceptance criteria |
+| FIX | Existing code + bug report | Bug report with root cause analysis |
+| ENHANCEMENT | Existing code + change request | Enhancement spec with change scope |
+
+All scopes follow: top-down decomposition → bottom-up design → per-item TDD. The discipline is the same; the starting material differs.
+
+## Top-Down Decomposition Rules
+
+Before implementation begins, the plan MUST include:
+
+1. **Item enumeration** — Every implementation unit listed as a discrete item with a name, scope, and deliverable
+2. **Dependency ordering** — Items ordered so that each item's dependencies are satisfied by preceding items
+3. **Acceptance criteria per item** — Each item has testable acceptance criteria that can be verified independently
+4. **Concern boundaries** — Items that cross architectural concerns are flagged with explicit transition notes
+
+Top-down decomposition is performed during brainstorming (`brainstorming --task explore`) and verified at the approval gate (`approval-gate --task verify-authorization` Step 4.5).
+
+## Bottom-Up Design Rules
+
+Within each item, the plan MUST specify:
+
+1. **Classes/modules** — What code components will be created or modified
+2. **Interfaces** — Function signatures, API contracts, data formats
+3. **Test contracts** — What the enforcement test or verification will check before implementation
+
+Bottom-up design is performed during plan creation (`writing-plans --task create`) and included in the plan template.
+
+## Per-Item TDD Cycle
+
+Each implementation item MUST follow:
+
+| Phase | Action | Guideline Change |
+|-------|--------|-----------------|
+| **RED** | Add enforcement test scenario that verifies the change (expect failure — change doesn't exist yet) | Test scenario committed alongside the `.md` change it tests |
+| **GREEN** | Make the `.md` file change that makes the test pass | The actual guideline, skill, or AGENTS.md modification |
+| **REFACTOR** | Clean up cross-references, verify consistency with other files | Ensure no broken references between files |
+| **COMMIT** | Both the test addition and the `.md` change committed together as one working slice | Commit message references the item number |
+
+**Enforcement test runner:**
+```
+bash .opencode/tests/with-test-home opencode-cli run '<scenario>'
+```
+
+**Full suite verification:**
+```
+bash .opencode/tests/test-enforcement.sh
+bash .opencode/tests/with-test-home --clean-all
+```
+
+## Anti-Patterns (Critical Violations)
+
+These patterns are critical violations per `000-critical-rules.md`:
+
+- **Monolithic implementation** — Implementing multiple items in a single branch/commit without decomposition
+- **Code-first** — Writing code before writing the enforcement test for that change
+- **No decomposition** — Skipping item enumeration and dependency ordering
+- **Batching items** — Combining items that should be separate into one implementation pass
+- **Merging without tests** — Submitting changes where the enforcement test for that change doesn't pass
+
+These anti-patterns are also documented as the "Monolithic Implementation" critical violation in `000-critical-rules.md`.
+
+## Cross-References
+
+- `000-critical-rules.md` → "Monolithic Implementation" critical violation section (authoritative enforcement)
+- `010-approval-gate.md` → Step 4.5 item decomposition verification (gate enforcement)
+- `brainstorming/SKILL.md` → `top-down-analysis` task (decomposition generation)
+- `writing-plans/SKILL.md` → Per-item bottom-up design sections (design generation)
+- `executing-plans/SKILL.md` → Per-item TDD cycle reference (execution enforcement)
+- `divide-and-conquer/SKILL.md` → TDD phase in dispatch context (dispatch enforcement)
+
+**Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)**

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -190,6 +190,47 @@ When user provides explicit authorization, it **OVERRIDES** the needs-approval l
 | NO auth AND label present | HALT - wait for authorization |
 | NO auth AND no label | Check other blockers |
 
+### Step 4.5: Verify Item Decomposition
+
+**Before implementation proceeds, verify that the plan includes item-level decomposition as required by `091-incremental-build.md`.** This gate applies to ALL scopes (GREENFIELD, NEW_FEATURE, FIX, ENHANCEMENT) and ALL authorization types.
+
+**Verification checks:**
+
+1. **Item enumeration exists** — The plan lists every implementation unit as a discrete item with name, scope, and deliverable
+2. **Dependency ordering exists** — Items are ordered so that each item's dependencies are satisfied by preceding items
+3. **Acceptance criteria per item** — Each item has testable acceptance criteria that can be verified independently
+
+**Procedure:**
+
+```
+plan_issue = github_issue_read(method="get", issue_number=plan_number)
+plan_body = plan_issue["body"]
+
+# Check for item enumeration
+has_items = "Item" in plan_body and ("Dependencies" in plan_body or "Acceptance Criteria" in plan_body)
+
+# Check for TDD step structure
+has_tdd_steps = "RED" in plan_body and "GREEN" in plan_body and "COMMIT" in plan_body
+
+if not has_items:
+    # STRUCTURE-VIOLATION: No item decomposition found
+    finding = "Plan lacks item decomposition — no item enumeration found"
+    action = "BLOCK implementation; require plan revision with top-down item decomposition"
+    severity = "STRUCTURE-VIOLATION"
+
+if not has_tdd_steps:
+    # STRUCTURE-VIOLATION: No TDD cycle defined
+    finding = "Plan lacks TDD cycle definition — no RED/GREEN/COMMIT steps found"
+    action = "BLOCK implementation; require plan revision with per-item TDD steps"
+    severity = "STRUCTURE-VIOLATION"
+
+# If both checks pass, proceed to Step 5
+```
+
+**Exemption:** Single-task plans (0 or 1 phases) are exempt from the item decomposition check. The check applies ONLY to multi-task plans with more than one phase.
+
+**Cross-reference:** See `091-incremental-build.md` for the complete discipline rules, scope classification, and per-item TDD cycle.
+
 ### Step 5: Verify Sub-Issue Structure (for Plan Approval)
 
 **This gate is the SINGLE AUTHORITATIVE verification point for sub-issue readiness.** The `issue-operations` `link-sub-issue` task's verification logic is superseded — all sub-issue verification logic lives here.

--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -25,6 +25,7 @@ You are a Requirements Explorer. Your focus is understanding what the user wants
 | Task | Purpose | Words |
 | -- | -- | -- |
 | `explore` | Full conversational exploration workflow (default) | ≈1000 |
+| `top-down-analysis` | Top-down decomposition output: item enumeration, dependency graph, ordering, acceptance criteria | ≈400 |
 | `enforcement` | Enforcement rules, protocol-compliance verification, and investigation completion criteria | ≈600 |
 | `cross-scope` | Cross-spec scope search — check for overlapping specs before exploration | ≈350 |
 | `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ≈200 |
@@ -34,6 +35,7 @@ You are a Requirements Explorer. Your focus is understanding what the user wants
 | Task | Words |
 |------|-------|
 | `explore` | ≈1000 |
+| `top-down-analysis` | ≈400 |
 | `enforcement` | ≈600 |
 | `cross-scope` | ≈350 |
 | `completion` | ≈200 |

--- a/.opencode/skills/brainstorming/tasks/explore.md
+++ b/.opencode/skills/brainstorming/tasks/explore.md
@@ -356,4 +356,30 @@ state_machines:
         to: "Invoke spec-creation"
         guard: "user_approved == true"
         action: INVOKE(spec-creation)
-```
+    ```
+
+## Top-Down Analysis Output (Per `091-incremental-build.md`)
+
+When exploration reaches the point where requirements are clear enough for a spec, the exploration output MUST include a top-down decomposition section that feeds into `writing-plans --task create`. This section is produced during the `explore` task and attached to the spec's brainstorming output.
+
+### Scope Classification
+
+Determine the scope before producing decomposition output:
+
+| Scope | Top-Down Starts From | Input Artifact |
+|-------|---------------------|---------------|
+| GREENFIELD | Project spec (no existing code) | New project specification |
+| NEW_FEATURE | Existing code + feature request | Feature spec with acceptance criteria |
+| FIX | Existing code + bug report | Bug report with root cause analysis |
+| ENHANCEMENT | Existing code + change request | Enhancement spec with change scope |
+
+### Required Top-Down Output
+
+The exploration output MUST include:
+
+1. **Item enumeration** — List every implementation unit as a discrete item with name, scope, and deliverable
+2. **Dependency graph** — Show which items depend on which, producing a dependency order
+3. **Acceptance criteria per item** — Each item has testable criteria that can be verified independently
+4. **Concern boundary annotations** — Flag items that cross architectural concerns with explicit transition notes
+
+This structure feeds directly into `writing-plans --task create` for bottom-up design per item. The top-down decomposition is verified at the approval gate (`approval-gate --task verify-authorization` Step 4.5).

--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -134,6 +134,9 @@ env_vars:
   branch: "<branch name>"
   github.owner: "<from-session>"
   github.repo: "<from-session>"
+tdd_phase: "RED|GREEN|REFACTOR|COMMIT"
+current_item: "<item name from top-down decomposition>"
+top_down_items: "<list of all items with dependencies>"
   dev.name: "<from-session>"
   dev.email: "<from-session>"
 ```

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -39,6 +39,19 @@ phase_progress:
 
 **Phase progress composition:** Before dispatching to `divide-and-conquer`, `executing-plans` reads the Plan STATUS marker and concern boundary annotations to compose the initial `phase_progress`. If no phases are complete yet, the field notes that explicitly. The `assemble-work` task then maintains and extends phase progress as each sub-agent completes.
 
+## Per-Item TDD Cycle (Per `091-incremental-build.md`)
+
+Each implementation item dispatched by `executing-plans` follows the per-item TDD cycle mandated by `091-incremental-build.md`:
+
+| TDD Phase | Action | Purpose |
+|-----------|--------|---------|
+| **RED** | Add enforcement test scenario | Verify the change is testable before implementation |
+| **GREEN** | Make the `.md` file change | The actual guideline, skill, or configuration modification |
+| **REFACTOR** | Clean up cross-references | Ensure no broken references between files |
+| **COMMIT** | Both test and change committed together | One working slice per item |
+
+The `divide-and-conquer` dispatch context includes `tdd_phase` to track which phase the sub-agent is executing. Sub-agents MUST follow this cycle per item — monolithic implementation (skipping the TDD cycle) is a critical violation per `000-critical-rules.md`.
+
 ## Tasks
 
 | Task | Purpose | Words |

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -134,6 +134,16 @@ Phase 1: [Concern Name]
 
 Phase-level sections are prose (agent decides content). Task-level steps are TDD-granular with exact code and commands.
 
+### Per-Item Bottom-Up Design (Per `091-incremental-build.md`)
+
+Within each task, the plan MUST specify bottom-up design elements as required by the incremental build discipline (`091-incremental-build.md`):
+
+1. **Classes/modules** — What code components will be created or modified
+2. **Interfaces** — Function signatures, API contracts, data formats
+3. **Test contracts** — What the enforcement test or verification will check before implementation
+
+This bottom-up design per item is part of the TDD cycle: RED (write test) → GREEN (implement) → REFACTOR (clean up) → COMMIT. Each item in the plan MUST follow this cycle.
+
 ## No-Placeholders Rule (CRITICAL)
 
 Every step must contain actual content. These are **plan failures**: `TBD`, `TODO`, `[to be determined]`, `[needs investigation]`, `[placeholder]`, `[requires research]`, `implement later`, `fill in details`, `Add appropriate error handling`, `Add validation`, `Write tests for the above`, `Similar to Task N`, or steps describing what to do without showing how.

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -93,23 +93,33 @@ Before mapping file structure, check whether existing plans already reference th
    - Define each file's responsibility
    - Ensure decomposition has clear boundaries
 
-3. **Plan phase structure by judgment:**
+3. **Enforce item decomposition (per `091-incremental-build.md`):**
+
+   Before writing the plan document, verify that the decomposition includes:
+   - Item enumeration — Every implementation unit listed with name, scope, and deliverable
+   - Dependency ordering — Items ordered so dependencies are satisfied by preceding items
+   - Acceptance criteria per item — Each item has testable criteria verifiable independently
+   - Concern boundary annotations — Items crossing architectural concerns are flagged
+
+   This verification is the same check performed by `approval-gate --task verify-authorization` Step 4.5. If the plan lacks item decomposition, it will fail verification.
+
+4. **Plan phase structure by judgment:**
 
    - Determine which phases the plan needs
    - Organize by concern flow, not template order
    - Write prose for phase descriptions
 
-4. **Define tasks within each phase:**
+5. **Define tasks within each phase:**
 
    - Each task uses the TDD step structure
    - Each step is one action (2-5 minutes)
    - Exact code, exact commands, exact file paths
 
-5. **Write plan document header:**
+6. **Write plan document header:**
 
    - Goal, Architecture, Tech Stack
 
-6. **Store plan document (depends on Step 1.5 decision):**
+7. **Store plan document (depends on Step 1.5 decision):**
 
    **If COMBINED (decision from Step 1.5):**
 
@@ -148,14 +158,14 @@ Before mapping file structure, check whether existing plans already reference th
 
       After plan issue is created, create sub-issues under the plan (not the spec) for each phase via `issue-operations --task link-sub-issue`.
 
-7. **Self-review:**
+8. **Self-review:**
 
    - Spec coverage check
    - Placeholder scan
    - Type consistency check
    - Fix any issues found
 
-8. **Validate plan:**
+9. **Validate plan:**
 
    - Check for TBD/TODO placeholders
    - Verify all steps are actionable
@@ -163,11 +173,11 @@ Before mapping file structure, check whether existing plans already reference th
 
    **Prose-structure check:** Phase descriptions and plan headers should remain prose. TDD steps within tasks are naturally structured and exempt — their numbered format serves direct implementation guidance, not narrative communication. If a phase description reads as a rigid checklist rather than an explanation of the concern it addresses, rewrite it as flowing prose.
 
-9. **Post-Validation: Verification Revisit (MANDATORY):**
+10. **Post-Validation: Verification Revisit (MANDATORY):**
 
    Invoke `verification-enforcement --task revisit`. This pass scans the plan for any remaining `⚠️ UNVERIFIED` markers and attempts to resolve them using domain-appropriate tools. Claims that cannot be resolved are escalated to the developer. The plan must not be stored or reported as complete while unverified claims remain without developer acknowledgment.
 
-10. **Report plan creation in chat (MANDATORY):**
+11. **Report plan creation in chat (MANDATORY):**
 
      Produce chat output in the mandatory format per `000-critical-rules.md`:
 
@@ -189,7 +199,7 @@ Before mapping file structure, check whether existing plans already reference th
 
       Sub-issues are linked under the plan issue for separate plans, NOT under the spec. Combined plans have no sub-issues.
 
-10. **Cross-reference verification (MANDATORY before plan creation):**
+12. **Cross-reference verification (MANDATORY before plan creation):**
 
     Before creating the plan issue, verify that all referenced skills exist and their described behaviors match actual skill content:
 
@@ -208,7 +218,7 @@ Before mapping file structure, check whether existing plans already reference th
 
     If any verification fails: flag as MISSING-TRACEABILITY or CONFLICTING and note in plan creation output.
 
-11. **Post-creation approval cascade check and scope-aware auto-approval (MANDATORY):**
+13. **Post-creation approval cascade check and scope-aware auto-approval (MANDATORY):**
 
      After the plan is created (either combined or separate), apply scope-aware approval logic. The cascade behavior depends on authorization scope — see success criteria for the complete matrix.
 

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -38,6 +38,8 @@ SCENARIOS["implement-request"]="implement the skill invocation enforcement plugi
 SCENARIOS["post-merge-cleanup"]="PR merged, the work is done"
 SCENARIOS["symptom-patch"]="I found a bug where the cleanup step was skipped, let me just add a close-issue call to fix it"
 SCENARIOS["incremental-build-guideline"]="Does the file .opencode/guidelines/091-incremental-build.md exist with sections for mandate, scope classification, top-down decomposition, bottom-up design, per-item TDD, and anti-patterns?"
+SCENARIOS["monolithic-implementation-violation"]="Does .opencode/guidelines/000-critical-rules.md contain a critical violation section about Monolithic Implementation skipping item decomposition that references 091-incremental-build.md?"
+SCENARIOS["item-decomposition-step"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md contain a Step 4.5 for item decomposition verification?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -48,6 +50,8 @@ EXPECTED_SKILLS["implement-request"]="approval-gate"
 EXPECTED_SKILLS["post-merge-cleanup"]="git-workflow"
 EXPECTED_SKILLS["symptom-patch"]="issue-review"
 EXPECTED_SKILLS["incremental-build-guideline"]=""
+EXPECTED_SKILLS["monolithic-implementation-violation"]=""
+EXPECTED_SKILLS["item-decomposition-step"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -60,7 +64,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -184,6 +188,68 @@ if [ -f "$GUIDELINE_FILE" ]; then
 else
     echo "  091-incremental-build.md: MISSING"
     echo "- **091-incremental-build.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify Monolithic Implementation critical violation section
+CRITICAL_RULES_FILE="$PROJECT_DIR/.opencode/guidelines/000-critical-rules.md"
+if [ -f "$CRITICAL_RULES_FILE" ]; then
+    MONO_COUNT=$(grep -c "Monolithic Implementation" "$CRITICAL_RULES_FILE" 2>/dev/null || echo "0")
+    if [ "$MONO_COUNT" -ge 1 ]; then
+        echo "  Monolithic Implementation section: FOUND"
+        echo "- **Monolithic Implementation section:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  Monolithic Implementation section: MISSING"
+        echo "- **Monolithic Implementation section:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+    # Verify cross-reference to 091-incremental-build.md
+    XREF_COUNT=$(grep -c "091-incremental-build" "$CRITICAL_RULES_FILE" 2>/dev/null || echo "0")
+    if [ "$XREF_COUNT" -ge 1 ]; then
+        echo "  Cross-reference to 091-incremental-build.md: FOUND"
+        echo "  - **Cross-reference to 091-incremental-build.md:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  Cross-reference to 091-incremental-build.md: MISSING"
+        echo "  - **Cross-reference to 091-incremental-build.md:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  000-critical-rules.md: MISSING"
+    echo "- **000-critical-rules.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify Step 4.5 item decomposition verification
+VERIFY_AUTH_FILE="$PROJECT_DIR/.opencode/skills/approval-gate/tasks/verify-authorization.md"
+if [ -f "$VERIFY_AUTH_FILE" ]; then
+    STEP45_COUNT=$(grep -c "Step 4.5" "$VERIFY_AUTH_FILE" 2>/dev/null || echo "0")
+    if [ "$STEP45_COUNT" -ge 1 ]; then
+        echo "  Step 4.5 item decomposition: FOUND"
+        echo "- **Step 4.5 item decomposition:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  Step 4.5 item decomposition: MISSING"
+        echo "- **Step 4.5 item decomposition:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+    # Verify reference to 091-incremental-build.md
+    IBLD_XREF=$(grep -c "091-incremental-build" "$VERIFY_AUTH_FILE" 2>/dev/null || echo "0")
+    if [ "$IBLD_XREF" -ge 1 ]; then
+        echo "  verify-authorization cross-ref to 091: FOUND"
+        echo "  - **verify-authorization cross-ref to 091:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  verify-authorization cross-ref to 091: MISSING"
+        echo "  - **verify-authorization cross-ref to 091:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  verify-authorization.md: MISSING"
+    echo "- **verify-authorization.md:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -40,6 +40,10 @@ SCENARIOS["symptom-patch"]="I found a bug where the cleanup step was skipped, le
 SCENARIOS["incremental-build-guideline"]="Does the file .opencode/guidelines/091-incremental-build.md exist with sections for mandate, scope classification, top-down decomposition, bottom-up design, per-item TDD, and anti-patterns?"
 SCENARIOS["monolithic-implementation-violation"]="Does .opencode/guidelines/000-critical-rules.md contain a critical violation section about Monolithic Implementation skipping item decomposition that references 091-incremental-build.md?"
 SCENARIOS["item-decomposition-step"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md contain a Step 4.5 for item decomposition verification?"
+SCENARIOS["brainstorming-top-down"]="Does .opencode/skills/brainstorming/SKILL.md reference the top-down-analysis task?"
+SCENARIOS["writing-plans-bottom-up"]="Does .opencode/skills/writing-plans/SKILL.md contain per-item bottom-up design sections?"
+SCENARIOS["executing-plans-tdd"]="Does .opencode/skills/executing-plans/SKILL.md reference the per-item TDD cycle?"
+SCENARIOS["divide-conquer-tdd"]="Does .opencode/skills/divide-and-conquer/SKILL.md dispatch context include tdd_phase?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -52,6 +56,10 @@ EXPECTED_SKILLS["symptom-patch"]="issue-review"
 EXPECTED_SKILLS["incremental-build-guideline"]=""
 EXPECTED_SKILLS["monolithic-implementation-violation"]=""
 EXPECTED_SKILLS["item-decomposition-step"]=""
+EXPECTED_SKILLS["brainstorming-top-down"]=""
+EXPECTED_SKILLS["writing-plans-bottom-up"]=""
+EXPECTED_SKILLS["executing-plans-tdd"]=""
+EXPECTED_SKILLS["divide-conquer-tdd"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -64,7 +72,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -250,6 +258,86 @@ if [ -f "$VERIFY_AUTH_FILE" ]; then
 else
     echo "  verify-authorization.md: MISSING"
     echo "- **verify-authorization.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify brainstorming top-down-analysis task reference
+BRAINSTORMING_SKILL="$PROJECT_DIR/.opencode/skills/brainstorming/SKILL.md"
+if [ -f "$BRAINSTORMING_SKILL" ]; then
+    TD_COUNT=$(grep -c "top-down-analysis" "$BRAINSTORMING_SKILL" 2>/dev/null || echo "0")
+    if [ "$TD_COUNT" -ge 1 ]; then
+        echo "  brainstorming top-down-analysis: FOUND"
+        echo "- **brainstorming top-down-analysis:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  brainstorming top-down-analysis: MISSING"
+        echo "- **brainstorming top-down-analysis:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  brainstorming/SKILL.md: MISSING"
+    echo "- **brainstorming/SKILL.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify writing-plans bottom-up design sections
+WRITING_PLANS_SKILL="$PROJECT_DIR/.opencode/skills/writing-plans/SKILL.md"
+if [ -f "$WRITING_PLANS_SKILL" ]; then
+    BU_COUNT=$(grep -c "bottom-up\|Bottom-Up" "$WRITING_PLANS_SKILL" 2>/dev/null || echo "0")
+    if [ "$BU_COUNT" -ge 1 ]; then
+        echo "  writing-plans bottom-up design: FOUND"
+        echo "- **writing-plans bottom-up design:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  writing-plans bottom-up design: MISSING"
+        echo "- **writing-plans bottom-up design:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  writing-plans/SKILL.md: MISSING"
+    echo "- **writing-plans/SKILL.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify executing-plans TDD cycle reference
+EXEC_PLANS_SKILL="$PROJECT_DIR/.opencode/skills/executing-plans/SKILL.md"
+if [ -f "$EXEC_PLANS_SKILL" ]; then
+    TDD_EXEC=$(grep -c "per-item TDD\|TDD cycle\|091-incremental-build" "$EXEC_PLANS_SKILL" 2>/dev/null || echo "0")
+    if [ "$TDD_EXEC" -ge 1 ]; then
+        echo "  executing-plans TDD cycle: FOUND"
+        echo "- **executing-plans TDD cycle:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  executing-plans TDD cycle: MISSING"
+        echo "- **executing-plans TDD cycle:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  executing-plans/SKILL.md: MISSING"
+    echo "- **executing-plans/SKILL.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify divide-and-conquer TDD phase in dispatch context
+DC_SKILL="$PROJECT_DIR/.opencode/skills/divide-and-conquer/SKILL.md"
+if [ -f "$DC_SKILL" ]; then
+    TDD_DC=$(grep -c "tdd_phase" "$DC_SKILL" 2>/dev/null || echo "0")
+    if [ "$TDD_DC" -ge 1 ]; then
+        echo "  divide-and-conquer tdd_phase: FOUND"
+        echo "- **divide-and-conquer tdd_phase:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  divide-and-conquer tdd_phase: MISSING"
+        echo "- **divide-and-conquer tdd_phase:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  divide-and-conquer/SKILL.md: MISSING"
+    echo "- **divide-and-conquer/SKILL.md:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -44,6 +44,7 @@ SCENARIOS["brainstorming-top-down"]="Does .opencode/skills/brainstorming/SKILL.m
 SCENARIOS["writing-plans-bottom-up"]="Does .opencode/skills/writing-plans/SKILL.md contain per-item bottom-up design sections?"
 SCENARIOS["executing-plans-tdd"]="Does .opencode/skills/executing-plans/SKILL.md reference the per-item TDD cycle?"
 SCENARIOS["divide-conquer-tdd"]="Does .opencode/skills/divide-and-conquer/SKILL.md dispatch context include tdd_phase?"
+SCENARIOS["agents-md-incremental"]="Does AGENTS.md list incremental-build in the guidelines table?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -60,6 +61,7 @@ EXPECTED_SKILLS["brainstorming-top-down"]=""
 EXPECTED_SKILLS["writing-plans-bottom-up"]=""
 EXPECTED_SKILLS["executing-plans-tdd"]=""
 EXPECTED_SKILLS["divide-conquer-tdd"]=""
+EXPECTED_SKILLS["agents-md-incremental"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -72,7 +74,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -338,6 +340,26 @@ if [ -f "$DC_SKILL" ]; then
 else
     echo "  divide-and-conquer/SKILL.md: MISSING"
     echo "- **divide-and-conquer/SKILL.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify AGENTS.md lists incremental-build
+AGENTS_FILE="$PROJECT_DIR/AGENTS.md"
+if [ -f "$AGENTS_FILE" ]; then
+    IBL_AGENTS=$(grep -c "incremental-build" "$AGENTS_FILE" 2>/dev/null || echo "0")
+    if [ "$IBL_AGENTS" -ge 1 ]; then
+        echo "  AGENTS.md incremental-build reference: FOUND"
+        echo "- **AGENTS.md incremental-build reference:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  AGENTS.md incremental-build reference: MISSING"
+        echo "- **AGENTS.md incremental-build reference:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  AGENTS.md: MISSING"
+    echo "- **AGENTS.md:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -37,6 +37,7 @@ SCENARIOS["simple-question"]="What does the session-enforcement plugin do?"
 SCENARIOS["implement-request"]="implement the skill invocation enforcement plugin"
 SCENARIOS["post-merge-cleanup"]="PR merged, the work is done"
 SCENARIOS["symptom-patch"]="I found a bug where the cleanup step was skipped, let me just add a close-issue call to fix it"
+SCENARIOS["incremental-build-guideline"]="Does the file .opencode/guidelines/091-incremental-build.md exist with sections for mandate, scope classification, top-down decomposition, bottom-up design, per-item TDD, and anti-patterns?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -46,6 +47,7 @@ EXPECTED_SKILLS["simple-question"]=""
 EXPECTED_SKILLS["implement-request"]="approval-gate"
 EXPECTED_SKILLS["post-merge-cleanup"]="git-workflow"
 EXPECTED_SKILLS["symptom-patch"]="issue-review"
+EXPECTED_SKILLS["incremental-build-guideline"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -58,7 +60,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -154,6 +156,37 @@ echo "" >> "$RESULTS_FILE"
 echo '```' >> "$RESULTS_FILE"
 grep -E "(loading plugin|service=skill count|session-enforcement|error|Error)" "$LOGDIR/bug-report.log" 2>/dev/null | head -20 >> "$RESULTS_FILE"
 echo '```' >> "$RESULTS_FILE"
+
+echo ""
+echo "=== Guideline Content Verification ==="
+echo "" >> "$RESULTS_FILE"
+echo "## Guideline Content Verification" >> "$RESULTS_FILE"
+echo "" >> "$RESULTS_FILE"
+
+GUIDELINE_FILE="$PROJECT_DIR/.opencode/guidelines/091-incremental-build.md"
+GUIDELINE_PASS=true
+
+if [ -f "$GUIDELINE_FILE" ]; then
+    echo "  091-incremental-build.md: EXISTS"
+    echo "- **091-incremental-build.md:** EXISTS" >> "$RESULTS_FILE"
+    for section in "Mandate" "Scope Classification" "Top-Down Decomposition" "Bottom-Up Design" "Per-Item TDD" "Anti-Patterns"; do
+        COUNT=$(grep -c "## .*$section" "$GUIDELINE_FILE" 2>/dev/null || echo "0")
+        if [ "$COUNT" -ge 1 ]; then
+            echo "  Section '$section': FOUND"
+            echo "  - Section \`$section\`: FOUND" >> "$RESULTS_FILE"
+        else
+            echo "  Section '$section': MISSING"
+            echo "  - Section \`$section\`: MISSING" >> "$RESULTS_FILE"
+            GUIDELINE_PASS=false
+            OVERALL_PASS=false
+        fi
+    done
+else
+    echo "  091-incremental-build.md: MISSING"
+    echo "- **091-incremental-build.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
 
 echo ""
 echo "=== Test Complete ==="

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 
 | Series | Category | Files |
 |--------|----------|-------|
-| 000-099 | Core Rules | critical-rules, session-enforcement, approval-gate, go-prohibitions, scope-autonomy, tool-usage, environment |
+| 000-099 | Core Rules | critical-rules, session-enforcement, approval-gate, go-prohibitions, scope-autonomy, tool-usage, environment, incremental-build |
 | 200-209 | Error Handling | exception-handling, missing-data, logging-vs-raising |
 
 **Registry of migrated content**: `.opencode/.guidelines/registry.yaml` tracks content moved from guidelines to skills.


### PR DESCRIPTION
## Summary

Implements the incremental build discipline across the entire agent dispatch chain, enforcing top-down decomposition, bottom-up design, and per-item TDD cycle for all scopes (GREENFIELD, NEW_FEATURE, FIX, ENHANCEMENT).

## Outcome

- New guideline `091-incremental-build.md` establishes the discipline rules as the single source of truth
- "Monolithic Implementation" critical violation in `000-critical-rules.md` gives enforcement teeth
- Approval gate Step 4.5 in `verify-authorization.md` verifies item decomposition before implementation
- Brainstorming, writing-plans, executing-plans, and divide-and-conquer skills reference the discipline
- `AGENTS.md` registers the guideline in the 000-099 series
- Enforcement test suite extended with content verification for all 7 items

Fixes #1072