### PR TITLE
feat(#1172): Session triggers act instead of echo

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -158,6 +158,15 @@ The audience separation principle requires that the agent identify the audience 
 - 🚫 FORBIDDEN: Acting after reading only the issue body; reviewing PRs without reading comments; assuming "no new comments"; caching comment state
 - ✅ REQUIRED: Read ALL comments before any action; show evidence of having read them; re-read before significant actions; use `github_issue_read` with `method=get_comments`
 
+## Critical Violation: Session Trigger Echo — Parroting Triggers in Agent Output
+
+**⚠️ Parroting `<SESSION_TRIGGERS>` content verbatim in agent output is a CRITICAL GUIDELINE VIOLATION.** Triggers drive internal agent behavior, not chat output.
+
+**See `117-session-trigger-behavior.md` for the complete trigger behavior map, diff analysis requirement, stash analysis protocol, and suppression rule.** **AUTHORITY: `117-session-trigger-behavior.md`** (this line is a reference only)
+
+- 🚫 FORBIDDEN: Printing trigger section headings (e.g., "Protected Branch with Uncommitted Changes") in agent responses; echoing trigger data verbatim (e.g., "3 uncommitted changes on dev"); printing "Suggest:" lines from trigger output; acknowledging triggers with a "Session triggers acknowledged" section
+- ✅ REQUIRED: Process triggers internally and take appropriate action; analyze diff data when `protected_branch_with_changes` fires; analyze stash contents when `stale_stash` fires; suggest pair mode with concrete issue reference; suppress triggers that don't drive meaningful action
+
 ## Critical Violation: Skipping Post-Implementation Verification Skills
 
 **⚠️ Failing to invoke `verification-before-completion` and `finishing-a-development-branch` after implementation is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/116-pair-mode.md
+++ b/.opencode/guidelines/116-pair-mode.md
@@ -52,11 +52,22 @@ Never `Fixes` or `Closes` — avoids premature issue closure. Use `Implements #N
 
 ## Session Detection
 
-The `session_context.py` plugin detects pair mode at session start when the current branch starts with `pair-`. It emits:
+The `session_context_triggers.py` script detects pair mode at session start when the current branch starts with `pair-`. It emits:
 
 - Identity section (always): `github.owner`, `github.repo`, `github.platform`, credential status
 - Pair mode resume context: branch name, related issue, diff summary
 - Trigger warnings: `on_main_branch`, `protected_branch_with_changes`, `uncommitted_work`
+
+### Pair Mode Suggestion Protocol
+
+When the agent detects uncommitted changes on a protected branch (`dev` or `main`) — not just when on a `pair-` branch — it MUST suggest entering pair mode as the default workflow:
+
+1. The agent analyzes the diff summary and produces an executive summary of pending changes
+2. The agent suggests entering pair mode with a concrete issue reference (if inferable from branch name, commit messages, or diff content) or prompts to create an issue
+3. The agent suggests a branch name: `pair-feature/<issue>-<description>` or `pair-spec/<issue>-<description>`
+4. The developer confirms or declines — pair mode entry requires developer confirmation (constraint C4)
+
+This is a behavioral trigger from `<SESSION_TRIGGERS>`, not a `pair-` branch detection. See `117-session-trigger-behavior.md` for the complete trigger behavior map.
 
 ## Task Sequence
 

--- a/.opencode/guidelines/117-session-trigger-behavior.md
+++ b/.opencode/guidelines/117-session-trigger-behavior.md
@@ -1,0 +1,83 @@
+# Session Trigger Behavior
+
+## Overview
+
+Session context triggers (`session_context_triggers.py` + `session-enforcement.ts`) detect repository state and inject `<SESSION_TRIGGERS>` data into the agent's first user message. This guideline prescribes how the agent MUST process that data — not by echoing it, but by taking intelligent action.
+
+**Core principle:** Triggers drive internal agent behavior, not chat output. The agent analyzes trigger data and acts on it; the agent does NOT print trigger content verbatim.
+
+## No-Echo Rule (Tier 1 Mandate)
+
+**The agent MUST NOT print `<SESSION_TRIGGERS>` content verbatim in chat output.** This includes:
+
+- Copying trigger section headings (e.g., "Protected Branch with Uncommitted Changes")
+- Parroting trigger data (e.g., "3 uncommitted changes on dev")
+- Printing "Suggest:" lines from trigger output
+- Acknowledging triggers with a "Session triggers acknowledged" section
+
+Triggers are internal state data for decision-making. The agent processes them and takes action — the trigger text itself never appears in the agent's response.
+
+**Violation of this rule is a CRITICAL GUIDELINE VIOLATION per `000-critical-rules.md`.**
+
+## Trigger Behavior Map
+
+Each trigger type maps to a required agent behavior:
+
+| Trigger Type | Agent Behavior |
+|---|---|
+| `protected_branch_with_changes` | Analyze `git diff --stat` and `git diff`, produce a 1-2 sentence exec summary, suggest entering pair mode with a concrete issue reference or prompt to create one |
+| `on_main_branch` | Same as `protected_branch_with_changes` plus explicit warning about working on production branch |
+| `stale_stash` | Analyze stash contents via `git stash show -p stash@{N}`, classify as resumable/obsolete/ambiguous, recommend action with issue reference when available |
+| `pair_mode_resume` | Continue pair mode workflow (already works correctly — no change needed) |
+| `merge_conflict` | Process internally: note conflict files, plan resolution approach, do not echo the file list |
+| `unpushed_commits` | Process internally: note count, do not echo. Push when explicitly asked or when review-prep requires it |
+| `orphaned_worktrees` | Process internally: note paths, suggest cleanup when appropriate, do not echo the path list |
+
+## Diff Analysis Requirement
+
+When the `protected_branch_with_changes` or `on_main_branch` trigger fires, the agent MUST:
+
+1. Run `git diff --stat` to understand the scope of changes
+2. Run `git diff` for key files to understand the nature of changes
+3. Produce a 1-2 sentence executive summary of what the pending changes are about
+4. Suggest entering pair mode with:
+   - A concrete issue number if one can be inferred from branch names, commit messages, or diff content
+   - A prompt to create an issue if no issue reference is found
+5. Example: "You have 3 uncommitted changes on `dev` (modifying session trigger handling and test updates). Want to enter pair mode for issue #1172?"
+
+## Stash Analysis Protocol
+
+When the `stale_stash` trigger fires, the agent MUST:
+
+1. Run `git stash show -p stash@{N}` for each stale stash to analyze contents
+2. Classify each stash as one of:
+   - **Resumable**: Contains meaningful, unmerged work with an issue reference → suggest resuming with `git stash pop` and entering pair mode for that issue
+   - **Obsolete**: Contains changes already merged or no longer relevant → suggest dropping with `git stash drop stash@{N}`
+   - **Ambiguous**: Cannot determine relevance → offer to create an issue for tracking
+3. Extract issue references from stash messages (e.g., "WIP: #931 ..." → issue #931)
+4. Present brief analysis, not raw stash list
+5. Example: "Stash `stash@{0}` contains work for #931 (spec-auditor ground-truth changes) that hasn't been merged. Want to resume this work?"
+
+## Pair Mode Suggestion Protocol
+
+When on a protected branch (`dev`/`main`) with uncommitted changes, the agent MUST suggest entering pair mode as the default workflow:
+
+1. Analyze the diff to understand the changes
+2. Extract or suggest an issue connection
+3. Suggest a `pair-feature/<issue>-<description>` or `pair-spec/<issue>-<description>` branch name
+4. Wait for developer confirmation (pair mode entry requires developer confirmation per `116-pair-mode.md` constraint C4)
+
+This applies regardless of whether the current branch has a `pair-` prefix. The suggestion comes from the trigger data, not the branch name.
+
+## Suppression Rule
+
+Triggers that cannot drive meaningful action in the current context should be processed internally and suppressed from the agent's response entirely. The `<SESSION_TRIGGERS>` block remains in the user message for internal reasoning, but if a trigger provides no actionable insight (e.g., `unpushed_commits` when no push is pending), the agent should not mention it.
+
+**The only triggers that produce visible agent behavior** are `protected_branch_with_changes`, `on_main_branch`, and `stale_stash` — all others are processed silently.
+
+## Cross-References
+
+- `116-pair-mode.md` — Pair mode branch discipline and session detection
+- `000-critical-rules.md` — Tier 1 mandate for trigger echo prohibition
+- `session_context_triggers.py` — Trigger detection and data generation
+- `session-enforcement.ts` — Plugin that injects `<SESSION_TRIGGERS>` into first user message

--- a/.opencode/scripts/session_context_triggers.py
+++ b/.opencode/scripts/session_context_triggers.py
@@ -62,6 +62,76 @@ def is_on_protected_branch() -> bool:
     return branch in ("main", "master", "dev")
 
 
+def get_diff_summary() -> dict[str, int | list[str]] | None:
+    diff_output = run_git(["diff", "--stat"])
+    if not diff_output:
+        return None
+    lines = diff_output.strip().splitlines()
+    if not lines:
+        return None
+    stat_line = lines[-1].strip() if lines else ""
+    file_count = len([entry for entry in lines[:-1] if entry.strip()])
+    key_files: list[str] = []
+    for line in lines[:-1]:
+        parts = line.split("|")
+        if parts:
+            filepath = parts[0].strip()
+            if filepath and not any(
+                pat in filepath for pat in ("package-lock.json", "pnpm-lock.yaml", "yarn.lock", ".lock")
+            ):
+                key_files.append(filepath)
+    key_files = key_files[:5]
+    insertions = 0
+    deletions = 0
+    ins_match = re.search(r"(\d+) insertion", stat_line)
+    del_match = re.search(r"(\d+) deletion", stat_line)
+    if ins_match:
+        insertions = int(ins_match.group(1))
+    if del_match:
+        deletions = int(del_match.group(1))
+    return {
+        "file_count": file_count,
+        "insertions": insertions,
+        "deletions": deletions,
+        "key_files": key_files,
+    }
+
+
+def get_stash_analysis() -> list[dict[str, str]]:
+    stash_list = run_git(["stash", "list"])
+    if not stash_list:
+        return []
+    analyses: list[dict[str, str]] = []
+    for line in stash_list.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(":", 2)
+        if len(parts) < 2:
+            continue
+        stash_ref = parts[0].strip()
+        branch_match = re.search(r"On ([^:]+)", line)
+        branch = branch_match.group(1) if branch_match else ""
+        message = parts[2].strip() if len(parts) >= 3 else ""
+        issue_match = re.search(r"#(\d+)", message)
+        issue_ref = issue_match.group(1) if issue_match else ""
+        file_summary = ""
+        show_output = run_git(["stash", "show", stash_ref])
+        if show_output:
+            file_summary = show_output.strip()
+        analyses.append(
+            {
+                "stash_ref": stash_ref,
+                "branch": branch,
+                "message": message,
+                "issue_ref": issue_ref,
+                "file_summary": file_summary,
+            }
+        )
+        if len(analyses) >= 5:
+            break
+    return analyses
+
+
 def has_uncommitted_changes() -> tuple[bool, list[str]]:
     result = run_git(["status", "--porcelain"])
     if not result:
@@ -179,11 +249,11 @@ def build_main_branch_warning(has_changes: bool, changed_files: list[str]) -> st
             lines.append(f"  - `{filepath}`: modified")
         if len(changed_files) > 10:
             lines.append(f"  - ... and {len(changed_files) - 10} more")
-        lines.append("- Suggest: WIP commit + switch to `dev`, then create a feature branch")
+        lines.append("- Action: WIP commit + switch to `dev`, then create a feature branch")
     else:
         lines.append(f"- Branch: `{branch}` (production)")
         lines.append("- WARNING: All work must happen on feature branches, not on `main`")
-        lines.append("- Suggest: switch to `dev` first, then create a feature branch")
+        lines.append("- Action: switch to `dev` first, then create a feature branch")
     return "\n".join(lines)
 
 
@@ -192,8 +262,23 @@ def build_protected_branch_warning(changed_files: list[str]) -> str:
     lines = [
         "## Protected Branch with Uncommitted Changes",
         f"- Branch: `{branch}` with {len(changed_files)} uncommitted changes",
-        "- Suggest: create a feature branch before making changes",
     ]
+    diff_summary = get_diff_summary()
+    if diff_summary:
+        lines.append(f"- Files changed: {diff_summary['file_count']}")
+        lines.append(f"- Lines: +{diff_summary['insertions']} / -{diff_summary['deletions']}")
+        if diff_summary["key_files"]:
+            lines.append("- Key files:")
+            for kf in diff_summary["key_files"]:
+                lines.append(f"  - `{kf}`")
+    for cf in changed_files[:5]:
+        _status = cf[:2].strip() if len(cf) >= 2 else "?"
+        filepath = cf[3:].strip() if len(cf) >= 3 else cf
+        if not diff_summary or filepath not in diff_summary.get("key_files", []):
+            lines.append(f"  - `{filepath}`: modified")
+    if len(changed_files) > 5:
+        lines.append(f"  - ... and {len(changed_files) - 5} more")
+    lines.append("- Diff summary available: analyze changes to suggest pair mode entry")
     return "\n".join(lines)
 
 
@@ -221,7 +306,7 @@ def build_uncommitted_work_warning(changed_files: list[str]) -> str:
     lines = [
         "## Uncommitted Work",
         f"- {len(changed_files)} uncommitted change(s) detected",
-        "- Suggest: commit or stash changes before switching branches",
+        "- Action: commit or stash changes before switching branches",
     ]
     return "\n".join(lines)
 
@@ -230,11 +315,19 @@ def build_stale_stash_warning(stashes: list[str]) -> str:
     lines = [
         "## Stale Stash Found",
     ]
-    for s in stashes[:3]:
-        lines.append(f"- `{s}`")
+    stash_analyses = get_stash_analysis()
+    for analysis in stash_analyses[:3]:
+        lines.append(f"- `{analysis['stash_ref']}`: branch={analysis['branch'] or 'unknown'}")
+        if analysis["issue_ref"]:
+            lines.append(f"  Related issue: #{analysis['issue_ref']}")
+        if analysis["message"]:
+            lines.append(f"  Message: {analysis['message']}")
+        if analysis["file_summary"]:
+            for fs_line in analysis["file_summary"].splitlines()[:3]:
+                lines.append(f"  {fs_line}")
     if len(stashes) > 3:
         lines.append(f"- ... and {len(stashes) - 3} more")
-    lines.append("- Suggest: resume or clean up the stash")
+    lines.append("- Stash analysis available: review contents to recommend resume/drop/issue")
     return "\n".join(lines)
 
 
@@ -247,7 +340,7 @@ def build_merge_conflict_warning(files: list[str]) -> str:
         lines.append(f"  - `{f}`")
     if len(files) > 5:
         lines.append(f"  - ... and {len(files) - 5} more")
-    lines.append("- Suggest: resolve conflicts before proceeding")
+    lines.append("- Action: resolve conflicts before proceeding")
     return "\n".join(lines)
 
 
@@ -255,7 +348,7 @@ def build_unpushed_commits_warning(count: int) -> str:
     lines = [
         "## Unpushed Commits",
         f"- {count} commit(s) ahead of remote",
-        "- Suggest: push when ready with `git push`",
+        "- Action: push when ready with `git push`",
     ]
     return "\n".join(lines)
 
@@ -268,7 +361,7 @@ def build_orphaned_worktrees_warning(wt_list: list[str]) -> str:
         lines.append(f"- {w}")
     if len(wt_list) > 3:
         lines.append(f"- ... and {len(wt_list) - 3} more")
-    lines.append("- Suggest: clean up with `git worktree remove <path>`")
+    lines.append("- Action: clean up with `git worktree remove <path>`")
     return "\n".join(lines)
 
 

--- a/test/test_session_context_triggers.py
+++ b/test/test_session_context_triggers.py
@@ -10,9 +10,12 @@ from session_context_triggers import (
     build_merge_conflict_warning,
     build_orphaned_worktrees_warning,
     build_pair_mode_resume,
+    build_protected_branch_warning,
     build_stale_stash_warning,
     build_uncommitted_work_warning,
     build_unpushed_commits_warning,
+    get_diff_summary,
+    get_stash_analysis,
     is_on_main_branch,
     is_on_protected_branch,
     is_pair_mode_branch,
@@ -115,6 +118,164 @@ class TestBuildUncommittedWorkWarning:
     def test_warning_output(self):
         result = build_uncommitted_work_warning(["file1.py", "file2.py"])
         assert "2 uncommitted change(s)" in result
+
+
+class TestGetDiffSummary:
+    def test_returns_structured_data_when_changes_exist(self):
+        diff_stat_output = (
+            " .opencode/scripts/session_context_triggers.py |  5 +++--\n"
+            " .opencode/guidelines/117-session-trigger-behavior.md | 42 +++++++++++++++++++\n"
+            " 2 files changed, 37 insertions(+), 10 deletions(-)"
+        )
+        with patch("session_context_triggers.run_git", return_value=diff_stat_output):
+            result = get_diff_summary()
+        assert result is not None
+        assert result["file_count"] == 2
+        assert result["insertions"] == 37
+        assert result["deletions"] == 10
+        assert len(result["key_files"]) == 2
+
+    def test_returns_none_when_no_changes(self):
+        with patch("session_context_triggers.run_git", return_value=None):
+            result = get_diff_summary()
+        assert result is None
+
+    def test_excludes_lockfiles_from_key_files(self):
+        diff_stat_output = (
+            " package-lock.json | 500 ++++++\n"
+            " src/main.py         |  10 +- \n"
+            " 2 files changed, 500 insertions(+), 5 deletions(-)"
+        )
+        with patch("session_context_triggers.run_git", return_value=diff_stat_output):
+            result = get_diff_summary()
+        assert result is not None
+        assert "package-lock.json" not in result["key_files"]
+        assert "src/main.py" in result["key_files"]
+
+    def test_limits_key_files_to_five(self):
+        lines = [f" src/file{i}.py |  5 +- \n" for i in range(10)]
+        diff_stat_output = "\n".join(lines) + "\n 10 files changed, 50 insertions(+), 50 deletions(-)"
+        with patch("session_context_triggers.run_git", return_value=diff_stat_output):
+            result = get_diff_summary()
+        assert result is not None
+        assert len(result["key_files"]) <= 5
+
+
+class TestGetStashAnalysis:
+    def test_parses_stash_with_issue_reference(self):
+        stash_show_output = " src/triggers.py | 3 ++-\n 1 file changed, 2 insertions(+), 1 deletion(-)"
+        with patch("session_context_triggers.run_git") as mock_git:
+            mock_git.side_effect = [
+                "stash@{0}: On main: WIP: #931 spec-auditor ground-truth changes\nstash@{1}: On dev: old work",
+                stash_show_output,
+                "old.py | 1 +\n 1 file changed, 1 insertion(+)",
+            ]
+            result = get_stash_analysis()
+        assert len(result) >= 1
+        first = result[0]
+        assert first["stash_ref"] == "stash@{0}"
+        assert first["branch"] == "main"
+        assert first["issue_ref"] == "931"
+        assert "spec-auditor" in first["message"]
+
+    def test_parses_stash_without_issue_reference(self):
+        stash_list_output = "stash@{0}: On feature/xyz: some work in progress"
+        with patch("session_context_triggers.run_git") as mock_git:
+            mock_git.side_effect = [stash_list_output, "file.py | 1 +\n 1 file changed, 1 insertion(+)"]
+            result = get_stash_analysis()
+        assert len(result) == 1
+        assert result[0]["issue_ref"] == ""
+
+    def test_returns_empty_when_no_stashes(self):
+        with patch("session_context_triggers.run_git", return_value=""):
+            result = get_stash_analysis()
+        assert result == []
+
+    def test_limits_analysis_to_five_stashes(self):
+        stash_lines = [f"stash@{{{i}}}: On dev: work {i}" for i in range(10)]
+        stash_list = "\n".join(stash_lines)
+        with patch("session_context_triggers.run_git") as mock_git:
+            mock_git.side_effect = [stash_list] + ["f.py | 1 +\n 1 file changed"] * 10
+            result = get_stash_analysis()
+        assert len(result) <= 5
+
+
+class TestBuildProtectedBranchWarningUpdated:
+    def test_includes_diff_summary(self):
+        with patch("session_context_triggers.get_current_branch", return_value="dev"):
+            with patch(
+                "session_context_triggers.get_diff_summary",
+                return_value={
+                    "file_count": 3,
+                    "insertions": 42,
+                    "deletions": 7,
+                    "key_files": ["src/main.py", "src/triggers.py", "test/test_triggers.py"],
+                },
+            ):
+                result = build_protected_branch_warning(
+                    ["M src/main.py", "A src/triggers.py", "M test/test_triggers.py"]
+                )
+        assert "Protected Branch with Uncommitted Changes" in result
+        assert "3 uncommitted changes" in result
+        assert "Files changed: 3" in result
+        assert "+42 / -7" in result
+        assert "Key files:" in result
+
+    def test_no_suggest_line(self):
+        with patch("session_context_triggers.get_current_branch", return_value="dev"):
+            with patch(
+                "session_context_triggers.get_diff_summary",
+                return_value={"file_count": 1, "insertions": 5, "deletions": 2, "key_files": ["src/main.py"]},
+            ):
+                result = build_protected_branch_warning(["M src/main.py"])
+        assert "Suggest:" not in result
+        assert "Diff summary available" in result
+
+    def test_no_diff_summary_when_none(self):
+        with patch("session_context_triggers.get_current_branch", return_value="dev"):
+            with patch("session_context_triggers.get_diff_summary", return_value=None):
+                result = build_protected_branch_warning(["M src/main.py"])
+        assert "Files changed:" not in result
+        assert "1 uncommitted changes" in result
+
+
+class TestBuildStaleStashWarningUpdated:
+    def test_includes_stash_analysis(self):
+        analyses = [
+            {
+                "stash_ref": "stash@{0}",
+                "branch": "main",
+                "message": "WIP: #931 spec-auditor ground-truth changes",
+                "issue_ref": "931",
+                "file_summary": "src/triggers.py | 3 ++-\n 1 file changed, 2 insertions(+), 1 deletion(-)",
+            }
+        ]
+        with patch("session_context_triggers.get_stash_analysis", return_value=analyses):
+            result = build_stale_stash_warning(["stash@{0}: On main: WIP: #931 ..."])
+        assert "Stale Stash" in result
+        assert "#931" in result
+        assert "Related issue:" in result
+        assert "branch=main" in result
+
+    def test_no_suggest_line(self):
+        with patch("session_context_triggers.get_stash_analysis", return_value=[]):
+            result = build_stale_stash_warning(["stash@{0}: On main: old work"])
+        assert "Suggest:" not in result
+        assert "Stash analysis available" in result
+
+    def test_shows_file_summary(self):
+        analyses = [
+            {
+                "stash_ref": "stash@{0}",
+                "branch": "feature",
+                "message": "work in progress",
+                "issue_ref": "",
+                "file_summary": "src/main.py | 2 ++\nsrc/util.py | 4 ++--",
+            }
+        ]
+        with patch("session_context_triggers.get_stash_analysis", return_value=analyses):
+            result = build_stale_stash_warning(["stash@{0}: On feature: work in progress"])
+        assert "src/main.py" in result
 
 
 class TestBuildStaleStashWarning:

--- a/test/test_session_trigger_behavior.py
+++ b/test/test_session_trigger_behavior.py
@@ -1,0 +1,144 @@
+"""Tests for session trigger behavior contract.
+
+Verifies that trigger output format drives correct agent behavior:
+- No "Suggest:" text in trigger output (replaced by structured data)
+- Structured data present for actionable triggers
+- Trigger types that should be suppressed produce no echo-friendly text
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".opencode" / "scripts"))
+
+from session_context_triggers import (
+    build_main_branch_warning,
+    build_merge_conflict_warning,
+    build_orphaned_worktrees_warning,
+    build_protected_branch_warning,
+    build_stale_stash_warning,
+    build_uncommitted_work_warning,
+    build_unpushed_commits_warning,
+)
+
+TRIGGER_BUILDERS = [
+    "build_main_branch_warning",
+    "build_protected_branch_warning",
+    "build_stale_stash_warning",
+    "build_merge_conflict_warning",
+    "build_unpushed_commits_warning",
+    "build_orphaned_worktrees_warning",
+]
+
+
+class TestNoSuggestLineInAnyTrigger:
+    def test_protected_branch_no_suggest(self):
+        with patch("session_context_triggers.get_current_branch", return_value="dev"):
+            with patch(
+                "session_context_triggers.get_diff_summary",
+                return_value={"file_count": 1, "insertions": 5, "deletions": 2, "key_files": ["src/main.py"]},
+            ):
+                result = build_protected_branch_warning(["M src/main.py"])
+        assert "Suggest:" not in result
+
+    def test_stale_stash_no_suggest(self):
+        with patch("session_context_triggers.get_stash_analysis", return_value=[]):
+            result = build_stale_stash_warning(["stash@{0}: On main: old work"])
+        assert "Suggest:" not in result
+
+    def test_uncommitted_work_no_suggest(self):
+        result = build_uncommitted_work_warning(["file1.py"])
+        assert "Suggest:" not in result
+
+    def test_main_branch_no_suggest(self):
+        result = build_main_branch_warning(True, ["M file.py"])
+        assert "Suggest:" not in result
+
+    def test_merge_conflict_no_suggest(self):
+        result = build_merge_conflict_warning(["conflicted.py"])
+        assert "Suggest:" not in result
+
+    def test_unpushed_commits_no_suggest(self):
+        result = build_unpushed_commits_warning(3)
+        assert "Suggest:" not in result
+
+    def test_orphaned_worktrees_no_suggest(self):
+        result = build_orphaned_worktrees_warning(["/path/wt (feat — merged)"])
+        assert "Suggest:" not in result
+
+
+class TestProtectedBranchOutputContainsDiffSummary:
+    def test_includes_diff_summary_section(self):
+        with patch("session_context_triggers.get_current_branch", return_value="dev"):
+            with patch(
+                "session_context_triggers.get_diff_summary",
+                return_value={
+                    "file_count": 3,
+                    "insertions": 20,
+                    "deletions": 5,
+                    "key_files": ["src/a.py", "src/b.py", "test/test_c.py"],
+                },
+            ):
+                result = build_protected_branch_warning(["M src/a.py", "M src/b.py", "M test/test_c.py"])
+        assert "Files changed:" in result
+        assert "+20 / -5" in result
+
+    def test_diff_summary_available_indicator(self):
+        with patch("session_context_triggers.get_current_branch", return_value="dev"):
+            with patch(
+                "session_context_triggers.get_diff_summary",
+                return_value={"file_count": 1, "insertions": 3, "deletions": 0, "key_files": ["src/x.py"]},
+            ):
+                result = build_protected_branch_warning(["M src/x.py"])
+        assert "Diff summary available" in result
+
+
+class TestStaleStashOutputContainsAnalysis:
+    def test_includes_stash_analysis_indicator(self):
+        with patch("session_context_triggers.get_stash_analysis", return_value=[]):
+            result = build_stale_stash_warning(["stash@{0}: On main: old"])
+        assert "Stash analysis available" in result
+
+    def test_includes_issue_reference(self):
+        analyses = [
+            {
+                "stash_ref": "stash@{0}",
+                "branch": "main",
+                "message": "WIP: #931 changes",
+                "issue_ref": "931",
+                "file_summary": "f.py | 1 +",
+            }
+        ]
+        with patch("session_context_triggers.get_stash_analysis", return_value=analyses):
+            result = build_stale_stash_warning(["stash@{0}: On main: WIP: #931 changes"])
+        assert "#931" in result
+
+
+class TestTriggerOutputIsMachineReadable:
+    def test_protected_branch_uses_structured_headers(self):
+        with patch("session_context_triggers.get_current_branch", return_value="dev"):
+            with patch(
+                "session_context_triggers.get_diff_summary",
+                return_value={"file_count": 1, "insertions": 2, "deletions": 1, "key_files": ["src/f.py"]},
+            ):
+                result = build_protected_branch_warning(["M src/f.py"])
+        assert result.startswith("## Protected Branch")
+        for line in result.splitlines():
+            if line.strip().startswith("- ") and "Branch:" not in line and "Key files:" not in line:
+                assert ": " in line or line.strip().startswith("- `"), f"Line not structured: {line}"
+
+    def test_stale_stash_uses_structured_headers(self):
+        analyses = [
+            {
+                "stash_ref": "stash@{0}",
+                "branch": "dev",
+                "message": "work",
+                "issue_ref": "",
+                "file_summary": "a.py | 1 +",
+            }
+        ]
+        with patch("session_context_triggers.get_stash_analysis", return_value=analyses):
+            result = build_stale_stash_warning(["stash@{0}: On dev: work"])
+        assert result.startswith("## Stale Stash")
+        assert "branch=" in result


### PR DESCRIPTION
## Summary

Session triggers now drive intelligent agent behavior instead of printing diagnostic text that gets echoed back to the user. Added diff summary analysis for protected branch warnings, stash content analysis for stale stash warnings, and replaced all "Suggest:" prefixes with actionable "Action:" or structured data indicators.

## Outcome

- Triggers provide machine-readable data (diff summaries, stash analysis) instead of plain-text suggestions
- No "Suggest:" lines remain in any trigger output — all replaced with "Action:" or structured headers
- Behavior contract tests enforce no-echo and structured-output invariants
- Critical violation rule added for session trigger echo

Fixes #1172