### PR TITLE
Fix hardcoded identity values in session-enforcement.ts identity echo directive (#1142)

### DIFF
--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -609,8 +609,8 @@ Before doing anything else, you MUST echo your platform identity as your very fi
 Platform: <platform>, Org: <owner>, Repo: <repo>
 🤖 <AgentName> (<ModelId>) <status-icon> <status>
 
-Example: Platform: github, Org: Brothertown-Language, Repo: snea-shoebox-editor
-🤖 OpenCode (ollama-cloud/glm-5) ✅ ready
+Example: Platform: <platform>, Org: <owner>, Repo: <repo>
+🤖 <AgentName> (<ModelId>) <status-icon> <status>
 
 The directive does NOT contain actual values — you MUST read github.platform, github.owner, and github.repo from the system prompt dotted pairs above. This ensures you have read and acknowledged the correct owner/repo before making any API calls.
 


### PR DESCRIPTION
## Summary

Replaces hardcoded identity values (`Brothertown-Language`, `snea-shoebox-editor`, `OpenCode`, `ollama-cloud/glm-5`) in `session-enforcement.ts` lines 612-613 with placeholder tokens (`<platform>`, `<owner>`, `<repo>`, `<AgentName>`, `<ModelId>`), aligning the IDENTITY_ECHO example with the directive's own instruction to read values from session-init output.

## Outcome

- Agents reading the directive example will no longer latch onto concrete identity values as authoritative data
- Cross-repo sync of `.opencode/` configuration will no longer propagate stale org/repo/agent values
- Complies with `080-code-standards.md` §"Hardcoded Identity Values in Skills and Guidelines"

Fixes #1142

*Note: #1140 was already implemented via PR #1141 (commit `bea51c5`).*