### PR TITLE
[SPEC] Self-identifying UI sub-agent skills with divide-and-conquer routing

### DIFF
--- a/.opencode/skills/divide-and-conquer/SKILL.md
+++ b/.opencode/skills/divide-and-conquer/SKILL.md
@@ -129,12 +129,13 @@ sub_task:
   description: "<what this sub-agent must implement>"
   scope: "<files, modules, functions>"
   boundaries: "<what is OUT of scope>"
+model_context: "<ollama-cloud-model-tag>"
 env_vars:
   worktree.path: "<worktree path>"
   branch: "<branch name>"
   github.owner: "<from-session>"
   github.repo: "<from-session>"
-tdd_phase: "RED|GREEN|REFACTOR|COMMIT"
+  tdd_phase: "RED|GREEN|REFACTOR|COMMIT"
 current_item: "<item name from top-down decomposition>"
 top_down_items: "<list of all items with dependencies>"
   dev.name: "<from-session>"
@@ -291,6 +292,44 @@ This validation gate runs BEFORE the Sub-Agent Completion Checkpoint. The sequen
 4. If both pass: accept result, proceed
 
 If the Result Validation gate triggers FALLBACK and inline succeeds, the Completion Checkpoint is skipped (inline execution produces its own result). If inline fails, the Double-Failure Protocol runs instead.
+
+## UI Sub-Agent Routing
+
+The divide-and-conquer orchestrator delegates UI-related tasks to specialized sub-agent skills based on task characteristics and trigger criteria.
+
+### Trigger Criteria Mapping
+
+| Task Characteristic | Target Skill | Model Context |
+|---|---|---|
+| Wireframe, mockup, visual layout, interaction design | `ui-design` | `kimi-k2.6:cloud` |
+| UI implementation, frontend code, framework component | `ui-engineer` | `glm-5.1:cloud` |
+| Screenshot capture, design review | `ui-design` | `kimi-k2.6:cloud` |
+| Design artifact validation | `ui-design` (review task) | `kimi-k2.6:cloud` |
+| Implementation validation against interaction-spec | `ui-engineer` (validate-impl task) | `glm-5.1:cloud` |
+
+### Three-Tier Trigger Model
+
+1. **Intelligence**: Main agent infers UI delegation from context analysis (spec mentions UI terms, layout descriptions, visual elements, interaction design)
+2. **Keyword-enhanced**: `[UI]` label on issues, `requires-ui: true` in spec frontmatter, `ui-design`/`ui-engineer` in task tags
+3. **Direct instruction**: User explicitly says "use ui-design" or "use ui-engineer" or invokes `/skill ui-design --task wireframe`
+
+### Model Context Assignment
+
+When dispatching to UI sub-agents, the orchestrator sets `model_context` in the Dispatch Context Contract:
+
+- `ui-design` tasks → `model_context: "kimi-k2.6:cloud"`
+- `ui-engineer` tasks → `model_context: "glm-5.1:cloud"`
+- Non-UI tasks → `model_context: ""` (default)
+
+### Parallel Dispatch
+
+UI and non-UI work CAN run concurrently when:
+- No shared file dependencies between UI and non-UI tasks
+- No data flow dependency (UI artifacts needed by non-UI tasks are already produced)
+
+UI sub-agents MUST NOT run concurrently when:
+- Non-UI tasks depend on UI artifacts not yet produced
+- The ui-design and ui-engineer sub-agents have a sequential dependency (ui-engineer consumes ui-design output)
 
 ## Worktree Mode
 

--- a/.opencode/skills/divide-and-conquer/tasks/dispatch.md
+++ b/.opencode/skills/divide-and-conquer/tasks/dispatch.md
@@ -32,6 +32,7 @@ sub_task:
   description: "<what to implement>"
   scope: "<files, modules, functions>"
   boundaries: "<what is OUT of scope>"
+model_context: "<ollama-cloud-model-tag>"
 env_vars:
   worktree.path: "<worktree path>"
   branch: "<branch name>"
@@ -46,6 +47,8 @@ env_vars:
 - `branch` matches the feature branch for this sub-task
 - `depth` is less than `max_depth`
 
