### PR TITLE
fix: Enforce API-response URL extraction instead of template construction (#1140, #1144)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -269,7 +269,30 @@ Feature branches target `dev`. Compare URLs: `compare/dev...<branch-name>`. Only
 
 ## Critical Violation: Fabricating URLs — ZERO TOLERANCE
 
-**⚠️ Generating URLs from memory, guesswork, or hardcoded patterns is a CRITICAL GUIDELINE VIOLATION.** All URLs must be constructed from session-enforcement plugin output. No exceptions.
+**⚠️ Generating URLs from memory, guesswork, or hardcoded patterns is a CRITICAL GUIDELINE VIOLATION.** All URLs must be sourced per the two mandatory URL sourcing rules below. No exceptions.
+
+- 🚫 FORBIDDEN: Hard-coding domains; using "known correct" URLs from previous sessions; guessing from git remotes; caching URL bases across sessions; constructing post-creation URLs from template variables
+- ✅ REQUIRED: Follow URL Sourcing Rule 1 and Rule 2 below
+
+### URL Sourcing Rule 1: Post-Creation URLs — Extract from API Response (NEVER construct)
+
+For URLs to resources that have been **created by an API call** (PR URL, Issue URL), the agent MUST extract the `html_url` field from the API response — never construct from template variables.
+
+- **PR URL:** Extract from `github_create_pull_request` response `html_url` field
+- **Issue URL:** Extract from `github_issue_write` response `html_url` field
+- **Template construction is FORBIDDEN** for post-creation URLs
+- The API response is the single source of truth for post-creation URLs
+
+### URL Sourcing Rule 2: Pre-Creation URLs — Construct from Verified Session-Init Values
+
+For URLs to resources that **haven't been created yet** (Compare URL before push), the agent MUST construct from session-init values with a mandatory character-match verification step:
+
+1. Read `<github.owner>`, `<github.repo>`, `<gitbucket.html_url>` from session init
+2. Construct the URL using those exact values
+3. **Character-match verification:** Confirm the constructed URL contains the exact `<github.owner>` and `<github.repo>` strings from session init (character-for-character match, no typos, no cached values)
+4. If any mismatch: HALT and report
+
+### Original Fabricating URLs Rule (superseded by Rule 1 and Rule 2 above)
 
 - 🚫 FORBIDDEN: Hard-coding domains; using "known correct" URLs from previous sessions; guessing from git remotes; caching URL bases across sessions
 - ✅ REQUIRED: Extract `<gitbucket.html_url>` from session init; construct all URLs from that value; HALT if session init missing

--- a/.opencode/skills/approval-gate/tasks/post-implementation.md
+++ b/.opencode/skills/approval-gate/tasks/post-implementation.md
@@ -71,11 +71,12 @@ This pushes the branch WITHOUT creating a PR.
 
 ### Step 3: Generate Compare URL
 
-Using session values (<github.owner>, <github.repo>):
+**Pre-Creation URL — Construct from verified session-init values:**
 
-```
-https://github.com/<github.owner>/<github.repo>/compare/dev...<branch-name>
-```
+1. Read `<github.owner>`, `<github.repo>`, `<gitbucket.html_url>` from session init
+2. Construct the Compare URL using those exact values
+3. **Character-match verification:** Confirm the constructed URL contains the exact `<github.owner>` and `<github.repo>` strings from session init (character-for-character match, no typos, no cached values)
+4. If any mismatch: HALT and report
 
 ### Step 4: Report Completion
 
@@ -87,7 +88,15 @@ Report to chat (exec summary + URL):
 
 **Outcome:** <What changed for stakeholders>
 
-https://github.com/<owner>/<repo>/compare/dev...<branch-name>
+Compare URL: <Character-match verified URL from session-init values>
+
+🤖 <AgentName> (<ModelId>) <status>
+```
+
+**If a PR was created during this workflow**, use the `html_url` from the `github_create_pull_request` API response instead of a constructed Compare URL:
+
+```
+PR URL: <html_url from github_create_pull_request API response>
 
 🤖 <AgentName> (<ModelId>) <status>
 ```

--- a/.opencode/skills/completion-core/completion-core.md
+++ b/.opencode/skills/completion-core/completion-core.md
@@ -25,14 +25,21 @@ Two URL patterns depending on workflow type:
 
 **Compare URL** (for git push workflows — implementation, git-workflow, finishing):
 
+Construct from session-init values with character-match verification:
+
+1. Read `<github.owner>`, `<github.repo>`, `<gitbucket.html_url>` from session init
+2. Construct: `${GITBUCKET_HTML_URL:-https://github.com/}${GIT_OWNER}/${GIT_REPO}/compare/dev...$(git branch --show-current)`
+3. **Character-match verification:** Confirm `GIT_OWNER` and `GIT_REPO` in the constructed URL match session-init values exactly (character-for-character, no typos, no cached values)
+4. If any mismatch: HALT and report
+
 ```bash
 COMPARE_URL="${GITBUCKET_HTML_URL:-https://github.com/}${GIT_OWNER}/${GIT_REPO}/compare/dev...$(git branch --show-current)"
 ```
 
 **Action URL** (for creation workflows — issue creation, approval gate):
 
-- Issue URL: `${GITBUCKET_HTML_URL:-https://github.com/}${GIT_OWNER}/${GIT_REPO}/issues/<number>`
-- PR URL: from `github_create_pull_request` response
+- **Issue URL:** Extract from `github_issue_write` API response `html_url` field — NEVER construct from template
+- **PR URL:** Extract from `github_create_pull_request` API response `html_url` field — NEVER construct from template
 
 ### 3. Post Status Comment (Substantive Only)
 

--- a/.opencode/skills/divide-and-conquer/tasks/assemble-work.md
+++ b/.opencode/skills/divide-and-conquer/tasks/assemble-work.md
@@ -238,12 +238,12 @@ Implemented <N> issues via branch-per-issue work orchestration.
 - #B: <summary> ✅
 - #C: <summary> ⚠️ (partial — see details)
 
-Compare URL: https://github.com/<owner>/<repo>/compare/dev...<work-branch>
+Compare URL: <<Character-match verified URL from session-init values per URL Sourcing Rules>>
 
-**If a PR has been created for this work set, use "PR URL" label with the `pull/<N>` format instead of "Compare URL":**
+**If a PR has been created for this work set, use "PR URL" label with the `html_url` from `github_create_pull_request` API response:**
 
 ```
-PR URL: https://github.com/<owner>/<repo>/pull/<PR-number>
+PR URL: <html_url from github_create_pull_request API response>
 ```
 
 **NEVER use the wrong label for the wrong URL format.** Label-format mismatch (e.g., "Compare URL" with `pull/N` URL, or "PR URL" with `compare/dev...` URL) is a critical violation.

--- a/.opencode/skills/divide-and-conquer/tasks/orchestrate.md
+++ b/.opencode/skills/divide-and-conquer/tasks/orchestrate.md
@@ -203,8 +203,8 @@ implementation_complete: true
 
 ```yaml
 status: success
-compare_url: https://github.com/owner/repo/compare/dev...branch
-exec_summary: |
+  compare_url: <<Compare URL from review-prep — character-match verified per URL Sourcing Rules>>
+  exec_summary: |
   **Summary:**
 
   Integrated workflow skills into the enforcement plugin.
@@ -230,7 +230,7 @@ Integrated workflow skills from Superpowers repository.
 
 Created 4 core skills for brainstorming, planning, execution, and verification.
 
-Compare URL: https://github.com/owner/repo/compare/dev...branch
+Compare URL: <<Character-match verified URL from session-init values>>
 
 🤖 <AgentName> (<ModelId>) completed
 ```

--- a/.opencode/skills/finishing-a-development-branch/tasks/completion.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/completion.md
@@ -46,7 +46,7 @@ Generate executive summary in chat:
 
 **Outcome:** <What stakeholders get — branch is ready/not ready for PR>
 
-Compare URL: <gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch>
+Compare URL: <<Character-match verified URL from session-init values per URL Sourcing Rules>>
 ```
 
 URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/finishing-a-development-branch/tasks/prepare.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/prepare.md
@@ -97,12 +97,10 @@ git branch -vv
 
 ### Step 5: Generate Compare URL
 
-```
-https://<GitBucketHost>/gitbucket/<owner>/<repo>/compare/<base>...<branch>
-```
-
-- URL must be accessible
-- Diff must show expected changes
+1. Read `<github.owner>`, `<github.repo>`, `<gitbucket.html_url>` from session init
+2. Construct the Compare URL using those exact values
+3. **Character-match verification:** Confirm the constructed URL contains the exact `<github.owner>` and `<github.repo>` strings from session init (character-for-character match)
+4. If any mismatch: HALT and report
 
 ## Enforcement Matrix
 

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -831,7 +831,7 @@ Fixes #505
 
 **Outcome:** <What changed for stakeholders>
 
-**PR URL:** <gitbucket.html_url><github.owner>/<github.repo>/pull/<number>
+**PR URL:** <html_url from github_create_pull_request API response — NEVER construct from template>
 
 Wait for human to merge.
 ```

--- a/.opencode/skills/git-workflow/tasks/review-prep.md
+++ b/.opencode/skills/git-workflow/tasks/review-prep.md
@@ -438,21 +438,19 @@ worktree.path = ""  (cleared — agent no longer references worktree)
 
 **⚠️ CRITICAL: URLs must be constructed from session init values ONLY. Never hardcode domains.**
 
-Using session values (<github.owner>, <github.repo>, github.platform, <gitbucket.html_url>):
+### URL Sourcing Rules (MANDATORY — per `000-critical-rules.md` §URL Sourcing)
 
-**For GitBucket (github.platform=gitbucket):**
+**Pre-Creation URLs (Compare URL before PR exists):** Construct from session-init values with mandatory character-match verification:
 
-```
-<gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch-name>
-```
+1. Read `<github.owner>`, `<github.repo>`, `<gitbucket.html_url>` from session init
+2. Construct the URL using those exact values
+3. **Character-match verification:** Confirm the constructed URL contains the exact `<github.owner>` and `<github.repo>` strings from session init (character-for-character match, no typos, no cached values)
+4. If any mismatch: HALT and report
 
-Where `<gitbucket.html_url>` comes from session init (read from `.env`).
+**Post-Creation URLs (PR URL after PR created):** Extract from API response `html_url` field — NEVER construct from template:
 
-**For GitHub (github.platform=github):**
-
-```
-https://github.com/<github.owner>/<github.repo>/compare/dev...<branch-name>
-```
+- PR URL: Extract from `github_create_pull_request` response `html_url` field
+- Template construction is FORBIDDEN for post-creation URLs
 
 **If <gitbucket.html_url> is empty (not in .env):**
 
@@ -473,12 +471,18 @@ Report to chat (exec summary + URL + AI byline):
 
 **Outcome:** <What changed for stakeholders>
 
-Compare URL: <gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch-name>
+Compare URL: <Constructed from session-init values per URL Sourcing Rules above — character-match verified>
 
 🤖 <AgentName> (<ModelId>) completed
 ```
 
-(GitBucket example — for GitHub use `https://github.com/<github.owner>/<github.repo>/compare/dev...<branch-name>`)
+**After a PR has been created**, use the `html_url` from the `github_create_pull_request` API response — NEVER construct the PR URL from template:
+
+```
+PR URL: <html_url from github_create_pull_request API response>
+
+🤖 <AgentName> (<ModelId>) completed
+```
 
 **URL Label Context:**
 
@@ -490,7 +494,7 @@ Compare URL: <gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<bra
 After a PR has been created, the chat output MUST use **"PR URL"** with the `pull/<N>` format — never "Compare URL". Before PR creation, the chat output MUST use **"Compare URL"** with the `compare/dev...` format — never "PR URL". The label and URL format MUST always match the current context:
 
 - **Before PR creation:** "Compare URL" label with `compare/dev...<branch-name>` format
-- **After PR creation:** "PR URL" label with `pull/<PR-number>` format
+- **After PR creation:** "PR URL" label with the `html_url` from `github_create_pull_request` API response — this URL comes from the API response, NOT from template construction
 
 **NEVER use the wrong label for the wrong URL format.** A label-format mismatch (e.g., "Compare URL" with a `pull/N` URL or "PR URL" with a `compare/dev...` URL) is a critical violation.
 
@@ -606,7 +610,7 @@ After generating the compare URL (Step 3) and before HALT (Step 5), verify ALL e
 | Executive summary present | Review chat output | First element is `**Summary:**` block | MISSING-ELEMENT → add before proceeding |
 | Outcome present | Review chat output | `**Outcome:**` line follows summary | MISSING-ELEMENT → add before proceeding |
 | URL label context-appropriate | Review chat output | Pre-PR: "Compare URL" with `compare/dev...`; Post-PR: "PR URL" with `pull/N`; label-format mismatch = critical violation | STRUCTURE-VIOLATION → fix label and format to match context |
-| URL present | Review chat output | URL starts with `https://github.com/` or `<gitbucket.html_url>` | MISSING-ELEMENT → generate URL before proceeding |
+| URL present | Review chat output | URL is present and sourced per URL Sourcing Rules (API `html_url` for post-creation, character-match verified construction for pre-creation) | MISSING-ELEMENT → generate URL before proceeding |
 | AI byline present | Review chat output | Ends with `🤖 <AgentName> (<ModelId>)` line | MISSING-ELEMENT → add before proceeding |
 | No URL before summary | Review chat output | URL appears AFTER summary, not before | STRUCTURE-VIOLATION → reorder output |
 | No byline before URL | Review chat output | Byline appears AFTER URL, not before | STRUCTURE-VIOLATION → reorder output |
@@ -622,15 +626,15 @@ After generating the compare URL (Step 3) and before HALT (Step 5), verify ALL e
 
 **Outcome:** <What changed for stakeholders>
 
-Compare URL: https://github.com/<github.owner>/<github.repo>/compare/dev...<branch-name>
+Compare URL: <Constructed from session-init values — character-match verified per URL Sourcing Rules>
 
 🤖 <AgentName> (<ModelId>) <status>
 ```
 
-**After a PR has been created**, replace "Compare URL" with "PR URL" and use the `pull/N` format:
+**After a PR has been created**, use `html_url` from `github_create_pull_request` API response:
 
 ```
-PR URL: https://github.com/<github.owner>/<github.repo>/pull/<PR-number>
+PR URL: <html_url from github_create_pull_request API response>
 
 🤖 <AgentName> (<ModelId>) <status>
 ```
@@ -711,7 +715,7 @@ Any halt point where the agent reports completion MUST produce this format. Skip
 - ✅ All file changes are committed (`git status` shows clean)
 - ✅ Branch is pushed to remote (`git branch -vv` shows upstream)
 - ✅ Temp files are cleaned (no `./tmp/temp_*.py` or `./tmp/*.json`)
-- ✅ Compare URL generated correctly (using session init base URL + `compare/dev...branch`)
+- ✅ Compare URL generated correctly (character-match verified from session-init values per URL Sourcing Rules)
 - ✅ Chat output format correct (summary BEFORE URL)
 - ✅ Issue comment posted (NO URL in issue comment) → Report to chat only (no issue comment per substantive-only policy)
 - ✅ All verification comparisons use exact-match semantics (per `065-verification-honesty.md` → "Verification Comparison Semantics")
@@ -842,7 +846,7 @@ Updated git-workflow skill to push feature branches after implementation and pro
 
 **Ready for Review:**
 
-<gitbucket.html_url><github.owner>/<github.repo>/compare/dev...<branch-name>
+<Constructed from session-init values — character-match verified per URL Sourcing Rules>
 
 ---
 🤖 <AgentName> (<ModelId>) completed

--- a/.opencode/skills/issue-operations/tasks/completion.md
+++ b/.opencode/skills/issue-operations/tasks/completion.md
@@ -47,7 +47,7 @@ Generate executive summary in chat:
 
 **Outcome:** <What stakeholders get from the new issue>
 
-Issue URL: <gitbucket.html_url><github.owner>/<github.repo>/issues/<number>
+Issue URL: <html_url from github_issue_write API response — NEVER construct from template>
 ```
 
 URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/skills/verification-before-completion/tasks/completion.md
+++ b/.opencode/skills/verification-before-completion/tasks/completion.md
@@ -28,7 +28,7 @@ Generate executive summary in chat:
 
 **Outcome:** <What stakeholders know — task is verified/not verified>
 
-Issue URL: <gitbucket.html_url><github.owner>/<github.repo>/issues/<number>
+Issue URL: <html_url from github_issue_write API response — NEVER construct from template>
 ```
 
 URL is ALWAYS last per `000-critical-rules.md`.

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -77,6 +77,11 @@ SCENARIOS["semantic-intent-writing-plans"]="Does .opencode/skills/writing-plans/
 SCENARIOS["why-specific-value-tdd"]="Does .opencode/skills/writing-plans/tasks/create.md include guidance for why-specific-value in TDD step descriptions?"
 SCENARIOS["verification-mechanics-brainstorming"]="Does .opencode/skills/brainstorming/tasks/explore.md include verification-mechanics prompting?"
 SCENARIOS["sc-precision-audit"]="Does .opencode/skills/spec-auditor/SKILL.md include an SC Precision Audit baseline subtask?"
+SCENARIOS["url-sourcing-rule1-pr"]="Does .opencode/skills/git-workflow/tasks/pr-creation.md instruct to use html_url from github_create_pull_request API response and NEVER construct the PR URL from template?"
+SCENARIOS["url-sourcing-rule1-review-prep"]="Does .opencode/skills/git-workflow/tasks/review-prep.md contain URL Sourcing Rules that require extracting html_url from github_create_pull_request API response for post-creation PR URLs?"
+SCENARIOS["url-sourcing-rule2-character-match"]="Does .opencode/skills/git-workflow/tasks/review-prep.md require character-match verification for pre-creation Compare URLs constructed from session-init values?"
+SCENARIOS["url-sourcing-guideline-rules"]="Does .opencode/guidelines/000-critical-rules.md contain URL Sourcing Rule 1 requiring html_url extraction from API response for post-creation URLs and URL Sourcing Rule 2 requiring character-match verification for pre-creation URLs?"
+SCENARIOS["url-sourcing-issue-operations"]="Does .opencode/skills/issue-operations/tasks/completion.md instruct to use html_url from github_issue_write API response instead of constructing issue URLs from template?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -126,6 +131,11 @@ EXPECTED_SKILLS["semantic-intent-writing-plans"]=""
 EXPECTED_SKILLS["why-specific-value-tdd"]=""
 EXPECTED_SKILLS["verification-mechanics-brainstorming"]=""
 EXPECTED_SKILLS["sc-precision-audit"]=""
+EXPECTED_SKILLS["url-sourcing-rule1-pr"]=""
+EXPECTED_SKILLS["url-sourcing-rule1-review-prep"]=""
+EXPECTED_SKILLS["url-sourcing-rule2-character-match"]=""
+EXPECTED_SKILLS["url-sourcing-guideline-rules"]=""
+EXPECTED_SKILLS["url-sourcing-issue-operations"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -138,7 +148,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"


### PR DESCRIPTION
## Summary

Enforce two mandatory URL sourcing rules across 11 skill/guideline files to prevent URL fabrication by AI agents.

## Outcome

- Rule 1: Post-creation URLs (PR, Issue) must extract `html_url` from API response — never construct from template
- Rule 2: Pre-creation URLs (Compare) must use character-match verification from session-init values
- #1140: Already implemented in prior PR #1143 — both branch reference violations were already fixed; remaining `origin/main` references are legitimate bootstrap fallbacks
- #1144: Fixed 11 files with URL sourcing instructions, added 5 enforcement test scenarios

Fixes #1140
Fixes #1144