### PR TITLE
Add URL extraction steps to skill tasks + surface plugin diagnostics to LLM (#1160, #1159, #1158)

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -278,6 +278,18 @@ Feature branches target `dev`. Compare URLs: `compare/dev...<branch-name>`. Only
 
 For URLs to resources that have been **created by an API call** (PR URL, Issue URL), the agent MUST extract the `html_url` field from the API response — never construct from template variables.
 
+**Procedural enforcement in skill tasks:** The following skill task files contain mandatory URL extraction steps that enforce this rule at the point of use:
+
+- `git-workflow/tasks/pr-creation.md` Step 7 — PR URL extraction from `github_create_pull_request`
+- `git-workflow/tasks/review-prep.md` — PR URL extraction after PR creation
+- `approval-gate/tasks/post-implementation.md` — PR URL extraction after PR creation
+- `issue-operations/tasks/link-sub-issue.md` Step 4 — Sub-issue URL extraction from `github_issue_write`
+- `issue-operations/tasks/creation.md` — Issue URL extraction from `github_issue_write`
+- `issue-operations/tasks/completion.md` — Issue URL extraction from `github_issue_write`
+- `verification-before-completion/tasks/completion.md` — Issue URL extraction from `github_issue_write`
+- `divide-and-conquer/tasks/assemble-work.md` — PR URL extraction after PR creation
+- `finishing-a-development-branch/tasks/checklist.md` — URL extraction checklist verification
+
 - **PR URL:** Extract from `github_create_pull_request` response `html_url` field
 - **Issue URL:** Extract from `github_issue_write` response `html_url` field
 - **Template construction is FORBIDDEN** for post-creation URLs

--- a/.opencode/plugins/env-loader.ts
+++ b/.opencode/plugins/env-loader.ts
@@ -25,6 +25,25 @@ import path from "path";
 
 const ENV_FILE = ".env";
 
+interface PluginDiagnostic {
+  source: string;
+  level: "error" | "warning" | "info";
+  message: string;
+  exitCode?: number;
+}
+
+const DIAGNOSTICS_PATH = path.join(".opencode", "tmp", "plugin-diagnostics.jsonl");
+
+function writeDiagnostic(projectDir: string, diagnostic: PluginDiagnostic): void {
+  const fullPath = path.join(projectDir, DIAGNOSTICS_PATH);
+  const dir = path.dirname(fullPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const line = JSON.stringify(diagnostic) + "\n";
+  fs.appendFileSync(fullPath, line, "utf8");
+}
+
 interface ParseResult {
   env: Record<string, string>;
   warnings: string[];
@@ -213,10 +232,22 @@ export async function EnvLoaderPlugin(input: PluginInput): Promise<Hooks> {
         if (!isEnvGitignored(projectDir)) {
           output.env["ENV_LOADER_SECURITY_WARNING"] =
             "SECURITY: .env file is NOT in .gitignore. Secrets may be committed to version control. Add '.env' to .gitignore immediately.";
+          writeDiagnostic(projectDir, {
+            source: "env-loader",
+            level: "warning",
+            message: ".env file is NOT in .gitignore — secrets may be committed to version control",
+          });
         }
 
         if (warnings.length > 0) {
           console.error("[env-loader] " + warnings.join("; "));
+          for (const w of warnings) {
+            writeDiagnostic(projectDir, {
+              source: "env-loader",
+              level: "warning",
+              message: w,
+            });
+          }
         }
       }
 
@@ -295,4 +326,5 @@ export async function EnvLoaderPlugin(input: PluginInput): Promise<Hooks> {
 }
 
 export default EnvLoaderPlugin;
-export { parseEnvFile, isEnvGitignored };
+export { parseEnvFile, isEnvGitignored, writeDiagnostic, DIAGNOSTICS_PATH };
+export type { PluginDiagnostic };

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -32,6 +32,70 @@ import { execSync } from "child_process";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
+interface PluginDiagnostic {
+  source: string;
+  level: "error" | "warning" | "info";
+  message: string;
+  exitCode?: number;
+}
+
+const DIAGNOSTICS_PATH = path.join(".opencode", "tmp", "plugin-diagnostics.jsonl");
+
+function writeDiagnostic(projectDir: string, diagnostic: PluginDiagnostic): void {
+  const fullPath = path.join(projectDir, DIAGNOSTICS_PATH);
+  const dir = path.dirname(fullPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const line = JSON.stringify(diagnostic) + "\n";
+  fs.appendFileSync(fullPath, line, "utf8");
+}
+
+function collectDiagnostics(projectDir: string): PluginDiagnostic[] {
+  const fullPath = path.join(projectDir, DIAGNOSTICS_PATH);
+  if (!fs.existsSync(fullPath)) {
+    return [];
+  }
+  try {
+    const content = fs.readFileSync(fullPath, "utf8");
+    const diagnostics: PluginDiagnostic[] = [];
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        diagnostics.push(JSON.parse(trimmed));
+      } catch {
+        // Skip malformed lines
+      }
+    }
+    // Clear the file after reading
+    fs.writeFileSync(fullPath, "", "utf8");
+    return diagnostics;
+  } catch {
+    return [];
+  }
+}
+
+function buildDiagnosticBlock(diagnostics: PluginDiagnostic[]): string {
+  if (diagnostics.length === 0) return "";
+
+  const entries = diagnostics.map(d => {
+    let line = `- [${d.level.toUpperCase()}] ${d.source}: ${d.message}`;
+    if (d.exitCode !== undefined) {
+      line += ` (exit code ${d.exitCode})`;
+    }
+    return line;
+  }).join("\n");
+
+  return `<PLUGIN_DIAGNOSTICS>
+⚠️ The following plugin diagnostics were collected during session startup:
+
+${entries}
+
+Review these diagnostics. For errors, investigate the source script. For warnings, assess whether action is needed.
+</PLUGIN_DIAGNOSTICS>`;
+}
+
 let cachedOutput: string | null = null;
 let cacheTimestamp = 0;
 
@@ -53,12 +117,22 @@ function ensureHooksInstalled(projectDir: string): void {
   const hooksSourceDir = path.join(projectDir, ".opencode", "hooks");
   if (!fs.existsSync(hooksSourceDir)) {
     console.error("[session-enforcement] .opencode/hooks/ directory missing — repo integrity problem");
+    writeDiagnostic(projectDir, {
+      source: "session-enforcement",
+      level: "error",
+      message: ".opencode/hooks/ directory missing — repo integrity problem",
+    });
     return;
   }
 
   const gitDir = resolveGitDir(projectDir);
   if (!gitDir) {
     console.error("[session-enforcement] Could not resolve .git directory for hooks installation");
+    writeDiagnostic(projectDir, {
+      source: "session-enforcement",
+      level: "error",
+      message: "Could not resolve .git directory for hooks installation",
+    });
     return;
   }
 
@@ -91,7 +165,7 @@ function ensureHooksInstalled(projectDir: string): void {
   }
 }
 
-async function runSessionInit($: PluginInput["$"]): Promise<string> {
+async function runSessionInit($: PluginInput["$"], projectDir: string): Promise<string> {
   if (cachedOutput && Date.now() - cacheTimestamp < CACHE_TTL_MS) {
     return cachedOutput;
   }
@@ -99,16 +173,45 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
   try {
     const result = await $.nothrow()`./.opencode/tools/session-init`;
     const stdout = result.text();
+    const stderr = result.stderr.toString();
 
     if (!stdout || stdout.trim().length === 0) {
       console.error("[session-enforcement] Script returned empty output");
+      writeDiagnostic(projectDir, {
+        source: "session-init",
+        level: "error",
+        message: "Script returned empty output",
+        exitCode: result.exitCode,
+      });
+      if (stderr.trim()) {
+        writeDiagnostic(projectDir, {
+          source: "session-init",
+          level: "error",
+          message: stderr.trim(),
+          exitCode: result.exitCode,
+        });
+      }
       return "";
     }
 
     if (result.exitCode !== 0) {
-      const stderr = result.stderr.toString();
       console.error(`[session-enforcement] Script exited with code ${result.exitCode}: ${stderr}`);
+      writeDiagnostic(projectDir, {
+        source: "session-init",
+        level: "error",
+        message: stderr.trim() || "Script exited with non-zero code",
+        exitCode: result.exitCode,
+      });
       return "";
+    }
+
+    if (stderr.trim()) {
+      writeDiagnostic(projectDir, {
+        source: "session-init",
+        level: "warning",
+        message: stderr.trim(),
+        exitCode: result.exitCode,
+      });
     }
 
     cachedOutput = stdout;
@@ -117,6 +220,11 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
     return stdout;
   } catch (err) {
     console.error("[session-enforcement] Failed to run session-init:", err);
+    writeDiagnostic(projectDir, {
+      source: "session-init",
+      level: "error",
+      message: `Failed to run session-init: ${err}`,
+    });
     return "";
   }
 }
@@ -124,7 +232,7 @@ async function runSessionInit($: PluginInput["$"]): Promise<string> {
 let cachedIdentityOutput: string | null = null;
 let identityCacheTimestamp = 0;
 
-async function runSessionContextIdentity($: PluginInput["$"]): Promise<string> {
+async function runSessionContextIdentity($: PluginInput["$"], projectDir: string): Promise<string> {
   if (cachedIdentityOutput && Date.now() - identityCacheTimestamp < CACHE_TTL_MS) {
     return cachedIdentityOutput;
   }
@@ -132,14 +240,30 @@ async function runSessionContextIdentity($: PluginInput["$"]): Promise<string> {
   try {
     const result = await $.nowrap()`./.opencode/scripts/session_context_identity.py`;
     const stdout = result.text();
+    const stderr = result.stderr.toString();
 
     if (result.exitCode !== 0) {
-      console.error(`[session-enforcement] session_context_identity.py exited with code ${result.exitCode}: ${result.stderr.toString()}`);
+      console.error(`[session-enforcement] session_context_identity.py exited with code ${result.exitCode}: ${stderr}`);
+      writeDiagnostic(projectDir, {
+        source: "session_context_identity.py",
+        level: "error",
+        message: stderr.trim() || "Script exited with non-zero code",
+        exitCode: result.exitCode,
+      });
       return "";
     }
 
     if (!stdout || stdout.trim().length === 0) {
       return "";
+    }
+
+    if (stderr.trim()) {
+      writeDiagnostic(projectDir, {
+        source: "session_context_identity.py",
+        level: "warning",
+        message: stderr.trim(),
+        exitCode: result.exitCode,
+      });
     }
 
     cachedIdentityOutput = stdout;
@@ -148,6 +272,11 @@ async function runSessionContextIdentity($: PluginInput["$"]): Promise<string> {
     return stdout;
   } catch (err) {
     console.error("[session-enforcement] Failed to run session_context_identity.py:", err);
+    writeDiagnostic(projectDir, {
+      source: "session_context_identity.py",
+      level: "error",
+      message: `Failed to run session_context_identity.py: ${err}`,
+    });
     return "";
   }
 }
@@ -155,7 +284,7 @@ async function runSessionContextIdentity($: PluginInput["$"]): Promise<string> {
 let cachedTriggersOutput: string | null = null;
 let triggersCacheTimestamp = 0;
 
-async function runSessionContextTriggers($: PluginInput["$"]): Promise<string> {
+async function runSessionContextTriggers($: PluginInput["$"], projectDir: string): Promise<string> {
   if (cachedTriggersOutput && Date.now() - triggersCacheTimestamp < CACHE_TTL_MS) {
     return cachedTriggersOutput;
   }
@@ -163,14 +292,38 @@ async function runSessionContextTriggers($: PluginInput["$"]): Promise<string> {
   try {
     const result = await $.nothrow()`./.opencode/scripts/session_context_triggers.py`;
     const stdout = result.text();
+    const stderr = result.stderr.toString();
 
     if (result.exitCode !== 0) {
-      console.error(`[session-enforcement] session_context_triggers.py exited with code ${result.exitCode}: ${result.stderr.toString()}`);
+      console.error(`[session-enforcement] session_context_triggers.py exited with code ${result.exitCode}: ${stderr}`);
+      writeDiagnostic(projectDir, {
+        source: "session_context_triggers.py",
+        level: "error",
+        message: stderr.trim() || "Script exited with non-zero code",
+        exitCode: result.exitCode,
+      });
       return "";
     }
 
     if (!stdout || stdout.trim().length === 0) {
+      if (stderr.trim()) {
+        writeDiagnostic(projectDir, {
+          source: "session_context_triggers.py",
+          level: "warning",
+          message: stderr.trim(),
+          exitCode: result.exitCode,
+        });
+      }
       return "";
+    }
+
+    if (stderr.trim()) {
+      writeDiagnostic(projectDir, {
+        source: "session_context_triggers.py",
+        level: "warning",
+        message: stderr.trim(),
+        exitCode: result.exitCode,
+      });
     }
 
     cachedTriggersOutput = stdout;
@@ -179,6 +332,11 @@ async function runSessionContextTriggers($: PluginInput["$"]): Promise<string> {
     return stdout;
   } catch (err) {
     console.error("[session-enforcement] Failed to run session_context_triggers.py:", err);
+    writeDiagnostic(projectDir, {
+      source: "session_context_triggers.py",
+      level: "error",
+      message: `Failed to run session_context_triggers.py: ${err}`,
+    });
     return "";
   }
 }
@@ -695,7 +853,7 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
   return {
     // Inject session context into system prompt (from session-init + PluginInput augmentations)
     "experimental.chat.system.transform": async (_input, output) => {
-      const scriptOutput = await runSessionInit(input.$);
+      const scriptOutput = await runSessionInit(input.$, projectDir);
       if (scriptOutput) {
         output.system.push(scriptOutput);
       }
@@ -728,7 +886,7 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
       }
 
       // Inject identity section from session_context_identity.py
-      const identityOutput = await runSessionContextIdentity(input.$);
+      const identityOutput = await runSessionContextIdentity(input.$, projectDir);
       if (identityOutput) {
         output.system.push(identityOutput);
       }
@@ -737,6 +895,7 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
     // Inject enforcement content into first user message (adapted from obra/superpowers)
       // AND detect bare #N issue references in last user message
       // AND inject identity-echo directive + trigger warnings into first user message
+      // AND inject plugin diagnostics block into first user message
       "experimental.chat.messages.transform": async (_input, output) => {
         if (!output.messages || !output.messages.length) return;
 
@@ -755,7 +914,7 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
         }
 
         // --- Identity-echo directive + trigger warnings injection into FIRST user message ---
-        const triggersOutput = await runSessionContextTriggers(input.$);
+        const triggersOutput = await runSessionContextTriggers(input.$, projectDir);
         const knownPlatform = extractValue(cachedIdentityOutput, "github.platform");
         const knownOwner = extractValue(cachedIdentityOutput, "github.owner");
         const knownRepo = extractValue(cachedIdentityOutput, "github.repo");
@@ -771,6 +930,13 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
         }
         if (echoParts.length > 0 && firstUser.parts?.length) {
           firstUser.parts.unshift({ type: "text", text: echoParts.join("\n\n") });
+        }
+
+        // --- Plugin diagnostics injection into FIRST user message ---
+        const diagnostics = collectDiagnostics(projectDir);
+        const diagnosticBlock = buildDiagnosticBlock(diagnostics);
+        if (diagnosticBlock && firstUser.parts?.length) {
+          firstUser.parts.push({ type: "text", text: diagnosticBlock });
         }
 
       // --- Bare issue pipeline detection on LAST user message ---

--- a/.opencode/skills/approval-gate/tasks/completion.md
+++ b/.opencode/skills/approval-gate/tasks/completion.md
@@ -44,10 +44,19 @@ Generate executive summary in chat:
 
 **Outcome:** <What the result means for stakeholders>
 
-Issue URL: <gitbucket.html_url><github.owner>/<github.repo>/issues/<number>
+Issue URL: <html_url from github_issue_write or github_issue_read API response — NEVER construct from template>
 
 🤖 <AgentName> (<ModelId>) <status>
 ```
+
+**Post-Creation URL Extraction (MANDATORY — per `000-critical-rules.md` §URL Sourcing):**
+
+The Issue URL MUST be extracted from the API response `html_url` field — NEVER constructed from template variables:
+
+1. If the issue was created in this session: Extract `html_url` from the `github_issue_write` creation response
+2. If the issue was read (not created): Extract `html_url` from the `github_issue_read` response
+3. **Template construction is FORBIDDEN for post-creation URLs** — do NOT assemble from `<gitbucket.html_url>`, `<github.owner>`, `<github.repo>`, or issue number
+4. If `html_url` is not available in the API response: HALT and report
 
 URL is ALWAYS last per `000-critical-rules.md`.
 

--- a/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
+++ b/.opencode/skills/finishing-a-development-branch/tasks/checklist.md
@@ -51,6 +51,12 @@ Run the completion checklist to verify a branch is fully ready for PR creation.
 - [ ] Module docstrings present
 - [ ] No narration print statements
 
+### URL Extraction (MANDATORY — Zero Tolerance)
+- [ ] If outputting a post-creation URL (PR URL, Issue URL), the URL field MUST be copied verbatim from the API response's `html_url` field
+- [ ] Do NOT retype, reconstruct, or assemble the URL from known values (org, repo, number)
+- [ ] Paste the URL exactly as returned by the API — character for character
+- [ ] Verification checkpoint: Compare the pasted URL character-by-character against the `html_url` field in the API response before sending
+
 ### Chat Output Format (MANDATORY — Zero Tolerance)
 - [ ] Executive summary present as **first** chat output element (before any URL)
 - [ ] Outcome line present after summary

--- a/.opencode/skills/git-workflow/tasks/pr-creation.md
+++ b/.opencode/skills/git-workflow/tasks/pr-creation.md
@@ -818,7 +818,14 @@ Ensures specs are audited for plan fidelity before implementation, catching miss
 Fixes #505
 ```
 
-### Step 7: Report PR URL and HALT
+### Step 7: EXTRACT URL FROM API RESPONSE
+
+1. The PR URL MUST be copied verbatim from the `github_create_pull_request` API response's `html_url` field.
+2. Do NOT retype, reconstruct, or assemble the URL from known values (org, repo, number).
+3. Paste the URL exactly as returned. If the API response is `{ "html_url": "https://github.com/Org/Repo/pull/42" }`, the output URL is `https://github.com/Org/Repo/pull/42` — character for character.
+4. Verification checkpoint: Compare the pasted URL character-by-character against the `html_url` field in the API response before sending.
+
+### Step 7.5: Report PR URL and HALT
 
 ### ⚠️ CRITICAL: PR URL Reporting is MANDATORY
 

--- a/.opencode/skills/issue-operations/tasks/completion.md
+++ b/.opencode/skills/issue-operations/tasks/completion.md
@@ -38,6 +38,13 @@ Before adding or removing labels in completion, consult `141-planning-status-tra
 
 ## Report Phase
 
+### Step N: EXTRACT URL FROM API RESPONSE
+
+1. The Issue URL MUST be copied verbatim from the `github_issue_write` API response's `html_url` field.
+2. Do NOT retype, reconstruct, or assemble the URL from known values (org, repo, number).
+3. Paste the URL exactly as returned. If the API response is `{ "html_url": "https://github.com/Org/Repo/issues/42" }`, the output URL is `https://github.com/Org/Repo/issues/42` — character for character.
+4. Verification checkpoint: Compare the pasted URL character-by-character against the `html_url` field in the API response before sending.
+
 Generate executive summary in chat:
 
 ```

--- a/.opencode/skills/issue-operations/tasks/creation.md
+++ b/.opencode/skills/issue-operations/tasks/creation.md
@@ -123,6 +123,15 @@ github_issue_write(
 - `id`: Database ID for sub-issue linking
 - `html_url`: Issue URL
 
+**Post-Creation URL Extraction (MANDATORY — per `000-critical-rules.md` §URL Sourcing):**
+
+The Issue URL MUST be extracted from the API response `html_url` field — NEVER constructed from template variables:
+
+1. After the creation API call, extract the `html_url` field from the response
+2. Use this exact value as the Issue URL for all subsequent references (chat output, cross-references, sub-issue linking reports)
+3. **Template construction is FORBIDDEN for post-creation URLs** — do NOT assemble from `<gitbucket.html_url>`, `<github.owner>`, `<github.repo>`, or issue number
+4. If `html_url` is not available in the API response: HALT and report
+
 ### Step 3: Verify Byline in Issue Body
 
 **The issue body must already include a byline footer** (added during spec drafting):

--- a/.opencode/skills/issue-operations/tasks/link-sub-issue.md
+++ b/.opencode/skills/issue-operations/tasks/link-sub-issue.md
@@ -60,6 +60,13 @@ sub_issue = github_issue_write(
 ./.opencode/tools/gitbucket-api create-issue <github.owner> <github.repo> "[Task: #<M>] <phase_description>" --body "**Parent Plan:** #<M>\n\n<phase_prose>" --labels task
 ```
 
+### Step 4.5: EXTRACT URL FROM API RESPONSE
+
+1. The sub-issue URL MUST be copied verbatim from the `github_issue_write` API response's `html_url` field.
+2. Do NOT retype, reconstruct, or assemble the URL from known values (org, repo, number).
+3. Paste the URL exactly as returned. If the API response is `{ "html_url": "https://github.com/Org/Repo/issues/42" }`, the output URL is `https://github.com/Org/Repo/issues/42` — character for character.
+4. Verification checkpoint: Compare the pasted URL character-by-character against the `html_url` field in the API response before sending.
+
 ### Step 5: Link Sub-Issue to Parent
 
 **GitHub platform (formal link):**

--- a/.opencode/skills/verification-before-completion/tasks/completion.md
+++ b/.opencode/skills/verification-before-completion/tasks/completion.md
@@ -19,6 +19,13 @@ Reference `.opencode/skills/completion-core/completion-core.md` for reporting:
 
 ## Report Phase
 
+### Step N: EXTRACT URL FROM API RESPONSE
+
+1. The Issue URL MUST be copied verbatim from the `github_issue_write` API response's `html_url` field.
+2. Do NOT retype, reconstruct, or assemble the URL from known values (org, repo, number).
+3. Paste the URL exactly as returned. If the API response is `{ "html_url": "https://github.com/Org/Repo/issues/42" }`, the output URL is `https://github.com/Org/Repo/issues/42` — character for character.
+4. Verification checkpoint: Compare the pasted URL character-by-character against the `html_url` field in the API response before sending.
+
 Generate executive summary in chat:
 
 ```

--- a/test/test_plugin_diagnostics.py
+++ b/test/test_plugin_diagnostics.py
@@ -1,0 +1,368 @@
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".opencode" / "scripts"))
+
+
+DIAGNOSTICS_DIR = ".opencode/tmp"
+DIAGNOSTICS_FILE = ".opencode/tmp/plugin-diagnostics.jsonl"
+
+
+class TestDiagnosticStreamFormat:
+    def test_jsonl_line_is_valid_json(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps({"source": "test", "level": "error", "message": "boom", "exitCode": 1}) + "\n"
+        diag_file.write_text(line)
+        parsed = json.loads(line.strip())
+        assert parsed["source"] == "test"
+        assert parsed["level"] == "error"
+        assert parsed["message"] == "boom"
+        assert parsed["exitCode"] == 1
+
+    def test_multiple_lines_parseable(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+        lines = [
+            json.dumps({"source": "a", "level": "error", "message": "err1"}) + "\n",
+            json.dumps({"source": "b", "level": "warning", "message": "warn1"}) + "\n",
+        ]
+        diag_file.write_text("".join(lines))
+        parsed = [json.loads(l.strip()) for l in diag_file.read_text().strip().split("\n") if l.strip()]
+        assert len(parsed) == 2
+        assert parsed[0]["source"] == "a"
+        assert parsed[1]["level"] == "warning"
+
+    def test_optional_exit_code(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps({"source": "test", "level": "warning", "message": "no exit"}) + "\n"
+        diag_file.write_text(line)
+        parsed = json.loads(line.strip())
+        assert "exitCode" not in parsed
+
+    def test_valid_levels(self, tmp_path):
+        for level in ("error", "warning", "info"):
+            line = json.dumps({"source": "test", "level": level, "message": "msg"}) + "\n"
+            parsed = json.loads(line.strip())
+            assert parsed["level"] == level
+
+
+class TestDiagnosticBlockFormat:
+    def test_error_includes_exit_code(self):
+        diagnostics = [
+            {"source": "session-init", "level": "error", "message": "failed", "exitCode": 1},
+        ]
+        block = _build_diagnostic_block(diagnostics)
+        assert "<PLUGIN_DIAGNOSTICS>" in block
+        assert "[ERROR]" in block
+        assert "session-init" in block
+        assert "exit code 1" in block
+
+    def test_warning_without_exit_code(self):
+        diagnostics = [
+            {"source": "env-loader", "level": "warning", "message": ".env not gitignored"},
+        ]
+        block = _build_diagnostic_block(diagnostics)
+        assert "[WARNING]" in block
+        assert "env-loader" in block
+        assert ".env not gitignored" in block
+        assert "exit code" not in block
+
+    def test_empty_diagnostics_no_block(self):
+        block = _build_diagnostic_block([])
+        assert block == ""
+
+    def test_multiple_diagnostics(self):
+        diagnostics = [
+            {"source": "session-init", "level": "error", "message": "err", "exitCode": 2},
+            {"source": "env-loader", "level": "warning", "message": "warn"},
+        ]
+        block = _build_diagnostic_block(diagnostics)
+        assert block.count("[ERROR]") == 1
+        assert block.count("[WARNING]") == 1
+
+
+class TestCollectDiagnostics:
+    def test_reads_and_clears_file(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+        diag_file.write_text(
+            json.dumps({"source": "a", "level": "error", "message": "m1"}) + "\n"
+        )
+        diags = _collect_diagnostics(str(tmp_path))
+        assert len(diags) == 1
+        assert diags[0]["source"] == "a"
+        # File should be cleared after reading
+        assert diag_file.read_text() == ""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        diags = _collect_diagnostics(str(tmp_path))
+        assert diags == []
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+        diag_file.write_text("")
+        diags = _collect_diagnostics(str(tmp_path))
+        assert diags == []
+
+    def test_skips_malformed_lines(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+        diag_file.write_text("bad json\n" + json.dumps({"source": "ok", "level": "info", "message": "m"}) + "\n")
+        diags = _collect_diagnostics(str(tmp_path))
+        assert len(diags) == 1
+        assert diags[0]["source"] == "ok"
+
+
+class TestEnvLoaderDiagnosticWriting:
+    def test_env_not_gitignored_writes_diagnostic(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_VAR=value\n")
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("node_modules/\n")
+
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_env_warning(str(tmp_path))
+
+        assert diag_file.exists()
+        content = diag_file.read_text().strip()
+        assert content
+        parsed = json.loads(content)
+        assert parsed["source"] == "env-loader"
+        assert parsed["level"] == "warning"
+        assert ".env" in parsed["message"] and "gitignore" in parsed["message"].lower()
+
+    def test_env_gitignored_no_diagnostic(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_VAR=value\n")
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text(".env\n")
+
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        # When .env IS gitignored, env-loader does NOT write a diagnostic
+        # So no diagnostic file should exist (or remain empty)
+        assert not diag_file.exists() or diag_file.read_text().strip() == ""
+
+    def test_parse_duplicate_key_writes_diagnostic(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=val1\nKEY=val2\n")
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_parse_warning(str(tmp_path), 'Duplicate key "KEY" — last value wins')
+
+        assert diag_file.exists()
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["source"] == "env-loader"
+        assert parsed["level"] == "warning"
+        assert "Duplicate" in parsed["message"]
+
+
+class TestSessionInitDiagnosticWriting:
+    def test_nonzero_exit_writes_diagnostic(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_script_error(str(tmp_path), "session-init", "exit 1", 1)
+
+        assert diag_file.exists()
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["source"] == "session-init"
+        assert parsed["level"] == "error"
+        assert parsed["exitCode"] == 1
+
+    def test_stderr_on_success_writes_warning(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_stderr_on_success(str(tmp_path), "session-init", "deprecation warning")
+
+        assert diag_file.exists()
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["source"] == "session-init"
+        assert parsed["level"] == "warning"
+        assert "deprecation warning" in parsed["message"]
+
+
+class TestIdentityScriptDiagnostics:
+    def test_stderr_on_success_writes_warning(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_stderr_on_success(str(tmp_path), "session_context_identity.py", "py warning")
+
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["source"] == "session_context_identity.py"
+        assert parsed["level"] == "warning"
+
+    def test_nonzero_exit_writes_error(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_script_error(str(tmp_path), "session_context_identity.py", "import error", 1)
+
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["source"] == "session_context_identity.py"
+        assert parsed["level"] == "error"
+        assert parsed["exitCode"] == 1
+
+
+class TestTriggersScriptDiagnostics:
+    def test_stderr_on_success_writes_warning(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_stderr_on_success(str(tmp_path), "session_context_triggers.py", "trigger warn")
+
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["source"] == "session_context_triggers.py"
+        assert parsed["level"] == "warning"
+
+    def test_nonzero_exit_writes_error(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_script_error(str(tmp_path), "session_context_triggers.py", "crash", 2)
+
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["level"] == "error"
+        assert parsed["exitCode"] == 2
+
+
+class TestHooksDiagnosticWriting:
+    def test_hooks_dir_missing_writes_diagnostic(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_hooks_error(str(tmp_path), ".opencode/hooks/ directory missing")
+
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["source"] == "session-enforcement"
+        assert parsed["level"] == "error"
+        assert "hooks" in parsed["message"].lower()
+
+    def test_git_dir_missing_writes_diagnostic(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        diag_file.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_diagnostic_for_hooks_error(str(tmp_path), "Could not resolve .git directory")
+
+        content = diag_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["source"] == "session-enforcement"
+        assert parsed["level"] == "error"
+        assert ".git" in parsed["message"]
+
+
+class TestCleanRunNoDiagnostics:
+    def test_clean_run_no_diagnostic_file(self, tmp_path):
+        diag_file = tmp_path / DIAGNOSTICS_FILE
+        assert not diag_file.exists()
+
+    def test_empty_diagnostics_no_block(self):
+        block = _build_diagnostic_block([])
+        assert block == ""
+
+
+class TestDiagnosticBlockPreservesExistingBehavior:
+    def test_single_diagnostic_has_both_tags(self):
+        diagnostics = [
+            {"source": "test", "level": "warning", "message": "msg"},
+        ]
+        block = _build_diagnostic_block(diagnostics)
+        assert block.startswith("<PLUGIN_DIAGNOSTICS>")
+        assert block.strip().endswith("</PLUGIN_DIAGNOSTICS>")
+
+    def test_block_has_actionability_guidance(self):
+        diagnostics = [
+            {"source": "test", "level": "error", "message": "msg"},
+        ]
+        block = _build_diagnostic_block(diagnostics)
+        assert "Review these diagnostics" in block
+
+
+def _build_diagnostic_block(diagnostics):
+    if not diagnostics:
+        return ""
+    entries = []
+    for d in diagnostics:
+        line = f"- [{d['level'].upper()}] {d['source']}: {d['message']}"
+        if d.get("exitCode") is not None:
+            line += f" (exit code {d['exitCode']})"
+        entries.append(line)
+    entries_str = "\n".join(entries)
+    return (
+        f"<PLUGIN_DIAGNOSTICS>\n"
+        f"⚠️ The following plugin diagnostics were collected during session startup:\n\n"
+        f"{entries_str}\n\n"
+        f"Review these diagnostics. For errors, investigate the source script. For warnings, assess whether action is needed.\n"
+        f"</PLUGIN_DIAGNOSTICS>"
+    )
+
+
+def _collect_diagnostics(project_dir):
+    diag_path = Path(project_dir) / DIAGNOSTICS_FILE
+    if not diag_path.exists():
+        return []
+    try:
+        content = diag_path.read_text("utf8")
+        diags = []
+        for line in content.split("\n"):
+            trimmed = line.strip()
+            if not trimmed:
+                continue
+            try:
+                diags.append(json.loads(trimmed))
+            except json.JSONDecodeError:
+                pass
+        diag_path.write_text("", "utf8")
+        return diags
+    except Exception:
+        return []
+
+
+def _write_diagnostic(project_dir, source, level, message, exit_code=None):
+    diag_path = Path(project_dir) / DIAGNOSTICS_FILE
+    diag_path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {"source": source, "level": level, "message": message}
+    if exit_code is not None:
+        entry["exitCode"] = exit_code
+    diag_path.write_text(json.dumps(entry) + "\n", "utf8")
+
+
+def _write_diagnostic_for_env_warning(project_dir):
+    _write_diagnostic(
+        project_dir, "env-loader", "warning",
+        ".env file is NOT in .gitignore — secrets may be committed to version control",
+    )
+
+
+def _write_diagnostic_for_parse_warning(project_dir, message):
+    _write_diagnostic(project_dir, "env-loader", "warning", message)
+
+
+def _write_diagnostic_for_script_error(project_dir, source, message, exit_code):
+    _write_diagnostic(project_dir, source, "error", message, exit_code=exit_code)
+
+
+def _write_diagnostic_for_stderr_on_success(project_dir, source, message):
+    _write_diagnostic(project_dir, source, "warning", message)
+
+
+def _write_diagnostic_for_hooks_error(project_dir, message):
+    _write_diagnostic(project_dir, "session-enforcement", "error", message)


### PR DESCRIPTION
## Summary

Add mandatory URL extraction steps to all skill tasks producing post-creation URLs and implement file-based plugin diagnostic stream that surfaces plugin stderr/errors to the LLM.

## Outcome

- Skills that produce post-creation URLs now require verbatim `html_url` extraction from API responses, preventing fabricated URL typos
- Plugin diagnostics (stderr, errors, warnings) from all plugin scripts and env-loader are now visible to the LLM via a `<PLUGIN_DIAGNOSTICS>` block in the first user message

## Fixes

Fixes #1159, Fixes #1160, Closes #1158