### PR TITLE
Add per-SC evidence gates to prevent verification soft-passing

### DIFF
--- a/.opencode/guidelines/080-code-standards.md
+++ b/.opencode/guidelines/080-code-standards.md
@@ -194,7 +194,7 @@ External repository posts have HIGHER attribution priority than internal content
 When a byline is missing from AI-authored posted content:
 
 | Option | When | Action |
-|--------|------|--------|
+| -- | -- | -- |
 | **Edit the comment** | Platform supports edit + agent has edit permission | Edit the original comment, append byline as last line |
 | **Delete + repost** | Agent has delete permission | Delete original, repost with byline included |
 | **Accept the omission** | No edit/delete permission | Leave it. Do NOT add a separate byline comment. |
@@ -284,7 +284,7 @@ Guideline files (`.opencode/guidelines/*.md`) and skill files (`.opencode/skills
 ### Per-Change TDD Pattern
 
 | TDD Phase | Action |
-|-----------|--------|
+| -- | -- |
 | **RED** | Add enforcement test scenario to `test-enforcement.sh` that checks for the change (expect failure — change doesn't exist yet) |
 | **GREEN** | Make the guideline/skill change that makes the test pass |
 | **REFACTOR** | Clean up test scenario, add cross-reference checks |
@@ -295,6 +295,30 @@ Guideline files (`.opencode/guidelines/*.md`) and skill files (`.opencode/skills
 Enforcement tests are the verification layer that proves agent guidelines are actually enforceable. A guideline without a test is a suggestion, not a rule. A skill without a test is documentation, not enforcement. The `with-test-home` wrapper prevents SQLite session conflicts between the desktop app and CLI tests.
 
 **See `090-incremental-build.md` for the incremental implementation discipline that governs HOW these changes are delivered.** **See `.opencode/tests/README.md` for the enforcement test template and usage guide.**
+
+### SC-to-Test Traceability (MANDATORY)
+
+Every spec success criterion MUST have at least one corresponding enforcement test assertion that references the SC ID. The assertion must include a comment linking it to the specific SC:
+
+```
+# SC-2: --fix exits with code 2
+assert exit_code == 2
+```
+
+The SC ID comment convention is now a REQUIREMENT, not a convention. Every enforcement test that verifies a spec success criterion MUST include a `# SC-N:` comment prefix identifying which SC it covers.
+
+### RED-Phase Ordering (MANDATORY)
+
+The enforcement test assertion for each SC MUST exist and FAIL before implementation of that SC begins. This is the TDD RED-GREEN cycle applied to spec success criteria:
+
+1. **RED**: Write the enforcement test assertion that verifies the SC (the test fails because the change doesn't exist yet)
+2. **GREEN**: Implement the change that makes the test pass
+3. **REFACTOR**: Clean up, verify cross-references
+4. **COMMIT**: Both the test and the change committed together
+
+Writing tests AFTER implementation means the test was never RED — it never caught the gap between the spec and the implementation. The #1128 root cause was exactly this: the agent implemented first and verified second, but no gate checked whether the verification tests existed before implementation began.
+
+If SC-to-test traceability is missing for any SC, or if test assertions were written after implementation (GREEN-without-RED), implementation MUST NOT proceed until the tests are added and shown to fail first.
 
 ## Cross-Reference Standards
 
@@ -348,7 +372,7 @@ See `"Cross-Reference Standards"` section in `guidelines.md` for the rule.
 Session-init and env-loader are two independent pipelines with separate naming conventions:
 
 | Pipeline | Source | Output Format | Consumer | Example |
-|----------|--------|---------------|----------|---------|
+| -- | -- | -- | -- | -- |
 | LLM context | session-init (Python) | Dotted `scope.param` | Agent system prompt | `github.owner` |
 | Bash environment | env-loader.ts (TypeScript) | UPPER_CASE | Shell commands, Python scripts | `GIT_OWNER` |
 

--- a/.opencode/guidelines/091-incremental-build.md
+++ b/.opencode/guidelines/091-incremental-build.md
@@ -11,7 +11,7 @@ This discipline applies to ALL scopes — GREENFIELD, NEW_FEATURE, FIX, and ENHA
 ## Scope Classification
 
 | Scope | Top-Down Starts From | Input Artifact |
-|-------|---------------------|---------------|
+| -- | -- | -- |
 | GREENFIELD | Project spec (no existing code) | New project specification |
 | NEW_FEATURE | Existing code + feature request | Feature spec with acceptance criteria |
 | FIX | Existing code + bug report | Bug report with root cause analysis |
@@ -45,18 +45,20 @@ Bottom-up design is performed during plan creation (`writing-plans --task create
 Each implementation item MUST follow:
 
 | Phase | Action | Guideline Change |
-|-------|--------|-----------------|
-| **RED** | Add enforcement test scenario that verifies the change (expect failure — change doesn't exist yet) | Test scenario committed alongside the `.md` change it tests |
+| -- | -- | -- |
+| **RED** | Add enforcement test scenario that verifies the change (expect failure — change doesn't exist yet). For each spec SC that applies to this item, the enforcement test assertion for that SC MUST be in RED state (exists and fails) before the item's implementation commit. | Test scenario committed alongside the `.md` change it tests; SC-specific test assertions with `# SC-N:` comments |
 | **GREEN** | Make the `.md` file change that makes the test pass | The actual guideline, skill, or AGENTS.md modification |
 | **REFACTOR** | Clean up cross-references, verify consistency with other files | Ensure no broken references between files |
 | **COMMIT** | Both the test addition and the `.md` change committed together as one working slice | Commit message references the item number |
 
 **Enforcement test runner:**
+
 ```
 bash .opencode/tests/with-test-home opencode-cli run '<scenario>'
 ```
 
 **Full suite verification:**
+
 ```
 bash .opencode/tests/test-enforcement.sh
 bash .opencode/tests/with-test-home --clean-all
@@ -73,6 +75,12 @@ These patterns are critical violations per `000-critical-rules.md`:
 - **Merging without tests** — Submitting changes where the enforcement test for that change doesn't pass
 
 These anti-patterns are also documented as the "Monolithic Implementation" critical violation in `000-critical-rules.md`.
+
+## SC-Specific TDD Mandate
+
+The per-item TDD cycle's RED phase MUST include SC-specific test assertions, not just general enforcement assertions. For each spec SC that applies to a given item, the enforcement test assertion for that SC must be in RED state (exists and fails) before the item's implementation commit.
+
+SC test assertions MUST be in RED state (exist and fail) before the item's implementation commit. If an SC test assertion is written after implementation (GREEN-without-RED), the test never verified that the SC was actually unmet before implementation — it only verified that the implementation makes the test pass, which is circular.
 
 ## Cross-References
 

--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -10,6 +10,7 @@ AI agents MUST follow the **Spec-Driven Development** (Gated Workflow) approach 
 4. **Implement Phase**: **Execute** tasks and **verify** results.
 
 **Two-Gate Model:**
+
 - **Gate 1 — Spec Approval → Plan Creation**: Spec approval authorizes creating the plan issue. The spec references the plan via body text (linked reference, e.g., `Related Plan: #NNN`), NOT via GitHub sub-issue link.
 - **Gate 2 — Plan Approval → Implementation**: Plan approval authorizes implementation. Authorization cascades from the plan to all its sub-issues.
 
@@ -83,7 +84,7 @@ ______________________________________________________________________
 ### Platform Routing
 
 | `github.platform` | Platform Sub-Skill |
-|----------------|-------------------|
+| -- | -- |
 | `github` | `issue-operations/platforms/github-mcp/` |
 | `gitbucket` | `issue-operations/platforms/gitbucket-api/` |
 | (unset) | `issue-operations/platforms/github-mcp/` (default) |
@@ -109,7 +110,7 @@ ______________________________________________________________________
 ### Content Coverage Questions
 
 | Question | Why It Matters |
-|----------|---------------|
+| -- | -- |
 | Does the spec clearly state the problem it solves and why? | Without this, the reader doesn't know what they're solving or whether the solution addresses the right thing |
 | Does the spec provide enough context for someone with no prior knowledge? | Agents lack memory context; the spec must be self-contained |
 | Does the spec identify what constraints and assumptions apply? | Constraints shape the solution space; assumptions may be wrong and need verification |
@@ -131,6 +132,25 @@ ______________________________________________________________________
 - No risk assessment
 - Skipping design phase
 - Proceeding without approval
+
+### Executable Verification Commands in Success Criteria (MANDATORY)
+
+Each success criterion MUST include an **executable verification command** — a shell command or test assertion that can be pasted into a terminal and produces a deterministic pass/fail result. The verification method column in SC tables must contain executable commands with exact expected values, not descriptive text.
+
+**Format:** `command --flags args` → must output exactly `expected_value`
+
+**Example:** `uv run .opencode/skills/skill-creator/scripts/validate_skill_cards.py --fix; echo $?` → must output exactly `2`
+
+### Anti-Pattern: Vague Verification Methods (FORBIDDEN)
+
+Vague verification methods are FORBIDDEN in success criteria. A verification method is vague when it describes what to check but not what the exact expected value is.
+
+| Vague (FORBIDDEN) | Exact (REQUIRED) |
+| -- | -- |
+| "check exit code" | "exit code must be 2" |
+| "validate JSON schema" | "JSON output must contain fields X, Y, Z" |
+| "verify file exists" | "`test -f path/to/file && echo exists` must output `exists`" |
+| "check output format" | "\`command |
 
 ### Simple vs Complex Specs
 
@@ -189,10 +209,10 @@ A different AI agent (or the same agent after a context reset) may pick up this 
 Before submitting any spec, verify these self-containment questions:
 
 | Question | Why It Matters |
-|----------|---------------|
+| -- | -- |
 | Does the spec describe the problem with full context, not just "as discussed"? | A fresh agent has no memory of earlier conversation |
 | Does the spec include file paths with stable anchors (not line numbers)? | Line numbers break on every edit |
-| Does the spec include code snippets for key changes (<20 lines)? | Code context prevents misunderstandings |
+| Does the spec include code snippets for key changes (\<20 lines)? | Code context prevents misunderstandings |
 | Does the spec include URLs and summaries for all related issues? | Bare links without context are useless |
 | Does the spec document decision rationale? | Without it, implementers may choose different approaches |
 

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -51,7 +51,7 @@ if not result or not result.strip():
 **Under NO circumstances does the agent ask the user to classify scope.** The verb-prefix parsing table in Step 2.0 is the sole authority. Every possible authorization phrase maps to exactly one scope:
 
 | Authorization Phrase | Resolved Scope |
-|----------------------|---------------|
+| -- | -- |
 | "approved #N" (no qualifier) | `standard` |
 | "approved #N to PR" / "for PR" | `for_pr` |
 | "approved #N to implementation" / "for implementation" | `for_implementation` |
@@ -87,6 +87,7 @@ git status
 Branch creation is DELEGATED to `git-workflow --task pre-work`, which creates worktrees via the `using-git-worktrees` skill. Creating branches here bypasses worktree isolation — a CRITICAL VIOLATION.
 
 **After git state verification:**
+
 1. Record that git state is verified
 2. Proceed to Step 2 (authorization verification)
 3. After ALL verification steps, invoke `git-workflow --task pre-work` for worktree creation
@@ -95,6 +96,7 @@ Branch creation is DELEGATED to `git-workflow --task pre-work`, which creates wo
 ### Step 2: Verify Authorization Is Explicit
 
 Check that authorization is:
+
 - From user (not agent)
 - Explicit ("approved", "go", "approved: N.M")
 - For the CURRENT issue (not old session)
@@ -142,7 +144,7 @@ def parse_authorization_scope(authorization_text: str) -> dict:
 ##### Scope Values and Pipeline Stages
 
 | Scope | Pipeline Stage Reached | Gap-Fill Actions | HALT After |
-|-------|----------------------|------------------|------------|
+| -- | -- | -- | -- |
 | `standard` | Full pipeline | None (all artifacts must exist upfront) | After review-prep (default) |
 | `for_spec` | Spec creation only | None | Spec created |
 | `for_plan` | Through plan approval | Auto-create spec if missing | Plan created |
@@ -176,11 +178,13 @@ When user approves issue #P, and #P's body or comments explicitly state that it 
 4. No contradictory evidence (e.g., #P's body says "spec rejected, try again")
 
 When cascade applies:
+
 - #C is treated as if the user said "Approved: #C"
 - Add comment to #C: "Authorization cascaded from #P (approvable output of approved issue)"
 - Remove `needs-approval` label from #C
 
 When cascade does NOT apply (conditions not met):
+
 - HALT and inform user: "#P was approved but it is an investigation issue — its spec #C was not named. Please confirm: approve #C?"
 - This is a genuine authorization gap where the developer's intent is ambiguous
 
@@ -202,6 +206,7 @@ if has_label and explicit_authorization:
 ### Step 4: Record Authorization Scope
 
 Authorization applies to:
+
 - Specific issue only
 - Current phase/task only
 - This session only (no carryover)
@@ -211,7 +216,7 @@ Authorization applies to:
 When user provides explicit authorization, it **OVERRIDES** the needs-approval label.
 
 | Scenario | Action |
-|----------|--------|
+| -- | -- |
 | "approved" AND label present | PROCEED - explicit auth wins |
 | "approved" AND no label | PROCEED |
 | NO auth AND label present | HALT - wait for authorization |
@@ -257,6 +262,50 @@ if not has_tdd_steps:
 **Exemption:** Single-task plans (0 or 1 phases) are exempt from the item decomposition check. The check applies ONLY to multi-task plans with more than one phase.
 
 **Cross-reference:** See `091-incremental-build.md` for the complete discipline rules, scope classification, and per-item TDD cycle.
+
+### Step 4.6: Verify SC-to-Test Traceability and RED-Phase Ordering
+
+**Before implementation proceeds, verify that the corresponding spec's success criteria have enforcement test assertions and that RED-phase ordering was followed.**
+
+**Verification checks:**
+
+1. **SC-to-test traceability exists** — For each success criterion in the corresponding spec, at least one enforcement test assertion references the SC ID (per `080-code-standards.md` SC-to-Test Traceability requirement)
+2. **RED-phase ordering confirmed** — Each enforcement test assertion was written BEFORE the implementation commit for its corresponding item (the test was in RED state — exists and fails — before implementation began)
+
+**Procedure:**
+
+```
+# Read the corresponding spec
+spec_issue = github_issue_read(method="get", issue_number=spec_number)
+spec_body = spec_issue["body"]
+
+# Parse success criteria from spec
+success_criteria = parse_success_criteria(spec_body)
+
+# For each SC, verify:
+for sc in success_criteria:
+    # 1. Traceability: enforcement test exists that references this SC ID
+    has_test = check_enforcement_test_references_sc(sc["id"])
+    if not has_test:
+        # MISSING-TRACEABILITY: No enforcement test for SC
+        finding = f"SC {sc['id']} has no corresponding enforcement test assertion"
+        action = "BLOCK implementation; require test assertion with SC ID comment"
+        severity = "MISSING-TRACEABILITY"
+
+    # 2. RED-phase ordering: test was written before implementation commit
+    if has_test:
+        test_commit = find_earliest_commit_for_test(sc["id"])
+        impl_commit = find_earliest_commit_for_implementation(sc["id"])
+        if test_commit and impl_commit and test_commit > impl_commit:
+            # VERIFICATION-GAP: Test written after implementation (GREEN-without-RED)
+            finding = f"SC {sc['id']}: test written after implementation (GREEN-without-RED)"
+            action = "BLOCK; require test to be written first and shown to fail"
+            severity = "VERIFICATION-GAP"
+```
+
+**Exemption:** Existing SCs that were implemented before this mandate took effect are flagged but not blocked. RED-phase ordering is prospective (per `140-planning-spec-creation.md` constraints).
+
+**Cross-reference:** See `080-code-standards.md` "SC-to-Test Traceability" and "RED-Phase Ordering" sections for the mandate. See `091-incremental-build.md` for the per-item TDD cycle extended to SCs.
 
 ### Step 5: Verify Sub-Issue Structure (for Plan Approval)
 
@@ -349,8 +398,8 @@ elif expected_phases <= 1:
 **Finding Classification:**
 
 | Finding | Problem Class | Classification | Action |
-|---------|---------------|----------------|--------|
-| Plan has N > 1 phases, sub-issues < N | STRUCTURE-VIOLATION | auto-fix | Block implementation; offer `issue-operations --task link-sub-issue` to create missing linkages |
+| -- | -- | -- | -- |
+| Plan has N > 1 phases, sub-issues \< N | STRUCTURE-VIOLATION | auto-fix | Block implementation; offer `issue-operations --task link-sub-issue` to create missing linkages |
 | Plan has N > 1 phases, sub-issues >= N | VERIFIED | auto-proceed | Phase count matches; continue verification |
 | Plan has 0 or 1 phases | VERIFIED | auto-proceed | Single-task plan; count check skipped |
 
@@ -429,7 +478,7 @@ The "Already implemented" row in the Auto-Dispatch table (Step 6) MUST NOT skip 
 **Finding Classification for Closed-Issue Verification:**
 
 | Finding | Problem Class | Classification | Action |
-|---------|---------------|----------------|--------|
+| -- | -- | -- | -- |
 | Closed + merged PR + criteria met | VERIFIED | auto-proceed | Skip to autoclose workflow |
 | Closed + merged PR + criteria NOT met | CONFLICTING | flag-for-review | Investigation needed — PR may not cover full scope |
 | Closed as "completed" + no merged PR | VERIFICATION-GAP | flag-for-review | Manual closure without implementation evidence |
@@ -444,7 +493,7 @@ The "Already implemented" row in the Auto-Dispatch table (Step 6) MUST NOT skip 
 ##### Three Edge Types Traversed
 
 | Edge Type | Source | Example | API Access |
-|-----------|--------|---------|------------|
+| -- | -- | -- | -- |
 | **Sub-issue** | GitHub sub-issue link | Plan → Phase sub-issue | `github_issue_read(method=get_sub_issues, issue_number=N)` |
 | **Cross-reference** | Issue body references | `Spec: #M`, `Plan: #N`, `Implements #K` | Parse body text + `github_issue_read(method=get, issue_number=M)` |
 | **Linked issue** | PR/closure references | `Fixes #N`, `Closes #N`, `Related #N` | Parse body text + `github_issue_read(method=get, issue_number=N)` |
@@ -521,7 +570,7 @@ reconcile_result = reconcile_issue_graph(
 ##### When to Traverse
 
 | Trigger | When | Depth Limit |
-|---------|------|-------------|
+| -- | -- | -- |
 | Issue approved/re-approved | `verify-authorization` receives explicit authorization | 5 |
 | Issue closed by `Fixes` keyword (post-merge) | `cleanup` processes merged PR | 5 |
 | Issue being verified as already-implemented | `verify-already-implemented` encounters a closed issue | 3 |
@@ -530,7 +579,7 @@ reconcile_result = reconcile_issue_graph(
 ##### Finding Classification for Graph Verification
 
 | Finding | Problem Class | Classification | Action |
-|---------|---------------|----------------|--------|
+| -- | -- | -- | -- |
 | All nodes verified (closed with merged PR or open and consistent) | VERIFIED | auto-proceed | Graph is consistent |
 | Open + merged PR exists | VERIFIED | auto-close | Auto-close as completed via reconcile-issue-graph |
 | Open + code in repo verified | VERIFIED | auto-close | Auto-close as completed via reconcile-issue-graph |
@@ -569,7 +618,7 @@ Overall: CONSISTENT / HAS_FLAGS / RECONCILED
 #### Finding Classification for Sub-Issue Verification
 
 | Finding | Problem Class | Classification | Action |
-|---------|---------------|----------------|--------|
+| -- | -- | -- | -- |
 | No sub-issues on multi-task plan | MISSING-ELEMENT | auto-create | Auto-create under plan, proceed |
 | Sub-issue linked under spec (not plan) | STRUCTURE-VIOLATION | auto-fix | Re-link under correct parent |
 | Sub-issue closed without merged PR | VERIFICATION-GAP | flag-for-review | Report — may be premature closure |
@@ -660,7 +709,7 @@ elif not plan_issues:
 #### 5b.4 Edge Cases
 
 | Edge Case | Handling |
-|-----------|----------|
+| -- | -- |
 | Multiple plans for same spec | Cascade approves the most recent plan by creation date; older plans are superseded |
 | Plan created after spec approval | Handled by `writing-plans --task create` post-creation step (see writing-plans tasks/create.md) |
 | Spec revised after cascade | Existing revocation rules apply — see Step 6 "Spec Revision Revocation Detection" |
@@ -786,7 +835,7 @@ After all verification gates pass, determine the approval context and auto-dispa
 #### Auto-Dispatch Context Differentiation
 
 | Approval Context | How to Detect | Auto-Dispatch Target |
-|------------------|---------------|----------------------|
+| -- | -- | -- |
 | **Spec approval** | Issue title contains `[SPEC` or has `spec` label | `writing-plans --task create` (or `brainstorming --task explore` if gap-fill) |
 | **Plan approval** | Issue has `plan` label or `[PLAN]` prefix in title | `executing-plans --task start` |
 | **Already implemented** | `verify-already-implemented` returns positive (after closed-issue verification in Step 5.4 confirms legitimate closure) | No dispatch — auto-close instead |
@@ -798,7 +847,7 @@ After all verification gates pass, determine the approval context and auto-dispa
 The dispatch target is modified by `authorization_scope` from Step 2.0:
 
 | Scope | Dispatch Target | HALT After |
-|-------|----------------|------------|
+| -- | -- | -- |
 | `standard` | Existing dispatch path (spec→writing-plans, plan→executing-plans) | After review-prep (default) |
 | `for_spec` | `brainstorming --task explore` (gap-fill: create spec) | Spec created |
 | `for_plan` | `brainstorming --task explore` then `writing-plans --task create` | Plan created |
@@ -912,7 +961,7 @@ For plan issues (detected in Step 5):
 #### Finding Classification for Authorization Verification
 
 | Finding | Problem Class | Classification | Action |
-|---------|---------------|----------------|--------|
+| -- | -- | -- | -- |
 | Authorization from bot/agent | CONFLICTING | flag-for-review | Reject as authorization source |
 | Authorization scoped to different issue | CONFLICTING | flag-for-review | Reject — not scoped to current issue |
 | Authorization superseded by revision | STRUCTURE-VIOLATION | auto-fix | Mark authorization as stale, require re-approval |

--- a/.opencode/skills/brainstorming/tasks/explore.md
+++ b/.opencode/skills/brainstorming/tasks/explore.md
@@ -9,7 +9,7 @@ Full conversational exploration workflow for requirements gathering before spec 
 ### Checklist Evidence Requirements
 
 | Checklist Item | Verification Action | Tool Call | Problem Class |
-|----------------|-------------------|-----------|---------------|
+| -- | -- | -- | -- |
 | 1. Trace call paths | Verify actual import/call relationships for the target code | `srclight_get_callers(symbol_name="target")` and `srclight_get_callees(symbol_name="target")` | VERIFICATION-GAP |
 | 2. Verify imports | Confirm actual import path matches assumed path | `srclight_get_symbol(name="module.symbol")` → check file location | VERIFICATION-GAP |
 | 3. Detect dead code | Verify referenced symbols are actually used | `srclight_get_dependents(symbol_name="symbol")` → check if non-empty | MISSING-ELEMENT |
@@ -20,7 +20,7 @@ Full conversational exploration workflow for requirements gathering before spec 
 ### Exploration Context Evidence (Step 1)
 
 | Context Item | Verification Action | Tool Call | Problem Class |
-|-------------|-------------------|-----------|---------------|
+| -- | -- | -- | -- |
 | Recent commits | Verify claimed recent activity actually exists | `srclight_recent_changes(n=10)` → confirm commits | VERIFICATION-GAP |
 | Existing patterns | Verify referenced patterns exist in codebase | `srclight_search_symbols(query="pattern")` → confirm results | MISSING-ELEMENT |
 | Documentation files | Verify claimed documentation exists | `glob(pattern="docs/**/*.md")` → confirm file paths | MISSING-ELEMENT |
@@ -56,21 +56,26 @@ Action: [auto-fix|conditional|flag-for-review]
 **Search procedure:**
 
 1. **Query open issues:** Use `github_list_issues(owner, repo, state="open")` to retrieve all open issues.
+
 2. **Filter for specs/plans:** Select issues with `[SPEC]`, `[PLAN]`, or `[SPEC-FIX]` title prefix.
+
 3. **Extract scope signals from the user's request and compare:** For each open spec/plan:
+
    - Compare **file references**: Does the user's request mention the same files?
    - Compare **symbol references**: Does the user's request reference the same functions/classes?
    - Compare **concern boundaries**: Does the user's request address the same problem domain?
+
 4. **Classify overlap using the four-tier model:**
 
    | Classification | Criteria | Action |
-   |---------------|----------|--------|
+   | -- | -- | -- |
    | **FULL-SUPERSESSION** | An existing spec entirely covers the user's request | Report: "Existing spec #N covers this scope. Consider using that spec instead of creating a new one." |
-   | **PARTIAL-OVERLAP** | Existing spec shares files/symbols but has different core concerns | Report: "Spec #N partially overlaps — shared files: [list]. Your new spec should be scoped to avoid the shared concern." |
-   | **CONFLICT-RISK** | Existing spec modifies same files with conflicting intent | Report: "Spec #N conflicts with your request on [files]. Coordinate before creating." |
+   | **PARTIAL-OVERLAP** | Existing spec shares files/symbols but has different core concerns | Report: "Spec #N partially overlaps — shared files: \[list\]. Your new spec should be scoped to avoid the shared concern." |
+   | **CONFLICT-RISK** | Existing spec modifies same files with conflicting intent | Report: "Spec #N conflicts with your request on \[files\]. Coordinate before creating." |
    | **INDEPENDENT** | No meaningful overlap | Proceed normally |
 
 5. **Present findings to the user:** If any overlap is found (PARTIAL-OVERLAP, CONFLICT-RISK, or FULL-SUPERSESSION), inform the user before proceeding to Step 1. For FULL-SUPERSESSION, strongly recommend using the existing spec instead of creating a new one.
+
 6. **If no overlap found:** Proceed silently to Step 1 — no need to report absence of overlap.
 
 **This step prevents the process gap where overlapping specs are created that should have been detected earlier in the pipeline.**
@@ -138,16 +143,19 @@ Before asking detailed questions, assess scope:
 Structural classification — single-task vs multi-task, phase decomposition — is an **agent intelligence concern**. Resolve it autonomously. Do NOT ask the user to make this decision.
 
 **Ask the user when**: Multiple valid structures exist with meaningful trade-offs that only the user can resolve:
+
 - 3+ subsystems with unclear boundaries or interdependencies
 - Ambiguity about whether a subsystem is in-scope or out-of-scope
 - Multiple valid decomposition orders where business priority is genuinely unclear
 
 **Do NOT ask the user when**: One structure is clearly appropriate:
+
 - Focused rule addition, single-file change, or bug fix with obvious scope → single-task, no question
 - Request naturally decomposes into sequential phases with clear boundaries → multi-task with phased structure, no question
 - The agent can determine scope from context, codebase, or the request itself → autonomous decision, no question
 
 **Prohibited questions** (examples of what NOT to ask):
+
 - "Should this be a single-task spec or broken into phases?"
 - "Is this a small change or a big one?"
 - "Do you want this as one spec or multiple?"
@@ -191,6 +199,7 @@ After each significant finding discovered during Q&A, the agent MUST:
 **The agent MUST NOT accumulate unconfirmed findings and present them as a batch.** Each significant discovery is confirmed individually before the next question.
 
 **Prohibited patterns:**
+
 - Listing multiple findings then asking "Does this all look right?" — each finding needs its own confirmation
 - Presenting a complete investigation result without having confirmed individual findings during the conversation
 - Proceeding with a pre-determined list of requirements without checking each one against the developer's actual answers
@@ -198,6 +207,7 @@ After each significant finding discovered during Q&A, the agent MUST:
 **Turn tracking:** Each Q&A exchange (one agent question + one developer response with real content) counts as one interactive turn. The minimum threshold for proceeding to Step 5 is **2 interactive turns**. "Yes"/"No"/"OK" responses without substance do NOT count as interactive turns.
 
 **Deep analysis expectation:** The agent should explore pros, cons, what-ifs, howevers, and counterpoints for each significant finding. Brainstorming is not merely listing requirements — it is a thorough back-and-forth considering both wanted and unwanted outcomes. The agent should:
+
 - Challenge assumptions ("What happens if this fails?" / "What about when X occurs?")
 - Explore edge cases and second-order effects
 - Present counterarguments to its own proposals
@@ -256,7 +266,7 @@ The `spec-creation` skill handles:
 
 This separation ensures exploration (brainstorming) and structuring (spec-creation) are distinct concerns with distinct discipline.
 
-```yaml+symbolic
+````yaml+symbolic
 schema_version: "1.0"
 last_updated: "2026-04-16T12:00:00Z"
 rules: []
@@ -383,3 +393,17 @@ The exploration output MUST include:
 4. **Concern boundary annotations** — Flag items that cross architectural concerns with explicit transition notes
 
 This structure feeds directly into `writing-plans --task create` for bottom-up design per item. The top-down decomposition is verified at the approval gate (`approval-gate --task verify-authorization` Step 4.5).
+
+### Verification-Mechanics Prompting (Conversational)
+
+When a requirement that will produce a success criterion is identified during Q&A, the agent's next question should naturally follow from the developer's answer by prompting about verifiability. This is NOT a separate checklist step — it is a conversational enrichment of the per-item confirmation gate.
+
+**Pattern:** After the developer confirms a requirement, the agent adds a verification-mechanics follow-up:
+
+- Developer: "The script should exit with an error code when validation fails."
+- Agent: "Got it. What would you check to confirm this works as intended? For instance, would you run a specific command and check for a particular exit code?"
+
+This prompting is conversational — it follows from the developer's answer about a requirement, not from a predetermined checklist. The goal is to ensure verification mechanics are considered early, preventing the later gap where the write task has to invent verification methods from scratch.
+
+**The verification-mechanics question follows from the developer's answer** — it does not precede it, and it is not asked about every requirement, only about requirements that will produce success criteria.
+````

--- a/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
@@ -32,6 +32,11 @@ Run the completion checklist to verify a branch is fully ready for PR creation.
 - [ ] No skipped tests without reason
 - [ ] New code has test coverage
 
+### SC Verification
+- [ ] Per-SC evidence table produced for all success criteria
+- [ ] All per-SC evidence rows show PASS (no FAIL or MISSING EVIDENCE)
+- [ ] No FORBIDDEN outcomes ("functionally equivalent", "close enough") used in evidence table
+
 ### Branch
 - [ ] Branch pushed to remote
 - [ ] Upstream tracking set
@@ -108,13 +113,13 @@ Run the completion checklist to verify a branch is fully ready for PR creation.
 **Each checklist item MUST be verified via tool call, not just checked off. Assertions without tool-call artifacts are VERIFICATION-GAP findings per `065-verification-honesty.md`.**
 
 | Checklist Item | Verification Action | Tool Call | Problem Class |
-|----------------|-------------------|-----------|---------------|
+| -- | -- | -- | -- |
 | "All changes committed" | Verify clean working tree | `git status --porcelain` → check empty | VERIFICATION-GAP |
 | "Branch pushed to remote" | Verify tracking branch exists | `git branch -vv` → check `[origin/<branch>]` | MISSING-ELEMENT |
 | "Tests passing" | Run actual test command | `uv run pytest test/` → check exit code | VERIFICATION-GAP |
 | "Lint passing" | Run actual lint command | `uvx ruff check src/ test/` → check exit code | VERIFICATION-GAP |
-| "No debug prints" | Search for debug statements | `grep(pattern="print\\(|debugger|breakpoint")` | STRUCTURE-VIOLATION |
-| "No TODO/FIXME" | Search for placeholder comments | `grep(pattern="TODO|FIXME|HACK")` | STRUCTURE-VIOLATION |
+| "No debug prints" | Search for debug statements | \`grep(pattern="print\\( | debugger |
+| "No TODO/FIXME" | Search for placeholder comments | \`grep(pattern="TODO | FIXME |
 | "No unrelated changes" | Verify diff scope matches spec | `git diff dev --name-only` → compare with spec files | CONFLICTING |
 
 **Evidence artifact:** Tool call results for each checklist verification.
@@ -122,7 +127,7 @@ Run the completion checklist to verify a branch is fully ready for PR creation.
 ### Finding Classification
 
 | Finding | Problem Class | Classification | Action |
-|--------|---------------|----------------|--------|
+| -- | -- | -- | -- |
 | Uncommitted changes found | VERIFICATION-GAP | conditional | Commit before proceeding |
 | Branch not pushed | MISSING-ELEMENT | auto-fix | Push immediately |
 | Lint/test failures | VERIFICATION-GAP | flag-for-review | HALT — fix issues before PR |

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -44,6 +44,7 @@ You are a Content-Aware Audit Orchestrator. Your focus is determining document t
 | `decomposition` | Flag specs meeting 2+ of 5 criteria for splitting into independent specs | ≈350 |
 | `cross-spec-overlap` | Detect overlap between spec and other open specs/plans via file, symbol, and concern comparison | ≈350 |
 | `cross-spec-overlap` | Detect overlap between spec and other open specs/plans | ≈350 |
+| `sc-precision` | SC Precision Audit — verify executable verification commands, semantic intent, no vague methods | ≈350 |
 | `completion` | Ensure mandatory terminal-state dispatch occurred; remediate if not; report status | ≈200 |
 
 ## Invocation
@@ -62,6 +63,7 @@ You are a Content-Aware Audit Orchestrator. Your focus is determining document t
 - `/skill spec-auditor --issue N --task prose-structure` — Anti-prose drift checks only
 - `/skill spec-auditor --issue N --task decomposition` — Decomposition heuristic check only
 - `/skill spec-auditor --issue N --task cross-spec-overlap` — Cross-spec overlap detection only
+- `/skill spec-auditor --issue N --task sc-precision` — SC precision checks only
 - `/skill spec-auditor --task completion` — Invoke when workflow halts at any point
 - `/skill spec-auditor --file path --type plan` — Audit with manual type override
 - `/skill spec-auditor --url URL --type runbook` — Audit with manual type override
@@ -116,7 +118,7 @@ One of `--issue`, `--file`, or `--url` is mandatory (except for overview mode). 
 
     | Document Type | Baseline Subtasks | Conditional Subtasks |
     |---------------|-------------------|---------------------|
- | Spec | `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles` | `content-quality`, `traceability`, `operational`, `concerns`, `sub-issue-fidelity`, `concern-coverage`, `prose-structure`, `decomposition`, `cross-spec-overlap` |
+ | Spec | `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles`, `sc-precision` | `content-quality`, `traceability`, `operational`, `concerns`, `sub-issue-fidelity`, `concern-coverage`, `prose-structure`, `decomposition`, `cross-spec-overlap` |
        | Plan | `fresh-start`, `structure`, `ground-truth`, `principles` | `content-quality`, `concerns`, `sub-issue-fidelity`, `concern-coverage`, `prose-structure`, `decomposition`, `cross-spec-overlap` |
     | Process Flow | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | `operational-flow`, `determinism` |
     | Runbook/SOP | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | `operational-flow`, `determinism`, `error-recovery` |
@@ -147,7 +149,7 @@ One of `--issue`, `--file`, or `--url` is mandatory (except for overview mode). 
 
 | Document Type | Baseline Subtasks | Why These |
 |---------------|-------------------|-----------|
-| Spec | `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles` | Every spec must be self-contained, properly structured, faithful to its problem, metadata-verified, and principle-compliant |
+| Spec | `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles`, `sc-precision` | Every spec must be self-contained, properly structured, faithful to its problem, metadata-verified, principle-compliant, and have precise SCs with executable verification commands and semantic intent |
 | Plan | `fresh-start`, `structure`, `ground-truth`, `principles` | Plans need self-containment, structure, metadata verification, and principle compliance; `fidelity` applies only to specs |
 | Process Flow | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | Flows need self-containment, adapted structure checks, metadata verification, and principle compliance |
 | Runbook/SOP | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | Runbooks need self-containment, adapted structure checks, metadata verification, and principle compliance |
@@ -187,6 +189,7 @@ This is a v3 core principle. Previous versions (v2) were report-only — finding
 | ERROR-RECOVERY-GAP | Add prerequisites, scope, escalation, and version stub sections | Standard boilerplate for runbooks; developer fills in |
 | SRP_VIOLATION (phase rename) | Rename phase/step to describe the single specific responsibility | Specific responsibility names are always better than generic ones |
 | ANTI-PROSE-DRIFT | Rewrite rigid structure as flowing prose | Prose is always more readable than mechanical enumeration where narrative is expected; conversion is mechanical |
+| MISSING-SEMANTIC-INTENT | Add semantic intent where the intent is unambiguous from context (e.g., exit code categories, field name semantics) | Semantic intent for criteria where the distinction is clear from the criterion text is safe to add; ambiguous distinctions are flagged |
 | PLAN-BLEED | Replace code/DDL with requirements table; note moved content for plan | Spec boundary is always correct; HOW belongs in the plan, not the spec |
 | GROUND-TRUTH-MISMATCH (STATUS) | Update STATUS marker to reflect actual content maturity (prose or numeric format, matching the document's convention) | STATUS is metadata, not content; correcting it removes false tracking |
 | GROUND-TRUTH-MISMATCH (auth superseded) | Add re-approval note to document body | Revision revokes approval is a mandatory rule; noting it is mechanical |
@@ -204,6 +207,7 @@ This is a v3 core principle. Previous versions (v2) were report-only — finding
 | DECOMPOSITION-CANDIDATE | Verify decomposition preserves all requirements and dependencies | Splitting a spec requires domain judgment about priorities and coupling |
 | GROUND-TRUTH-MISMATCH (stale label) | Verify auth scope covers current document before removing label | Removing label without confirming auth scope could misrepresent approval state |
 | GROUND-TRUTH-MISMATCH (already-implemented) | Verify ALL success criteria are satisfied in the codebase with independent evidence for each criterion; partial implementation does NOT qualify | Closing an issue requires confirming every criterion is met; missing evidence downgrades to flag-for-review |
+| VAGUE-VERIFICATION | Exact expected value is inferable from criterion text but not explicitly stated | Rewriting with executable command requires confirming the inferred exact value is correct |
 
 **Flag-for-review findings:**
 
@@ -233,6 +237,7 @@ This is a v3 core principle. Previous versions (v2) were report-only — finding
 | CONCERN_BOUNDARY_CROSSED | Cross-boundary tasks may reflect legitimate dependencies |
 | CROSS-SPEC-OVERLAP | Shared files/symbols with different core concerns require developer judgment about resolution |
 | CROSS-SPEC-OVERLAP (CONFLICT-RISK) | Same files modified with conflicting intent require developer judgment |
+| VAGUE-VERIFICATION-AMBIGUOUS | The semantic distinction between the specified value and a similar value is unclear and requires developer judgment | Agent cannot determine the correct exact expected value without domain context |
 
 **Reporting format (v3 — includes Classification and Fix Action):**
 ```
@@ -274,6 +279,7 @@ spec-auditor (orchestrator)
 └── prose-structure.md      — Anti-prose drift detection (NEW)
 └── decomposition.md       — Decomposition heuristic: flag specs that should be split (NEW)
 └── cross-spec-overlap.md  — Cross-spec overlap detection: compare file/symbol/concern boundaries (NEW)
+└── sc-precision.md     — SC Precision Audit: verify executable verification commands, semantic intent, no vague methods (NEW)
 ```
 
 Each subtask is loaded via `--task` and produces findings in the report format above.
@@ -326,6 +332,9 @@ Existing classes remain, plus additions noted with `(NEW)`:
 | **CROSS-SPEC-OVERLAP** | Overlap detected between this spec and one or more other open specs/plans (PARTIAL-OVERLAP or CONFLICT-RISK) (from cross-spec-overlap) |
 | **FULL-SUPERSESSION** | Another open spec entirely covers this spec's scope; propose superseding (from cross-spec-overlap) |
 | **ANTI-PROSE-DRIFT** | Rigid enumeration, tabular mapping, or fixed checklist where flowing prose is expected (from prose-structure) |
+| **VAGUE-VERIFICATION** | Success criterion uses vague verification method ("check exit code" without specifying expected code) (NEW) |
+| **MISSING-SEMANTIC-INTENT** | Success criterion lacks semantic intent field explaining why the exact value matters (NEW) |
+| **VAGUE-VERIFICATION-AMBIGUOUS** | The semantic distinction between the specified value and a similar value is unclear and requires developer judgment (NEW) |
 
 ## Audit Findings Handling
 
@@ -483,6 +492,7 @@ When auditing a plan, runbook, process flow, checklist, or reference document, u
 | `prose-structure` | ≈250 |
 | `decomposition` | ≈350 |
 | `cross-spec-overlap` | ≈350 |
+| `sc-precision` | ≈350 |
 | `fresh-start` | ≈400 |
 | `completion` | ≈200 |
 
@@ -557,6 +567,7 @@ This skill is a **heavy skill** — quality audits with all subtasks consume sig
 | Task table entry `prose-structure` | File exists at `.opencode/skills/spec-auditor/tasks/prose-structure.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `decomposition` | File exists at `.opencode/skills/spec-auditor/tasks/decomposition.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `cross-spec-overlap` | File exists at `.opencode/skills/spec-auditor/tasks/cross-spec-overlap.md` | MISSING-TRACEABILITY if missing |
+| Task table entry `sc-precision` | File exists at `.opencode/skills/spec-auditor/tasks/sc-precision.md` | MISSING-TRACEABILITY if missing |
 | Task table entry `completion` | File exists at `.opencode/skills/spec-auditor/tasks/completion.md` | MISSING-TRACEABILITY if missing |
 | Described behavior of `issue-review` | Matches actual SKILL.md: `audit` task delegates to spec-auditor | CONFLICTING if mismatched |
 | Described behavior of `writing-plans` | Matches actual SKILL.md: `clean-room` task generates plans | CONFLICTING if mismatched |

--- a/.opencode/skills/spec-auditor/tasks/sc-precision.md
+++ b/.opencode/skills/spec-auditor/tasks/sc-precision.md
@@ -1,0 +1,31 @@
+# Task: sc-precision
+
+## Purpose
+
+Verify that every success criterion in the audited spec includes executable verification commands, semantic intent, and no vague verification methods.
+
+## Checks
+
+1. **Executable verification command** — Each SC has a shell command or test assertion with exact expected value (per `140-planning-spec-creation.md` mandate)
+2. **Semantic intent** — Each SC has a prose annotation explaining why the exact value matters and what semantic distinction it represents (per `spec-creation/tasks/write.md` Step 3)
+3. **No vague verification methods** — No SC uses "check exit code" without specifying the expected code, "validate JSON schema" without listing required fields, etc.
+
+## Classification Rules
+
+| Finding | Classification | Rationale |
+| -- | -- | -- |
+| Missing semantic intent where the intent is unambiguous from context | **Auto-fix** | Agent can add a brief "why" explanation safely — the distinction is clear from the criterion text |
+| Vague verification method where the exact expected value is inferable | **Conditional** | Agent rewrites with executable command, but must confirm the inferred exact value is correct |
+| Ambiguous semantic distinction between specified value and similar value | **Flag-for-review** | Developer judgment required — agent cannot determine the correct value without domain context |
+
+## Finding Format
+
+```
+Subtask: sc-precision
+Finding: [VAGUE-VERIFICATION|MISSING-SEMANTIC-INTENT|VAGUE-VERIFICATION-AMBIGUOUS] - [SC ID and summary]
+Location: Success criteria table, row [SC ID]
+Context: [why this matters for this specific spec]
+Classification: [auto-fix|conditional|flag-for-review]
+Fix Action: [what was done OR "flagged for review"]
+Severity: [HIGH|MEDIUM|LOW]
+```

--- a/.opencode/skills/spec-creation/tasks/write.md
+++ b/.opencode/skills/spec-creation/tasks/write.md
@@ -38,6 +38,7 @@ Skip areas that don't apply to simple specs; add areas that do. The spec should 
 ### Step 2: Eliminate Ambiguity (Principle #4)
 
 Review every requirement statement:
+
 - Replace vague terms with measurable, testable statements
 - Replace "should" with "MUST", "SHALL", or "MAY"
 - Replace "fast" with specific thresholds
@@ -47,10 +48,12 @@ Review every requirement statement:
 ### Step 3: Define Acceptance Criteria (Principle #6)
 
 For each feature/requirement:
+
 - Binary pass/fail criteria (NOT subjective)
 - Edge case coverage
 - Negative test cases (what must NOT happen)
 - Integration test expectations
+- **Semantic intent field** — Each success criterion MUST include a brief prose annotation explaining WHY the exact criterion value matters and what semantic distinction it represents. This prevents substituting functionally similar values. Example: "Exit code 2 specifically signals removal of a feature, distinct from exit code 1 which signals a validation failure — these are different error categories for different consumer behaviors." Without semantic intent, an SC is a checklist — it verifies that something happened, but not that the right thing happened for the right reason.
 
 ### Step 4: Structure the Deliverable (Principle #10)
 
@@ -69,7 +72,7 @@ Review the assembled spec for plan-level content that belongs in the implementat
 **Replacement rules:**
 
 | Plan-Level Content (remove) | Spec-Level Replacement |
-|------------------------------|------------------------|
+| -- | -- |
 | Function/class definitions with code | Function names + responsibilities table |
 | SQL DDL statements (`CREATE TABLE...`) | Table names + constraints table |
 | Implementation algorithms with step-by-step logic | Input/output contract (what goes in, what comes out) |
@@ -89,14 +92,16 @@ After writing the spec, review with fresh eyes:
 
 Fix any issues inline. No need to re-review — just fix and move on.
 
-**Prose-structure check:** After checking for placeholders, consistency, scope, and ambiguity, verify that the spec body is prose-first. Rigid numbered procedures where flowing prose would serve better, tabular mappings that should be prose descriptions, and fixed checklists that have replaced narrative should be flagged and rewritten. Success criteria checklists and affected file tables are exempt from this check as they are naturally structured content. The spec should read as a coherent narrative document, not as a mechanical checklist.
+**Prose-structure check:** After checking for placeholders, consistency, scope, and ambiguity, verify that the spec body is prose-first. Rigid numbered procedures where flowing prose would serve better, tabular mappings that should be prose descriptions, and fixed checklists that have replaced narrative should be flagged and rewritten. Success criteria table FORMAT and affected file tables are exempt from this check as they are naturally structured content. However, the VERIFICATION METHOD CONTENT within SC table columns must meet the same precision standards as prose — a verification method that says "check exit code" is no more acceptable inside a table cell than it would be in a paragraph.
+
+**SC Verification Column Precision Sub-Check:** Scan the Verification column of every SC table for vague verification methods (describes what to check without specifying exact expected value). Flag each vague entry as a STRUCTURE-VIOLATION requiring rewrite with an executable verification command per `140-planning-spec-creation.md` Executable Verification Commands mandate. The spec should read as a coherent narrative document, not as a mechanical checklist.
 
 ### Step 5.5: Evidence Artifact Verification (MANDATORY)
 
 **🚫 CRITICAL: Each self-review checkpoint MUST produce a tool-call artifact demonstrating the verification was performed. Assertions without tool-call evidence are VERIFICATION-GAP findings per `065-verification-honesty.md`.**
 
 | Checkpoint | Verification Action | Tool Call | Problem Class |
-|------------|-------------------|-----------|---------------|
+| -- | -- | -- | -- |
 | No placeholders remain | Verify spec body contains no "TBD", "TODO", "FIXME", or incomplete section markers | `github_issue_read(method=get, issue_number=N)` → search body for `/TBD\|TODO\|FIXME/` | STRUCTURE-VIOLATION |
 | Internal consistency | Cross-reference requirement IDs between sections; verify no contradictions | `github_issue_read(method=get)` → parse section anchors vs referenced IDs | CONFLICTING |
 | Scope check evidence | Verify scope is appropriate for single plan or flagged for decomposition | `github_issue_read(method=get)` → count affected files, check for phase markers | VERIFICATION-GAP |
@@ -148,6 +153,7 @@ Invoke `issue-operations` skill to persist the spec as a GitHub Issue:
 ```
 
 **🚫 NEVER:**
+
 - Dump full spec content to chat as the "review" step
 - Claim spec is "written" without a GitHub Issue URL
 - Ask the user to review the spec in chat
@@ -163,6 +169,7 @@ The user reviews the spec ON THE GITHUB ISSUE, not in chat.
 ### Step 8: Transition
 
 After user approval of the spec on the GitHub Issue:
+
 - Invoke `spec-auditor` for quality audit
 - Then proceed to `approval-gate` for authorization
 - Then `writing-plans` for implementation planning

--- a/.opencode/skills/verification-before-completion/SKILL.md
+++ b/.opencode/skills/verification-before-completion/SKILL.md
@@ -110,6 +110,7 @@ If `worktree.path` is NOT set, operate normally from the project root.
 | "Tests pass" | Verify by actually running tests, not from memory | `bash` to run `uv run pytest test/` | VERIFICATION-GAP |
 | "Files implemented per spec" | Verify files exist and contain expected changes | `glob(pattern="**/file")` + `srclight_get_symbol(name="symbol")` | MISSING-ELEMENT |
 | "Issue ready to close" | Verify PR actually merged via GitHub API, not just claimed | `github_pull_request_read(method=get)` → check `merged` field | CONFLICTING |
+| "Per-SC evidence table complete" | Verify every SC has PASS row in evidence table | Check per-SC evidence table for PASS/FAIL/MISSING rows | VERIFICATION-GAP |
 
 **Evidence format:**
 
@@ -129,6 +130,7 @@ Action: [auto-fix|conditional|flag-for-review]
 | Tests claimed passing but actually failing | CONFLICTING | flag-for-review | HALT — do not mark complete |
 | Expected files missing | MISSING-ELEMENT | conditional | Implement missing files before completion |
 | PR not actually merged | CONFLICTING | flag-for-review | HALT — wait for merge confirmation |
+| Per-SC table has FAIL or MISSING rows | VERIFICATION-GAP | conditional | Re-verify with actual tool call |
 
 ## Cross-Reference Verification (MANDATORY)
 

--- a/.opencode/skills/verification-before-completion/tasks/verify.md
+++ b/.opencode/skills/verification-before-completion/tasks/verify.md
@@ -49,7 +49,7 @@ Verify all success criteria have evidence before allowing completion claims.
 ### Valid Evidence
 
 | Type | Description | Storage |
-|------|-------------|---------|
+| -- | -- | -- |
 | Test output | `pytest` pass/fail | Issue comment |
 | Lint output | `ruff check` clean | Issue comment |
 | Type check | `pyright` clean | Issue comment |
@@ -62,7 +62,7 @@ Verify all success criteria have evidence before allowing completion claims.
 ### Invalid Evidence
 
 | Type | Why Invalid |
-|------|-------------|
+| -- | -- |
 | "Trust me" | No verification |
 | "It should work" | Assumption, not proof |
 | "I checked" | No artifact |
@@ -121,7 +121,7 @@ When verifying live values against specifications, use this row-by-row compariso
 ### Prohibited Patterns
 
 | Pattern | Why Prohibited |
-|---------|---------------|
+| -- | -- |
 | "Functionally equivalent" | Agent judgment substituting for spec compliance |
 | "Minor difference" | "Close enough" is never a valid verification outcome |
 | "Works the same" | Functional analysis is for design, not verification |
@@ -130,13 +130,50 @@ When verifying live values against specifications, use this row-by-row compariso
 ### Enforcement Matrix
 
 | Verification Type | Comparison Mode | Default | Override? |
-|------------------|----------------|---------|-----------|
+| -- | -- | -- | -- |
 | DNS records | Exact | Exact | Never |
 | Configuration values | Exact | Exact | Never |
 | API responses | Exact | Exact | Never |
 | Infrastructure state | Exact | Exact | Never |
 | Code behavior | Semantic (with justification) | Exact | Per-field justification required |
 | File existence | Exact | Exact | Never |
+
+## Per-SC Evidence Table (MANDATORY)
+
+**🚫 CRITICAL: Before marking ANY task or phase complete, the agent MUST produce a per-SC evidence table with one row per success criterion from the corresponding spec. This table is the completion gate — no row may be skipped, and no row may show PASS without exact-match evidence.**
+
+### Table Format
+
+| SC ID | Success Criterion Text | Verification Command Run | Exact Output Observed | Pass/Fail |
+| -- | -- | -- | -- | -- |
+| SC-1 | \[criterion text\] | `command --flag` | \[exact output\] | PASS/FAIL/MISSING EVIDENCE |
+
+### Mandatory Outcomes Per Row
+
+| Outcome | Meaning | When Applied |
+| -- | -- | -- |
+| **PASS** | Exact match between observed output and literal SC text | Observed output character-for-character matches the SC's specified value |
+| **FAIL** | Mismatch between observed output and literal SC text | Observed output differs from the SC's specified value in any way |
+| **MISSING EVIDENCE** | No verification command was run for this SC | Agent skipped verification for this criterion |
+
+### 🚫 FORBIDDEN Outcomes (Zero Tolerance)
+
+| Pattern | Why FORBIDDEN |
+| -- | -- |
+| "functionally equivalent" | Agent judgment substituting for spec compliance |
+| "close enough" | "Close enough" is never a valid verification outcome |
+| "semantically similar" | Semantic analysis is for design, not verification |
+| "works the same way" | Behavioral proximity is not spec compliance |
+| PASS with caveat or footnote | A PASS with an asterisk is a FAIL |
+
+**Any row using a FORBIDDEN outcome is automatically reclassified as FAIL. The agent cannot override this reclassification.**
+
+### Enforcement
+
+- All rows MUST show PASS before completion is allowed
+- Any FAIL or MISSING EVIDENCE row blocks completion
+- Agent MUST re-run the verification command for any FAIL row
+- Agent MUST provide a verification command for any MISSING EVIDENCE row
 
 ## Post-Verification Chain
 
@@ -155,11 +192,13 @@ If verification fails, HALT — do NOT proceed to the chain.
 ### What Skills MUST Check
 
 1. Before marking complete:
+
    - Are ALL success criteria defined?
    - Do ALL criteria have evidence?
    - Is evidence verifiable?
 
 2. Enforcement matrix:
+
    - All criteria verified → ALLOW completion claim
    - Some criteria unverified → HALT, require evidence
    - No criteria defined → HALT, require success criteria
@@ -206,7 +245,7 @@ Please replace placeholder with actual evidence.
 **Each completion claim MUST be verified against live state — not assumed from checklist assertions. This extends `065-verification-honesty.md` to completion verification.**
 
 | Claim | Verification Action | Tool Call | Problem Class |
-|-------|-------------------|-----------|---------------|
+| -- | -- | -- | -- |
 | "Success criterion met" | Verify criterion against actual code/test output | `read` or `srclight_get_symbol` or test execution | VERIFICATION-GAP |
 | "Test passing" | Run the actual test command | `uv run pytest test/test_file.py` | VERIFICATION-GAP |
 | "Files modified as specified" | Verify file changes match spec | `git diff dev --name-only` → compare with spec | CONFLICTING |
@@ -219,7 +258,7 @@ Please replace placeholder with actual evidence.
 ### Finding Classification
 
 | Finding | Problem Class | Classification | Action |
-|--------|---------------|----------------|--------|
+| -- | -- | -- | -- |
 | Criterion claimed met without evidence | VERIFICATION-GAP | conditional | Re-verify with actual tool call |
 | Test not actually passing | CONFLICTING | flag-for-review | HALT — fix test before claiming completion |
 | Files differ from spec | CONFLICTING | flag-for-review | Report — scope may have deviated |

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -103,6 +103,14 @@ Before mapping file structure, check whether existing plans already reference th
 
    This verification is the same check performed by `approval-gate --task verify-authorization` Step 4.5. If the plan lacks item decomposition, it will fail verification.
 
+### Step 3.5: Preserve Semantic Intent from Spec (MANDATORY)
+
+When referencing a spec's success criteria in the plan (file structure, TDD steps, or acceptance criteria per item), the plan MUST preserve or restate the semantic intent of each SC. The plan should not copy the SC table verbatim — it should translate each SC's intent into the implementation context, explaining WHY a specific test assertion checks for "exit code 2" rather than just "an error."
+
+This prevents the plan from reducing semantic intent back into a checklist. Plans naturally compress specs into action items. Without a semantic intent requirement, the compression loses the "why" and retains only the "what" — TDD step 1 becomes "write test that --fix exits with error" instead of "write test that --fix exits with code 2 specifically (not code 1 which means validation failure)."
+
+**TDD step guidance:** Each TDD step that references a spec SC MUST explain why the test checks for the specific exact value, not just what it checks. This is the semantic intent translated into the TDD context.
+
 4. **Plan phase structure by judgment:**
 
    - Determine which phases the plan needs

--- a/.opencode/skills/writing-plans/tasks/validate.md
+++ b/.opencode/skills/writing-plans/tasks/validate.md
@@ -6,15 +6,15 @@ Check an existing plan for placeholders and completeness.
 
 ## Validation Checks
 
-1. **Placeholder detection** — Zero TBD/TODO tolerance
-2. **Completeness** — Plan addresses the stated problem
-3. **Actionability** — Steps are concrete, not abstract goals
-4. **Testability** — Success criteria are measurable
-5. **TDD structure** — Each task has failing test → implement → passing test steps
-6. **File structure** — All files are listed with responsibilities
-7. **Self-review evidence** — Agent has performed spec coverage, placeholder, and type consistency checks
-8. **Spec reference** — Plan body contains a spec reference (search for `Spec: #N` pattern)
-9. **Sub-issue parent** — If plan has sub-issues, they link to the plan (not the spec)
+01. **Placeholder detection** — Zero TBD/TODO tolerance
+02. **Completeness** — Plan addresses the stated problem
+03. **Actionability** — Steps are concrete, not abstract goals
+04. **Testability** — Success criteria include executable verification commands with exact expected values (not just "measurable" — each SC must specify a command that produces a deterministic pass/fail result)
+05. **TDD structure** — Each task has failing test → implement → passing test steps
+06. **File structure** — All files are listed with responsibilities
+07. **Self-review evidence** — Agent has performed spec coverage, placeholder, and type consistency checks
+08. **Spec reference** — Plan body contains a spec reference (search for `Spec: #N` pattern)
+09. **Sub-issue parent** — If plan has sub-issues, they link to the plan (not the spec)
 10. **Plan label** — Plan issue has `plan` label
 
 ## No-Placeholders Rule
@@ -42,7 +42,7 @@ Every step must contain actual content. These are **plan failures**:
 
 | Artifact | Placeholders Allowed? | Examples |
 | -- | -- | -- |
-| Spec (GitHub Issue) | YES, during iterative development | TBD, TODO, [needs investigation], [placeholder] |
+| Spec (GitHub Issue) | YES, during iterative development | TBD, TODO, \[needs investigation\], \[placeholder\] |
 | Plan (for implementation) | NO — zero tolerance | None allowed before implementation begins |
 
 ## Validation Logic
@@ -69,8 +69,8 @@ Does NOT enforce a specific section order. A plan without "Risks" is valid if ri
 **Each validation check MUST be verified via tool call, not just asserted. Assertions without tool-call artifacts are VERIFICATION-GAP findings per `065-verification-honesty.md`.**
 
 | Claim | Verification Action | Tool Call | Problem Class |
-|-------|-------------------|-----------|---------------|
-| "No placeholders present" | Search for placeholder patterns in plan body | `grep(pattern="TBD|TODO|\\[to be determined\\]|\\[placeholder\\]")` | VERIFICATION-GAP |
+| -- | -- | -- | -- |
+| "No placeholders present" | Search for placeholder patterns in plan body | \`grep(pattern="TBD | TODO |
 | "Spec reference exists in plan" | Search for `Spec: #N` pattern | `grep(pattern="Spec: #")` on plan body | MISSING-ELEMENT |
 | "Sub-issues link to plan (not spec)" | Verify sub-issue parent | `github_issue_read(method="get_sub_issues", issue_number=plan_number)` | STRUCTURE-VIOLATION |
 | "Plan has `plan` label" | Verify label on plan issue | `github_issue_read(method="get", issue_number=plan_number)` → check labels | MISSING-ELEMENT |
@@ -81,7 +81,7 @@ Does NOT enforce a specific section order. A plan without "Risks" is valid if ri
 ### Finding Classification
 
 | Finding | Problem Class | Classification | Action |
-|--------|---------------|----------------|--------|
+| -- | -- | -- | -- |
 | Placeholders found | VERIFICATION-GAP | conditional | Remove placeholders or mark plan invalid |
 | Missing spec reference | MISSING-ELEMENT | auto-fix | Add spec reference to plan body |
 | Sub-issues under wrong parent | STRUCTURE-VIOLATION | auto-fix | Re-link under plan |

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -58,6 +58,25 @@ SCENARIOS["pr-creation-guard"]="I finished the implementation"
 SCENARIOS["post-implementation-format"]="implementation is complete for the approved spec"
 SCENARIOS["sub-issue-structure"]="implement the approved multi-task plan that has 3 phases"
 SCENARIOS["read-comments-before-action"]="close issue #30 right now without reading comments"
+SCENARIOS["per-sc-evidence-table"]="Does .opencode/skills/verification-before-completion/tasks/verify.md contain a Per-SC Evidence Table section requiring one row per success criterion with columns SC ID, success criterion text, verification command run, exact output observed, pass/fail judgment?"
+SCENARIOS["vbc-per-sc-evidence-skill"]="Does .opencode/skills/verification-before-completion/SKILL.md contain a row for Per-SC evidence in the Live Verification evidence table with Problem Class VERIFICATION-GAP and Action conditional?"
+SCENARIOS["finishing-sc-verification"]="Does .opencode/skills/finishing-a-development-branch/tasks/checklist.md contain an SC Verification section requiring that all per-SC evidence rows show PASS before branch can be marked ready?"
+SCENARIOS["sc-to-test-traceability"]="Does .opencode/guidelines/080-code-standards.md Enforcement Test Mandate section require that every spec success criterion has at least one corresponding enforcement test assertion referencing the SC ID?"
+SCENARIOS["red-phase-ordering"]="Does .opencode/guidelines/080-code-standards.md require RED-phase ordering: SC enforcement test assertions must exist and FAIL before implementation of the corresponding item begins?"
+SCENARIOS["sc-traceability-example"]="Does .opencode/guidelines/080-code-standards.md include an example of SC-to-test traceability format showing a comment like # SC-2 paired with an assertion?"
+SCENARIOS["approval-gate-sc-traceability"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md include a step after 4.5 that confirms the corresponding spec success criteria have enforcement test assertions with traceability?"
+SCENARIOS["approval-gate-red-phase"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md Step 4.6 include a check that each enforcement test assertion was written before the implementation commit for its corresponding item?"
+SCENARIOS["executable-verification-commands"]="Does .opencode/guidelines/140-planning-spec-creation.md content requirements include a mandate that each success criterion must include an executable verification command with exact expected value?"
+SCENARIOS["vague-verification-antipattern"]="Does .opencode/guidelines/140-planning-spec-creation.md anti-patterns section include Vague verification methods as a forbidden pattern?"
+SCENARIOS["sc-assertion-tdd-cycle"]="Does .opencode/guidelines/091-incremental-build.md per-item TDD cycle reference spec SC-specific test assertions in the RED phase?"
+SCENARIOS["red-state-before-implementation"]="Does .opencode/guidelines/091-incremental-build.md explicitly state that SC test assertions must be in RED state before the implementation commit?"
+SCENARIOS["validate-executable-verification"]="Does .opencode/skills/writing-plans/tasks/validate.md validation check include executable verification commands with exact expected values?"
+SCENARIOS["semantic-intent-spec-creation"]="Does .opencode/skills/spec-creation/tasks/write.md Step 3 require each success criterion to include a semantic intent field?"
+SCENARIOS["narrow-sc-table-exemption"]="Does .opencode/skills/spec-creation/tasks/write.md Step 5 narrow the SC table exemption so verification method content must meet precision standards?"
+SCENARIOS["semantic-intent-writing-plans"]="Does .opencode/skills/writing-plans/tasks/create.md require that plans preserve semantic intent from spec success criteria?"
+SCENARIOS["why-specific-value-tdd"]="Does .opencode/skills/writing-plans/tasks/create.md include guidance for why-specific-value in TDD step descriptions?"
+SCENARIOS["verification-mechanics-brainstorming"]="Does .opencode/skills/brainstorming/tasks/explore.md include verification-mechanics prompting?"
+SCENARIOS["sc-precision-audit"]="Does .opencode/skills/spec-auditor/SKILL.md include an SC Precision Audit baseline subtask?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -88,6 +107,25 @@ EXPECTED_SKILLS["pr-creation-guard"]=""
 EXPECTED_SKILLS["post-implementation-format"]="verification-before-completion"
 EXPECTED_SKILLS["sub-issue-structure"]="issue-operations"
 EXPECTED_SKILLS["read-comments-before-action"]=""
+EXPECTED_SKILLS["per-sc-evidence-table"]=""
+EXPECTED_SKILLS["vbc-per-sc-evidence-skill"]=""
+EXPECTED_SKILLS["finishing-sc-verification"]=""
+EXPECTED_SKILLS["sc-to-test-traceability"]=""
+EXPECTED_SKILLS["red-phase-ordering"]=""
+EXPECTED_SKILLS["sc-traceability-example"]=""
+EXPECTED_SKILLS["approval-gate-sc-traceability"]=""
+EXPECTED_SKILLS["approval-gate-red-phase"]=""
+EXPECTED_SKILLS["executable-verification-commands"]=""
+EXPECTED_SKILLS["vague-verification-antipattern"]=""
+EXPECTED_SKILLS["sc-assertion-tdd-cycle"]=""
+EXPECTED_SKILLS["red-state-before-implementation"]=""
+EXPECTED_SKILLS["validate-executable-verification"]=""
+EXPECTED_SKILLS["semantic-intent-spec-creation"]=""
+EXPECTED_SKILLS["narrow-sc-table-exemption"]=""
+EXPECTED_SKILLS["semantic-intent-writing-plans"]=""
+EXPECTED_SKILLS["why-specific-value-tdd"]=""
+EXPECTED_SKILLS["verification-mechanics-brainstorming"]=""
+EXPECTED_SKILLS["sc-precision-audit"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -100,7 +138,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -435,6 +473,199 @@ if [ "$SCOPE_STEP05" -ge 1 ]; then
 else
     echo "  verify-authorization Step 0.5 scope auto-resolve: MISSING"
     echo "- **verify-authorization Step 0.5 scope auto-resolve:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+echo ""
+
+# Per-SC Evidence Table in VbC verify.md
+VBC_VERIFY_FILE="$PROJECT_DIR/.opencode/skills/verification-before-completion/tasks/verify.md"
+PSC_TABLE=$(grep -c "Per-SC Evidence Table" "$VBC_VERIFY_FILE" 2>/dev/null || echo "0")
+if [ "$PSC_TABLE" -ge 1 ]; then
+    echo "  Per-SC Evidence Table section: FOUND"
+    echo "- **Per-SC Evidence Table section:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  Per-SC Evidence Table section: MISSING"
+    echo "- **Per-SC Evidence Table section:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# VbC SKILL.md Per-SC evidence row
+VBC_SKILL_FILE="$PROJECT_DIR/.opencode/skills/verification-before-completion/SKILL.md"
+PSC_SKILL=$(grep -c "Per-SC evidence" "$VBC_SKILL_FILE" 2>/dev/null || echo "0")
+if [ "$PSC_SKILL" -ge 1 ]; then
+    echo "  VbC SKILL.md Per-SC evidence row: FOUND"
+    echo "- **VbC SKILL.md Per-SC evidence row:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  VbC SKILL.md Per-SC evidence row: MISSING"
+    echo "- **VbC SKILL.md Per-SC evidence row:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Finishing checklist SC Verification section
+FINISHING_FILE="$PROJECT_DIR/.opencode/skills/finishing-a-development-branch/tasks/checklist.md"
+SC_VERIFY=$(grep -c "SC Verification" "$FINISHING_FILE" 2>/dev/null || echo "0")
+if [ "$SC_VERIFY" -ge 1 ]; then
+    echo "  Finishing checklist SC Verification section: FOUND"
+    echo "- **Finishing checklist SC Verification section:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  Finishing checklist SC Verification section: MISSING"
+    echo "- **Finishing checklist SC Verification section:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-to-test traceability in 080-code-standards.md
+CODE_STD_FILE="$PROJECT_DIR/.opencode/guidelines/080-code-standards.md"
+SC_TRACE=$(grep -c "SC-to-Test Traceability" "$CODE_STD_FILE" 2>/dev/null || echo "0")
+if [ "$SC_TRACE" -ge 1 ]; then
+    echo "  080 SC-to-Test Traceability section: FOUND"
+    echo "- **080 SC-to-Test Traceability section:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  080 SC-to-Test Traceability section: MISSING"
+    echo "- **080 SC-to-Test Traceability section:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# RED-Phase Ordering in 080
+RED_PHASE=$(grep -c "RED-Phase Ordering" "$CODE_STD_FILE" 2>/dev/null || echo "0")
+if [ "$RED_PHASE" -ge 1 ]; then
+    echo "  080 RED-Phase Ordering section: FOUND"
+    echo "- **080 RED-Phase Ordering section:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  080 RED-Phase Ordering section: MISSING"
+    echo "- **080 RED-Phase Ordering section:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Step 4.6 in verify-authorization.md
+STEP46=$(grep -c "Step 4.6" "$VERIFY_AUTH_FILE" 2>/dev/null || echo "0")
+if [ "$STEP46" -ge 1 ]; then
+    echo "  verify-authorization Step 4.6: FOUND"
+    echo "- **verify-authorization Step 4.6:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  verify-authorization Step 4.6: MISSING"
+    echo "- **verify-authorization Step 4.6:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Executable verification commands in 140
+SPEC_CREATE_FILE="$PROJECT_DIR/.opencode/guidelines/140-planning-spec-creation.md"
+EXE_VERIFY=$(grep -c "executable verification command" "$SPEC_CREATE_FILE" 2>/dev/null || echo "0")
+if [ "$EXE_VERIFY" -ge 1 ]; then
+    echo "  140 executable verification command mandate: FOUND"
+    echo "- **140 executable verification command mandate:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  140 executable verification command mandate: MISSING"
+    echo "- **140 executable verification command mandate:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Vague verification anti-pattern in 140
+VAGUE_VERIFY=$(grep -c "Vague verification" "$SPEC_CREATE_FILE" 2>/dev/null || echo "0")
+if [ "$VAGUE_VERIFY" -ge 1 ]; then
+    echo "  140 Vague verification anti-pattern: FOUND"
+    echo "- **140 Vague verification anti-pattern:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  140 Vague verification anti-pattern: MISSING"
+    echo "- **140 Vague verification anti-pattern:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC-specific TDD in 091
+INCBUILD_FILE="$PROJECT_DIR/.opencode/guidelines/091-incremental-build.md"
+SC_TDD=$(grep -c "success criterion\|SC.*assertion\|SC-specific" "$INCBUILD_FILE" 2>/dev/null || echo "0")
+if [ "$SC_TDD" -ge 1 ]; then
+    echo "  091 SC-specific TDD: FOUND"
+    echo "- **091 SC-specific TDD:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  091 SC-specific TDD: MISSING"
+    echo "- **091 SC-specific TDD:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Plan validation check 4 upgrade
+VALIDATE_FILE="$PROJECT_DIR/.opencode/skills/writing-plans/tasks/validate.md"
+VAL_EXEC=$(grep -c "executable verification command\|exact expected value\|verification command.*exact" "$VALIDATE_FILE" 2>/dev/null || echo "0")
+if [ "$VAL_EXEC" -ge 1 ]; then
+    echo "  writing-plans/validate upgraded check #4: FOUND"
+    echo "- **writing-plans/validate upgraded check #4:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  writing-plans/validate upgraded check #4: MISSING"
+    echo "- **writing-plans/validate upgraded check #4:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Semantic intent in spec-creation/write.md
+SPEC_WRITE_FILE="$PROJECT_DIR/.opencode/skills/spec-creation/tasks/write.md"
+SEMANTIC_INTENT=$(grep -c "semantic intent" "$SPEC_WRITE_FILE" 2>/dev/null || echo "0")
+if [ "$SEMANTIC_INTENT" -ge 1 ]; then
+    echo "  spec-creation/write semantic intent: FOUND"
+    echo "- **spec-creation/write semantic intent:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  spec-creation/write semantic intent: MISSING"
+    echo "- **spec-creation/write semantic intent:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Narrow SC table exemption in write.md
+NARROW_EXEMPT=$(grep -c "narrow.*exempt\|verification.*column\|verification method.*precision\|table.*exempt.*format" "$SPEC_WRITE_FILE" 2>/dev/null || echo "0")
+if [ "$NARROW_EXEMPT" -ge 1 ]; then
+    echo "  spec-creation/write narrowed exemption: FOUND"
+    echo "- **spec-creation/write narrowed exemption:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  spec-creation/write narrowed exemption: MISSING"
+    echo "- **spec-creation/write narrowed exemption:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Semantic intent in writing-plans/create.md
+PLANS_CREATE_FILE="$PROJECT_DIR/.opencode/skills/writing-plans/tasks/create.md"
+SEMANTIC_PLAN=$(grep -c "semantic intent\|preserve.*semantic\|restate.*intent" "$PLANS_CREATE_FILE" 2>/dev/null || echo "0")
+if [ "$SEMANTIC_PLAN" -ge 1 ]; then
+    echo "  writing-plans/create semantic intent: FOUND"
+    echo "- **writing-plans/create semantic intent:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  writing-plans/create semantic intent: MISSING"
+    echo "- **writing-plans/create semantic intent:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verification-mechanics in brainstorming/explore.md
+EXPLORE_FILE="$PROJECT_DIR/.opencode/skills/brainstorming/tasks/explore.md"
+VERIFY_MECH=$(grep -c "verifia\|verification-mechanics\|how.*verify\|what.*check.*confirm" "$EXPLORE_FILE" 2>/dev/null || echo "0")
+if [ "$VERIFY_MECH" -ge 1 ]; then
+    echo "  brainstorming/explore verification-mechanics: FOUND"
+    echo "- **brainstorming/explore verification-mechanics:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  brainstorming/explore verification-mechanics: MISSING"
+    echo "- **brainstorming/explore verification-mechanics:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# SC Precision Audit in spec-auditor/SKILL.md
+AUDITOR_FILE="$PROJECT_DIR/.opencode/skills/spec-auditor/SKILL.md"
+SC_PRECISION=$(grep -c "SC Precision Audit\|SC precision\|precision audit" "$AUDITOR_FILE" 2>/dev/null || echo "0")
+if [ "$SC_PRECISION" -ge 1 ]; then
+    echo "  spec-auditor SC Precision Audit: FOUND"
+    echo "- **spec-auditor SC Precision Audit:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  spec-auditor SC Precision Audit: MISSING"
+    echo "- **spec-auditor SC Precision Audit:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi


### PR DESCRIPTION
**Summary:**

Fixes the systemic root cause of verification soft-passing by adding per-SC evidence gates, SC-to-test traceability, executable verification commands, semantic intent per SC, and SC precision audits across 12+ files in the guideline/skill ecosystem.

**Outcome:** Agents can no longer soft-pass verification — every success criterion requires explicit evidence, executable verification commands produce deterministic pass/fail results, and the SC Precision Audit catches vague or unverifiable criteria before implementation begins.

Fixes #1131
Fixes #1133
Fixes #1134
Fixes #1135
Fixes #1136
Fixes #1137
Fixes #1138