### PR TITLE
fix(skill-creator): validation script and discoverability failures from #1128

### DIFF
--- a/.opencode/skills/skill-creator/SKILL.md
+++ b/.opencode/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Use when creating a new skill or updating an existing skill that extends AI capabilities with specialized knowledge, workflows, or tool integrations. Triggers on: new skill, update skill, create skill, skill template, skill structure, SKILL.md.
+description: Use when creating a new skill, updating an existing skill, or validating skill cards. Triggers on: new skill, update skill, create skill, skill template, skill structure, SKILL.md, validate skill cards, review skills, skill card review.
 license: Apache-2.0
 compatibility: opencode
 type: technique
@@ -25,10 +25,12 @@ Creating skills IS Test-Driven Development applied to process documentation. Wri
 ## Invocation
 
 - `/skill skill-creator` - Overview and skill creation process
+- `/skill skill-creator --task validate` - Agent-driven semantic review of all skill cards (script sensor + intelligent corrections, conflict/ambiguity detection)
 - `./.opencode/skills/skill-creator/scripts/init_skill.py <skill-name> --path <output-directory>` - Initialize new skill
 - `./.opencode/skills/skill-creator/scripts/package_skill.py <skill-folder> [output-dir]` - Package skill
-- `./.opencode/skills/skill-creator/scripts/quick_validate.py <skill-folder>` - Validate skill
-- `uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py --json` - Validate with JSON output for programmatic consumption
+- `./.opencode/skills/skill-creator/scripts/quick_validate.py <skill-folder>` - Quick single-skill frontmatter check
+- `uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py` - Mechanical REQ-1/2/3 validation across all skills (sensor only)
+- `uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py --json` - Mechanical validation with JSON output for programmatic consumption
 
 ## Skill Type Taxonomy
 