+**Model context:** The `model_context` field specifies the Ollama Cloud model for UI sub-agents (e.g., `kimi-k2.6:cloud` for `ui-design`, `glm-5.1:cloud` for `ui-engineer`). Use an empty string for non-UI tasks (default model).
+
 ### Step 2: Spawn Sub-agent
 
 ```python
@@ -56,6 +59,8 @@ Use divide-and-conquer skill with context:
 
 worktree.path: <value>
 If worktree.path is set, all file operations and git commands MUST use it as the base directory.
+
+Model context: <value from model_context field, or "default" if empty>
 
 Sub-task: <description from dispatch context>
 Scope: <scope>

--- a/.opencode/skills/ui-design/SKILL.md
+++ b/.opencode/skills/ui-design/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: ui-design
+description: Use when designing UI wireframes, mockups, interaction specs, or visual artifacts. Triggers on: ui design, wireframe, mockup, interaction spec, visual layout, UI mock, screenshot capture, sidebar navigation, page layout.
+type: technique
+license: MIT
+compatibility: opencode
+---
+
+# UI Design Skill
+
+## Overview
+
+The `ui-design` skill produces toolkit-agnostic design artifacts (wireframes, mockups, interaction specs) that can be consumed by any implementation skill or sub-agent. It operates as a sub-agent dispatched by `divide-and-conquer` or invoked directly via `/skill ui-design`.
+
+**Model assignment:** `kimi-k2.6:cloud`
+
+All design output is framework-neutral. The skill does NOT embed Streamlit, web, Android, Godot, Flutter, or any other framework-specific concepts into its artifacts. Framework binding is the responsibility of `ui-engineer`, not `ui-design`.
+
+## Persona
+
+**UI Design Specialist** — produces clear, implementable design artifacts that separate visual structure from framework implementation. Focuses on information architecture, component relationships, navigation flow, and accessibility requirements.
+
+## Sub-Agent Tasks
+
+| Task | Word Count | Description |
+|------|-----------|-------------|
+| `design` | ≈800 | Full UI design pass: layout, components, navigation, accessibility |
+| `wireframe` | ≈400 | Low-fidelity wireframe from template |
+| `mockup` | ≈400 | High-fidelity mockup from template |
+| `interaction-spec` | ≈500 | YAML interaction specification from schema |
+| `screenshot` | ≈300 | Capture screenshot of rendered artifact |
+| `review` | ≈400 | Review design artifact against spec requirements |
+| `completion` | ≈200 | Idempotent cleanup and final summary |
+
+Result contracts (returned by each sub-agent):
+
+```yaml
+design:
+  status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
+  artifacts: [list of file paths relative to worktree]
+  summary: string
+  concerns: string (empty if none)
+
+wireframe:
+  status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
+  artifact_path: string (relative to worktree)
+  summary: string
+  concerns: string (empty if none)
+
+mockup:
+  status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
+  artifact_path: string (relative to worktree)
+  summary: string
+  concerns: string (empty if none)
+
+interaction-spec:
+  status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
+  artifact_path: string (relative to worktree)
+  summary: string
+  concerns: string (empty if none)
+
+screenshot:
+  status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
+  artifact_path: string (relative to worktree)
+  summary: string
+  concerns: string (empty if none)
+
+review:
+  status: PASS | CONCERNS | FAIL
+  findings: [list of {severity, description, recommendation}]
+  summary: string
+
+completion:
+  status: DONE
+  cleaned_up: [list of temp resources cleaned]
+  summary: string
+```
+
+## Invocation
+
+```
+/skill ui-design --task design
+/skill ui-design --task wireframe
+/skill ui-design --task mockup
+/skill ui-design --task interaction-spec
+/skill ui-design --task screenshot
+/skill ui-design --task review
+/skill ui-design --task completion
+```
+
+Dispatch context for sub-agents MUST include: `worktree.path`, `github.owner`, `github.repo`, `dev.name`, `dev.email`, plus any spec or context parameters relevant to the task.
+
+## Operating Protocol
+
+1. **Load spec/context before designing.** Read the relevant spec issue, plan, and any referenced context files before producing any design artifact.
+2. **Produce toolkit-agnostic artifacts only.** Wireframes use SVG, mockups use HTML+CSS, interaction specs use YAML per `interaction_spec_schema.yaml`. No framework-specific markup, classes, or patterns.
+3. **Never reference specific UI frameworks in design artifacts.** Artifacts must not contain Streamlit, React, Vue, Godot, Flutter, Android, or any other framework-specific terminology. Framework binding is `ui-engineer`'s responsibility.
+4. **Use PEP 723 scripts from `scripts/` for rendering and validation.** Call `render_svg_to_png.py`, `render_html_screenshot.py`, `validate_svg.py`, `validate_interaction_spec.py`, etc. via `uv run --script` — never install dependencies globally.
+5. **Completion guarantee.** Every task invocation MUST end with the `completion` subtask to clean up temporary resources and produce a final summary. The `completion` task is idempotent and safe to invoke multiple times.
+
+## Trigger Self-Identification (Three Tiers)
+
+### Tier 1: Intelligence (Context Inference)
+
+When the context involves designing screens, layouts, navigation structures, component relationships, or visual hierarchies, and no other skill is more specific, `ui-design` should activate.
+
+### Tier 2: Keyword-Enhanced
+
+- Issue body contains `[UI]` label or `requires-ui: true` field
+- Plan phase mentions "wireframe", "mockup", "interaction spec", "visual layout"
+- Spec includes UI-related success criteria
+
+### Tier 3: Direct
+
+- `/skill ui-design` explicit invocation
+- `--task <task-name>` explicit task selection
+
+## Model Assignment
+
+| Task | Model | Rationale |
+|------|-------|-----------|
+| All tasks | `kimi-k2.6:cloud` | Strong visual design reasoning, good at structured output |
+
+## Cross-References
+
+- **`ui-engineer`**: Consumes `ui-design` artifacts and binds them to a specific UI framework. The handoff point is the interaction spec and wireframe/mockup files.
+- **`divide-and-conquer`**: Dispatches `ui-design` as a sub-agent via `assemble-work` when the plan includes UI design phases.
+- **`issue-operations`**: Used for posting progress comments and linking design artifacts to issues.
+- **`verification-before-completion`**: Validates design artifacts against spec success criteria before marking the phase complete.

--- a/.opencode/skills/ui-design/scripts/animate_flow.py
+++ b/.opencode/skills/ui-design/scripts/animate_flow.py
@@ -1,0 +1,51 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "playwright>=1.58.0",
+#     "pyyaml>=6.0",
+# ]
+#
+# ///
+import argparse
+import asyncio
+from pathlib import Path
+
+import yaml
+from playwright.async_api import async_playwright
+
+
+async def animate_flow(interaction_spec_path: str, output_dir: str) -> list[str]:
+    spec_file = Path(interaction_spec_path)
+    out_dir = Path(output_dir)
+    if not spec_file.exists():
+        raise FileNotFoundError(f"Interaction spec not found: {interaction_spec_path}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(spec_file) as f:
+        spec = yaml.safe_load(f)
+    routes = spec.get("navigation", {}).get("routes", [])
+    spec.get("navigation", {}).get("transitions", [])
+    screenshots = []
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(viewport={"width": 1280, "height": 800})
+        for idx, route in enumerate(routes):
+            await page.set_content(f"<html><body><h1>{route.get('path', 'unknown')}</h1></body></html>")
+            out_path = out_dir / f"step_{idx:03d}.png"
+            await page.screenshot(path=str(out_path))
+            screenshots.append(str(out_path))
+        await browser.close()
+    return screenshots
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Animate interaction spec flow")
+    parser.add_argument("interaction_spec_path", help="Path to interaction spec YAML")
+    parser.add_argument("output_dir", help="Output directory for screenshot sequence")
+    args = parser.parse_args()
+    result = asyncio.run(animate_flow(args.interaction_spec_path, args.output_dir))
+    for path in result:
+        print(f"Captured: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.opencode/skills/ui-design/scripts/diff_mockups.py
+++ b/.opencode/skills/ui-design/scripts/diff_mockups.py
@@ -1,0 +1,44 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "Pillow>=10.0.0",
+# ]
+#
+# ///
+import argparse
+from pathlib import Path
+
+from PIL import Image, ImageChops
+
+
+def diff_mockups(before_path: str, after_path: str, output_path: str) -> str:
+    before_file = Path(before_path)
+    after_file = Path(after_path)
+    out_file = Path(output_path)
+    if not before_file.exists():
+        raise FileNotFoundError(f"Before image not found: {before_path}")
+    if not after_file.exists():
+        raise FileNotFoundError(f"After image not found: {after_path}")
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    img_before = Image.open(before_file).convert("RGB")
+    img_after = Image.open(after_file).convert("RGB")
+    if img_before.size != img_after.size:
+        img_after = img_after.resize(img_before.size)
+    diff = ImageChops.difference(img_before, img_after)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    diff.save(str(out_file))
+    return str(out_file)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visual diff of two mockup images")
+    parser.add_argument("before_path", help="Path to before image")
+    parser.add_argument("after_path", help="Path to after image")
+    parser.add_argument("output_path", help="Path to output diff image")
+    args = parser.parse_args()
+    result = diff_mockups(args.before_path, args.after_path, args.output_path)
+    print(f"Diff saved: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.opencode/skills/ui-design/scripts/render_html_screenshot.py
+++ b/.opencode/skills/ui-design/scripts/render_html_screenshot.py
@@ -1,0 +1,42 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "playwright>=1.58.0",
+# ]
+#
+# ///
+import argparse
+import asyncio
+from pathlib import Path
+
+from playwright.async_api import async_playwright
+
+
+async def render_html_screenshot(html_path: str, output_path: str, viewport: str = "1280x800") -> str:
+    width, height = [int(x) for x in viewport.split("x")]
+    html_file = Path(html_path)
+    out_file = Path(output_path)
+    if not html_file.exists():
+        raise FileNotFoundError(f"HTML file not found: {html_path}")
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(viewport={"width": width, "height": height})
+        await page.goto(html_file.as_uri())
+        await page.screenshot(path=str(out_file), full_page=True)
+        await browser.close()
+    return str(out_file)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render HTML to screenshot PNG")
+    parser.add_argument("html_path", help="Path to input HTML file")
+    parser.add_argument("output_path", help="Path to output PNG file")
+    parser.add_argument("--viewport", default="1280x800", help="Viewport size WxH (default: 1280x800)")
+    args = parser.parse_args()
+    result = asyncio.run(render_html_screenshot(args.html_path, args.output_path, args.viewport))
+    print(f"Screenshot {args.html_path} -> {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.opencode/skills/ui-design/scripts/render_svg_to_png.py
+++ b/.opencode/skills/ui-design/scripts/render_svg_to_png.py
@@ -1,0 +1,40 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "cairosvg>=2.7.0",
+# ]
+#
+# ///
+import argparse
+from pathlib import Path
+
+import cairosvg
+
+
+def render_svg_to_png(svg_path: str, output_path: str, dpi: int = 96) -> str:
+    svg_file = Path(svg_path)
+    out_file = Path(output_path)
+    if not svg_file.exists():
+        raise FileNotFoundError(f"SVG file not found: {svg_path}")
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    scale = dpi / 96.0
+    cairosvg.svg2png(
+        url=str(svg_file),
+        write_to=str(out_file),
+        scale=scale,
+    )
+    return str(out_file)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render SVG to PNG")
+    parser.add_argument("svg_path", help="Path to input SVG file")
+    parser.add_argument("output_path", help="Path to output PNG file")
+    parser.add_argument("--dpi", type=int, default=96, help="Output DPI (default: 96)")
+    args = parser.parse_args()
+    result = render_svg_to_png(args.svg_path, args.output_path, args.dpi)
+    print(f"Rendered {args.svg_path} -> {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.opencode/skills/ui-design/scripts/validate_interaction_spec.py
+++ b/.opencode/skills/ui-design/scripts/validate_interaction_spec.py
@@ -1,0 +1,102 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pyyaml>=6.0",
+# ]
+#
+# ///
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+REQUIRED_TOP_LEVEL_KEYS = ["metadata", "layout", "components", "navigation", "accessibility"]
+METADATA_KEYS = ["spec_version", "created_by", "created_at"]
+LAYOUT_KEYS = ["regions"]
+COMPONENT_KEYS = ["id", "type", "label"]
+NAVIGATION_KEYS = ["routes"]
+ACCESSIBILITY_KEYS = ["aria_labels", "keyboard_nav", "screen_reader"]
+FRAMEWORK_TERMS = frozenset(
+    [
+        "streamlit",
+        "react",
+        "vue",
+        "angular",
+        "svelte",
+        "godot",
+        "flutter",
+        "android",
+        "ios",
+        "swiftui",
+        "gtk",
+        "qt",
+        "wxwidgets",
+        "winforms",
+        "wpf",
+        "nextjs",
+        "nuxt",
+        "remix",
+    ]
+)
+
+
+def _check_framework_terms(data, path="") -> list[str]:
+    errors = []
+    if isinstance(data, str):
+        lower = data.lower()
+        for term in FRAMEWORK_TERMS:
+            if term in lower:
+                errors.append(f"Framework-specific term '{term}' found at {path}")
+    elif isinstance(data, dict):
+        for k, v in data.items():
+            errors.extend(_check_framework_terms(v, f"{path}.{k}" if path else k))
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            errors.extend(_check_framework_terms(item, f"{path}[{i}]"))
+    return errors
+
+
+def validate_interaction_spec(spec_path: str, schema_path: str | None = None) -> dict:
+    spec_file = Path(spec_path)
+    if not spec_file.exists():
+        return {"valid": False, "errors": [f"Spec file not found: {spec_path}"]}
+    with open(spec_file) as f:
+        spec = yaml.safe_load(f)
+    if spec is None:
+        return {"valid": False, "errors": ["Spec file is empty"]}
+    errors = []
+    for key in REQUIRED_TOP_LEVEL_KEYS:
+        if key not in spec:
+            errors.append(f"Missing required top-level key: {key}")
+    metadata = spec.get("metadata", {})
+    for key in METADATA_KEYS:
+        if key not in metadata:
+            errors.append(f"Missing required metadata key: {key}")
+    fw_errors = _check_framework_terms(spec)
+    errors.extend(fw_errors)
+    layout = spec.get("layout", {})
+    if "regions" not in layout and "layout" in spec:
+        errors.append("Missing required layout key: regions")
+    if errors:
+        return {"valid": False, "errors": errors}
+    return {"valid": True, "errors": []}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate interaction spec YAML against schema")
+    parser.add_argument("spec_path", help="Path to interaction spec YAML file")
+    parser.add_argument("--schema-path", default=None, help="Optional path to schema YAML (reserved for future use)")
+    args = parser.parse_args()
+    result = validate_interaction_spec(args.spec_path, args.schema_path)
+    if result["valid"]:
+        print(f"VALID: {args.spec_path}")
+    else:
+        print(f"INVALID: {args.spec_path}")
+        for err in result["errors"]:
+            print(f"  - {err}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.opencode/skills/ui-design/scripts/validate_svg.py
+++ b/.opencode/skills/ui-design/scripts/validate_svg.py
@@ -1,0 +1,68 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "lxml>=5.0.0",
+# ]
+#
+# ///
+import argparse
+import sys
+from pathlib import Path
+
+from lxml import etree
+
+SVG_NS = "http://www.w3.org/2000/svg"
+SVG_SCHEMA = [
+    ("root_tag", f"{{{SVG_NS}}}svg"),
+    ("viewBox_attr", "viewBox"),
+    ("named_groups", ["header", "content", "footer", "sidebar"]),
+]
+
+REQUIRED_REGIONS = {"header", "content", "footer"}
+
+
+def validate_svg(svg_path: str) -> dict:
+    svg_file = Path(svg_path)
+    if not svg_file.exists():
+        return {"valid": False, "errors": [f"File not found: {svg_path}"]}
+    try:
+        tree = etree.parse(str(svg_file))
+    except etree.XMLSyntaxError as e:
+        return {"valid": False, "errors": [f"XML syntax error: {e}"]}
+    root = tree.getroot()
+    errors = []
+    if root.tag != SVG_SCHEMA[0][1]:
+        local = root.tag.split("}")[-1] if "}" in root.tag else root.tag
+        if local != "svg":
+            errors.append(f"Root element is '{local}', expected 'svg'")
+    if "viewBox" not in root.attrib:
+        errors.append("Missing required 'viewBox' attribute on root <svg>")
+    found_regions = set()
+    for g in root.iter(f"{{{SVG_NS}}}g"):
+        gid = g.attrib.get("id", "")
+        if gid in SVG_SCHEMA[2][1]:
+            found_regions.add(gid)
+    missing = REQUIRED_REGIONS - found_regions
+    if missing:
+        errors.append(f"Missing required named groups: {sorted(missing)}")
+    if errors:
+        return {"valid": False, "errors": errors}
+    return {"valid": True, "errors": []}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate SVG structure for ui-design wireframes")
+    parser.add_argument("svg_path", help="Path to SVG file to validate")
+    args = parser.parse_args()
+    result = validate_svg(args.svg_path)
+    if result["valid"]:
+        print(f"VALID: {args.svg_path}")
+    else:
+        print(f"INVALID: {args.svg_path}")
+        for err in result["errors"]:
+            print(f"  - {err}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.opencode/skills/ui-design/tasks/completion.md
+++ b/.opencode/skills/ui-design/tasks/completion.md
@@ -1,0 +1,25 @@
+# UI Design — completion task
+
+## Purpose
+
+Idempotent cleanup of temporary resources and production of a final summary after any ui-design task.
+
+## Entry Criteria
+
+- `worktree.path` is set and verified.
+- One or more ui-design tasks have been executed (or attempted).
+
+## Exit Criteria
+
+- Temporary files in `./tmp/` related to ui-design are cleaned up.
+- Final summary is produced.
+- Result contract returned: `{status, cleaned_up, summary}`.
+
+## Procedure
+
+1. List temporary files in `./tmp/` related to ui-design tasks (rendered PNGs, intermediate screenshots, etc.).
+2. Remove temporary files that are not referenced by any final artifact.
+3. Verify all final artifacts (wireframes, mockups, interaction specs) still exist and are valid.
+4. Produce a final summary of all artifacts created, their locations, and any concerns.
+5. Return result contract.
+6. HALT — no further action after completion.

--- a/.opencode/skills/ui-design/tasks/design.md
+++ b/.opencode/skills/ui-design/tasks/design.md
@@ -1,0 +1,32 @@
+# UI Design — design task
+
+## Purpose
+
+Produce a complete toolkit-agnostic UI design covering layout, components, navigation, and accessibility from a spec.
+
+## Entry Criteria
+
+- Spec or context document is available and has been read.
+- `worktree.path` is set and verified.
+- Target design scope is understood (which screens/flows the spec covers).
+
+## Exit Criteria
+
+- One or more design artifact files exist in the worktree.
+- Design artifacts contain no framework-specific references.
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, artifacts, summary, concerns}`.
+
+## Procedure
+
+1. Read the spec issue and any linked context files from the worktree.
+2. Identify screens, flows, and components required by the spec.
+3. For each screen/flow, produce a design artifact:
+   - Wireframes (SVG) for layout structure — use `templates/wireframe_template.svg` as starting point.
+   - Interaction specs (YAML) for navigation and data flow — use `templates/interaction_spec_schema.yaml` for validation.
+   - Mockups (HTML) for visual fidelity — use `templates/mockup_template.html` as starting point.
+4. Validate all SVG artifacts with `scripts/validate_svg.py`.
+5. Validate all interaction specs with `scripts/validate_interaction_spec.py`.
+6. Ensure no artifact contains framework-specific terminology (Streamlit, React, Vue, Godot, Flutter, Android, etc.).
+7. Invoke `completion` subtask to clean up temporary resources and produce final summary.
+8. Return result contract.

