### PR TITLE
Fix session plugin failures, enforcement gaps, and add Node.js type-checking infrastructure

### DIFF
--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -3,4 +3,5 @@ package.json
 package-lock.json
 bun.lock
 tmp/
+.node/
 .gitignore

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -87,6 +87,28 @@ function buildDiagnosticBlock(diagnostics: PluginDiagnostic[]): string {
     return line;
   }).join("\n");
 
+  const hasErrors = diagnostics.some(d => d.level.toUpperCase() === "ERROR");
+
+  if (hasErrors) {
+    const actions = diagnostics
+      .filter(d => d.level.toUpperCase() === "ERROR")
+      .map(d => `- Investigate and resolve the ${d.source} ERROR before proceeding`)
+      .join("\n");
+
+    return `<PLUGIN_DIAGNOSTICS>
+⚠️ The following plugin diagnostics were collected during session startup:
+
+${entries}
+
+🚫 MUST NOT proceed — ERROR-level diagnostics detected. HALT immediately and resolve these errors.
+
+**MANDATORY ACTIONS:**
+${actions}
+
+Do NOT continue with any operations until ALL ERROR-level diagnostics are resolved.
+</PLUGIN_DIAGNOSTICS>`;
+  }
+
   return `<PLUGIN_DIAGNOSTICS>
 ⚠️ The following plugin diagnostics were collected during session startup:
 
@@ -175,15 +197,20 @@ async function runSessionInit($: PluginInput["$"], projectDir: string): Promise<
     const stdout = result.text();
     const stderr = result.stderr.toString();
 
+    const bunNotFound = result.exitCode !== 0 && /bun: command not found/i.test(stderr);
+
     if (!stdout || stdout.trim().length === 0) {
-      console.error("[session-enforcement] Script returned empty output");
+      const errorMsg = bunNotFound
+        ? "bun runtime not found — session context unavailable. Install bun or check .opencode/tools/ensure-node for a private Node.js runtime."
+        : "Script returned empty output";
+      console.error(`[session-enforcement] session-init: ${errorMsg}`);
       writeDiagnostic(projectDir, {
         source: "session-init",
         level: "error",
-        message: "Script returned empty output",
+        message: errorMsg,
         exitCode: result.exitCode,
       });
-      if (stderr.trim()) {
+      if (stderr.trim() && !bunNotFound) {
         writeDiagnostic(projectDir, {
           source: "session-init",
           level: "error",
@@ -195,11 +222,14 @@ async function runSessionInit($: PluginInput["$"], projectDir: string): Promise<
     }
 
     if (result.exitCode !== 0) {
-      console.error(`[session-enforcement] Script exited with code ${result.exitCode}: ${stderr}`);
+      const errorMsg = bunNotFound
+        ? "bun runtime not found — session context unavailable. Install bun or check .opencode/tools/ensure-node for a private Node.js runtime."
+        : (stderr.trim() || "Script exited with non-zero code");
+      console.error(`[session-enforcement] session-init exited with code ${result.exitCode}: ${errorMsg}`);
       writeDiagnostic(projectDir, {
         source: "session-init",
         level: "error",
-        message: stderr.trim() || "Script exited with non-zero code",
+        message: errorMsg,
         exitCode: result.exitCode,
       });
       return "";
@@ -238,22 +268,37 @@ async function runSessionContextIdentity($: PluginInput["$"], projectDir: string
   }
 
   try {
-    const result = await $.nowrap()`./.opencode/scripts/session_context_identity.py`;
+    const result = await $.nothrow()`./.opencode/scripts/session_context_identity.py`;
     const stdout = result.text();
     const stderr = result.stderr.toString();
 
-    if (result.exitCode !== 0) {
-      console.error(`[session-enforcement] session_context_identity.py exited with code ${result.exitCode}: ${stderr}`);
+    if (!stdout || stdout.trim().length === 0) {
+      const bunNotFound = result.exitCode !== 0 && /bun: command not found/i.test(stderr);
+      const errorMsg = bunNotFound
+        ? "bun runtime not found — session context unavailable. Install bun or check .opencode/tools/ensure-node for a private Node.js runtime."
+        : (stderr.trim() || "Script returned empty output");
+      console.error(`[session-enforcement] session_context_identity.py: ${errorMsg}`);
       writeDiagnostic(projectDir, {
         source: "session_context_identity.py",
         level: "error",
-        message: stderr.trim() || "Script exited with non-zero code",
+        message: errorMsg,
         exitCode: result.exitCode,
       });
       return "";
     }
 
-    if (!stdout || stdout.trim().length === 0) {
+    if (result.exitCode !== 0) {
+      const bunNotFound = /bun: command not found/i.test(stderr);
+      const errorMsg = bunNotFound
+        ? "bun runtime not found — session context unavailable. Install bun or check .opencode/tools/ensure-node for a private Node.js runtime."
+        : (stderr.trim() || "Script exited with non-zero code");
+      console.error(`[session-enforcement] session_context_identity.py exited with code ${result.exitCode}: ${errorMsg}`);
+      writeDiagnostic(projectDir, {
+        source: "session_context_identity.py",
+        level: "error",
+        message: errorMsg,
+        exitCode: result.exitCode,
+      });
       return "";
     }
 
@@ -294,12 +339,17 @@ async function runSessionContextTriggers($: PluginInput["$"], projectDir: string
     const stdout = result.text();
     const stderr = result.stderr.toString();
 
+    const bunNotFound = result.exitCode !== 0 && /bun: command not found/i.test(stderr);
+
     if (result.exitCode !== 0) {
-      console.error(`[session-enforcement] session_context_triggers.py exited with code ${result.exitCode}: ${stderr}`);
+      const errorMsg = bunNotFound
+        ? "bun runtime not found — session context unavailable. Install bun or check .opencode/tools/ensure-node for a private Node.js runtime."
+        : (stderr.trim() || "Script exited with non-zero code");
+      console.error(`[session-enforcement] session_context_triggers.py exited with code ${result.exitCode}: ${errorMsg}`);
       writeDiagnostic(projectDir, {
         source: "session_context_triggers.py",
         level: "error",
-        message: stderr.trim() || "Script exited with non-zero code",
+        message: errorMsg,
         exitCode: result.exitCode,
       });
       return "";
@@ -970,7 +1020,21 @@ export default async function sessionEnforcementPlugin(input: PluginInput): Prom
       }
 
       // --- Identity echo validation on assistant messages ---
-      if (knownPlatform && knownOwner && knownRepo) {
+      if (!knownPlatform || !knownOwner || !knownRepo) {
+        const missing = [
+          !knownPlatform ? "github.platform" : null,
+          !knownOwner ? "github.owner" : null,
+          !knownRepo ? "github.repo" : null,
+        ].filter(Boolean).join(", ");
+
+        const injectTarget = lastUser;
+        if (injectTarget?.parts?.length) {
+          injectTarget.parts.push({
+            type: "text",
+            text: `<IDENTITY_VALIDATION_FAILURE>\n⚠️ FATAL: Session identity values are MISSING. HALT all operations immediately.\n\nMissing values: ${missing}\n\nIdentity validation cannot proceed without these values. Do NOT infer identity from repository names, file paths, or environment variables. Resolve the missing identity values before continuing any operations.\n</IDENTITY_VALIDATION_FAILURE>`
+          });
+        }
+      } else {
         const assistantMessages = output.messages.filter(m => m.info?.role === "assistant");
         if (assistantMessages.length > 0) {
           const firstAssistant = assistantMessages[0];

--- a/.opencode/tools/ensure-node
+++ b/.opencode/tools/ensure-node
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+NODE_DIR="${REPO_ROOT}/.opencode/.node"
+NODE_BIN="${NODE_DIR}/bin/node"
+TSC_BIN="${NODE_DIR}/bin/tsc"
+
+NODE_VERSION="22.14.0"
+TSC_VERSION="5.8.2"
+
+if [[ -x "${NODE_BIN}" ]]; then
+    INSTALLED=$("${NODE_BIN}" --version 2>/dev/null || echo "unknown")
+    echo "Node.js already installed: ${INSTALLED}"
+    if [[ -x "${TSC_BIN}" ]]; then
+        TSC_INSTALLED=$("${TSC_BIN}" --version 2>/dev/null || echo "unknown")
+        echo "TypeScript already installed: ${TSC_INSTALLED}"
+    fi
+    exit 0
+fi
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "${OS}" in
+    Linux)
+        case "${ARCH}" in
+            x86_64)  PLATFORM="linux-x64" ;;
+            aarch64) PLATFORM="linux-arm64" ;;
+            *)       echo "Unsupported Linux architecture: ${ARCH}" >&2; echo "Supported: x86_64, aarch64" >&2; exit 1 ;;
+        esac
+        EXT="tar.xz"
+        ;;
+    Darwin)
+        case "${ARCH}" in
+            x86_64)  PLATFORM="darwin-x64" ;;
+            arm64)   PLATFORM="darwin-arm64" ;;
+            *)       echo "Unsupported macOS architecture: ${ARCH}" >&2; echo "Supported: x86_64, arm64" >&2; exit 1 ;;
+        esac
+        EXT="tar.xz"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        case "${ARCH}" in
+            x86_64)  PLATFORM="win-x64" ;;
+            *)       echo "Unsupported Windows architecture: ${ARCH}" >&2; echo "Supported: x86_64" >&2; exit 1 ;;
+        esac
+        EXT="zip"
+        ;;
+    *)
+        echo "Unsupported operating system: ${OS}" >&2
+        echo "Supported: Linux, macOS, Windows (WSL)" >&2
+        exit 1
+        ;;
+esac
+
+NODE_FILE="node-v${NODE_VERSION}-${PLATFORM}"
+NODE_DIST_URL="https://nodejs.org/dist/v${NODE_VERSION}/${NODE_FILE}.${EXT}"
+
+echo "Downloading Node.js v${NODE_VERSION} for ${PLATFORM}..."
+echo "URL: ${NODE_DIST_URL}"
+
+TMPDIR=$(mktemp -d "${REPO_ROOT}/.opencode/tmp/node-download-XXXXXX")
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+if ! curl --fail --progress-bar -o "${TMPDIR}/${NODE_FILE}.${EXT}" "${NODE_DIST_URL}" 2>&1; then
+    echo "ERROR: Failed to download Node.js from ${NODE_DIST_URL}" >&2
+    echo "Check your internet connection and the Node.js distribution site." >&2
+    rm -rf "${NODE_DIR}"
+    exit 1
+fi
+
+echo "Extracting Node.js..."
+mkdir -p "${NODE_DIR}"
+
+case "${EXT}" in
+    tar.xz)
+        if ! tar -xJf "${TMPDIR}/${NODE_FILE}.${EXT}" -C "${TMPDIR}" 2>&1; then
+            echo "ERROR: Failed to extract Node.js archive." >&2
+            rm -rf "${NODE_DIR}"
+            exit 1
+        fi
+        cp -a "${TMPDIR}/${NODE_FILE}/." "${NODE_DIR}/"
+        ;;
+    zip)
+        if ! unzip -q "${TMPDIR}/${NODE_FILE}.${EXT}" -d "${TMPDIR}" 2>&1; then
+            echo "ERROR: Failed to extract Node.js archive." >&2
+            rm -rf "${NODE_DIR}"
+            exit 1
+        fi
+        cp -a "${TMPDIR}/${NODE_FILE}/." "${NODE_DIR}/"
+        ;;
+esac
+
+if [[ ! -x "${NODE_BIN}" ]]; then
+    echo "ERROR: Node binary not found or not executable at ${NODE_BIN}" >&2
+    rm -rf "${NODE_DIR}"
+    exit 1
+fi
+
+echo "Node.js installed: $("${NODE_BIN}" --version)"
+
+echo "Installing TypeScript v${TSC_VERSION}..."
+NPM="${NODE_DIR}/bin/npm"
+if [[ ! -x "${NPM}" ]]; then
+    NPM="${NODE_DIR}/bin/npx"
+fi
+
+"${NODE_BIN}" "${NPM}" install --prefix "${NODE_DIR}" typescript@"${TSC_VERSION}" --global 2>&1
+
+if [[ ! -x "${TSC_BIN}" ]]; then
+    echo "ERROR: Failed to install TypeScript" >&2
+    exit 1
+fi
+
+echo "TypeScript installed: $("${TSC_BIN}" --version)"
+echo ""
+echo "Setup complete! Run type checking with:"
+echo "  ./.opencode/.node/bin/tsc --noEmit --project .opencode/tsconfig.json"

--- a/.opencode/tsconfig.json
+++ b/.opencode/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@opencode-ai/plugin": ["./node_modules/@opencode-ai/plugin/dist/index"],
+      "@opencode-ai/plugin/*": ["./node_modules/@opencode-ai/plugin/dist/*"],
+      "@opencode-ai/sdk": ["./node_modules/@opencode-ai/sdk/dist/index"]
+    }
+  },
+  "include": [
+    "plugins/session-enforcement.ts",
+    "plugins/env-loader.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes three related issues in the session enforcement and plugin infrastructure:
- Session startup failures when `bun` is not installed and `$.nowrap()` API misuse
- Enforcement gap allowing agents to proceed past ERROR-level plugin diagnostics
- Missing identity validation when session values are absent
- Adds private Node.js 22 LTS runtime for TypeScript plugin type-checking

## Outcome

- Plugin errors now produce mandatory HALT instructions instead of advisory text
- `$.nowrap()` replaced with correct `$.nothrow()` API method
- Bun-not-found errors now produce clear, actionable diagnostic messages
- Identity validation gate inverted: missing values trigger `IDENTITY_VALIDATION_FAILURE` instead of silently skipping validation
- Private Node.js runtime available via `./.opencode/tools/ensure-node` for `tsc --noEmit` verification

## Fixes

- Fixes #1164 — Session plugins fail on startup
- Fixes #1165 — Plugin diagnostics are informational-only, no enforcement mechanism
- Fixes #1163 — Private Node.js Runtime for TypeScript Plugin Verification

🤖 OpenCode (ollama-cloud/glm-5.1) ✅