### PR TITLE
Fix merge conflicts in skill files and enforce spec-creation skill chain

### DIFF
--- a/.opencode/guidelines/140-planning-spec-creation.md
+++ b/.opencode/guidelines/140-planning-spec-creation.md
@@ -162,6 +162,12 @@ Vague verification methods are FORBIDDEN in success criteria. A verification met
 
 **The key principle: every content area must be addressed, but agents choose the format that matches the spec's complexity.**
 
+## Spec Creation Skill Chain (MANDATORY)
+
+To create a spec, invoke: brainstorming (`--task explore`) → spec-creation (`--task write`) → issue-operations (`--task creation`).
+
+Never write a spec directly in chat. Always persist via this skill chain. The brainstorming skill explores the problem and produces raw design output; the spec-creation skill structures that output into a formal spec; the issue-operations skill persists the spec as a GitHub Issue. Skipping any link in this chain produces specs that lack discipline or traceability.
+
 ______________________________________________________________________
 
 ## 1.2. Fresh-Start Context Requirements

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -531,10 +531,10 @@ Critical rules:
 function buildEnforcementContent(skillDescriptions: Array<{ name: string; description: string }>): string {
   // Process skills first, implementation skills second (adapted from superpowers priority)
   const processSkills = skillDescriptions.filter(s =>
-    ["approval-gate", "brainstorming", "writing-plans", "executing-plans",
+    ["approval-gate", "brainstorming", "spec-creation", "writing-plans", "executing-plans",
      "verification-before-completion", "finishing-a-development-branch",
      "git-workflow", "using-git-worktrees", "systematic-debugging", "spec-auditor",
-     "github-issue-creation", "github-sub-issues"].includes(s.name)
+     "issue-operations"].includes(s.name)
   );
   const implSkills = skillDescriptions.filter(s => !processSkills.includes(s));
 
@@ -559,7 +559,7 @@ This is not negotiable. This is not optional. You cannot rationalize your way ou
 
 When multiple skills could apply, use this order:
 
-1. **Process skills first** (approval-gate, brainstorming, writing-plans, systematic-debugging) — these determine HOW to approach the task
+1. **Process skills first** (approval-gate, brainstorming, spec-creation, issue-operations, writing-plans, systematic-debugging) — these determine HOW to approach the task
 2. **Implementation skills second** — these guide execution
 
 ## Red Flags — STOP and Invoke the Skill

--- a/.opencode/skills/brainstorming/SKILL.md
+++ b/.opencode/skills/brainstorming/SKILL.md
@@ -67,7 +67,7 @@ You are a Requirements Explorer. Your focus is understanding what the user wants
 8. **Visual companion conditional:** Offered only when topic involves visual decisions. Do NOT offer by default for this backend/Python project.
 
 9. **Terminal state is three-path:**
-   - **Path A (spec NOT yet a GitHub Issue):** Invoke `issue-operations` skill to create the spec as a GitHub Issue with `needs-approval` label → HALT for review.
+   - **Path A (spec NOT yet a GitHub Issue):** Invoke `spec-creation` skill to structure exploration results into a formal spec → `spec-creation` internally invokes `issue-operations` to persist as GitHub Issue with `needs-approval` label → HALT for review.
    - **Path B (spec already a GitHub Issue AND approved):** Transition directly to `writing-plans` skill.
    - **Path C (user declines spec/plan → FAILURE):** If the user declines both creating a new spec and selecting an existing candidate (from the search-prompt-fail workflow), this is a FAILURE state. Report: "Spec/Plan Required → Cannot proceed without a spec or plan to track this work." HALT.
 
@@ -85,7 +85,7 @@ You are a Requirements Explorer. Your focus is understanding what the user wants
 
 ```
 brainstorming (mandatory)
-   ├─ Path A: spec NOT yet GitHub Issue → issue-operations → HALT for review
+   ├─ Path A: spec NOT yet GitHub Issue → spec-creation → issue-operations → HALT for review
   ├─ Path B: spec already GitHub Issue AND approved → writing-plans → executing-plans
   └─ Path C: user declines spec/plan → FAILURE: Spec/Plan Required → HALT
 ```

--- a/.opencode/skills/brainstorming/tasks/enforcement.md
+++ b/.opencode/skills/brainstorming/tasks/enforcement.md
@@ -18,7 +18,8 @@ Enforcement rules and messages for the brainstorming skill. Ensures brainstormin
    | Exploration invoked, no turns | Skill loaded but no interactive Q&A turns recorded | HALT — require at least one Q&A exchange |
    | Exploration invoked, batch-dump detected | Agent produced findings without developer interaction | HALT — require developer confirmation of each item |
    | Exploration invoked, partial protocol | Agent asked one question then ignored the answer | HALT — require per-item developer confirmation before proceeding |
-   | Exploration invoked, protocol followed | Interactive Q&A with developer confirmation for key items | PROCEED to spec creation |
+    | Exploration invoked, protocol followed | Interactive Q&A with developer confirmation for key items | PROCEED to spec creation |
+    | Terminal dispatch to spec-creation occurred (not just issue-operations)? | Verify spec-creation was invoked after exploration | Chat + tool call evidence | SOFT-PASS |
 
 3. **What does NOT bypass exploration:**
 

--- a/.opencode/skills/brainstorming/tasks/explore.md
+++ b/.opencode/skills/brainstorming/tasks/explore.md
@@ -251,6 +251,11 @@ You use these dimensions internally to decide what to ask about. The user never 
 - Include targeted improvements only where they serve the current goal
 - Don't propose unrelated refactoring
 
+⚠️ HARD GATE: Design approval is NOT spec completion.
+The design you presented is raw input TO spec-creation.
+You MUST invoke spec-creation to structure it into a formal spec.
+Do NOT output the design as the final spec in chat.
+
 ## Step 7: Transition to spec-creation
 
 **The terminal state is invoking spec-creation.** Do NOT write the spec in brainstorming — that is the responsibility of the `spec-creation` skill.

--- a/.opencode/skills/correspondence/SKILL.md
+++ b/.opencode/skills/correspondence/SKILL.md
@@ -39,15 +39,9 @@ Three distinct failures occur when drafting email correspondence without this sk
 
 2. **Format template REQUIRED.** Every email draft MUST use the multipart/alternative template defined in the `draft` task. No exceptions. The text/plain part uses the Summary/Outcome/byline format. The text/html part renders that same format in proper HTML with structural markup.
 
-<<<<<<< HEAD
-3. **Stakeholder content rules REQUIRED.** Content must be filtered through audience-awareness rules before inclusion. Internal ops details are PROHIBITED in external-facing correspondence.
-
-4. **Audience classification FIRST.** Before drafting, the agent MUST classify the audience as internal or external. This classification drives content filtering rules.
-=======
 3. **Audience separation REQUIRED.** Content must be filtered through the Audience Separation Principle (stakeholder tier vs. operator tier) before inclusion. Internal artifacts are PROHIBITED in stakeholder-tier correspondence.
 
 4. **Audience classification FIRST.** Before drafting, the agent MUST classify the audience using the Audience Separation Principle (stakeholder tier vs. operator tier). Default to stakeholder tier when audience is unclear or mixed.
->>>>>>> spec/1099-fix
 
 5. **Verification gate AFTER drafting.** The agent MUST invoke `verification-enforcement --task revisit` after self-review. Any claims that could not be verified must be marked `⚠️ UNVERIFIED` and escalated to the developer.
 
@@ -108,15 +102,9 @@ The HTML part renders the same content with proper structural HTML markup:
 | Internal system names/identifiers | ⚠️ Include with context | 🚫 PROHIBITED — rephrase generically |
 | Error messages and stack traces | ✅ Include | 🚫 PROHIBITED — summarize impact only |
 
-<<<<<<< HEAD
-#### Prohibited Content in External-Facing Email
-
-The following content types are ABSOLUTELY PROHIBITED in emails to external stakeholders:
-=======
 #### Prohibited Content in Stakeholder-Tier Correspondence
 
 The following content types are ABSOLUTELY PROHIBITED in stakeholder-tier correspondence (external clients, customers, vendors, partners, internal executives):
->>>>>>> spec/1099-fix
 
 - **Runbook file paths** (e.g., `docs/runbooks/videoconcerthall-dns-correction.md`)
 - **Step numbers from internal procedures** (e.g., "repeat Steps 2-6")
@@ -129,21 +117,6 @@ The following content types are ABSOLUTELY PROHIBITED in stakeholder-tier corres
 
 When a stakeholder email MUST reference technical details, rephrase them in stakeholder-relevant terms. Instead of "repeat Steps 2-6 of the runbook," say "the standard DNS correction procedure was applied." Instead of "parking IP 10.0.0.5," say "the registrar's parking page."
 
-<<<<<<< HEAD
-### Audience-Awareness Rules (MANDATORY)
-
-Before drafting, the agent MUST classify the correspondence audience:
-
-| Audience | Classification | Content Level |
-|----------|---------------|---------------|
-| External client or customer | External | Outcome-only: what happened, what was fixed, current state |
-| External vendor or partner | External | Outcome-only: relevant facts about the interaction only |
-| Internal team members | Internal | Full context: technical details, commands, internal references |
-| Internal stakeholders (execs, managers) | Internal-Executive | Business-level context: outcomes, timelines, decisions needed |
-| Mixed (internal + external on same thread) | Conservative | Apply external rules — assume the most restrictive audience |
-
-**Conservative default rule:** When the audience is mixed or unclear, apply external-stakeholder rules. It is always safer to under-share than to leak internal details.
-=======
 ### Audience Separation Principle (MANDATORY)
 
 All generated content has an implicit audience. The agent MUST identify the audience before generating content and filter information accordingly. Two tiers exist:
@@ -164,7 +137,6 @@ All generated content has an implicit audience. The agent MUST identify the audi
 | Mixed (internal + external on same thread) | Stakeholder | Apply stakeholder tier — assume the most restrictive audience |
 
 **Conservative default rule:** When the audience is mixed or unclear, apply stakeholder tier. It is always safer to under-share than to leak internal details. Escalating to operator tier requires explicit authorization — either the communication is clearly between ops team members, or the recipient has explicitly requested operator-level detail.
->>>>>>> spec/1099-fix
 
 ### AI Byline Rule (MANDATORY)
 
@@ -178,8 +150,6 @@ The AI byline is MANDATORY in ALL correspondence produced by this skill. It MUST
 
 The byline MUST NOT be removed on subsequent edits.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 ### Matching Original Format (MANDATORY)
 
 When replying to an existing email thread:
@@ -188,11 +158,6 @@ When replying to an existing email thread:
 2. **Match original structure.** If the original email uses HTML formatting, the reply MUST also use HTML formatting. Never downgrade an HTML thread to plain text.
 3. **Preserve thread context.** Include relevant context from the original email (quoted or summarized) in the reply.
 
-<<<<<<< HEAD
-=======
-=======
-=======
->>>>>>> spec/1099-fix
 ### Content-Type Propagation (MANDATORY)
 
 When generating a reply to existing communication, the output format MUST match the source communication's content type. This is a **verification step**, not a formatting preference — the agent MUST inspect the content type of the source before drafting the reply.
@@ -216,10 +181,6 @@ When generating a reply to existing communication, the output format MUST match 
 3. **Never downgrade.** If the source uses HTML, the reply MUST include HTML. Never downgrade an HTML thread to plain text with markdown syntax.
 4. **Preserve thread context.** Include relevant context from the original communication (quoted or summarized) in the reply.
 
-<<<<<<< HEAD
->>>>>>> spec/1098-fix
-=======
->>>>>>> spec/1099-fix
 ### Attribution Verification (MANDATORY)
 
 When correspondence attributes an action to a person (e.g., "completed by Person X", "Person X renewed the domain"), the attribution MUST be verified against source evidence before inclusion. This is a specialized application of the verification-enforcement attribution domain to correspondence.
@@ -236,13 +197,6 @@ When correspondence attributes an action to a person (e.g., "completed by Person
 
 **Attribution rule:** If the source does not explicitly state who performed an action, the agent MUST NOT attribute — either omit the person's name entirely or write "completed per [reference]" without naming an individual. Inferring "who did what" from role proximity (e.g., "the tech person must have done the tech work") is prohibited.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> spec/1097-fix
-=======
->>>>>>> spec/1098-fix
-=======
->>>>>>> spec/1099-fix
 ### Verification-Enforcement Integration (MANDATORY)
 
 The verification-enforcement skill applies to email correspondence the same way it applies to specs, plans, and runbooks:
@@ -257,27 +211,6 @@ After drafting email correspondence, the agent MUST validate against ALL of the 
 
 - [ ] Both text/plain and text/html parts are present
 - [ ] HTML part uses proper structural markup (no markdown syntax in email body)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-- [ ] Content-type propagation verified: source Content-Type header inspected before drafting, reply format matches source format
-- [ ] No markdown syntax in email body unless source email uses markdown
->>>>>>> spec/1098-fix
-- [ ] Summary section is 1-2 sentences maximum
-- [ ] Outcome section states what changed for stakeholders
-- [ ] AI byline appears in both text/plain and text/html parts
-- [ ] Content is filtered by audience classification (internal vs. external)
-- [ ] No internal ops details appear in external-facing correspondence
-- [ ] No runbook paths, step numbers, internal IPs, or internal tool names in external content
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-- [ ] All person-action attributions verified against source evidence (no role-proximity inference)
->>>>>>> spec/1097-fix
-=======
-- [ ] All person-action attributions verified against source evidence (no role-proximity inference)
->>>>>>> spec/1098-fix
-=======
 - [ ] Content-type propagation verified: source Content-Type header inspected before drafting, reply format matches source format
 - [ ] No markdown syntax in email body unless source email uses markdown
 - [ ] Summary section is 1-2 sentences maximum
@@ -287,7 +220,6 @@ After drafting email correspondence, the agent MUST validate against ALL of the 
 - [ ] No internal ops details appear in stakeholder-tier correspondence
 - [ ] No runbook paths, step numbers, internal IPs, or internal tool names in stakeholder-tier content
 - [ ] All person-action attributions verified against source evidence (no role-proximity inference)
->>>>>>> spec/1099-fix
 - [ ] Verification-enforcement verify task was invoked before drafting
 - [ ] Verification-enforcement revisit task was invoked after self-review
 - [ ] All `⚠️ UNVERIFIED` markers resolved or escalated

--- a/.opencode/skills/issue-operations/SKILL.md
+++ b/.opencode/skills/issue-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-operations
-description: Platform-agnostic issue operations dispatcher. Routes to GitHub MCP or GitBucket API based on github.platform. Triggers on: create issue, new issue, spec creation, submit issue, issue, bug report, comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator, sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue, close issue, verify merge.
+description: Use when creating, commenting on, or closing GitHub Issues. Routes to GitHub MCP or GitBucket API based on github.platform. Triggers on: create issue, new issue, spec creation, submit issue, issue, bug report, comment, progress update, issue comment, PR comment, post to GitHub, byline, status indicator, sub-issue, phase issue, multi-task, create sub issue, link issue, task breakdown, subtask, parent issue, close issue, verify merge.
 type: technique
 license: MIT
 compatibility: opencode

--- a/.opencode/skills/sre-runbook/SKILL.md
+++ b/.opencode/skills/sre-runbook/SKILL.md
@@ -75,12 +75,9 @@ You are an SRE-oriented operator writing runbooks for sysops under pressure. You
 - Referencing CLI commands, GUI paths, or API calls without verifying against live documentation
 - Annotating unverified information with "(unverified)" instead of excluding it
 - Falling back to training knowledge when live verification fails
-<<<<<<< HEAD
 - Proceeding past a section when ALL verification sources for that section's claims returned errors or were unreachable
 - Producing operational steps for a domain without confirming the available mechanisms (e.g., DNS record types at apex, provider-specific capabilities)
-=======
 - Reporting verification mismatches as "functionally equivalent" or "minor difference" instead of FAIL
->>>>>>> spec/fix-1088
 
 ### ✅ REQUIRED
 
@@ -107,9 +104,6 @@ You are an SRE-oriented operator writing runbooks for sysops under pressure. You
 
 After generating a runbook, the agent MUST validate the output against ALL enforcement rules BEFORE presenting it. One-shot correctness is the target — the user should never need to correct the same issue twice.
 
-<<<<<<< HEAD
-## Runbook Type Taxonomy
-=======
 ## Verification Row-by-Row Exact Comparison Template (MANDATORY)
 
 When the runbook includes a verification section that compares live values against a specification, each value MUST be compared exactly using this row-by-row template:
@@ -139,7 +133,8 @@ When the runbook includes a verification section that compares live values again
 | "Close enough to the specification" | ❌ FAIL — exact match required |
 
 ## Dual-Output Contract
->>>>>>> spec/fix-1088
+
+## Runbook Type Taxonomy
 
 Not all runbooks need the same format. The skill classifies runbooks into four types, each with a different output contract:
 

--- a/.opencode/skills/verification-enforcement/SKILL.md
+++ b/.opencode/skills/verification-enforcement/SKILL.md
@@ -55,18 +55,9 @@ The verification domains represent the kinds of factual claims that content gene
 
 API signatures and function parameters are verified against live source code using `srclight_get_signature`, `srclight_get_symbol`, or direct file reads. Config schemas and environment variables are verified against schema definitions, `.env.example` files, or configuration documentation. Code behavior — what a function does, what it returns, how classes interact — is verified by reading source code or using `srclight_get_symbol` and `srclight_get_type_hierarchy`. Documentation references are verified by fetching the referenced document and confirming the claims match. External tool commands and flags are verified by running `--help` or checking official vendor documentation.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-**Content-type propagation** — matching the output format to the source communication's format — is verified by inspecting the source communication's Content-Type header or format before drafting a reply. For emails, this means reading the `.eml` file and confirming its `Content-Type` value. For structured data, it means confirming the source format (JSON, YAML, etc.) and producing output in that format. The verification step is: before generating reply content, the agent MUST confirm what format the source uses and produce output in that same format. A reply in markdown to an HTML email, or a reply in plain text with markdown syntax to a multipart/alternative email, is a verification failure — the content type was not propagated.
-
->>>>>>> spec/1098-fix
-=======
 **Content-type propagation** — matching the output format to the source communication's format — is verified by inspecting the source communication's Content-Type header or format before drafting a reply. For emails, this means reading the `.eml` file and confirming its `Content-Type` value. For structured data, it means confirming the source format (JSON, YAML, etc.) and producing output in that format. The verification step is: before generating reply content, the agent MUST confirm what format the source uses and produce output in that same format. A reply in markdown to an HTML email, or a reply in plain text with markdown syntax to a multipart/alternative email, is a verification failure — the content type was not propagated.
 
 **Audience separation** — ensuring generated content does not leak internal artifacts to stakeholders — is verified during the revisit pass by scanning for operator-tier content in stakeholder-tier communications. The agent identifies the audience tier from the correspondence skill's audience classification, then scans the generated content for internal artifacts that violate the audience separation principle: runbook paths, step numbers from internal procedures, internal IP addresses (unless subject of report), internal file paths, configuration paths, internal tool or script names, CLI commands for internal operations, debugging output, and internal documentation references. When such artifacts appear in stakeholder-tier content, they must be rephrased in stakeholder-relevant terms or removed. This domain is closely related to the correspondence skill's Audience Separation Principle and Prohibited Content rules — the revisit pass enforces them after generation, just as the verify pass enforces verification before generation.
-
->>>>>>> spec/1099-fix
 **Attribution** — who performed an action — is verified against the source communication. When content states "completed by Person X" or "Person X did Y", the attribution must be traced to evidence: email From/Sender headers, GitHub commit authors, PR creators, issue comment authors, or explicit statements in the source material. Attribution evidence sources include: `github_issue_read(method=get)` for issue authors and commenters, `github_pull_request_read(method=get)` for PR creators, `srclight_blame_symbol` for commit authors, and direct file reads of email headers or forwarded messages. If the source does not explicitly state who did something, the agent must not attribute — it must either omit the name or write "completed per [reference]" without naming an individual. Inferring "who did what" from role proximity (e.g., "tech person → did the tech work") without source evidence is an attribution hallucination and is prohibited.
 
 The agent selects verification tools based on the domain, not by following a lookup table, but by reasoning about what evidence source would authoritatively confirm the claim. A claim about a Python function's parameters calls for `srclight_get_signature`; a claim about a CLI flag calls for running the command with `--help`; a claim about a GUI path calls for checking vendor documentation. When multiple sources are available, the most authoritative and most recent source wins.
@@ -81,15 +72,7 @@ The evidence artifact format is:
 
 ```
 Claim: <what the content asserts>
-<<<<<<< HEAD
-<<<<<<< HEAD
-Domain: <verification domain — API, config, code behavior, docs, CLI, attribution>
-=======
-Domain: <verification domain — API, config, code behavior, docs, CLI, attribution, content-type>
->>>>>>> spec/1098-fix
-=======
-Domain: <verification domain — API, config, code behavior, docs, CLI, attribution, content-type>
->>>>>>> spec/1099-fix
+Domain: <verification domain — API, config, code behavior, docs, CLI, attribution, content-type, audience-separation>
 Source: <tool call or document that provided the evidence>
 Verified: <yes|no>
 Marker: <if no, ⚠️ UNVERIFIED>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,4 @@ When parent issue has sub-issues, authorization cascades to ALL sub-issues:
 - Use `/tmp/` — only use `./tmp/`
 - Assume cached values from previous sessions
 - HALT after each phase of multi-task spec (see Multi-Task Spec Workflow above)
+- Write spec/plan content directly to chat as the final deliverable — ALWAYS invoke brainstorming → spec-creation → issue-operations to persist specs as GitHub Issues


### PR DESCRIPTION
## Summary

Resolves merge conflict markers in 3 skill files and enforces the spec-creation → issue-operations skill chain to prevent agents from dumping spec content directly into chat.

## Outcome

- #1147: Merge conflicts removed from sre-runbook/SKILL.md, correspondence/SKILL.md, and verification-enforcement/SKILL.md — incoming branch content preserved (Verification Row-by-Row Template, Audience Separation Principle, Content-Type Propagation, attribution verification)
- #1148: 7 root causes addressed — processSkills array fixed, brainstorming routing corrected, hard gate added, skill chain documented, frontmatter fixed, AGENTS.md prohibition added, enforcement check added

Fixes #1147
Fixes #1148