--- a/.opencode/skills/ui-design/tasks/interaction-spec.md
+++ b/.opencode/skills/ui-design/tasks/interaction-spec.md
@@ -1,0 +1,30 @@
+# UI Design — interaction-spec task
+
+## Purpose
+
+Produce a toolkit-agnostic interaction specification in YAML from a spec or design context.
+
+## Entry Criteria
+
+- Spec or context document is available and has been read.
+- `worktree.path` is set and verified.
+- Navigation flows, component states, and data requirements are understood.
+
+## Exit Criteria
+
+- Interaction spec YAML file exists in the worktree.
+- YAML validates against `templates/interaction_spec_schema.yaml`.
+- No framework-specific properties in the spec (no Streamlit, React, Vue, Godot, Flutter, Android references).
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, artifact_path, summary, concerns}`.
+
+## Procedure
+
+1. Read the spec or context for the interaction flows being specified.
+2. Create a YAML file based on `templates/interaction_spec_schema.yaml` structure.
+3. Fill in metadata, layout regions, components, navigation, data_flow, and accessibility sections.
+4. Ensure `target_framework` is omitted or set to a generic value (not a specific framework).
+5. Validate the YAML with `scripts/validate_interaction_spec.py`.
+6. Ensure no framework-specific properties exist anywhere in the spec.
+7. Invoke `completion` subtask.
+8. Return result contract.

--- a/.opencode/skills/ui-design/tasks/mockup.md
+++ b/.opencode/skills/ui-design/tasks/mockup.md
@@ -1,0 +1,30 @@
+# UI Design — mockup task
+
+## Purpose
+
+Produce a high-fidelity mockup HTML file from a wireframe or design context.
+
+## Entry Criteria
+
+- Wireframe SVG or design context is available.
+- `worktree.path` is set and verified.
+- Visual fidelity requirements are understood from the spec.
+
+## Exit Criteria
+
+- Mockup HTML file exists in the worktree.
+- HTML renders correctly with embedded CSS (no external framework dependencies).
+- No framework-specific references in the mockup.
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, artifact_path, summary, concerns}`.
+
+## Procedure
+
+1. Read the wireframe SVG or design context for the screen being mocked up.
+2. Copy `templates/mockup_template.html` as the starting point.
+3. Fill in component placeholders (header, nav, main, sidebar, footer) with spec content.
+4. Add inline CSS for visual fidelity (colors, typography, spacing) — toolkit-agnostic.
+5. Optionally capture a screenshot with `scripts/render_html_screenshot.py`.
+6. Ensure no framework-specific content (no Streamlit, React, Vue classes, etc.).
+7. Invoke `completion` subtask.
+8. Return result contract.

