### PR TITLE
Fix main→dev branch references in skill files

### DIFF
--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -991,7 +991,7 @@ git branch feature/recovery HEAD
 
 # Reset protected branch to match remote
 git checkout dev  # or main/master
-git reset --hard origin/dev  # or origin/main/origin.master
+git reset --hard origin/dev
 
 # Switch to recovery branch
 git checkout feature/recovery

--- a/.opencode/skills/pr-creation-workflow/tasks/pre-pr-checklist.md
+++ b/.opencode/skills/pr-creation-workflow/tasks/pre-pr-checklist.md
@@ -124,7 +124,7 @@ If you accidentally create a PR with multiple commits:
 
 1. **DO NOT ask user to fix it** — Fix it yourself:
     ```bash
-    git reset --soft origin/main
+    git reset --soft origin/dev
     git commit -m "<descriptive message>" \
         --trailer "Co-authored-by: <AgentName> (<ModelId>) <ai-email>" \
         --trailer "Co-authored-by: <Human-Name> <human-email>"


### PR DESCRIPTION
## Summary

Corrects 2 remaining `main` → `dev` branch reference violations from the #281 audit regression in skill markdown files.

## Outcome

Squash reset and hard reset commands in skill files now correctly target `origin/dev` instead of `origin/main`, eliminating branch reference violations that contradict the repo's `main` → `dev` → `feature/*` hierarchy.

Fixes #1140