### PR TITLE
feat(#1102 #1107 #1110): split session context + dedup enforcement + natural counting

### DIFF
--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -132,6 +132,8 @@ All enumeration lists, numbered sections, and step sequences in documentation MU
 
 **Rationale:** Documentation is for humans. Natural counting matches human cognition.
 
+**Grandfather clause:** Existing skill files, guideline files, and documentation that use 0-based counting (Step 0, Phase 0) are exempt from this rule. Only newly created or substantially updated files must comply. When updating an existing file that uses 0-based counting, only new or changed sections need to comply — existing 0-based sections are preserved.
+
 ## AI Co-Authored Attribution (MANDATORY)
 
 **AI-generated creative content MUST include co-authored attribution where the content format supports it.**

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -121,20 +121,20 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
   }
 }
 
-let cachedContextOutput: string | null = null;
-let contextCacheTimestamp = 0;
+let cachedIdentityOutput: string | null = null;
+let identityCacheTimestamp = 0;
 
-async function runSessionContext($: PluginInput["$"]): Promise<string> {
-  if (cachedContextOutput && Date.now() - contextCacheTimestamp < CACHE_TTL_MS) {
-    return cachedContextOutput;
+async function runSessionContextIdentity($: PluginInput["$"]): Promise<string> {
+  if (cachedIdentityOutput && Date.now() - identityCacheTimestamp < CACHE_TTL_MS) {
+    return cachedIdentityOutput;
   }
 
   try {
-    const result = await $.nothrow()`./.opencode/scripts/session_context.py`;
+    const result = await $.nowrap()`./.opencode/scripts/session_context_identity.py`;
     const stdout = result.text();
 
     if (result.exitCode !== 0) {
-      console.error(`[session-enforcement] session_context.py exited with code ${result.exitCode}: ${result.stderr.toString()}`);
+      console.error(`[session-enforcement] session_context_identity.py exited with code ${result.exitCode}: ${result.stderr.toString()}`);
       return "";
     }
 
@@ -142,12 +142,43 @@ async function runSessionContext($: PluginInput["$"]): Promise<string> {
       return "";
     }
 
-    cachedContextOutput = stdout;
-    contextCacheTimestamp = Date.now();
+    cachedIdentityOutput = stdout;
+    identityCacheTimestamp = Date.now();
 
     return stdout;
   } catch (err) {
-    console.error("[session-enforcement] Failed to run session_context.py:", err);
+    console.error("[session-enforcement] Failed to run session_context_identity.py:", err);
+    return "";
+  }
+}
+
+let cachedTriggersOutput: string | null = null;
+let triggersCacheTimestamp = 0;
+
+async function runSessionContextTriggers($: PluginInput["$"]): Promise<string> {
+  if (cachedTriggersOutput && Date.now() - triggersCacheTimestamp < CACHE_TTL_MS) {
+    return cachedTriggersOutput;
+  }
+
+  try {
+    const result = await $.nothrow()`./.opencode/scripts/session_context_triggers.py`;
+    const stdout = result.text();
+
+    if (result.exitCode !== 0) {
+      console.error(`[session-enforcement] session_context_triggers.py exited with code ${result.exitCode}: ${result.stderr.toString()}`);
+      return "";
+    }
+
+    if (!stdout || stdout.trim().length === 0) {
+      return "";
+    }
+
+    cachedTriggersOutput = stdout;
+    triggersCacheTimestamp = Date.now();
+
+    return stdout;
+  } catch (err) {
+    console.error("[session-enforcement] Failed to run session_context_triggers.py:", err);
     return "";
   }
 }
@@ -261,28 +292,6 @@ function buildTrainingStalenessBlock(): string {
 
 This is a CRITICAL rule. Violations result in incorrect guidance and broken implementations.
 </TRAINING_STALENESS_CRITICAL>`;
-}
-
-function buildPlatformReportBlock(scriptOutput: string): string {
-  const platformMatch = scriptOutput.match(/^github\.platform:\s*(.+)$/m);
-  const ownerMatch = scriptOutput.match(/^github\.owner:\s*(.+)$/m);
-  const repoMatch = scriptOutput.match(/^github\.repo:\s*(.+)$/m);
-
-  const platform = platformMatch?.[1]?.trim() || "unknown";
-  const owner = ownerMatch?.[1]?.trim() || "unknown";
-  const repo = repoMatch?.[1]?.trim() || "unknown";
-
-  if (platform === "unknown" && owner === "unknown" && repo === "unknown") {
-    return "";
-  }
-
-  return `<PLATFORM_REPORT>
-At the very start of the session, before doing anything else, you MUST report the platform info to the user in this exact format on a single line:
-
-Platform: ${platform}, Org: ${owner}, Repo: ${repo}
-
-This is a mandatory startup report. Output this line before any other response.
-</PLATFORM_REPORT>`;
 }
 
 function buildWorktreeBlock(input: PluginInput): string {
@@ -542,6 +551,22 @@ Invoke relevant skills BEFORE any response or action. Even a 1% chance means inv
 </EXTREMELY_IMPORTANT>`;
 }
 
+function buildIdentityEchoDirective(): string {
+  return `<IDENTITY_ECHO>
+Before doing anything else, you MUST echo your platform identity as your very first output. Read the values from the system prompt dotted pairs (github.platform, github.owner, github.repo) and output them in this exact format:
+
+Platform: <platform>, Org: <owner>, Repo: <repo>
+🤖 <AgentName> (<ModelId>) <status-icon> <status>
+
+Example: Platform: github, Org: Brothertown-Language, Repo: snea-shoebox-editor
+🤖 OpenCode (ollama-cloud/glm-5) ✅ ready
+
+The directive does NOT contain actual values — you MUST read github.platform, github.owner, and github.repo from the system prompt dotted pairs above. This ensures you have read and acknowledged the correct owner/repo before making any API calls.
+
+After the identity echo, acknowledge any trigger warnings from the SESSION_TRIGGERS block above.
+</IDENTITY_ECHO>`;
+}
+
 export default async function sessionEnforcementPlugin(input: PluginInput): Promise<Hooks> {
   // Determine skills directory and project directory
   const projectDir = input?.directory || process.cwd();
@@ -559,14 +584,6 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
       const scriptOutput = await runSessionInit(input.$);
       if (scriptOutput) {
         output.system.push(scriptOutput);
-      }
-
-      // Inject platform report block (instructs agent to report platform/org/repo at session start)
-      if (scriptOutput) {
-        const platformBlock = buildPlatformReportBlock(scriptOutput);
-        if (platformBlock) {
-          output.system.push(platformBlock);
-        }
       }
 
       // Inject worktree context when session is operating in a worktree
@@ -590,31 +607,48 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
         output.system.push(warning);
       }
 
-      // Inject session context (identity + triggers) from session_context.py
-      const contextOutput = await runSessionContext(input.$);
-      if (contextOutput) {
-        output.system.push(contextOutput);
+      // Inject identity section from session_context_identity.py
+      const identityOutput = await runSessionContextIdentity(input.$);
+      if (identityOutput) {
+        output.system.push(identityOutput);
       }
     },
 
     // Inject enforcement content into first user message (adapted from obra/superpowers)
-    // AND detect bare #N issue references in last user message
-    "experimental.chat.messages.transform": async (_input, output) => {
-      if (!output.messages || !output.messages.length) return;
+      // AND detect bare #N issue references in last user message
+      // AND inject identity-echo directive + trigger warnings into first user message
+      "experimental.chat.messages.transform": async (_input, output) => {
+        if (!output.messages || !output.messages.length) return;
 
-      const userMessages = output.messages.filter(m => m.info?.role === "user");
-      if (!userMessages.length) return;
+        const userMessages = output.messages.filter(m => m.info?.role === "user");
+        if (!userMessages.length) return;
 
-      const firstUser = userMessages[0];
+        const firstUser = userMessages[0];
 
-      // --- Enforcement injection into FIRST user message ---
-      const enforcementContent = buildEnforcementContent(skillDescriptions);
-      if (enforcementContent && firstUser.parts?.length) {
-        if (!firstUser.parts.some(p => p.type === "text" && p.text?.includes("EXTREMELY_IMPORTANT"))) {
-          const ref = firstUser.parts[0];
-          firstUser.parts.unshift({ ...ref, type: "text", text: enforcementContent });
+        // --- Enforcement injection into FIRST user message ---
+        const enforcementContent = buildEnforcementContent(skillDescriptions);
+        if (enforcementContent && firstUser.parts?.length) {
+          if (!firstUser.parts.some(p => p.type === "text" && p.text?.includes("EXTREMELY_IMPORTANT"))) {
+            const ref = firstUser.parts[0];
+            firstUser.parts.unshift({ ...ref, type: "text", text: enforcementContent });
+          }
         }
-      }
+
+        // --- Identity-echo directive + trigger warnings injection into FIRST user message ---
+        const triggersOutput = await runSessionContextTriggers(input.$);
+        const identityBlock = buildIdentityEchoDirective();
+        const triggerBlock = triggersOutput ? `<SESSION_TRIGGERS>\n${triggersOutput}\n</SESSION_TRIGGERS>` : "";
+
+        const echoParts: string[] = [];
+        if (identityBlock) {
+          echoParts.push(identityBlock);
+        }
+        if (triggerBlock) {
+          echoParts.push(triggerBlock);
+        }
+        if (echoParts.length > 0 && firstUser.parts?.length) {
+          firstUser.parts.unshift({ type: "text", text: echoParts.join("\n\n") });
+        }
 
       // --- Bare issue pipeline detection on LAST user message ---
       const lastUser = userMessages[userMessages.length - 1];

--- a/.opencode/scripts/session_context_identity.py
+++ b/.opencode/scripts/session_context_identity.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "~=3.12"
+# dependencies = []
+# ///
+"""Identity section emitter for AI agent session context.
+
+Extracted from session_context.py per spec #1107 (R6: intentional
+deduplication of shared helpers across split scripts).
+
+Emits ONLY the Repository Identity section — no trigger warnings, no
+"Respond to the above" directive. Called by session-enforcement.ts at
+system.transform time.
+
+Exit codes:
+    0: Success
+    1: No git remote or identity resolution failure
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_git(args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return None
+
+
+def get_remote_url() -> str | None:
+    return run_git(["remote", "get-url", "origin"])
+
+
+def get_root_dir() -> str | None:
+    return run_git(["rev-parse", "--show-toplevel"])
+
+
+def detect_platform(remote_url: str) -> str:
+    if "github.com" in remote_url:
+        return "github"
+    if "gitbucket" in remote_url.lower() or (
+        not remote_url.startswith("git@github.com") and not remote_url.startswith("https://github.com")
+    ):
+        try:
+            result = subprocess.run(
+                ["git", "ls-remote", "--heads", remote_url],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=3,
+            )
+            if result.returncode == 0:
+                return "gitbucket"
+        except (subprocess.SubprocessError, OSError):
+            pass
+    return "unknown"
+
+
+def parse_owner_repo(remote_url: str, platform: str) -> tuple[str | None, str | None]:
+    if platform == "github":
+        for pattern in [
+            r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$",
+            r"^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$",
+        ]:
+            m = re.match(pattern, remote_url)
+            if m:
+                return m.group(1), m.group(2)
+    else:
+        for pattern in [
+            r"^ssh://git@[^:/]+:\d+/([^/]+)/([^/]+?)(?:\.git)?$",
+            r"^git@[^:]+:([^/]+)/([^/]+?)(?:\.git)?$",
+            r"^https://[^/]+/([^/]+)/([^/]+?)(?:\.git)?$",
+        ]:
+            m = re.match(pattern, remote_url)
+            if m:
+                return m.group(1), m.group(2)
+    return None, None
+
+
+def probe_credentials_tier1(platform: str, root_dir: str) -> str:
+    env_path = Path(root_dir) / ".env"
+    secrets_path = Path(root_dir) / ".streamlit" / "secrets.toml"
+
+    github_token_keys = ["GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN"]
+    gitbucket_token_keys = ["GITBUCKET_TOKEN"]
+
+    token_keys = github_token_keys if platform == "github" else gitbucket_token_keys
+
+    for _source_label, source_path, parser in [
+        (".env", env_path, _parse_env_token),
+        ("secrets.toml", secrets_path, _parse_secrets_toml_token),
+        ("environment", None, _parse_env_var_token),
+    ]:
+        token_value = parser(source_path, token_keys) if source_path else _parse_env_var_token(None, token_keys)
+        if token_value:
+            return "present"
+
+    return "missing"
+
+
+def _parse_env_token(env_path: Path, keys: list[str]) -> str | None:
+    if not env_path.is_file():
+        return None
+    try:
+        content = env_path.read_text()
+        for line in content.splitlines():
+            stripped = line.strip()
+            for key in keys:
+                if stripped.startswith(f"{key}="):
+                    value = stripped.split("=", 1)[1].strip().strip("'\"")
+                    if value:
+                        return value
+    except OSError:
+        pass
+    return None
+
+
+def _parse_secrets_toml_token(secrets_path: Path, keys: list[str]) -> str | None:
+    if not secrets_path.is_file():
+        return None
+    try:
+        content = secrets_path.read_text()
+        toml_keys = [k.lower().replace("_", "") for k in keys]
+        for line in content.splitlines():
+            stripped = line.strip()
+            for _key, toml_key in zip(keys, toml_keys, strict=False):
+                if stripped.startswith(f"{toml_key} =") or stripped.startswith(f"{toml_key}="):
+                    value = stripped.split("=", 1)[1].strip().strip("'\"")
+                    if value:
+                        return value
+    except OSError:
+        pass
+    return None
+
+
+def _parse_env_var_token(_: None, keys: list[str]) -> str | None:
+    for key in keys:
+        value = os.environ.get(key, "")
+        if value:
+            return value
+    return None
+
+
+def probe_credentials_tier3(platform: str, root_dir: str, tier1_status: str) -> str:
+    if tier1_status == "missing":
+        return "missing"
+
+    probe_file = Path(root_dir) / ".opencode-issue-probe"
+    if not probe_file.exists():
+        return tier1_status
+
+    if platform == "github":
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return "verified"
+            if result.returncode != 0 and "not logged in" in (result.stdout + result.stderr).lower():
+                return "stale"
+            return "stale"
+        except (subprocess.SubprocessError, OSError):
+            return tier1_status
+
+    if platform == "gitbucket":
+        try:
+            result = subprocess.run(
+                ["curl", "-sf", "-o", "/dev/null", "--max-time", "5", "http://localhost:8080/api/v3/"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return "verified"
+            return "stale"
+        except (subprocess.SubprocessError, OSError):
+            return tier1_status
+
+    return tier1_status
+
+
+def build_identity_section(owner: str, repo: str, platform: str, credential_status: str) -> str:
+    lines = [
+        "## Repository Identity",
+        f"- github.owner={owner}",
+        f"- github.repo={repo}",
+        f"- github.platform={platform}",
+    ]
+    cred_key = f"{platform.upper()}_CREDENTIALS" if platform != "unknown" else "CREDENTIALS"
+    lines.append(f"- {cred_key}={credential_status}")
+    lines.append("- Use these exact values for ALL GitHub MCP and GitBucket API calls")
+
+    if credential_status == "missing":
+        lines.append(f"- WARNING: No {platform} credentials found in .env, secrets.toml, or environment variables")
+    elif credential_status == "stale":
+        lines.append(
+            f"- WARNING: {platform} token was rejected — "
+            "check credentials in .env, secrets.toml, or environment variables"
+        )
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    remote_url = get_remote_url()
+    if not remote_url:
+        print("No git remote configured. Cannot determine repository identity.", file=sys.stderr)
+        return 1
+
+    root_dir = get_root_dir()
+    if not root_dir:
+        print("Not in a git repository.", file=sys.stderr)
+        return 1
+
+    platform = detect_platform(remote_url)
+    owner, repo = parse_owner_repo(remote_url, platform)
+
+    if not owner or not repo:
+        print(f"Could not parse owner/repo from remote: {remote_url}", file=sys.stderr)
+        return 1
+
+    if platform == "unknown":
+        owner, repo = parse_owner_repo(remote_url, "gitbucket")
+        if not owner or not repo:
+            print(f"Could not parse owner/repo from remote: {remote_url}", file=sys.stderr)
+            return 1
+        platform = "gitbucket"
+
+    tier1 = probe_credentials_tier1(platform, root_dir)
+    credential_status = probe_credentials_tier3(platform, root_dir, tier1)
+
+    print(build_identity_section(owner, repo, platform, credential_status))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.opencode/scripts/session_context_triggers.py
+++ b/.opencode/scripts/session_context_triggers.py
@@ -3,37 +3,26 @@
 # requires-python = "~=3.12"
 # dependencies = []
 # ///
-"""Session context plugin for AI agents.
+"""Trigger section emitter for AI agent session context.
 
-Called after session_init.py. Probes git state, validates credentials,
-and conditionally emits a reply injection for trigger states.
+Extracted from session_context.py per spec #1107 (R6: intentional
+deduplication of shared helpers across split scripts).
 
-Identity section (always-emit):
-  github.owner, github.repo, github.platform, _CREDENTIALS=
-
-Trigger conditions (appended when detected):
-  on_main_branch, protected_branch_with_changes, pair_mode_resume,
-  uncommitted_work, stale_stash, merge_conflict, unpushed_commits,
-  orphaned_worktrees
-
-Tier 3 (opt-in, .opencode-issue-probe):
-  open_pr_on_branch, ci_failure, stale_pr
-
-Output: Reply injection block for LLM context.
+Emits ONLY trigger warning sections — no identity, no "Respond to the
+above" directive. Called by session-enforcement.ts at
+chat.messages.transform time. Output is empty when no triggers fire.
 
 Exit codes:
     0: Success
-    1: No git remote or identity resolution failure
+    1: No git remote or root directory resolution failure
 """
 
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 import sys
 from datetime import datetime
-from pathlib import Path
 
 
 def run_git(args: list[str]) -> str | None:
@@ -61,155 +50,6 @@ def get_current_branch() -> str | None:
 
 def get_root_dir() -> str | None:
     return run_git(["rev-parse", "--show-toplevel"])
-
-
-def detect_platform(remote_url: str) -> str:
-    if "github.com" in remote_url:
-        return "github"
-    if "gitbucket" in remote_url.lower() or (
-        not remote_url.startswith("git@github.com") and not remote_url.startswith("https://github.com")
-    ):
-        try:
-            result = subprocess.run(
-                ["git", "ls-remote", "--heads", remote_url],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=3,
-            )
-            if result.returncode == 0:
-                return "gitbucket"
-        except (subprocess.SubprocessError, OSError):
-            pass
-    return "unknown"
-
-
-def parse_owner_repo(remote_url: str, platform: str) -> tuple[str | None, str | None]:
-    if platform == "github":
-        for pattern in [
-            r"^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$",
-            r"^https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$",
-        ]:
-            m = re.match(pattern, remote_url)
-            if m:
-                return m.group(1), m.group(2)
-    else:
-        for pattern in [
-            r"^ssh://git@[^:/]+:\d+/([^/]+)/([^/]+?)(?:\.git)?$",
-            r"^git@[^:]+:([^/]+)/([^/]+?)(?:\.git)?$",
-            r"^https://[^/]+/([^/]+)/([^/]+?)(?:\.git)?$",
-        ]:
-            m = re.match(pattern, remote_url)
-            if m:
-                return m.group(1), m.group(2)
-    return None, None
-
-
-def probe_credentials_tier1(platform: str, root_dir: str) -> str:
-    env_path = Path(root_dir) / ".env"
-    secrets_path = Path(root_dir) / ".streamlit" / "secrets.toml"
-
-    github_token_keys = ["GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN"]
-    gitbucket_token_keys = ["GITBUCKET_TOKEN"]
-
-    token_keys = github_token_keys if platform == "github" else gitbucket_token_keys
-
-    for _source_label, source_path, parser in [
-        (".env", env_path, _parse_env_token),
-        ("secrets.toml", secrets_path, _parse_secrets_toml_token),
-        ("environment", None, _parse_env_var_token),
-    ]:
-        token_value = parser(source_path, token_keys) if source_path else _parse_env_var_token(None, token_keys)
-        if token_value:
-            return "present"
-
-    return "missing"
-
-
-def _parse_env_token(env_path: Path, keys: list[str]) -> str | None:
-    if not env_path.is_file():
-        return None
-    try:
-        content = env_path.read_text()
-        for line in content.splitlines():
-            stripped = line.strip()
-            for key in keys:
-                if stripped.startswith(f"{key}="):
-                    value = stripped.split("=", 1)[1].strip().strip("'\"")
-                    if value:
-                        return value
-    except OSError:
-        pass
-    return None
-
-
-def _parse_secrets_toml_token(secrets_path: Path, keys: list[str]) -> str | None:
-    if not secrets_path.is_file():
-        return None
-    try:
-        content = secrets_path.read_text()
-        toml_keys = [k.lower().replace("_", "") for k in keys]
-        for line in content.splitlines():
-            stripped = line.strip()
-            for _key, toml_key in zip(keys, toml_keys, strict=False):
-                if stripped.startswith(f"{toml_key} =") or stripped.startswith(f"{toml_key} ="):
-                    value = stripped.split("=", 1)[1].strip().strip("'\"")
-                    if value:
-                        return value
-    except OSError:
-        pass
-    return None
-
-
-def _parse_env_var_token(_: None, keys: list[str]) -> str | None:
-    for key in keys:
-        value = os.environ.get(key, "")
-        if value:
-            return value
-    return None
-
-
-def probe_credentials_tier3(platform: str, root_dir: str, tier1_status: str) -> str:
-    if tier1_status == "missing":
-        return "missing"
-
-    probe_file = Path(root_dir) / ".opencode-issue-probe"
-    if not probe_file.exists():
-        return tier1_status
-
-    if platform == "github":
-        try:
-            result = subprocess.run(
-                ["gh", "auth", "status"],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=10,
-            )
-            if result.returncode == 0:
-                return "verified"
-            if result.returncode != 0 and "not logged in" in (result.stdout + result.stderr).lower():
-                return "stale"
-            return "stale"
-        except (subprocess.SubprocessError, OSError):
-            return tier1_status
-
-    if platform == "gitbucket":
-        try:
-            result = subprocess.run(
-                ["curl", "-sf", "-o", "/dev/null", "--max-time", "5", "http://localhost:8080/api/v3/"],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=10,
-            )
-            if result.returncode == 0:
-                return "verified"
-            return "stale"
-        except (subprocess.SubprocessError, OSError):
-            return tier1_status
-
-    return tier1_status
 
 
 def is_on_main_branch() -> bool:
@@ -323,28 +163,6 @@ def has_orphaned_worktrees() -> list[str]:
             if dev_hash and merge_base == dev_hash:
                 orphaned.append(f"{wt_path} ({branch_name} — merged into dev)")
     return orphaned
-
-
-def build_identity_section(owner: str, repo: str, platform: str, credential_status: str) -> str:
-    lines = [
-        "## Repository Identity",
-        f"- github.owner={owner}",
-        f"- github.repo={repo}",
-        f"- github.platform={platform}",
-    ]
-    cred_key = f"{platform.upper()}_CREDENTIALS" if platform != "unknown" else "CREDENTIALS"
-    lines.append(f"- {cred_key}={credential_status}")
-    lines.append("- Use these exact values for ALL GitHub MCP and GitBucket API calls")
-
-    if credential_status == "missing":
-        lines.append(f"- WARNING: No {platform} credentials found in .env, secrets.toml, or environment variables")
-    elif credential_status == "stale":
-        lines.append(
-            f"- WARNING: {platform} token was rejected — "
-            "check credentials in .env, secrets.toml, or environment variables"
-        )
-
-    return "\n".join(lines)
 
 
 def build_main_branch_warning(has_changes: bool, changed_files: list[str]) -> str:
@@ -465,26 +283,7 @@ def main() -> int:
         print("Not in a git repository.", file=sys.stderr)
         return 1
 
-    platform = detect_platform(remote_url)
-    owner, repo = parse_owner_repo(remote_url, platform)
-
-    if not owner or not repo:
-        print(f"Could not parse owner/repo from remote: {remote_url}", file=sys.stderr)
-        return 1
-
-    if platform == "unknown":
-        owner, repo = parse_owner_repo(remote_url, "gitbucket")
-        if not owner or not repo:
-            print(f"Could not parse owner/repo from remote: {remote_url}", file=sys.stderr)
-            return 1
-        platform = "gitbucket"
-
-    tier1 = probe_credentials_tier1(platform, root_dir)
-    credential_status = probe_credentials_tier3(platform, root_dir, tier1)
-
     sections: list[str] = []
-
-    sections.append(build_identity_section(owner, repo, platform, credential_status))
 
     on_main = is_on_main_branch()
     on_protected = is_on_protected_branch()
@@ -519,11 +318,7 @@ def main() -> int:
         sections.append(build_orphaned_worktrees_warning(orphaned))
 
     if len(sections) > 0:
-        print("# Session Context Alert")
-        print()
         print("\n\n".join(sections))
-        print()
-        print("Respond to the above before waiting for user input.")
 
     return 0
 

--- a/.opencode/skills/issue-operations/SKILL.md
+++ b/.opencode/skills/issue-operations/SKILL.md
@@ -233,11 +233,13 @@ When platform PATCH endpoint is broken (returns 404):
 - Create sub-issues directly under spec (sub-issues go under plan)
 - Post non-substantive comments to issues
 - Create an issue without checking for existing matches first
+- Create an issue via `creation` task without Step 0.5 dedup evidence
 
 ### ALWAYS DO
 
 - Invoke `pre-creation` task before creating issue
 - Run Step 0.5 title dedup gate before any issue creation
+- Verify Step 0.5 dedup evidence before proceeding to `creation` task
 - Apply `needs-approval` label to new specs
 - Add creation byline in issue body footer
 - Invoke auditors before approval

--- a/.opencode/skills/issue-operations/tasks/creation.md
+++ b/.opencode/skills/issue-operations/tasks/creation.md
@@ -8,10 +8,12 @@ Create issue with proper title format, labels, and byline after validation passe
 
 1. **Run after `pre-creation` validation passes.**
 2. **DO NOT skip validation.**
+3. **HALT if Step 0.5 dedup gate evidence is missing.**
 
 ## Entry Criteria
 
 - Pre-creation validation passed
+- Step 0.5 dedup gate evidence available (OR Step 0.75 runtime search fallback completed)
 - Single-task vs multi-task determination complete
 - User has authorized creation
 
@@ -23,6 +25,68 @@ Create issue with proper title format, labels, and byline after validation passe
 - Issue number available for sub-issue linking
 
 ## Procedure
+
+### Step 0.5: Dedup Evidence Gate
+
+**MANDATORY before proceeding to any creation step.**
+
+Verify that the `pre-creation` task's Step 0.5 title dedup gate was executed. This step MUST produce evidence that dedup was performed before the creation API call is allowed.
+
+**Required evidence (from `pre-creation` Step 0.5 output):**
+
+```
+Check: Title dedup gate for "<proposed title>"
+Tool: github_search_issues / gitbucket-api issues
+Result: [N candidates found, match levels classified]
+Classification: [EXACT-DUPLICATE|NEAR-DUPLICATE|CLOSED-IN-ERROR|RELATED-BUT-DISTINCT|FALSE-POSITIVE]
+Action: [auto-resolved strategy | proceed | HALT]
+```
+
+**Gate logic:**
+
+| Evidence Present? | Result Classified Non-Duplicate? | Action |
+|-------------------|----------------------------------|--------|
+| Yes | Yes | Proceed to Step 1 |
+| Yes | No (EXACT-DUPLICATE / NEAR-DUPLICATE) | HALT — do not create duplicate |
+| No | — | Proceed to Step 0.75 (runtime search fallback) |
+
+**If Step 0.5 evidence is missing and runtime search fallback (Step 0.75) also fails → HALT with:**
+
+```
+Cannot create issue: Step 0.5 dedup gate evidence missing. Run pre-creation task first.
+```
+
+### Step 0.75: Runtime Search Fallback
+
+**When Step 0.5 evidence is unavailable, perform a lightweight dedup search before allowing creation.**
+
+This fallback catches the scenario where `pre-creation` was not run or its output is not in the current session context.
+
+1. Extract significant keywords from the proposed title (remove stop words, prefixes like `[SPEC]`, `[SPEC-FIX]`, `[Task:]`)
+2. Search for existing issues via platform API:
+   - **GitHub:** `github_search_issues(query="<keywords> repo:<owner>/<repo>", owner=<owner>, repo=<repo>)`
+   - **GitBucket:** `./.opencode/tools/gitbucket-api issues --state open` + `--state closed` (filter client-side by keyword match)
+3. Collect candidate matches (issues whose titles share ≥2 significant keywords with proposed title)
+4. For each candidate, classify match level per `pre-creation.md` Step 0.5 Phase 2 classification table
+5. If any EXACT-DUPLICATE or NEAR-DUPLICATE found → HALT, report conflict
+6. If all candidates are RELATED-BUT-DISTINCT or FALSE-POSITIVE → generate runtime search evidence artifact, proceed to Step 1
+
+**Evidence artifact (MANDATORY):**
+
+```
+Check: Runtime search fallback for "<proposed title>"
+Tool: github_search_issues / gitbucket-api issues
+Result: [N candidates found, match levels classified]
+Classification: [EXACT-DUPLICATE|NEAR-DUPLICATE|CLOSED-IN-ERROR|RELATED-BUT-DISTINCT|FALSE-POSITIVE]
+Action: [HALT | proceed with runtime evidence]
+Fallthrough reason: Step 0.5 evidence unavailable
+```
+
+**If this fallback also fails (search API unavailable or returns error) → HALT with:**
+
+```
+Cannot create issue: Step 0.5 dedup gate evidence missing and runtime search fallback failed. Run pre-creation task first.
+```
 
 ### Step 1: Determine Title Format
 
@@ -91,6 +155,7 @@ Report: "Created issue #<number>. Next step: Invoke auditors before approval."
 
 Before proceeding, verify ALL:
 
+- Step 0.5 dedup evidence present OR Step 0.75 runtime search fallback completed
 - Pre-creation validation passed
 - Title follows proper format
 - `needs-approval` label applied
@@ -110,7 +175,7 @@ Before proceeding, verify ALL:
 
 | Claim | Verification Action | Tool Call | Problem Class |
 |-------|-------------------|-----------|---------------|
-| "Title dedup gate performed" | Verify dedup was run before creation | Check pre-creation output for Step 0.5 evidence | MISSING-ELEMENT |
+| "Title dedup gate performed" | Verify dedup was run before creation | Check pre-creation output for Step 0.5 evidence; if missing, run Step 0.75 runtime search fallback | MISSING-ELEMENT → HALT |
 | "Pre-creation validation passed" | Verify validation result exists | Check pre-creation output in session | MISSING-ELEMENT |
 | "No conflicting spec exists" | Search for overlapping issues | `github_search_issues(query="label:spec <keyword>")` | CONFLICTING |
 | "Title follows format" | Verify title prefix | Check `[SPEC]`, `[SPEC-FIX]`, `[SPEC-ENHANCEMENT]`, `[Task:` prefix | STRUCTURE-VIOLATION |
@@ -124,6 +189,8 @@ Before proceeding, verify ALL:
 
 | Finding | Problem Class | Classification | Action |
 |--------|---------------|----------------|--------|
+| Step 0.5 dedup evidence missing | MISSING-ELEMENT | HALT | HALT — "Cannot create issue: Step 0.5 dedup gate evidence missing. Run pre-creation task first." |
+| Step 0.75 runtime search found duplicate | CONFLICTING | HALT | HALT — report duplicate, do not create |
 | Pre-creation not run | MISSING-ELEMENT | flag-for-review | HALT — run pre-creation first |
 | Conflicting spec found | CONFLICTING | flag-for-review | HALT — report conflict |
 | Wrong title format | STRUCTURE-VIOLATION | auto-fix | Correct title before creation |

--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -150,6 +150,7 @@ If worktree.path is set, all file operations and git commands MUST use it as the
 The `validate` task (`quick_validate.py`) SHOULD check for:
 - Skills with `bash` or `git` operations that lack a "Worktree Mode" section
 - Skills that dispatch sub-agents but don't pass `worktree.path` in context
+- New or updated SKILL.md and task/*.md files containing 0-based counting patterns (`Step 0`, `Phase 0`, `Step 0.`, `Phase 0.`) outside of code blocks, code-fenced examples, or inline code references — flag as validation error requiring correction before skill can be approved
 
 **Rationale:** Sub-agents that don't receive worktree context silently modify the main repo instead of the feature branch. This is a context window safety issue (see #741).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 - `docs/`: Documentation and specifications
 - `.opencode/`: Skills, guidelines, and agent tools
   - `tools/`: Agent utility scripts (guidelines, md, memory, py, jupyter, etc.)
-  - `scripts/`: Session context scripts (session_context.py)
+  - `scripts/`: Session context scripts (session_context_identity.py, session_context_triggers.py)
   - `skills/`: Self-contained skills (no guideline dependencies)
   - `guidelines/`: Core zero-tolerance rules only
   - `hooks/`: Git hooks (auto-installed to .git/hooks/ by session-enforcement.ts at session start)
@@ -73,12 +73,14 @@ Guidelines are pruned to the absolute minimum. See `.opencode/guidelines/` for:
 Two plugins run at session start:
 
 1. **session-init** (`tools/session-init`): Emits session variables silently (owner, repo, platform, hooks)
-2. **session_context.py** (`scripts/session_context.py`): Conditionally emits identity + trigger alerts
+2. **session_context_identity.py** (`scripts/session_context_identity.py`): Emits identity section (owner, repo, platform, credentials) into system prompt
+3. **session_context_triggers.py** (`scripts/session_context_triggers.py`): Emits trigger warnings into first user message
 
 Session context output includes:
 
-- **Identity section** (always): `github.owner`, `github.repo`, `github.platform`, credential status
-- **Trigger alerts** (when detected): `on_main_branch`, `protected_branch_with_changes`, `pair_mode_resume`, `uncommitted_work`, `stale_stash`, `merge_conflict`, `unpushed_commits`, `orphaned_worktrees`
+- **Identity section** (always, in system prompt): `github.owner`, `github.repo`, `github.platform`, credential status
+- **Identity-echo directive** (always, in first user message): mandatory identity echo at session start
+- **Trigger alerts** (when detected, in first user message): `on_main_branch`, `protected_branch_with_changes`, `pair_mode_resume`, `uncommitted_work`, `stale_stash`, `merge_conflict`, `unpushed_commits`, `orphaned_worktrees`
 - **Tier 3 probes** (opt-in via `.opencode-issue-probe`): `open_pr_on_branch`, `ci_failure`, `stale_pr`
 
 Credential status values: `verified` (token exists + API ping succeeds), `present` (token exists, liveness unchecked), `missing` (no token found), `stale` (token rejected by API), `unavailable` (platform unknown).

--- a/test/test_pair_mode.py
+++ b/test/test_pair_mode.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".opencode" / "scripts"))
 
-from session_context import is_pair_mode_branch
+from session_context_triggers import is_pair_mode_branch
 
 
 class TestPairModeDetection:

--- a/test/test_session_context.py
+++ b/test/test_session_context.py
@@ -6,39 +6,43 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".opencode" / "scripts"))
 
-from session_context import (
+from session_context_identity import (
     _parse_env_token,
     _parse_env_var_token,
     _parse_secrets_toml_token,
     build_identity_section,
-    build_main_branch_warning,
-    build_pair_mode_resume,
     detect_platform,
-    is_on_main_branch,
-    is_on_protected_branch,
-    is_pair_mode_branch,
     parse_owner_repo,
     probe_credentials_tier1,
     probe_credentials_tier3,
-    run_git,
+)
+from session_context_identity import (
+    run_git as run_git_identity,
+)
+from session_context_triggers import (
+    build_main_branch_warning,
+    build_pair_mode_resume,
+    is_on_main_branch,
+    is_on_protected_branch,
+    is_pair_mode_branch,
 )
 
 
-class TestRunGit:
+class TestRunGitIdentity:
     def test_returns_stripped_stdout_on_success(self):
         with patch.object(subprocess, "run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="  hello  \n")
-            result = run_git(["status"])
+            result = run_git_identity(["status"])
             assert result == "hello"
 
     def test_returns_none_on_nonzero_exit(self):
         with patch.object(subprocess, "run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
-            assert run_git(["status"]) is None
+            assert run_git_identity(["status"]) is None
 
     def test_returns_none_on_exception(self):
         with patch.object(subprocess, "run", side_effect=subprocess.SubprocessError):
-            assert run_git(["status"]) is None
+            assert run_git_identity(["status"]) is None
 
 
 class TestDetectPlatform:

--- a/test/test_session_context_identity.py
+++ b/test/test_session_context_identity.py
@@ -1,0 +1,211 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".opencode" / "scripts"))
+
+from session_context_identity import (
+    _parse_env_token,
+    _parse_env_var_token,
+    _parse_secrets_toml_token,
+    build_identity_section,
+    detect_platform,
+    parse_owner_repo,
+    probe_credentials_tier1,
+    probe_credentials_tier3,
+    run_git,
+)
+from session_context_identity import (
+    main as identity_main,
+)
+
+
+class TestRunGit:
+    def test_returns_stripped_stdout_on_success(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="  hello  \n")
+            result = run_git(["status"])
+            assert result == "hello"
+
+    def test_returns_none_on_nonzero_exit(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+            assert run_git(["status"]) is None
+
+    def test_returns_none_on_exception(self):
+        with patch.object(subprocess, "run", side_effect=subprocess.SubprocessError):
+            assert run_git(["status"]) is None
+
+
+class TestDetectPlatform:
+    def test_github_https(self):
+        assert detect_platform("https://github.com/owner/repo.git") == "github"
+
+    def test_github_ssh(self):
+        assert detect_platform("git@github.com:owner/repo.git") == "github"
+
+    def test_github_without_git_suffix(self):
+        assert detect_platform("https://github.com/owner/repo") == "github"
+
+
+class TestParseOwnerRepo:
+    def test_github_https(self):
+        owner, repo = parse_owner_repo("https://github.com/MyOrg/my-repo.git", "github")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+
+    def test_github_ssh(self):
+        owner, repo = parse_owner_repo("git@github.com:MyOrg/my-repo.git", "github")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+
+    def test_gitbucket_https(self):
+        owner, repo = parse_owner_repo("https://gitbucket.example.com/MyOrg/my-repo.git", "gitbucket")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+
+
+class TestParseEnvToken:
+    def test_finds_token_in_env_file(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("GITHUB_TOKEN=ghp_abc123\n")
+        result = _parse_env_token(env_file, ["GITHUB_TOKEN", "GH_TOKEN"])
+        assert result == "ghp_abc123"
+
+    def test_no_token_returns_none(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("SOME_OTHER_VAR=value\n")
+        result = _parse_env_token(env_file, ["GITHUB_TOKEN"])
+        assert result is None
+
+
+class TestParseEnvVarToken:
+    def test_finds_token_in_environ(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "ghp_env123"}):
+            result = _parse_env_var_token(None, ["GITHUB_TOKEN", "GH_TOKEN"])
+            assert result == "ghp_env123"
+
+    def test_no_matching_env_returns_none(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = _parse_env_var_token(None, ["GITHUB_TOKEN"])
+            assert result is None
+
+
+class TestParseSecretsTomlToken:
+    def test_finds_token_in_toml(self, tmp_path):
+        secrets_file = tmp_path / "secrets.toml"
+        secrets_file.write_text('githubtoken = "ghp_toml123"\n')
+        result = _parse_secrets_toml_token(secrets_file, ["GITHUB_TOKEN"])
+        assert result == "ghp_toml123"
+
+
+class TestProbeCredentialsTier1:
+    def test_returns_present_when_token_found(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("GITHUB_TOKEN=ghp_test\n")
+        result = probe_credentials_tier1("github", str(tmp_path))
+        assert result == "present"
+
+    def test_returns_missing_when_no_token(self, tmp_path):
+        result = probe_credentials_tier1("github", str(tmp_path))
+        assert result == "missing"
+
+
+class TestProbeCredentialsTier3:
+    def test_returns_tier1_if_no_probe_file(self, tmp_path):
+        result = probe_credentials_tier3("github", str(tmp_path), "present")
+        assert result == "present"
+
+    def test_github_verified(self, tmp_path):
+        probe_file = tmp_path / ".opencode-issue-probe"
+        probe_file.write_text("")
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = probe_credentials_tier3("github", str(tmp_path), "present")
+            assert result == "verified"
+
+
+class TestBuildIdentitySection:
+    def test_github_verified(self):
+        result = build_identity_section("MyOrg", "my-repo", "github", "verified")
+        assert "github.owner=MyOrg" in result
+        assert "github.repo=my-repo" in result
+        assert "github.platform=github" in result
+        assert "GITHUB_CREDENTIALS=verified" in result
+
+    def test_missing_credential_warning(self):
+        result = build_identity_section("MyOrg", "my-repo", "github", "missing")
+        assert "WARNING" in result
+
+    def test_unknown_platform(self):
+        result = build_identity_section("MyOrg", "my-repo", "unknown", "unavailable")
+        assert "CREDENTIALS=unavailable" in result
+
+
+class TestIdentityOnlyOutput:
+    def test_identity_only_output(self, tmp_path):
+        with (
+            patch("session_context_identity.get_remote_url", return_value="https://github.com/MyOrg/my-repo.git"),
+            patch("session_context_identity.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_identity.probe_credentials_tier1", return_value="present"),
+            patch("session_context_identity.probe_credentials_tier3", return_value="present"),
+            patch("sys.stdout") as mock_stdout,
+        ):
+            identity_main()
+        output = "".join(c[0][0] for c in mock_stdout.write.call_args_list)
+        assert "## Repository Identity" in output
+
+    def test_credential_status_present(self, tmp_path, capsys):
+        with (
+            patch("session_context_identity.get_remote_url", return_value="https://github.com/MyOrg/my-repo.git"),
+            patch("session_context_identity.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_identity.probe_credentials_tier1", return_value="present"),
+            patch("session_context_identity.probe_credentials_tier3", return_value="present"),
+        ):
+            identity_main()
+        captured = capsys.readouterr()
+        assert "GITHUB_CREDENTIALS=present" in captured.out
+
+    def test_credential_status_missing(self, tmp_path, capsys):
+        with (
+            patch("session_context_identity.get_remote_url", return_value="https://github.com/MyOrg/my-repo.git"),
+            patch("session_context_identity.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_identity.probe_credentials_tier1", return_value="missing"),
+            patch("session_context_identity.probe_credentials_tier3", return_value="missing"),
+        ):
+            identity_main()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+
+    def test_no_triggers_in_output(self, tmp_path, capsys):
+        with (
+            patch("session_context_identity.get_remote_url", return_value="https://github.com/MyOrg/my-repo.git"),
+            patch("session_context_identity.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_identity.probe_credentials_tier1", return_value="present"),
+            patch("session_context_identity.probe_credentials_tier3", return_value="present"),
+        ):
+            identity_main()
+        captured = capsys.readouterr()
+        assert "on_main_branch" not in captured.out
+        assert "Uncommitted Work" not in captured.out
+        assert "Merge Conflict" not in captured.out
+        assert "Stale Stash" not in captured.out
+        assert "Unpushed Commits" not in captured.out
+        assert "Orphaned Worktrees" not in captured.out
+        assert "Pair Mode" not in captured.out
+        assert "Protected Branch" not in captured.out
+
+    def test_exit_code_0(self, tmp_path):
+        with (
+            patch("session_context_identity.get_remote_url", return_value="https://github.com/MyOrg/my-repo.git"),
+            patch("session_context_identity.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_identity.probe_credentials_tier1", return_value="present"),
+            patch("session_context_identity.probe_credentials_tier3", return_value="present"),
+        ):
+            assert identity_main() == 0
+
+    def test_exit_code_1_no_remote(self, tmp_path):
+        with patch("session_context_identity.get_remote_url", return_value=None):
+            assert identity_main() == 1

--- a/test/test_session_context_triggers.py
+++ b/test/test_session_context_triggers.py
@@ -1,0 +1,333 @@
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".opencode" / "scripts"))
+
+from session_context_triggers import (
+    build_main_branch_warning,
+    build_merge_conflict_warning,
+    build_orphaned_worktrees_warning,
+    build_pair_mode_resume,
+    build_stale_stash_warning,
+    build_uncommitted_work_warning,
+    build_unpushed_commits_warning,
+    is_on_main_branch,
+    is_on_protected_branch,
+    is_pair_mode_branch,
+    run_git,
+)
+from session_context_triggers import (
+    main as triggers_main,
+)
+
+
+class TestRunGit:
+    def test_returns_stripped_stdout_on_success(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="  hello  \n")
+            assert run_git(["status"]) == "hello"
+
+    def test_returns_none_on_nonzero_exit(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+            assert run_git(["status"]) is None
+
+
+class TestIsOnMainBranch:
+    def test_on_main(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="main\n")
+            assert is_on_main_branch() is True
+
+    def test_on_dev(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="dev\n")
+            assert is_on_main_branch() is False
+
+    def test_on_feature_branch(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="feature/123-xyz\n")
+            assert is_on_main_branch() is False
+
+
+class TestIsOnProtectedBranch:
+    def test_on_main(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="main\n")
+            assert is_on_protected_branch() is True
+
+    def test_on_dev(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="dev\n")
+            assert is_on_protected_branch() is True
+
+    def test_on_feature_branch(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="feature/123\n")
+            assert is_on_protected_branch() is False
+
+
+class TestIsPairModeBranch:
+    def test_pair_feature(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="pair-feature/123-xyz\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is True
+            assert branch == "pair-feature/123-xyz"
+
+    def test_pair_spec(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="pair-spec/456-abc\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is True
+
+    def test_regular_feature(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="feature/789-xyz\n")
+            is_pair, branch = is_pair_mode_branch()
+            assert is_pair is False
+
+
+class TestBuildMainBranchWarning:
+    def test_warning_with_changes(self):
+        result = build_main_branch_warning(True, ["M file1.py", "A file2.py"])
+        assert "Production Branch" in result
+        assert "2 uncommitted changes" in result
+
+    def test_warning_without_changes(self):
+        result = build_main_branch_warning(False, [])
+        assert "Production Branch" in result
+        assert "switch to `dev`" in result
+
+
+class TestBuildPairModeResume:
+    def test_resume_with_issue_number(self):
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="3 files changed\n1 insertions\n")
+            result = build_pair_mode_resume("pair-feature/123-xyz")
+            assert "Pair Mode Resumed" in result
+            assert "#123" in result
+
+
+class TestBuildUncommittedWorkWarning:
+    def test_warning_output(self):
+        result = build_uncommitted_work_warning(["file1.py", "file2.py"])
+        assert "2 uncommitted change(s)" in result
+
+
+class TestBuildStaleStashWarning:
+    def test_warning_output(self):
+        result = build_stale_stash_warning(["stash@{0}: On feature: old work"])
+        assert "Stale Stash" in result
+
+
+class TestBuildMergeConflictWarning:
+    def test_warning_output(self):
+        result = build_merge_conflict_warning(["file1.py"])
+        assert "Merge Conflict" in result
+        assert "1 unmerged file(s)" in result
+
+
+class TestBuildUnpushedCommitsWarning:
+    def test_warning_output(self):
+        result = build_unpushed_commits_warning(5)
+        assert "5 commit(s) ahead" in result
+
+
+class TestBuildOrphanedWorktreesWarning:
+    def test_warning_output(self):
+        result = build_orphaned_worktrees_warning(["/path/to/wt (branch — merged into dev)"])
+        assert "Orphaned Worktrees" in result
+
+
+class TestTriggersOutput:
+    def test_no_identity_in_output(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "## Repository Identity" not in captured.out
+
+    def test_main_branch_trigger(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=True),
+            patch("session_context_triggers.is_on_protected_branch", return_value=True),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "Production Branch" in captured.out
+
+    def test_uncommitted_work_trigger(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(True, ["M file.py"])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "Uncommitted Work" in captured.out
+
+    def test_stale_stash_trigger(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=["stash@{0}: old stash"]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "Stale Stash" in captured.out
+
+    def test_merge_conflict_trigger(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(True, ["conflicted.py"])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "Merge Conflict" in captured.out
+
+    def test_unpushed_commits_trigger(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(True, 3)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "Unpushed Commits" in captured.out
+
+    def test_orphaned_worktrees_trigger(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=["/path/wt (feat — merged)"]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "Orphaned Worktrees" in captured.out
+
+    def test_pair_mode_trigger(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(True, "pair-feature/123-xyz")),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "Pair Mode Resumed" in captured.out
+
+    def test_no_triggers_empty_output(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+
+    def test_no_respond_directive(self, tmp_path, capsys):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=True),
+            patch("session_context_triggers.is_on_protected_branch", return_value=True),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(True, ["M file.py"])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=["stash@{0}: old"]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            triggers_main()
+        captured = capsys.readouterr()
+        assert "Respond to the above" not in captured.out
+
+    def test_exit_code_0(self, tmp_path):
+        with (
+            patch("session_context_triggers.get_remote_url", return_value="https://github.com/Org/repo.git"),
+            patch("session_context_triggers.get_root_dir", return_value=str(tmp_path)),
+            patch("session_context_triggers.is_on_main_branch", return_value=False),
+            patch("session_context_triggers.is_on_protected_branch", return_value=False),
+            patch("session_context_triggers.has_uncommitted_changes", return_value=(False, [])),
+            patch("session_context_triggers.is_pair_mode_branch", return_value=(False, None)),
+            patch("session_context_triggers.has_stale_stash", return_value=[]),
+            patch("session_context_triggers.has_merge_conflict", return_value=(False, [])),
+            patch("session_context_triggers.has_unpushed_commits", return_value=(False, 0)),
+            patch("session_context_triggers.has_orphaned_worktrees", return_value=[]),
+        ):
+            assert triggers_main() == 0
+
+    def test_exit_code_1_no_remote(self):
+        with patch("session_context_triggers.get_remote_url", return_value=None):
+            assert triggers_main() == 1


### PR DESCRIPTION
## Summary

Splits the monolithic session_context.py into two independent scripts (identity for system prompt, triggers for first user message), adds an enforcement gate to prevent duplicate issue creation, and adds natural counting validation for new skill files.

## Outcome

- **#1102**: Bug fix — enforces dedup verification in issue-operations creation.md with hard HALT gate, runtime search fallback, and escalated Live Verification classification
- **#1107**: Spec implementation — splits session_context.py into session_context_identity.py (identity → system prompt) and session_context_triggers.py (triggers → first user message), adds identity-echo directive, removes buildPlatformReportBlock, updates session-enforcement.ts with dual script calls
- **#1110**: Guideline mandate — adds natural counting enforcement validation to skill-creator SKILL.md and explicit grandfather clause to 080-code-standards.md

## Test Results

137 tests pass (including new session_context_identity and session_context_triggers test suites)

🤖 OpenCode (ollama-cloud/glm-5) ✅ completed