--- a/.opencode/skills/ui-design/tasks/review.md
+++ b/.opencode/skills/ui-design/tasks/review.md
@@ -1,0 +1,33 @@
+# UI Design — review task
+
+## Purpose
+
+Review a design artifact against spec requirements for completeness, consistency, and toolkit-agnostic compliance.
+
+## Entry Criteria
+
+- Design artifact(s) exist in the worktree.
+- Spec or context document is available for comparison.
+- `worktree.path` is set and verified.
+
+## Exit Criteria
+
+- Review findings documented as a result contract.
+- Each finding has severity (critical, warning, info), description, and recommendation.
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, findings, summary}`.
+
+## Procedure
+
+1. Read the spec or context document defining the design requirements.
+2. Read each design artifact (wireframe, mockup, interaction spec).
+3. Check each artifact for:
+   - Completeness: all spec-required screens, components, and flows are present.
+   - Consistency: naming, layout, and interactions are consistent across artifacts.
+   - Toolkit-agnostic compliance: no framework-specific references (no Streamlit, React, Vue, Godot, Flutter, Android).
+   - Accessibility: ARIA labels, keyboard navigation, and screen reader considerations are addressed.
+4. Validate SVG artifacts with `scripts/validate_svg.py`.
+5. Validate interaction specs with `scripts/validate_interaction_spec.py`.
+6. Compile findings with severity levels.
+7. Invoke `completion` subtask.
+8. Return result contract.

--- a/.opencode/skills/ui-design/tasks/screenshot.md
+++ b/.opencode/skills/ui-design/tasks/screenshot.md
@@ -1,0 +1,27 @@
+# UI Design — screenshot task
+
+## Purpose
+
+Capture a screenshot of a rendered design artifact (HTML mockup or SVG wireframe).
+
+## Entry Criteria
+
+- An HTML mockup or SVG wireframe file exists in the worktree.
+- `worktree.path` is set and verified.
+- The rendering script dependencies are available via PEP 723.
+
+## Exit Criteria
+
+- Screenshot PNG file exists in the worktree.
+- Screenshot accurately represents the source artifact.
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, artifact_path, summary, concerns}`.
+
+## Procedure
+
+1. Identify the source artifact (HTML mockup or SVG wireframe) to capture.
+2. For HTML mockups: run `scripts/render_html_screenshot.py` with the mockup path, output path, and viewport dimensions.
+3. For SVG wireframes: first render to PNG with `scripts/render_svg_to_png.py`, then optionally capture a screenshot of the rendered output.
+4. Verify the screenshot file was created and is non-empty.
+5. Invoke `completion` subtask.
+6. Return result contract.

