### PR TITLE
[SPEC-FIX] Scope auto-resolve enforcement (#1104)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -801,9 +801,13 @@ Structural decisions — single-task vs multi-task classification, phase decompo
 - 🚫 FORBIDDEN: "How should we handle this partially-implemented issue?" — scope-reduce and continue
 - 🚫 FORBIDDEN: "Should we re-plan?" — yes, if authorization says "re-plan as needed"
 - 🚫 FORBIDDEN: "How should we close this already-implemented issue?" — via verify-already-implemented or via referenced spec-fix
+- 🚫 FORBIDDEN: "Should this be standard scope or for_implementation?" — the verb-prefix parsing table resolves this
+- 🚫 FORBIDDEN: "What scope of authorization?" — the verb-prefix table is deterministic
+- 🚫 FORBIDDEN: "Is this approved to PR or just to implementation?" — parse the phrase, don't ask
 - 🚫 FORBIDDEN: Any question where the answer is determinable from context, codebase, or request analysis
 - ✅ REQUIRED: Classify autonomously and state the classification as part of the design proposal
 - ✅ REQUIRED: Only ask when multiple valid structures exist with genuinely ambiguous trade-offs (e.g., 3+ subsystems with unclear boundaries)
+- ✅ REQUIRED: Authorization scope MUST be auto-resolved from the verb-prefix parsing table per the approval-gate skill → Authorization Scope Model
 
 **See `brainstorming` skill → `explore` task → "Autonomous Structural Classification" for the complete criteria. See `approval-gate/tasks/pre-implementation-analysis.md` Step 0.15 for the classification decision table that maps screening results to autonomous actions. See `approval-gate/tasks/screen-issue.md` §"Autonomous Resolution" for the exhaustive `requires_developer: true` conditions.**
 

--- a/.opencode/guidelines/020-go-prohibitions.md
+++ b/.opencode/guidelines/020-go-prohibitions.md
@@ -43,6 +43,7 @@
 - **"GO" requires unambiguous scope; clarify only when ambiguous.** If the user types "GO" (or equivalent), treat it as valid authorization ONLY when the immediate session context identifies exactly one plan/scope target.
 - **Clarification gate for ambiguous "GO" only.** Ask for scope clarification only when more than one plausible plan file, phase, or implementation scope is active.
 - **Pipeline-scoped "GO" phrases specify scope horizon.** "Approved #N to PR", "#N approved for plan", "approved #N through implementation" — these carry implicit scope. Parse per `approval-gate` skill → "Authorization Scope Model" and HALT at the specified pipeline stage.
+- **Scope detection via the verb-prefix parsing table is NEVER ambiguous — the table maps every possible phrase to exactly one scope.** Do not ask the user to classify scope. "Approved #N" (no qualifier) → ALWAYS `standard` scope. No clarification needed. "Approved #N to PR" → ALWAYS `for_pr` scope. The parsing table in `approval-gate` skill → Authorization Scope Model is the sole authority for scope determination.
 
 ### ✅ ALWAYS DO
 

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -42,6 +42,33 @@ if not result or not result.strip():
 
 **No regression:** When sub-agent returns a valid result, this guard is not triggered — Steps 1-6 execute normally from the sub-agent's result.
 
+### Step 0.5: Scope Auto-Resolve (MANDATORY BEFORE ANY HUMAN-FACING OUTPUT)
+
+**This step MUST execute before Step 1, Step 2.0, and before any screen-issue dispatch.**
+
+**The agent MUST resolve `authorization_scope` from the authorization phrase using the verb-prefix parsing table BEFORE asking any question or dispatching any sub-agent.** Scope detection is NEVER ambiguous — the parsing table is deterministic. Per `000-critical-rules.md` → "Pushing Agent Intelligence Decisions" and `020-go-prohibitions.md` §1 "ASK FIRST", scope detection via parsing table is NEVER ambiguous.
+
+**Under NO circumstances does the agent ask the user to classify scope.** The verb-prefix parsing table in Step 2.0 is the sole authority. Every possible authorization phrase maps to exactly one scope:
+
+| Authorization Phrase | Resolved Scope |
+|----------------------|---------------|
+| "approved #N" (no qualifier) | `standard` |
+| "approved #N to PR" / "for PR" | `for_pr` |
+| "approved #N to implementation" / "for implementation" | `for_implementation` |
+| "approved #N to plan" / "for plan" | `for_plan` |
+| "approved #N for review" | `for_code_review` |
+| "approved #N to spec" / "for spec" | `for_spec` |
+
+**Procedure:**
+
+1. Parse the authorization text using the verb-prefix regex patterns from the approval-gate skill → Authorization Scope Model → Scope Detection (Verb-Prefix Parsing) table
+2. If a qualifier matches, set `authorization_scope` to the corresponding scope value with `scope_source = "parsed"`
+3. If no qualifier matches, set `authorization_scope = "standard"` with `scope_source = "default"`
+4. Derive `halt_at`, `pr_strategy`, and `gap_fill_actions` from the resolved scope per the Authorization Scope Model
+5. Record the parsed result as an evidence artifact — no human input is solicited
+
+**Evidence artifact:** The parsed authorization text, matched regex pattern (or default fallback), and resulting `(authorization_scope, scope_source, halt_at, pr_strategy, gap_fill_actions)` tuple MUST be recorded in the verification report without soliciting human input.
+
 ### Step 1: Verify Git State (MANDATORY FIRST)
 
 **🚫 CRITICAL: This check MUST happen BEFORE any other work.**

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -46,6 +46,8 @@ SCENARIOS["executing-plans-tdd"]="Does .opencode/skills/executing-plans/SKILL.md
 SCENARIOS["divide-conquer-tdd"]="Does .opencode/skills/divide-and-conquer/SKILL.md dispatch context include tdd_phase?"
 SCENARIOS["agents-md-incremental"]="Does AGENTS.md list incremental-build in the guidelines table?"
 SCENARIOS["worktree-handoff-step"]="Does .opencode/skills/git-workflow/tasks/review-prep.md contain a Step 2.5 for worktree handoff after push?"
+SCENARIOS["scope-auto-resolve-guideline"]="Does .opencode/guidelines/000-critical-rules.md contain scope classification FORBIDDEN examples in the Pushing Agent Intelligence section?"
+SCENARIOS["scope-auto-resolve-step"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md contain a Step 0.5 for scope auto-resolve?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -64,6 +66,8 @@ EXPECTED_SKILLS["executing-plans-tdd"]=""
 EXPECTED_SKILLS["divide-conquer-tdd"]=""
 EXPECTED_SKILLS["agents-md-incremental"]=""
 EXPECTED_SKILLS["worktree-handoff-step"]=""
+EXPECTED_SKILLS["scope-auto-resolve-guideline"]=""
+EXPECTED_SKILLS["scope-auto-resolve-step"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -76,7 +80,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -374,6 +378,43 @@ if [ "$WH_COUNT" -ge 1 ]; then
 else
     echo "  review-prep Step 2.5 worktree handoff: MISSING"
     echo "- **review-prep Step 2.5 worktree handoff:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify scope classification FORBIDDEN examples in 000-critical-rules.md
+SCOPE_FORBIDDENS=$(grep -c "verb-prefix parsing table\|verb-prefix table is deterministic" "$CRITICAL_RULES_FILE" 2>/dev/null || echo "0")
+if [ "$SCOPE_FORBIDDENS" -ge 1 ]; then
+    echo "  000-critical-rules.md scope FORBIDDEN examples: FOUND"
+    echo "- **000-critical-rules.md scope FORBIDDEN examples:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  000-critical-rules.md scope FORBIDDEN examples: MISSING"
+    echo "- **000-critical-rules.md scope FORBIDDEN examples:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify scope NEVER ambiguous in 020-go-prohibitions.md
+GO_PROHIB_FILE="$PROJECT_DIR/.opencode/guidelines/020-go-prohibitions.md"
+SCOPE_NEVER_AMBIG=$(grep -c "NEVER ambiguous" "$GO_PROHIB_FILE" 2>/dev/null || echo "0")
+if [ "$SCOPE_NEVER_AMBIG" -ge 1 ]; then
+    echo "  020-go-prohibitions.md scope NEVER ambiguous: FOUND"
+    echo "- **020-go-prohibitions.md scope NEVER ambiguous:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  020-go-prohibitions.md scope NEVER ambiguous: MISSING"
+    echo "- **020-go-prohibitions.md scope NEVER ambiguous:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify Step 0.5 scope auto-resolve in verify-authorization.md
+SCOPE_STEP05=$(grep -c "Step 0.5" "$VERIFY_AUTH_FILE" 2>/dev/null || echo "0")
+if [ "$SCOPE_STEP05" -ge 1 ]; then
+    echo "  verify-authorization Step 0.5 scope auto-resolve: FOUND"
+    echo "- **verify-authorization Step 0.5 scope auto-resolve:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  verify-authorization Step 0.5 scope auto-resolve: MISSING"
+    echo "- **verify-authorization Step 0.5 scope auto-resolve:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi


### PR DESCRIPTION
**Summary:**

Add three enforcement layers preventing agents from asking users to classify authorization scope when the verb-prefix parsing table deterministically resolves it.

**Outcome:** Agents will auto-resolve authorization scope from the parsing table instead of asking users. Enforcement at principles layer (000-critical-rules.md), interpretation layer (020-go-prohibitions.md), and procedural layer (verify-authorization.md Step 0.5).

Implements #1104