--- a/.opencode/skills/skill-creator/scripts/validate_skill_cards.py
+++ b/.opencode/skills/skill-creator/scripts/validate_skill_cards.py
@@ -48,11 +48,13 @@ FILE_OPS_PATTERN = re.compile(
 
 
 class Violation(NamedTuple):
-    req: str
+    violation_type: str
     skill_name: str
-    field: str
+    rule_id: str
     message: str
     detail: str = ""
+    file_path: str = ""
+    line_approx: int | None = None
 
 
 def discover_skill_cards(root: Path) -> list[Path]:
@@ -66,13 +68,13 @@ def parse_frontmatter(content: str) -> tuple[dict[str, str], str, str]:
     if not match:
         return {}, "", content
     fm_text = match.group(1)
-    body = content[match.end():]
+    body = content[match.end() :]
     fields: dict[str, str] = {}
     for line in fm_text.split("\n"):
         colon = line.find(":")
         if colon > 0:
             key = line[:colon].strip()
-            val = line[colon + 1:].strip()
+            val = line[colon + 1 :].strip()
             fields[key] = val
     return fields, fm_text, body
 
@@ -80,43 +82,60 @@ def parse_frontmatter(content: str) -> tuple[dict[str, str], str, str]:
 def skill_name_from_path(p: Path) -> str:
     parts = p.parts
     idx = parts.index("skills")
-    return "/".join(parts[idx + 1:-1])
+    return "/".join(parts[idx + 1 : -1])
 
 
-def validate_req1(name: str, fields: dict[str, str], fm_text: str) -> list[Violation]:
+def validate_req1(name: str, fields: dict[str, str], fm_text: str, file_path: str) -> list[Violation]:
     violations: list[Violation] = []
     if "name" not in fields:
-        violations.append(Violation("REQ-1", name, "name", "Missing 'name' field"))
+        violations.append(Violation("REQ-1", name, "name", "Missing 'name' field", file_path=file_path))
     else:
         val = fields["name"]
         if not re.match(r"^[a-z0-9-]+$", val):
-            violations.append(Violation("REQ-1", name, "name", f"Name '{val}' not hyphen-case", val))
+            violations.append(
+                Violation("REQ-1", name, "name", f"Name '{val}' not hyphen-case", val, file_path=file_path)
+            )
         elif val.startswith("-") or val.endswith("-") or "--" in val:
-            violations.append(Violation("REQ-1", name, "name", f"Name '{val}' has bad hyphens", val))
+            violations.append(
+                Violation("REQ-1", name, "name", f"Name '{val}' has bad hyphens", val, file_path=file_path)
+            )
     if "description" not in fields:
-        violations.append(Violation("REQ-1", name, "description", "Missing 'description' field"))
+        violations.append(Violation("REQ-1", name, "description", "Missing 'description' field", file_path=file_path))
     else:
         desc = fields["description"]
         if not desc.startswith("Use when"):
             violations.append(
-                Violation("REQ-1", name, "description", "Description doesn't start with 'Use when'", desc[:60])
+                Violation(
+                    "REQ-1",
+                    name,
+                    "description",
+                    "Description doesn't start with 'Use when'",
+                    desc[:60],
+                    file_path=file_path,
+                )
             )
         if "<" in desc or ">" in desc:
             violations.append(
-                Violation("REQ-1", name, "description", "Description contains angle brackets", desc[:60])
+                Violation(
+                    "REQ-1", name, "description", "Description contains angle brackets", desc[:60], file_path=file_path
+                )
             )
     if "type" not in fields:
-        violations.append(Violation("REQ-1", name, "type", "Missing 'type' field"))
+        violations.append(Violation("REQ-1", name, "type", "Missing 'type' field", file_path=file_path))
     elif fields["type"] not in VALID_TYPES:
-        violations.append(Violation("REQ-1", name, "type", f"Invalid type '{fields['type']}'", fields["type"]))
+        violations.append(
+            Violation("REQ-1", name, "type", f"Invalid type '{fields['type']}'", fields["type"], file_path=file_path)
+        )
     if "license" not in fields:
-        violations.append(Violation("REQ-1", name, "license", "Missing 'license' field"))
+        violations.append(Violation("REQ-1", name, "license", "Missing 'license' field", file_path=file_path))
     if "compatibility" not in fields:
-        violations.append(Violation("REQ-1", name, "compatibility", "Missing 'compatibility' field"))
+        violations.append(
+            Violation("REQ-1", name, "compatibility", "Missing 'compatibility' field", file_path=file_path)
+        )
     return violations
 
 
-def validate_req2(name: str, content: str) -> list[Violation]:
+def validate_req2(name: str, content: str, file_path: str) -> list[Violation]:
     violations: list[Violation] = []
     content_no_code = CODE_BLOCK_RE.sub("", content)
     lines_no_code = content_no_code.split("\n")
@@ -132,23 +151,30 @@ def validate_req2(name: str, content: str) -> list[Violation]:
             for m in pattern.finditer(line):
                 violations.append(
                     Violation(
-                        "REQ-2", name, "placeholder",
+                        "REQ-2",
+                        name,
+                        "placeholder",
                         f"Hardcoded {label}: '{m.group()}' — use {placeholder}",
                         f"line~{i + 1}",
+                        file_path,
+                        i + 1,
                     )
                 )
     return violations
 
 
-def validate_req3(name: str, body: str) -> list[Violation]:
+def validate_req3(name: str, body: str, file_path: str) -> list[Violation]:
     violations: list[Violation] = []
     if WORKTREE_MODE_HEADING_RE.search(body):
         return violations
     if FILE_OPS_PATTERN.search(body):
         violations.append(
             Violation(
-                "REQ-3", name, "worktree-mode",
+                "REQ-3",
+                name,
+                "worktree-mode",
                 "Missing 'Worktree Mode' section (skill contains bash/git/file operations)",
+                file_path=file_path,
             )
         )
     return violations
@@ -156,34 +182,31 @@ def validate_req3(name: str, body: str) -> list[Violation]:
 
 def validate_card(card_path: Path, root: Path) -> list[Violation]:
     name = skill_name_from_path(card_path.relative_to(root))
+    rel_path = str(card_path.relative_to(root))
     content = card_path.read_text(encoding="utf-8")
     fields, fm_text, body = parse_frontmatter(content)
     violations: list[Violation] = []
     if not content.startswith("---"):
-        violations.append(Violation("REQ-1", name, "frontmatter", "No YAML frontmatter found"))
+        violations.append(Violation("REQ-1", name, "frontmatter", "No YAML frontmatter found", file_path=rel_path))
         return violations
     if not fields:
-        violations.append(Violation("REQ-1", name, "frontmatter", "Invalid frontmatter format"))
+        violations.append(Violation("REQ-1", name, "frontmatter", "Invalid frontmatter format", file_path=rel_path))
         return violations
-    violations.extend(validate_req1(name, fields, fm_text))
-    violations.extend(validate_req2(name, content))
-    violations.extend(validate_req3(name, body))
+    violations.extend(validate_req1(name, fields, fm_text, rel_path))
+    violations.extend(validate_req2(name, content, rel_path))
+    violations.extend(validate_req3(name, body, rel_path))
     return violations
-
-
-def extract_line(detail: str) -> int | None:
-    match = re.search(r"line~(\d+)", detail)
-    return int(match.group(1)) if match else None
 
 
 def violation_to_dict(v: Violation) -> dict:
     return {
-        "skill": v.skill_name,
-        "req": v.req,
-        "field": v.field,
+        "skill_name": v.skill_name,
+        "file_path": v.file_path,
+        "violation_type": v.violation_type,
+        "rule_id": v.rule_id,
         "message": v.message,
         "detail": v.detail,
-        "line": extract_line(v.detail),
+        "line_approx": v.line_approx,
     }
 
 
@@ -194,7 +217,7 @@ def main() -> int:
             "Use the skill-creator validate task for semantic review and correction.\n"
             "Invoke: /skill skill-creator --task validate"
         )