--- a/.opencode/skills/ui-design/tasks/wireframe.md
+++ b/.opencode/skills/ui-design/tasks/wireframe.md
@@ -1,0 +1,30 @@
+# UI Design — wireframe task
+
+## Purpose
+
+Produce a low-fidelity wireframe SVG from a spec or design context.
+
+## Entry Criteria
+
+- Spec or context document is available and has been read.
+- `worktree.path` is set and verified.
+- Screen/layout scope is identified.
+
+## Exit Criteria
+
+- Wireframe SVG file exists in the worktree.
+- SVG passes `validate_svg.py` validation.
+- No framework-specific references in the wireframe.
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, artifact_path, summary, concerns}`.
+
+## Procedure
+
+1. Read the spec or context for the screen/layout being wireframed.
+2. Copy `templates/wireframe_template.svg` as the starting point.
+3. Modify named groups (`header`, `content`, `footer`, `sidebar`) to reflect the spec layout.
+4. Add placeholder text elements for labels, headings, and data fields.
+5. Validate the wireframe SVG with `scripts/validate_svg.py`.
+6. Ensure no framework-specific content (Streamlit, React, Vue, etc.).
+7. Invoke `completion` subtask.
+8. Return result contract.

--- a/.opencode/skills/ui-design/templates/interaction_spec_schema.yaml
+++ b/.opencode/skills/ui-design/templates/interaction_spec_schema.yaml
@@ -1,0 +1,138 @@
+metadata:
+  spec_version: "1.0.0"
+  created_by: ""
+  created_at: ""
+  target_framework:
+
+layout:
+  regions:
+    - id: header
+      type: banner
+      label: "Page Header"
+      position:
+        row: 1
+        col: 1
+        span: full
+      size:
+        width: 100%
+        height: auto
+    - id: sidebar
+      type: nav
+      label: "Primary Navigation"
+      position:
+        row: 2
+        col: 1
+        span: 1
+      size:
+        width: 240px
+        height: 100%
+    - id: content
+      type: main
+      label: "Main Content"
+      position:
+        row: 2
+        col: 2
+        span: 1
+      size:
+        width: flexible
+        height: 100%
+    - id: footer
+      type: contentinfo
+      label: "Page Footer"
+      position:
+        row: 3
+        col: 1
+        span: full
+      size:
+        width: 100%
+        height: auto
+  containers:
+    - id: page_layout
+      type: grid
+      label: "Page Grid Layout"
+      regions:
+        - header
+        - sidebar
+        - content
+        - footer
+  responsive_rules:
+    - breakpoint: 768px
+      behavior: stack_vertically
+      affected_regions:
+        - sidebar
+        - content
+        - footer
+
+components:
+  - id: nav_menu
+    type: navigation_list
+    label: "Navigation Menu"
+    state: default
+    actions:
+      - name: navigate
+        trigger: click
+        target: route_change
+    validation: []
+  - id: content_area
+    type: content_container
+    label: "Content Display"
+    state: default
+    actions: []
+    validation: []
+
+navigation:
+  routes:
+    - id: home
+      path: /
+      label: "Home"
+    - id: items
+      path: /items
+      label: "Items"
+    - id: settings
+      path: /settings
+      label: "Settings"
+  transitions:
+    - from: home
+      to: items
+      trigger: nav_click
+      animation: fade
+    - from: items
+      to: home
+      trigger: nav_click
+      animation: fade
+  guards:
+    - route: settings
+      condition: "user_authenticated"
+      redirect: home
+
+data_flow:
+  sources:
+    - id: data_source_primary
+      type: api
+      label: "Primary Data Source"
+  consumers:
+    - id: content_area
+      source: data_source_primary
+      transform: none
+  transforms:
+    - id: format_display
+      type: formatter
+      input: raw_data
+      output: display_data
+
+accessibility:
+  aria_labels:
+    - target: nav_menu
+      label: "Main Navigation"
+    - target: content_area
+      label: "Main Content Area"
+  keyboard_nav:
+    - target: nav_menu
+      pattern: "arrow_keys"
+    - target: content_area
+      pattern: "tab_index"
+  screen_reader:
+    - target: nav_menu
+      announcement: "Navigation menu with {count} items"
+    - target: content_area
+      announcement: "Main content area"

--- a/.opencode/skills/ui-design/templates/mockup_template.html
+++ b/.opencode/skills/ui-design/templates/mockup_template.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>UI Design Mockup Template</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+    html, body {
+      height: 100%;
+      font-family: sans-serif;
+      color: #333;
+      background: #fff;
+    }
+    .container {
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      grid-template-columns: 240px 1fr 240px;
+      grid-template-areas:
+        "header header header"
+        "sidebar main aside"
+        "footer footer footer";
+      min-height: 100vh;
+    }
+    .header {
+      grid-area: header;
+      background: #f0f0f0;
+      padding: 16px 24px;
+      border-bottom: 1px solid #ccc;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .header h1 {
+      font-size: 18px;
+      font-weight: 600;
+    }
+    .nav {
+      grid-area: sidebar;
+      background: #e8e8e8;
+      padding: 16px;
+      border-right: 1px solid #ccc;
+    }
+    .nav ul {
+      list-style: none;
+    }
+    .nav li {
+      padding: 8px 0;
+      border-bottom: 1px solid #ddd;
+    }
+    .main {
+      grid-area: main;
+      padding: 24px;
+    }
+    .main h2 {
+      font-size: 16px;
+      margin-bottom: 16px;
+    }
+    .aside {
+      grid-area: aside;
+      background: #f8f8f8;
+      padding: 16px;
+      border-left: 1px solid #ccc;
+    }
+    .footer {
+      grid-area: footer;
+      background: #f0f0f0;
+      padding: 12px 24px;
+      border-top: 1px solid #ccc;
+      text-align: center;
+      font-size: 12px;
+    }
+    @media (max-width: 768px) {
+      .container {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+          "header"
+          "main"
+          "sidebar"
+          "aside"
+          "footer";
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header class="header">
+      <h1>App Title</h1>
+      <div>Header Actions</div>
+    </header>
+    <nav class="nav">
+      <ul>
+        <li>Nav Item 1</li>
+        <li>Nav Item 2</li>
+        <li>Nav Item 3</li>
+      </ul>
+    </nav>
+    <main class="main">
+      <h2>Main Content</h2>
+      <p>Content area placeholder.</p>
+    </main>
+    <aside class="aside">
+      <p>Supplementary content.</p>
+    </aside>
+    <footer class="footer">
+      <p>Footer content</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/.opencode/skills/ui-design/templates/wireframe_template.svg
+++ b/.opencode/skills/ui-design/templates/wireframe_template.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" width="1200" height="800">
+  <g id="header">
+    <rect x="0" y="0" width="1200" height="60" fill="#f0f0f0" stroke="#cccccc"/>
+    <text x="20" y="38" font-family="sans-serif" font-size="18" fill="#333333">Header</text>
+  </g>
+  <g id="sidebar">
+    <rect x="0" y="60" width="240" height="740" fill="#e8e8e8" stroke="#cccccc"/>
+    <text x="20" y="100" font-family="sans-serif" font-size="14" fill="#333333">Navigation</text>
+  </g>
+  <g id="content">
+    <rect x="240" y="60" width="720" height="740" fill="#ffffff" stroke="#cccccc"/>
+    <text x="260" y="100" font-family="sans-serif" font-size="14" fill="#333333">Main Content Area</text>
+  </g>
+  <g id="footer">
+    <rect x="960" y="60" width="240" height="740" fill="#f8f8f8" stroke="#cccccc"/>
+    <text x="980" y="100" font-family="sans-serif" font-size="14" fill="#333333">Footer / Supplementary</text>
+  </g>
+</svg>

--- a/.opencode/skills/ui-engineer/SKILL.md
+++ b/.opencode/skills/ui-engineer/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ui-engineer
+description: Use when implementing UI from design artifacts, producing framework-specific code. Triggers on: implement UI, UI implementation, UI code, frontend code, Streamlit component, framework implementation, build page, create view.
+type: technique
+license: MIT
+compatibility: opencode
+---
+
+# UI Engineer Skill
+
+## Overview
+
+The `ui-engineer` skill consumes toolkit-agnostic design artifacts produced by `ui-design` and translates them into framework-specific implementations. It operates as a sub-agent dispatched by `divide-and-conquer` or invoked directly via `/skill ui-engineer`.
+
+**Model assignment:** `glm-5.1:cloud`
+
+All implementation output is framework-specific (currently Streamlit). The skill binds design artifacts — interaction specs, wireframes, mockups — to concrete UI code, templates, and test specifications.
+
+## Persona
+
+**UI Implementation Engineer** — translates design artifacts into production-quality framework-specific code. Focuses on component mapping, accessibility implementation, state management, and testable UI structure.
+
+## Sub-Agent Tasks
+
+| Task | Word Count | Description |
+|------|-----------|-------------|
+| `implement` | ≈800 | Full UI implementation pass: component mapping, code generation, framework binding |
+| `validate-impl` | ≈400 | Validate implementation against interaction-spec requirements |
+| `test-ui` | ≈400 | Generate UI test specifications from interaction specs |
+| `framework-config` | ≈500 | Configure target framework, component library, and project conventions |
+| `completion` | ≈200 | Idempotent cleanup and final summary |
+
+Result contracts (returned by each sub-agent):
+
+```yaml
+implement:
+  status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
+  files_changed: [list of paths relative to worktree]
+  summary: string
+  concerns: string (empty if none)
+
+validate-impl:
+  status: PASS | CONCERNS | FAIL
+  findings: [list of {severity, description, recommendation}]
+  summary: string
+
+test-ui:
+  status: DONE | DONE_WITH_CONCERNS | OVERFLOW | BLOCKED
+  artifacts: [list of test spec paths relative to worktree]
+  summary: string
+  concerns: string (empty if none)
+
+framework-config:
+  status: DONE | DONE_WITH_CONCERNS | BLOCKED
+  config_path: string (relative to worktree)
+  summary: string
+  concerns: string (empty if none)
+
+completion:
+  status: DONE
+  cleaned_up: [list of temp resources cleaned]
+  summary: string
+```
+
+## Invocation
+
+```
+/skill ui-engineer --task implement
+/skill ui-engineer --task validate-impl
+/skill ui-engineer --task test-ui
+/skill ui-engineer --task framework-config
+/skill ui-engineer --task completion
+```
+
+Dispatch context for sub-agents MUST include: `worktree.path`, `github.owner`, `github.repo`, `dev.name`, `dev.email`, plus any spec or design artifact paths relevant to the task.
+
+## Operating Protocol
+
+1. **Load design artifacts as input.** Read the interaction spec (`interaction-spec.yaml`), mockup (`mockup.html`), screenshot (`screenshot.png`), and wireframe (`wireframe.svg`) produced by `ui-design`. The interaction spec is REQUIRED; other artifacts are recommended or reference-only.
+2. **Select target framework via `framework-config` task.** Determine the framework (Streamlit, currently) and project conventions before generating any code.
+3. **Produce framework-specific implementation code.** Map toolkit-agnostic design components to framework widgets, layout primitives, and state patterns. Use project templates from `templates/streamlit_template.py`.
+4. **Validate implementation against interaction-spec requirements.** Every route, component state, navigation guard, and accessibility requirement in the interaction spec must be present in the implementation.
+5. **Generate UI test specifications.** Derive test specs from the interaction spec's navigation routes, component states, and accessibility requirements.
+6. **Completion guarantee.** Every task invocation MUST end with the `completion` subtask to clean up temporary resources and produce a final summary. The `completion` task is idempotent and safe to invoke multiple times.
+
+## Trigger Self-Identification (Three Tiers)
+
+### Tier 1: Intelligence (Context Inference)
+
+When the context involves writing UI code, building pages, creating views, or translating a design spec into framework-specific implementation, and no other skill is more specific, `ui-engineer` should activate.
+
+### Tier 2: Keyword-Enhanced
+
+- Issue body contains `[UI]` label or `requires-ui: true` field
+- Plan phase mentions "implement UI", "UI code", "frontend code", "Streamlit component", "framework implementation"
+- Spec includes UI implementation success criteria
+
+### Tier 3: Direct
+
+- `/skill ui-engineer` explicit invocation
+- `--task <task-name>` explicit task selection
+
+## Model Assignment
+
+| Task | Model | Rationale |
+|------|-------|-----------|
+| All tasks | `glm-5.1:cloud` | Strong code generation, good at framework-specific implementation patterns |
+
+## Design Artifact Consumption
+
+| Artifact | Priority | Source Skill | Description |
+|----------|----------|-------------|-------------|
+| `interaction-spec.yaml` | REQUIRED | `ui-design` | Navigation routes, component states, data flow, accessibility requirements |
+| `mockup.html` | Recommended | `ui-design` | Visual layout reference for component placement and styling |
+| `screenshot.png` | Reference | `ui-design` | Rendered visual of mockup for pixel-level comparison |
+| `wireframe.svg` | Reference | `ui-design` | Structural layout information for grid/region mapping |
+
+## Cross-References
+
+- **`ui-design`**: Produces the design artifacts that `ui-engineer` consumes. The handoff point is the interaction spec and wireframe/mockup files.
+- **`divide-and-conquer`**: Dispatches `ui-engineer` as a sub-agent via `assemble-work` when the plan includes UI implementation phases.
+- **`issue-operations`**: Used for posting progress comments and linking implementation artifacts to issues.
+- **`verification-before-completion`**: Validates implementation against spec success criteria before marking the phase complete.

--- a/.opencode/skills/ui-engineer/scripts/README.md
+++ b/.opencode/skills/ui-engineer/scripts/README.md
@@ -1,0 +1,16 @@
+# UI Engineer Scripts
+
+Scripts for the `ui-engineer` skill are inherited from `ui-design` via PEP 723 path references.
+
+There are no ui-engineer-specific scripts. All rendering and validation scripts live in the `ui-design` skill and are invoked via relative path references:
+
+- `../../ui-design/scripts/render_svg_to_png.py` — Render SVG wireframes to PNG
+- `../../ui-design/scripts/render_html_screenshot.py` — Capture screenshots of HTML mockups
+- `../../ui-design/scripts/validate_svg.py` — Validate SVG wireframe structure
+- `../../ui-design/scripts/validate_interaction_spec.py` — Validate interaction spec YAML against schema
+- `../../ui-design/scripts/diff_mockups.py` — Compare two mockup HTML files
+- `../../ui-design/scripts/animate_flow.py` — Animate interaction flows
+
+Invoke with: `uv run --script ../../ui-design/scripts/<script>.py`
+
+This avoids script duplication and ensures both skills use the same validated tooling.

--- a/.opencode/skills/ui-engineer/tasks/completion.md
+++ b/.opencode/skills/ui-engineer/tasks/completion.md
@@ -1,0 +1,25 @@
+# UI Engineer — completion task
+
+## Purpose
+
+Idempotent cleanup of temporary resources and production of a final summary after any ui-engineer task.
+
+## Entry Criteria
+
+- `worktree.path` is set and verified.
+- One or more ui-engineer tasks have been executed (or attempted).
+
+## Exit Criteria
+
+- Temporary files in `./tmp/` related to ui-engineer tasks are cleaned up.
+- Final summary is produced.
+- Result contract returned: `{status, cleaned_up, summary}`.
+
+## Procedure
+
+1. List temporary files in `./tmp/` related to ui-engineer tasks (intermediate renders, build artifacts, etc.).
+2. Remove temporary files that are not referenced by any final artifact.
+3. Verify all final implementation files, test specs, and config files still exist and are valid.
+4. Produce a final summary of all artifacts created, their locations, and any concerns.
+5. Return result contract.
+6. HALT — no further action after completion.

--- a/.opencode/skills/ui-engineer/tasks/framework-config.md
+++ b/.opencode/skills/ui-engineer/tasks/framework-config.md
@@ -1,0 +1,38 @@
+# UI Engineer — framework-config task
+
+## Purpose
+
+Configure the target framework, component library, and project conventions for UI implementation. Establishes the binding between toolkit-agnostic design artifacts and framework-specific code patterns.
+
+## Entry Criteria
+
+- `worktree.path` is set and verified.
+- Project structure is accessible (especially `src/frontend/` and `docs/ui-guidelines.md`).
+
+## Exit Criteria
+
+- Framework configuration is documented with target framework, component conventions, and project-specific patterns.
+- Supported frameworks are listed with their status (primary, experimental, planned).
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, config_path, summary, concerns}`.
+
+## Procedure
+
+1. Read `docs/ui-guidelines.md` for established UI conventions.
+2. Scan `src/frontend/` for existing UI components, utilities, and patterns:
+   - `ui_utils.py` for shared utilities (e.g., `hide_sidebar_nav()`).
+   - Existing pages for layout patterns (e.g., `upload_mdf.py`, `table_maintenance.py`).
+   - Session state patterns for RBAC and state management.
+3. Determine the target framework:
+   - Primary: **Streamlit** (the project's current and only supported frontend framework).
+   - Experimental: None currently.
+   - Planned: None currently.
+4. Document component conventions:
+   - Navigation: `st.sidebar` with `hide_sidebar_nav()`.
+   - RBAC: `st.session_state.get("user_role")` guard.
+   - Status feedback: `st.status()` or `st.toast()` for non-blocking feedback.
+   - Per-record controls: inline with data rows, not in global toolbar.
+   - Import pattern: `import streamlit as st`, `from src.frontend.ui_utils import ...`.
+5. Write configuration to `ui_framework_config.yaml` in the worktree (or update existing).
+6. Invoke `completion` subtask.
+7. Return result contract.

--- a/.opencode/skills/ui-engineer/tasks/implement.md
+++ b/.opencode/skills/ui-engineer/tasks/implement.md
@@ -1,0 +1,45 @@
+# UI Engineer — implement task
+
+## Purpose
+
+Produce a complete framework-specific UI implementation from design artifacts (interaction spec, mockup, wireframe) and spec requirements.
+
+## Entry Criteria
+
+- Design artifacts exist in the worktree (interaction-spec.yaml is REQUIRED; mockup.html, screenshot.png, wireframe.svg are recommended/reference).
+- `worktree.path` is set and verified.
+- Target framework is known (Streamlit by default, or configured via `framework-config` task).
+- Spec or context document is available and has been read.
+
+## Exit Criteria
+
+- Framework-specific implementation files exist in the worktree.
+- Implementation covers all routes, components, states, and guards defined in the interaction spec.
+- RBAC guards, sidebar navigation pattern, and accessibility features from the interaction spec are implemented.
+- Implementation follows `docs/ui-guidelines.md` conventions (sidebar pattern, RBAC, per-record controls, status feedback).
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, files_changed, summary, concerns}`.
+
+## Procedure
+
+1. Read the interaction spec YAML file from the worktree.
+2. Read the mockup HTML and/or wireframe SVG for layout reference.
+3. Read `docs/ui-guidelines.md` for project UI conventions.
+4. Copy `templates/streamlit_template.py` as the starting point for each page/view.
+5. Map interaction spec components to Streamlit widgets:
+   - `navigation_list` → `st.sidebar` navigation with `st.radio` or `st.sidebar.selectbox`
+   - `content_container` → main panel with `st.container`
+   - `banner` → `st.header` in sidebar
+   - Data sources → `st.session_state` or API calls via `ui_utils`
+6. Implement RBAC guards from interaction spec `guards` section:
+   - Check `st.session_state.get("user_role")` against required roles.
+   - Redirect or show error for unauthorized access.
+7. Implement navigation transitions from interaction spec `transitions` section.
+8. Implement accessibility features from interaction spec `accessibility` section:
+   - ARIA labels via `st.markdown` with accessible HTML.
+   - Keyboard navigation patterns.
+   - Screen reader announcements via `st.status` or `st.toast`.
+9. Implement per-record controls inline with data, not in global toolbars.
+10. Use `st.status()` or `st.toast()` for feedback — no `st.error()` for advisory validation.
+11. Invoke `completion` subtask.
+12. Return result contract.

--- a/.opencode/skills/ui-engineer/tasks/test-ui.md
+++ b/.opencode/skills/ui-engineer/tasks/test-ui.md
@@ -1,0 +1,33 @@
+# UI Engineer — test-ui task
+
+## Purpose
+
+Generate UI test specifications from interaction spec requirements, covering navigation, component states, RBAC guards, and accessibility.
+
+## Entry Criteria
+
+- Interaction spec YAML is available in the worktree.
+- Implementation files exist in the worktree.
+- `worktree.path` is set and verified.
+
+## Exit Criteria
+
+- Test specification file(s) exist in the worktree.
+- Every navigation route, transition, guard, and accessibility requirement from the interaction spec has a corresponding test case.
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, artifacts, summary, concerns}`.
+
+## Procedure
+
+1. Read the interaction spec YAML file from the worktree.
+2. Read the implementation files for context on actual component mapping.
+3. Generate test specifications covering:
+   - **Route tests**: Each route in `navigation.routes` is reachable and renders expected content.
+   - **Transition tests**: Each transition in `navigation.transitions` triggers correctly.
+   - **Guard tests**: Each guard in `navigation.guards` enforces access control (authorized roles pass, unauthorized roles are blocked).
+   - **Component state tests**: Each component in `components` renders in its default state and any defined alternate states.
+   - **Accessibility tests**: ARIA labels, keyboard navigation, and screen reader announcements match `accessibility` section.
+4. Structure test specs as pytest-compatible test function descriptions with setup, action, and assertion steps.
+5. Write test specification to a file in the worktree (e.g., `test_ui_<feature>.py` or `test_specs/<feature>_test_spec.yaml`).
+6. Invoke `completion` subtask.
+7. Return result contract.

