### PR TITLE
feat: add Southeastern US English language preference to system prompt injection

### DIFF
--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -294,6 +294,19 @@ This is a CRITICAL rule. Violations result in incorrect guidance and broken impl
 </TRAINING_STALENESS_CRITICAL>`;
 }
 
+function buildLanguagePreferenceBlock(): string {
+  return `<LANGUAGE_PREFERENCE>
+All communications MUST use **formal/business/professional Southeastern United States English**.
+
+This means:
+- Use Southern US English spelling, vocabulary, and phrasing conventions
+- Maintain a formal, professional, and business-appropriate register
+- Prefer clarity and directness with Southern politeness conventions
+- Avoid regional colloquialisms that sacrifice professionalism
+- Use "y'all" only in informal context; prefer "you" or "your team" in formal writing
+</LANGUAGE_PREFERENCE>`;
+}
+
 function buildWorktreeBlock(input: PluginInput): string {
   const mainRepoDir = input?.directory || "";
   const worktreeDir = input?.worktree || "";
@@ -600,6 +613,9 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
 
       // Inject training staleness warning (verifying everything is mandatory)
       output.system.push(buildTrainingStalenessBlock());
+
+      // Inject language preference (Southeastern US English mandate)
+      output.system.push(buildLanguagePreferenceBlock());
 
       // Inject frontmatter validation warning if any skills have broken frontmatter
       const warning = buildFrontmatterWarning(frontmatterErrors);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
-<<<<<<< HEAD
+### config/1112-american-english-mandate
+
+- **Southeastern United States English Language Preference** (#1112) - Added language preference block to session-enforcement.ts system prompt injection. All agent communications now default to formal/business/professional Southeastern United States English, balancing Southern politeness conventions with professional clarity.
+
 ### spec-fix/1066-1067-byline-enforcement-gaps
 
 - **External Repository Byline Requirement** (#1066) - Added "Posted Content Requiring Attribution" table to 080-code-standards.md covering issue comments, PR comments, PR bodies, and issue bodies on any repository. Clarified that external posts have HIGHER attribution priority than internal content.
@@ -21,7 +24,6 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 ### spec-fix/1053-simple-work-dispatch-path
 
 - **Add Simple Work Dispatch Path** (#1053, #1063, #1064) - Added lightweight dispatch path for "clearly simple work" (docs, runbooks, minor config) that resolves agent contention between Tier 1 safety mandates and Tier 2 process waivers. Simple work now follows: pre-work → implement → VbC → checklist → review-prep, preserving worktree mandates while skipping spec/plan requirements. Added "Simple Work Dispatch Path (Tier 2 Waiver)" section to 000-critical-rules.md with classification table, "Decision Table: Simple Work + File Modifications" to 010-approval-gate.md, simple-work dispatch branch to approval-gate/SKILL.md, and "Simple Work Worktree" section to using-git-worktrees/SKILL.md.
->>>>>>> origin/dev
 
 ### spec-fix/1042-1043-approval-gate-autonomous-classification
 


### PR DESCRIPTION
**Summary:**

Adds a language preference directive to the system prompt plugin injection, specifying that all communications should use formal/business/professional Southeastern United States English.

**Outcome:** All LLM sessions will receive an explicit language register directive, ensuring consistent Southern US English conventions with professional tone.

Fixes #1112