### PR TITLE
Post-Push Worktree Handoff: Switch Main Repo to Feature Branch

### DIFF
--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -150,6 +150,7 @@ task: review-prep
 branch_pushed: bool
 compare_url: <url>
 commits_count: <int>
+worktree_handoff: bool
 ```
 
 #### pr-creation

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -348,7 +348,93 @@ git push -u origin <branch-name>
 
 **This ensures compare URL will work correctly.**
 
-### Step 3: Generate Compare URL
+### Step 2.5: Worktree Handoff (CONDITIONAL)
+
+**After pushing, hand the branch back to the developer's normal working environment.**
+
+**This step ONLY runs when `worktree.path` is set (autonomous mode). Skip entirely when:**
+
+- `worktree.path` is empty or not set (pair mode — developer already in main repo)
+- Branch is on `dev` or `main` (no worktree to remove)
+
+**If skipping:** Report "Worktree handoff skipped (no worktree)" and proceed to Step 3.
+
+#### Worktree Handoff Sequence
+
+When `worktree.path` IS set, perform the following sequence inside the **main repo** (not the worktree):
+
+```bash
+# Run from main repo working directory
+cd <main-repo-path>
+
+# 1. Remove the worktree
+git worktree remove <worktree.path>
+
+# 1a. Force fallback (if worktree has locked files or stale state)
+git worktree remove --force <worktree.path>
+```
+
+**Worktree removal failure handling:**
+
+| Failure | Action |
+| -- | -- |
+| `already locked` or stale state | `git worktree remove --force <worktree.path>` |
+| Directory not recognized as worktree | `rm -rf <worktree.path>` (directory is orphaned) |
+| Any other error | HALT — report error, do not force-remove |
+
+#### Checkout to Feature Branch
+
+After worktree removal, switch the main repo to the feature branch so the developer can review code in their normal environment:
+
+```bash
+# 2. Checkout the feature branch in the main repo
+git checkout <branch-name>
+```
+
+**Stash + retry fallback (if checkout fails due to dirty working tree):**
+
+```bash
+# 2a. Stash uncommitted changes in main repo
+git stash push -m "auto-stash before worktree-handoff to <branch-name>"
+
+# 2b. Retry checkout
+git checkout <branch-name>
+```
+
+**Stash preservation:** The auto-stash is preserved — do NOT auto-pop it. The developer decides when to restore it.
+
+#### Branch Not Found Locally
+
+If the feature branch does not exist in the main repo's local refs (possible when the worktree was the only place it existed):
+
+```bash
+# 3. Fetch branch from remote
+git fetch origin <branch-name>
+
+# 3a. Create local tracking branch
+git checkout -b <branch-name> origin/<branch-name>
+```
+
+#### Clear worktree.path Session Variable
+
+After successful handoff, clear the session variable:
+
+```
+worktree.path = ""  (cleared — agent no longer references worktree)
+```
+
+**This prevents subsequent tool calls from targeting the removed worktree directory.**
+
+#### Rollback Guarantee
+
+| Scenario | State Before | State After | Rollback |
+| -- | -- | -- | -- |
+| Successful handoff | Worktree exists, main on `dev` | Worktree removed, main on `<branch>` | `git checkout dev && git worktree add <path> -b <branch>` |
+| Checkout fails (dirty tree) | Worktree removed, stash created | Main on `<branch>`, stash available | `git stash pop` restores changes |
+| Branch not found locally | Worktree removed | Branch fetched, main on `<branch>` | N/A (branch exists on remote) |
+| Worktree removal fails | Worktree locked | HALT — report error | Worktree still intact, no state change |
+
+**⚠️ The worktree path is removed from the filesystem after this step. ALL subsequent file operations MUST use the main repo path (relative paths from project root).**
 
 **⚠️ CRITICAL: URLs must be constructed from session init values ONLY. Never hardcode domains.**
 

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -45,6 +45,7 @@ SCENARIOS["writing-plans-bottom-up"]="Does .opencode/skills/writing-plans/SKILL.
 SCENARIOS["executing-plans-tdd"]="Does .opencode/skills/executing-plans/SKILL.md reference the per-item TDD cycle?"
 SCENARIOS["divide-conquer-tdd"]="Does .opencode/skills/divide-and-conquer/SKILL.md dispatch context include tdd_phase?"
 SCENARIOS["agents-md-incremental"]="Does AGENTS.md list incremental-build in the guidelines table?"
+SCENARIOS["worktree-handoff-step"]="Does .opencode/skills/git-workflow/tasks/review-prep.md contain a Step 2.5 for worktree handoff after push?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -62,6 +63,7 @@ EXPECTED_SKILLS["writing-plans-bottom-up"]=""
 EXPECTED_SKILLS["executing-plans-tdd"]=""
 EXPECTED_SKILLS["divide-conquer-tdd"]=""
 EXPECTED_SKILLS["agents-md-incremental"]=""
+EXPECTED_SKILLS["worktree-handoff-step"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -74,7 +76,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -360,6 +362,18 @@ if [ -f "$AGENTS_FILE" ]; then
 else
     echo "  AGENTS.md: MISSING"
     echo "- **AGENTS.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+WORKTREE_HANDOFF_FILE="$PROJECT_DIR/.opencode/skills/git-workflow/tasks/review-prep.md"
+WH_COUNT=$(grep -c "Step 2.5" "$WORKTREE_HANDOFF_FILE" 2>/dev/null || echo "0")
+if [ "$WH_COUNT" -ge 1 ]; then
+    echo "  review-prep Step 2.5 worktree handoff: FOUND"
+    echo "- **review-prep Step 2.5 worktree handoff:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  review-prep Step 2.5 worktree handoff: MISSING"
+    echo "- **review-prep Step 2.5 worktree handoff:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi


### PR DESCRIPTION
## Summary

After pushing a feature branch, review-prep now switches the main repo working directory to the feature branch so developers can immediately review and test changes without manual branch switching.

## Outcome

Developers no longer need to manually switch branches after a push; the worktree handoff automates the transition for seamless review workflows.

Implements #1080