--- a/.opencode/skills/ui-engineer/tasks/validate-impl.md
+++ b/.opencode/skills/ui-engineer/tasks/validate-impl.md
@@ -1,0 +1,36 @@
+# UI Engineer — validate-impl task
+
+## Purpose
+
+Validate a framework-specific UI implementation against interaction spec requirements for completeness, correctness, and convention compliance.
+
+## Entry Criteria
+
+- Implementation files exist in the worktree.
+- Interaction spec YAML is available for comparison.
+- `worktree.path` is set and verified.
+
+## Exit Criteria
+
+- All interaction spec routes, component states, navigation guards, and accessibility requirements are verified present in the implementation.
+- Review findings documented as a result contract with severity levels.
+- `completion` subtask has been invoked.
+- Result contract returned: `{status, findings, summary}`.
+
+## Procedure
+
+1. Read the interaction spec YAML file from the worktree.
+2. Read each implementation file in the worktree.
+3. For each route in `navigation.routes`, verify a corresponding view or page exists.
+4. For each transition in `navigation.transitions`, verify the navigation trigger is implemented.
+5. For each guard in `navigation.guards`, verify the RBAC check or condition is present.
+6. For each component in `components`, verify a corresponding Streamlit widget exists.
+7. For each accessibility requirement in `accessibility`, verify ARIA labels, keyboard navigation, or screen reader announcements are present.
+8. Check convention compliance with `docs/ui-guidelines.md`:
+   - Sidebar pattern: `hide_sidebar_nav()`, sidebar header, back navigation.
+   - RBAC: role guard at page entry.
+   - Per-record controls inline, not in global toolbar.
+   - Status feedback via `st.status()` or `st.toast()`, not `st.error()` for advisory messages.
+9. Compile findings with severity levels (critical, warning, info).
+10. Invoke `completion` subtask.
+11. Return result contract.

