### PR TITLE
feat(skill-creator): replace --fix autocorrection with agent-driven semantic review (#1128)

### DIFF
--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -20,7 +20,7 @@ Creating skills IS Test-Driven Development applied to process documentation. Wri
 |------|---------|-------|
 | `init` | Create new skill from template using init_skill.py | ≈200 |
 | `package` | Package skill into distributable zip | ≈150 |
-| `validate` | Validate skill structure and format | ≈100 |
+| `validate` | Agent-driven semantic review of all skill cards (script sensor + intelligent corrections, conflict/ambiguity detection) | ≈100 |
 
 ## Invocation
 
@@ -28,6 +28,7 @@ Creating skills IS Test-Driven Development applied to process documentation. Wri
 - `./.opencode/skills/skill-creator/scripts/init_skill.py <skill-name> --path <output-directory>` - Initialize new skill
 - `./.opencode/skills/skill-creator/scripts/package_skill.py <skill-folder> [output-dir]` - Package skill
 - `./.opencode/skills/skill-creator/scripts/quick_validate.py <skill-folder>` - Validate skill
+- `uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py --json` - Validate with JSON output for programmatic consumption
 
 ## Skill Type Taxonomy
 
@@ -147,7 +148,7 @@ If worktree.path is set, all file operations and git commands MUST use it as the
 
 ### Validation Gate
 
-The `validate` task (`quick_validate.py`) SHOULD check for:
+The `validate` task provides comprehensive checks via `validate_skill_cards.py` for multi-skill reviews and conflict/ambiguity detection, while `quick_validate.py` is for single-skill quick structural checks. Validation SHOULD check for:
 - Skills with `bash` or `git` operations that lack a "Worktree Mode" section
 - Skills that dispatch sub-agents but don't pass `worktree.path` in context
 - New or updated SKILL.md and task/*.md files containing 0-based counting patterns (`Step 0`, `Phase 0`, `Step 0.`, `Phase 0.`) outside of code blocks, code-fenced examples, or inline code references — flag as validation error requiring correction before skill can be approved
@@ -167,7 +168,7 @@ The `validate` task (`quick_validate.py`) SHOULD check for:
 
 ### Validation Gate
 
-The `validate` task (`quick_validate.py`) SHOULD check for and flag:
+The `validate` task uses `validate_skill_cards.py` for comprehensive cross-skill placeholder checks (conflict/ambiguity detection across all skill cards) and `quick_validate.py` for single-skill quick structural checks. Validation SHOULD check for and flag:
 - Specific agent names in SKILL.md or task files — must use `<AgentName>` placeholder token
 - Specific model IDs in SKILL.md or task files — must use `<ModelId>` placeholder token
 - Specific developer names or emails in SKILL.md or task files

--- a/.opencode/skills/skill-creator/scripts/validate_skill_cards.py
+++ b/.opencode/skills/skill-creator/scripts/validate_skill_cards.py
@@ -4,7 +4,7 @@
 # dependencies = []
 # ///
 """
-Comprehensive skill card validation and autocorrection system.
+Skill card validation only (sensor mode). Corrections are agent-driven.
 
 Validates SKILL.md files per spec #1124:
   REQ-1: Frontmatter validation (name, description, type, license, compatibility)
@@ -12,21 +12,19 @@ Validates SKILL.md files per spec #1124:
   REQ-3: Worktree Mode section requirement for skills with bash/git/file ops
 
 Usage:
-    uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py           # validate only
-    uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py --fix     # autocorrect
+    uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py           # validate
+    uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py --json   # JSON output
 
 Exit codes: 0 = all pass, 1 = any fail
 """
 
+import json
 import re
-import subprocess
 import sys
-import time
 from pathlib import Path
 from typing import NamedTuple
 
 VALID_TYPES = {"discipline-enforcing", "technique", "pattern", "reference", "orchestrator"}
-
 HARDCODED_AGENT_NAMES = re.compile(r"\bOpenCode\b|\bClaude\b|\bCopilot\b|\bGemini\b|\bGPT-4\b")
 HARDCODED_MODEL_IDS = re.compile(
     r"\bollama-cloud/[a-z0-9._-]+\b"
@@ -38,34 +36,15 @@ HARDCODED_MODEL_IDS = re.compile(
 )
 HARDCODED_DEV_NAMES = re.compile(r"\bexample-developer\b|\bexample-dev-alias\b")
 HARDCODED_ORG_REPO = re.compile(r"\bexample-org\b|\bexample-repo\b")
-
 ATTRIBUTION_EXEMPT = re.compile(r"Co-authored with AI:.*<AgentName>.*<ModelId>")
-
 CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```", re.MULTILINE)
-
 WORKTREE_MODE_HEADING_RE = re.compile(r"^##\s+Worktree\s+Mode", re.MULTILINE | re.IGNORECASE)
-
 FILE_OPS_PATTERN = re.compile(
     r"`?read`?|`?write`?|`?edit`?|`?glob`?|`?grep`?"
     r"|\bbash\b.*tool\b|\bgit\s+\w"
     r"|worktree\.path",
     re.IGNORECASE,
 )
-
-WORKTREE_MODE_TEMPLATE = """
-## Worktree Mode
-
-When operating in a git worktree (`worktree.path` is set), all file operations
-MUST prefix paths with `worktree.path`:
-
-- `read(filePath=f"{worktree.path}/src/main.py")` — not `read(filePath="src/main.py")`
-- `edit(filePath=f"{worktree.path}/src/main.py", ...)` — not `edit(filePath="src/main.py", ...)`
-- Bash commands: use `workdir=worktree.path` parameter
-- `glob(pattern="src/**/*.py", path=worktree.path)` — not `glob(pattern="src/**/*.py")`
-- `grep(pattern="TODO", path=f"{worktree.path}/src/")` — not `grep(pattern="TODO", path="src/")`
-
-**When `worktree.path` is NOT set** (main repo): relative paths function as expected.
-"""
 
 
 class Violation(NamedTuple):
@@ -87,13 +66,13 @@ def parse_frontmatter(content: str) -> tuple[dict[str, str], str, str]:
     if not match:
         return {}, "", content
     fm_text = match.group(1)
-    body = content[match.end() :]
+    body = content[match.end():]
     fields: dict[str, str] = {}
     for line in fm_text.split("\n"):
         colon = line.find(":")
         if colon > 0:
             key = line[:colon].strip()
-            val = line[colon + 1 :].strip()
+            val = line[colon + 1:].strip()
             fields[key] = val
     return fields, fm_text, body
 
@@ -101,7 +80,7 @@ def parse_frontmatter(content: str) -> tuple[dict[str, str], str, str]:
 def skill_name_from_path(p: Path) -> str:
     parts = p.parts
     idx = parts.index("skills")
-    return "/".join(parts[idx + 1 : -1])
+    return "/".join(parts[idx + 1:-1])
 
 
 def validate_req1(name: str, fields: dict[str, str], fm_text: str) -> list[Violation]:
@@ -114,43 +93,26 @@ def validate_req1(name: str, fields: dict[str, str], fm_text: str) -> list[Viola
             violations.append(Violation("REQ-1", name, "name", f"Name '{val}' not hyphen-case", val))
         elif val.startswith("-") or val.endswith("-") or "--" in val:
             violations.append(Violation("REQ-1", name, "name", f"Name '{val}' has bad hyphens", val))
-
     if "description" not in fields:
         violations.append(Violation("REQ-1", name, "description", "Missing 'description' field"))
     else:
         desc = fields["description"]
         if not desc.startswith("Use when"):
             violations.append(
-                Violation(
-                    "REQ-1",
-                    name,
-                    "description",
-                    "Description doesn't start with 'Use when'",
-                    desc[:60],
-                )
+                Violation("REQ-1", name, "description", "Description doesn't start with 'Use when'", desc[:60])
             )
         if "<" in desc or ">" in desc:
             violations.append(
-                Violation(
-                    "REQ-1",
-                    name,
-                    "description",
-                    "Description contains angle brackets",
-                    desc[:60],
-                )
+                Violation("REQ-1", name, "description", "Description contains angle brackets", desc[:60])
             )
-
     if "type" not in fields:
         violations.append(Violation("REQ-1", name, "type", "Missing 'type' field"))
     elif fields["type"] not in VALID_TYPES:
         violations.append(Violation("REQ-1", name, "type", f"Invalid type '{fields['type']}'", fields["type"]))
-
     if "license" not in fields:
         violations.append(Violation("REQ-1", name, "license", "Missing 'license' field"))
-
     if "compatibility" not in fields:
         violations.append(Violation("REQ-1", name, "compatibility", "Missing 'compatibility' field"))
-
     return violations
 
 
@@ -170,9 +132,7 @@ def validate_req2(name: str, content: str) -> list[Violation]:
             for m in pattern.finditer(line):
                 violations.append(
                     Violation(
-                        "REQ-2",
-                        name,
-                        "placeholder",
+                        "REQ-2", name, "placeholder",
                         f"Hardcoded {label}: '{m.group()}' — use {placeholder}",
                         f"line~{i + 1}",
                     )
@@ -187,9 +147,7 @@ def validate_req3(name: str, body: str) -> list[Violation]:
     if FILE_OPS_PATTERN.search(body):
         violations.append(
             Violation(
-                "REQ-3",
-                name,
-                "worktree-mode",
+                "REQ-3", name, "worktree-mode",
                 "Missing 'Worktree Mode' section (skill contains bash/git/file operations)",
             )
         )
@@ -213,161 +171,54 @@ def validate_card(card_path: Path, root: Path) -> list[Violation]:
     return violations
 
 
-def apply_fixes(card_path: Path, root: Path, violations: list[Violation]) -> bool:
-    content = card_path.read_text(encoding="utf-8")
-    fields, fm_text, body = parse_frontmatter(content)
-    changed = False
-
-    for v in violations:
-        if v.field == "type" and v.message.startswith("Missing"):
-            fm_text += "\ntype: technique"
-            changed = True
-        elif v.field == "license" and v.message.startswith("Missing"):
-            fm_text += "\nlicense: MIT"
-            changed = True
-        elif v.field == "compatibility" and v.message.startswith("Missing"):
-            fm_text += "\ncompatibility: opencode"
-            changed = True
-        elif v.field == "description" and "doesn't start with 'Use when'" in v.message:
-            if "description" in fields:
-                old_desc = fields["description"]
-                new_desc = "Use when " + old_desc[0].lower() + old_desc[1:]
-                fm_text = fm_text.replace(old_desc, new_desc, 1)
-                changed = True
-        elif v.field == "description" and "angle brackets" in v.message:
-            if "description" in fields:
-                old_desc = fields["description"]
-                new_desc = old_desc.replace("<", "").replace(">", "")
-                fm_text = fm_text.replace(old_desc, new_desc, 1)
-                changed = True
-        elif v.field == "placeholder" and v.message.startswith("Hardcoded agent name"):
-            for agent in ["OpenCode", "Claude", "Copilot", "Gemini", "GPT-4"]:
-                content = content.replace(agent, "<AgentName>")
-            changed = True
-        elif v.field == "placeholder" and v.message.startswith("Hardcoded model ID"):
-            content = re.sub(r"\bollama-cloud/[a-z0-9._-]+\b", "<ModelId>", content)
-            content = re.sub(r"claude-3[-_]5[-_]sonnet", "<ModelId>", content)
-            content = re.sub(r"claude-3-opus", "<ModelId>", content)
-            content = re.sub(r"claude-3-sonnet", "<ModelId>", content)
-            content = re.sub(r"gpt-4[a-z0-9-]*", "<ModelId>", content)
-            content = re.sub(r"\bglm-[0-9.]+\b", "<ModelId>", content)
-            changed = True
-        elif v.field == "placeholder" and v.message.startswith("Hardcoded developer name"):
-            content = content.replace("example-developer", "<dev.name>")
-            content = content.replace("example-dev-alias", "<dev.email>")
-            changed = True
-        elif v.field == "placeholder" and v.message.startswith("Hardcoded org/repo"):
-            content = content.replace("example-org", "<github.owner>")
-            content = content.replace("example-repo", "<github.repo>")
-            changed = True
-        elif v.field == "worktree-mode":
-            body += WORKTREE_MODE_TEMPLATE
-            changed = True
-
-    if changed:
-        new_content = f"---\n{fm_text}\n---{body}"
-        card_path.write_text(new_content, encoding="utf-8")
-    return changed
+def extract_line(detail: str) -> int | None:
+    match = re.search(r"line~(\d+)", detail)
+    return int(match.group(1)) if match else None
 
 
-def run_fix_mode(root: Path, all_violations: dict[str, list[Violation]]) -> None:
-    timestamp = int(time.time())
-    branch_name = f"fix/skill-card-validation-{timestamp}"
-    print("\n=== Autocorrect Mode ===")
-    print(f"Creating fix branch: {branch_name}")
-
-    try:
-        subprocess.run(["git", "worktree", "list"], capture_output=True, text=True, check=True)
-    except Exception:
-        current_wt = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True
-        ).stdout.strip()
-        if current_wt != str(root):
-            print("Already in a worktree — creating branch here instead of new worktree.")
-            subprocess.run(["git", "checkout", "-b", branch_name], check=True, cwd=str(root))
-        else:
-            wt_path = root.parent / f".worktrees/fix-skill-card-validation-{timestamp}"
-            subprocess.run(
-                ["git", "worktree", "add", str(wt_path), "-b", branch_name],
-                check=True,
-                cwd=str(root),
-            )
-            fix_root = wt_path
-            cards = discover_skill_cards(fix_root)
-            for card_path in cards:
-                name = skill_name_from_path(card_path.relative_to(fix_root))
-                if name in all_violations and all_violations[name]:
-                    applied = apply_fixes(card_path, fix_root, all_violations[name])
-                    if applied:
-                        print(f"  Fixed: {name}")
-            subprocess.run(["git", "add", ".opencode/skills/"], check=True, cwd=str(wt_path))
-            subprocess.run(
-                ["git", "commit", "-m", "fix(skill-cards): correct validation violations"],
-                check=True,
-                cwd=str(wt_path),
-            )
-            subprocess.run(["git", "push", "-u", "origin", branch_name], check=True, cwd=str(wt_path))
-            re_violations = []
-            for card_path in cards:
-                re_violations.extend(validate_card(card_path, fix_root))
-            if re_violations:
-                print(f"\nWARNING: {len(re_violations)} violations remain after fix:")
-                for v in re_violations:
-                    print(f"  [{v.req}] {v.skill_name}: {v.message}")
-            else:
-                print("All violations resolved after fix.")
-            return
-
-    cards = discover_skill_cards(root)
-    for card_path in cards:
-        name = skill_name_from_path(card_path.relative_to(root))
-        if name in all_violations and all_violations[name]:
-            applied = apply_fixes(card_path, root, all_violations[name])
-            if applied:
-                print(f"  Fixed: {name}")
-
-    subprocess.run(["git", "add", ".opencode/skills/"], check=True, cwd=str(root))
-    subprocess.run(
-        ["git", "commit", "-m", "fix(skill-cards): correct validation violations"],
-        check=True,
-        cwd=str(root),
-    )
-    subprocess.run(["git", "push", "-u", "origin", branch_name], check=True, cwd=str(root))
-
-    re_violations = []
-    for card_path in cards:
-        re_violations.extend(validate_card(card_path, root))
-    if re_violations:
-        print(f"\nWARNING: {len(re_violations)} violations remain after fix:")
-        for v in re_violations:
-            print(f"  [{v.req}] {v.skill_name}: {v.message}")
-    else:
-        print("All violations resolved after fix.")
+def violation_to_dict(v: Violation) -> dict:
+    return {
+        "skill": v.skill_name,
+        "req": v.req,
+        "field": v.field,
+        "message": v.message,
+        "detail": v.detail,
+        "line": extract_line(v.detail),
+    }
 
 
 def main() -> int:
-    fix_mode = "--fix" in sys.argv
+    if "--fix" in sys.argv:
+        print(
+            "ERROR: --fix mode has been removed. Autocorrection is now agent-driven.\n"
+            "Use the skill-creator validate task for semantic review and correction.\n"
+            "Invoke: /skill skill-creator --task validate"
+        )
+        return 1
+    json_mode = "--json" in sys.argv
     root = Path.cwd()
     cards = discover_skill_cards(root)
-
     if not cards:
-        print("No SKILL.md files found.")
+        if json_mode:
+            print(json.dumps([]))
+        else:
+            print("No SKILL.md files found.")
         return 1
-
+    all_violations: list[Violation] = []
+    for card_path in cards:
+        all_violations.extend(validate_card(card_path, root))
+    if json_mode:
+        print(json.dumps([violation_to_dict(v) for v in all_violations], indent=2))
+        return 0 if not all_violations else 1
     print("=== Skill Card Validation ===")
     print(f"Discovered {len(cards)} skill cards\n")
-
-    all_violations: dict[str, list[Violation]] = {}
-    total_violations = 0
-    all_pass = True
-
+    by_skill: dict[str, list[Violation]] = {}
+    for v in all_violations:
+        by_skill.setdefault(v.skill_name, []).append(v)
     for card_path in cards:
         name = skill_name_from_path(card_path.relative_to(root))
-        violations = validate_card(card_path, root)
-        all_violations[name] = violations
-        total_violations += len(violations)
+        violations = by_skill.get(name, [])
         if violations:
-            all_pass = False
             print(f"FAIL  {name}")
             for v in violations:
                 print(f"  [{v.req}] {v.field}: {v.message}")
@@ -375,18 +226,12 @@ def main() -> int:
                     print(f"         detail: {v.detail}")
         else:
             print(f"PASS  {name}")
-
     print("\n--- Summary ---")
-    print(f"Cards: {len(cards)}, Violations: {total_violations}")
-
-    if not all_pass:
-        violating_skills = sorted({v.skill_name for vl in all_violations.values() for v in vl if v})
+    print(f"Cards: {len(cards)}, Violations: {len(all_violations)}")
+    if all_violations:
+        violating_skills = sorted({v.skill_name for v in all_violations})
         print(f"Failing skills: {', '.join(violating_skills)}")
-
-    if fix_mode and not all_pass:
-        run_fix_mode(root, all_violations)
-
-    return 0 if all_pass else 1
+    return 0 if not all_violations else 1
 
 
 if __name__ == "__main__":

--- a/.opencode/skills/skill-creator/tasks/validate.md
+++ b/.opencode/skills/skill-creator/tasks/validate.md
@@ -1,0 +1,75 @@
+# Validate
+
+Agent-driven semantic review workflow for skill card validation. Triggered when a developer requests "validate skill cards", "review skills", "skill card review", or similar phrasing. The validation script (`validate_skill_cards.py`) serves as a sensor that detects mechanical violations; the agent is the actor that interprets findings, resolves semantic issues, and applies corrections.
+
+## Two Tiers of Invocation
+
+There are two tiers of invocation depending on what the developer needs.
+
+The default tier is script-only validation. Running `uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py` performs fast mechanical checks against REQ-1 (frontmatter fields), REQ-2 (CSO description format), and REQ-3 (worktree mode section). This tier is used during the enforcement test pipeline and for quick validation when the developer wants a fast read on skill card health.
+
+The second tier is full review, which layers agent-driven semantic analysis on top of the mechanical checks. This tier is triggered when the developer explicitly requests skill card validation or a skill review — phrases like "validate skill cards", "review skills", or "skill card review". The full review runs the script first, then the agent performs its own analysis across all skill cards in the repository.
+
+## Phase 1: Script Validation
+
+The agent begins by running `uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py` and collecting the output. This identifies which skills fail mechanical REQ-1/2/3 checks and how. The script output is parsed to build a working list of mechanically-failing skills that need content-level attention in Phase 2. Skills that pass mechanical checks still proceed to Phases 3 through 5 for cross-skill and within-skill semantic analysis.
+
+## Phase 2: Content and Intent Analysis for Failing Skills
+
+For each skill that failed mechanical validation, the agent reads the full SKILL.md content and understands the skill's purpose, operations, and triggering conditions before writing any corrections. This is not a search-and-replace exercise — each fix must reflect what the skill actually does.
+
+CSO descriptions are the most common mechanical failure. The fix is not to prepend "Use when" to an existing noun phrase like "Skill-creator" or "Git-workflow". Instead, the agent reformulates the description as a proper sentence that captures the skill's triggering conditions: "Use when creating a new skill or updating an existing skill that extends AI capabilities with specialized knowledge, workflows, or tool integrations." The triggering conditions come from reading the skill, not from pattern-matching the old description.
+
+Worktree mode sections fail REQ-3 when they are missing or generic. The agent writes a section that reflects the skill's specific operations in a worktree context. For example, `git-workflow` discusses branch operations and how branch targets change when working in a worktree, while `notebook-operations` discusses Jupyter file path handling and why notebook operations must target the worktree path. A generic boilerplate section like "This skill operates in worktrees by using worktree.path" signals that the agent did not read the skill.
+
+Placeholder substitutions handle hardcoded identity values. Attribution lines use the canonical format `Co-authored with AI: <AgentName> (<ModelId>)`. Other prose uses angle-bracket placeholders: `<github.owner>`, `<github.repo>`, `<dev.name>`, and so on. The agent replaces hardcoded values with the appropriate placeholder based on context — attribution lines follow one format, prose references follow another.
+
+Missing frontmatter fields receive values drawn from the skill's actual content. The `type` field matches the skill's type per the taxonomy — `discipline-enforcing` for skills that constrain agent behavior, `workflow` for skills that define procedural sequences, `utility` for helper tools — not a default value applied uniformly.
+
+## Phase 3: Cross-Skill Conflict Detection Across All Skills
+
+This phase reads every SKILL.md in the repository, not just the mechanically-failing ones. The agent looks for four categories of cross-skill conflict.
+
+First, two skills giving contradictory instructions for the same scenario. If one skill says "always create a worktree first" and another skill's operating protocol assumes the working directory is the main repo, that contradiction will produce inconsistent agent behavior depending on which skill loads first.
+
+Second, overlapping trigger keywords without differentiation. If two skills both trigger on the word "plan", the agent must be able to determine which skill applies from context — or the trigger keywords need to be narrowed so that ambiguity is resolved.
+
+Third, cascading references forming cycles. If skill A's operating protocol references skill B, and skill B's protocol references skill A, the agent may loop or fail to terminate. Cycles must be broken by making one direction authoritative and the other a soft reference.
+
+Fourth, contradictory enforcement rules for the same context. If one skill says "HALT on missing approval" and another says "proceed if authorization scope covers it", the agent needs to know which rule takes precedence for that specific context.
+
+## Phase 4: Within-Skill Conflict Detection Across All Skills
+
+For each individual skill, the agent checks for internal consistency.
+
+An overview section that contradicts the task body or operating protocol is a within-skill conflict. If the overview says "this skill never modifies files" but a task body describes file-editing steps, the overview or the task body is wrong, and the developer must decide which.
+
+A frontmatter `type` field that does not match the skill's actual structure is another within-skill conflict. A skill labeled `discipline-enforcing` that contains only workflow steps without enforcement rules is misclassified.
+
+Enforcement rules that conflict with the operating protocol create ambiguity about what the agent should do when both apply. The agent flags these and waits for the developer to specify which takes precedence.
+
+Cross-references to non-existent files or tasks — a MISSING-TRACEABILITY finding — indicate that the skill's structure has drifted from its documentation. The agent reports the broken reference and the expected target.
+
+## Phase 5: Ambiguity Detection Across All Skills
+
+For each skill, the agent scans for vague or underspecified language that could produce inconsistent agent behavior.
+
+Vague trigger phrases like "when appropriate" or "if needed" give no guidance on when the skill should be invoked. The agent reports the ambiguous phrase and asks the developer to sharpen it.
+
+Underspecified enforcement rule conditions create the same problem. An enforcement rule that says "halt on error" without specifying what counts as an error will produce different halting behavior depending on the agent's interpretation.
+
+Ambiguous authorization language — phrases that could be read as either requiring or merely permitting an action — must be clarified so that the agent's behavior is deterministic.
+
+Missing edge cases in enforcement rules leave the agent without guidance when uncommon situations arise. The agent reports the gap and the edge case that exposed it.
+
+## Phase 6: Presenting Findings
+
+Findings are presented to the developer one at a time, not as a bulk report. This allows the developer to consider each finding individually without being overwhelmed.
+
+Auto-fixable findings — wrong placeholder values, missing frontmatter fields with unambiguous correct values — are applied by the agent immediately. The agent confirms each fix with the developer before moving on.
+
+Conflicts — contradictory rules across skills or within a skill — are presented with the contradiction described in plain language. The agent asks the developer which rule or interpretation should govern, and waits for a response before proceeding. The agent does not resolve conflicts autonomously because the resolution may depend on project priorities or architectural intent that only the developer can assess.
+
+Ambiguities — vague triggers, underspecified conditions, missing edge cases — are presented with the problematic language quoted and the ambiguity explained. The agent asks the developer to clarify and waits for a response. The agent does not sharpen ambiguous language on its own because the correct specificity depends on the developer's intent for the skill.
+
+This separation between auto-fixable findings and findings requiring developer feedback is important. Mechanical violations have objectively correct fixes — a missing `type` field has a value determined by the skill's content, a wrong placeholder has a correct substitution. Semantic conflicts and ambiguities do not have objectively correct resolutions; they require judgment about project intent, and that judgment belongs to the developer.


### PR DESCRIPTION
## Summary

Replaces the broken `--fix` autocorrection pipeline in `validate_skill_cards.py` with an agent-driven semantic review workflow. The script becomes sensor-only (validate and report), while corrections are produced by AI agent intelligence reading each skill's content, intent, and semantics — not by stamping static templates.

## Outcome

Engineering teams can run `validate_skill_cards.py` for fast mechanical REQ-1/2/3 checks, or invoke the agent-driven `validate` task for full semantic review including cross-skill conflict detection, within-skill conflict detection, and ambiguity detection. The `--fix` flag now exits with an error pointing to the agent workflow. `--json` output enables programmatic consumption.

Fixes #1128