-        return 1
+        return 2
     json_mode = "--json" in sys.argv
     root = Path.cwd()
     cards = discover_skill_cards(root)
@@ -221,7 +244,7 @@ def main() -> int:
         if violations:
             print(f"FAIL  {name}")
             for v in violations:
-                print(f"  [{v.req}] {v.field}: {v.message}")
+                print(f"  [{v.violation_type}] {v.rule_id}: {v.message}")
                 if v.detail:
                     print(f"         detail: {v.detail}")
         else:

--- a/.opencode/skills/skill-creator/tasks/validate.md
+++ b/.opencode/skills/skill-creator/tasks/validate.md
@@ -14,6 +14,8 @@ The second tier is full review, which layers agent-driven semantic analysis on t
 
 The agent begins by running `uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py` and collecting the output. This identifies which skills fail mechanical REQ-1/2/3 checks and how. The script output is parsed to build a working list of mechanically-failing skills that need content-level attention in Phase 2. Skills that pass mechanical checks still proceed to Phases 3 through 5 for cross-skill and within-skill semantic analysis.
 
+When using `--json` for programmatic consumption, the JSON array contains objects with fields: `skill_name`, `file_path`, `violation_type`, `rule_id`, `message`, `detail`, `line_approx`.
+
 ## Phase 2: Content and Intent Analysis for Failing Skills
 
 For each skill that failed mechanical validation, the agent reads the full SKILL.md content and understands the skill's purpose, operations, and triggering conditions before writing any corrections. This is not a search-and-replace exercise — each fix must reflect what the skill actually does.

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -463,6 +463,17 @@ if [ -f "$SKILL_CARD_SCRIPT" ]; then
         echo "  $line"
         echo "  $line" >> "$RESULTS_FILE"
     done
+    # Verify --fix exits with code 2 (removed mode)
+    FIX_OUTPUT=$(uv run "$SKILL_CARD_SCRIPT" --fix 2>&1) || FIX_RC=$? || FIX_RC=0
+    if [ "${FIX_RC:-0}" -eq 2 ]; then
+        echo "  Skill Card --fix Exit Code: PASS (exit 2)"
+        echo "- **Skill Card --fix Exit Code:** PASS (exit 2)" >> "$RESULTS_FILE"
+    else
+        echo "  Skill Card --fix Exit Code: FAIL (expected 2, got ${FIX_RC:-0})"
+        echo "- **Skill Card --fix Exit Code:** FAIL (expected 2, got ${FIX_RC:-0})" >> "$RESULTS_FILE"
+        SKILL_CARD_PASS=false
+        OVERALL_PASS=false
+    fi
 else
     echo "  Skill Card Validation: SKIP (script not found)"
     echo "- **Skill Card Validation:** SKIP (script not found)" >> "$RESULTS_FILE"


### PR DESCRIPTION
## Summary

Fixes four root causes from the #1128 implementation that prevented the skill card validation system from working correctly: wrong `--fix` exit code, wrong JSON schema, missing trigger keyword discoverability, and missing validate task invocation path.

## Outcome

- `--fix` now exits with code 2 (distinct from code 1 for validation failures)
- JSON output uses correct schema with all 7 required fields (`skill_name`, `file_path`, `violation_type`, `rule_id`, `message`, `detail`, `line_approx`)
- "validate skill cards", "review skills", and "skill card review" now trigger the skill-creator skill
- `/skill skill-creator --task validate` is documented in the Invocation section
- Enforcement test verifies `--fix` exit code 2

Fixes #1130

🤖 OpenCode (ollama-cloud/glm-5.1) ✅ complete