--- a/.opencode/skills/ui-engineer/templates/streamlit_template.py
+++ b/.opencode/skills/ui-engineer/templates/streamlit_template.py
@@ -1,0 +1,43 @@
+# SNEA Streamlit Page Template
+#
+# This is a TEMPLATE file, not directly executable. Replace placeholder
+# markers (<PAGE_TITLE>, <ROLE_REQUIREMENT>, etc.) with actual values.
+#
+# Reference: docs/ui-guidelines.md for the SNEA Sidebar Pattern
+
+import streamlit as st
+
+from src.frontend.ui_utils import hide_sidebar_nav
+
+
+def main():
+    hide_sidebar_nav()
+
+    user_role = st.session_state.get("user_role")
+    if user_role not in ("<ROLE_REQUIREMENT>",):
+        st.error("You do not have permission to access this page. <ROLE_DESCRIPTION> role required.")
+        return
+
+    with st.sidebar:
+        st.header("<PAGE_TITLE>")
+
+        # <SIDEBAR_FILTERS> — page-specific filters, selectors, settings
+
+        if st.button("← Back to Main Menu"):
+            st.switch_page("Home.py")
+
+    # Main panel — data display and primary interactions
+    st.markdown("### <PAGE_TITLE>")
+
+    # <DATA_DISPLAY_AREA> — primary content using st.dataframe, st.columns, etc.
+
+    # <PER_RECORD_CONTROLS> — inline with data, not in sidebar or global toolbar
+
+    # Status feedback — use st.status() or st.toast() for non-blocking messages
+    # with st.status("<STATUS_MESSAGE>", expanded=False) as status:
+    #     st.write("<STATUS_DETAIL>")
+    #     status.update(label="<STATUS_LABEL>", state="complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 
 ## [0.2.0] - Unreleased
 
+### spec/1119-ui-sub-agent-skills
+
+- **Self-Identifying UI Sub-Agent Skills** (#1119, #1120, #1121, #1122, #1123) - Added two self-identifying UI sub-agent skills (ui-design with kimi-k2.6:cloud, ui-engineer with glm-5.1:cloud) with three-tier trigger self-identification, 12 task files, 6 PEP 723 scripts (including Playwright-based render/screenshot), 4 templates (SVG wireframe, HTML mockup, YAML interaction spec schema, Streamlit app), and divide-and-conquer enhancement for UI sub-agent routing with model context propagation.
+
 ### spec/1115-reference-verification-mandate
 
 - **References Verification Mandate** (#1115, references #1113) - Added `REFERENCES_VERIFICATION_MANDATE` injection block to session-enforcement plugin, closing the "I already know this" rationalization loophole. Names specific bypass patterns as FORBIDDEN, imposes a self-audit gate requiring tool-call artifacts before claims, and is unconditional with no scope, exemption, size, or qualification bypasses.


### PR DESCRIPTION
**Summary:**

Adds two self-identifying UI sub-agent skills (ui-design with kimi-k2.6:cloud, ui-engineer with glm-5.1:cloud) that integrate with the divide-and-conquer orchestration layer for automatic routing based on design and implementation tasks.

**Outcome:** Developers can delegate UI design (wireframes, mockups, interaction specs) and UI engineering (Streamlit component implementation) to specialized sub-agents with model-appropriate routing and design artifact handoff.

Implements #1120
Implements #1121
Implements #1122
Implements #1123