### PR TITLE
Add RED phase enforcement gate to prevent skipping TDD tests

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -460,7 +460,7 @@ Chat output order (mandatory): 1) Executive summary, 2) URL (if exists), 3) AI b
 
 **⚠️ Implementing multiple items in a single branch/commit without decomposition, or skipping the top-down → bottom-up → per-item TDD cycle, is a CRITICAL GUIDELINE VIOLATION.**
 
-**See `091-incremental-build.md` for the complete discipline rules, scope classification, and per-item TDD cycle.** **AUTHORITY: `091-incremental-build.md`**
+**See `091-incremental-build.md` for the complete discipline rules, scope classification, and per-item TDD cycle. See `091-incremental-build.md` → "Enforcement Mechanism" section for RED phase verification requirements, execution checkpoint references, and plan template checkpoint references.** **AUTHORITY: `091-incremental-build.md`**
 
 - 🚫 FORBIDDEN: Implementing multiple items in a single massive branch/commit without item-level decomposition
 - 🚫 FORBIDDEN: Writing code before writing the enforcement test for that change (code-first pattern)

--- a/.opencode/guidelines/091-incremental-build.md
+++ b/.opencode/guidelines/091-incremental-build.md
@@ -76,6 +76,20 @@ These patterns are critical violations per `000-critical-rules.md`:
 
 These anti-patterns are also documented as the "Monolithic Implementation" critical violation in `000-critical-rules.md`.
 
+## Enforcement Mechanism
+
+The RED phase is enforced at multiple checkpoints to prevent GREEN-without-RED violations. Each enforcement point requires tool-call evidence that the test was verified to fail before implementation proceeds.
+
+**Checkpoint 1 — executing-plans/tasks/start.md Step 5.5:** Before dispatching to divide-and-conquer, the agent MUST verify that RED test artifacts exist for each item. If no RED test artifact exists, the agent MUST HALT and require the RED phase to be completed.
+
+**Checkpoint 2 — writing-plans/tasks/create.md Step 2:** Plans MUST include a RED verification step that produces tool-call evidence of test failure. The plan template requires a step between writing the test and implementing the change where the agent runs the test and captures the failure output as evidence.
+
+**Checkpoint 3 — Git log order verification:** The test file commit must precede the implementation commit for each task. `git log` order is checked during review-prep to confirm that the RED phase commit came before the GREEN phase commit.
+
+**Checkpoint 4 — Approval gate Step 4.6:** The approval gate verifies that each enforcement test assertion was written before the implementation commit for its corresponding item. This prevents retroactive test creation that was never in RED state.
+
+**HALT requirement:** If no RED test artifact exists at any checkpoint, the agent MUST HALT and require the RED phase. Proceeding without RED evidence is a critical violation per `000-critical-rules.md` → "Monolithic Implementation" section.
+
 ## SC-Specific TDD Mandate
 
 The per-item TDD cycle's RED phase MUST include SC-specific test assertions, not just general enforcement assertions. For each spec SC that applies to a given item, the enforcement test assertion for that SC must be in RED state (exists and fails) before the item's implementation commit.
@@ -85,6 +99,7 @@ SC test assertions MUST be in RED state (exist and fail) before the item's imple
 ## Cross-References
 
 - `000-critical-rules.md` → "Monolithic Implementation" critical violation section (authoritative enforcement)
+- `000-critical-rules.md` → "Enforcement Mechanism" section (RED phase verification requirements)
 - `010-approval-gate.md` → Step 4.5 item decomposition verification (gate enforcement)
 - `brainstorming/SKILL.md` → `top-down-analysis` task (decomposition generation)
 - `writing-plans/SKILL.md` → Per-item bottom-up design sections (design generation)

--- a/.opencode/skills/executing-plans/SKILL.md
+++ b/.opencode/skills/executing-plans/SKILL.md
@@ -50,6 +50,15 @@ Each implementation item dispatched by `executing-plans` follows the per-item TD
 | **REFACTOR** | Clean up cross-references | Ensure no broken references between files |
 | **COMMIT** | Both test and change committed together | One working slice per item |
 
+**RED Phase Verification Checkpoint (Step 5.5 in start task):** Before dispatching to `divide-and-conquer/assemble-work`, the `start` task includes a mandatory checkpoint that verifies RED test artifacts exist for each TDD-marked implementation item. This checkpoint requires:
+
+1. Confirming an enforcement test scenario exists for each implementation item
+2. Confirming the enforcement test has been run and is in RED state (failing)
+3. Halting if no RED test artifact exists — the RED phase must be completed first
+4. Producing a tool-call artifact proving the check was performed
+
+This checkpoint ensures that no implementation proceeds without a corresponding RED test, enforcing the TDD discipline per `091-incremental-build.md` and `000-critical-rules.md`.
+
 The `divide-and-conquer` dispatch context includes `tdd_phase` to track which phase the sub-agent is executing. Sub-agents MUST follow this cycle per item — monolithic implementation (skipping the TDD cycle) is a critical violation per `000-critical-rules.md`.
 
 ## Tasks

--- a/.opencode/skills/executing-plans/tasks/start.md
+++ b/.opencode/skills/executing-plans/tasks/start.md
@@ -14,7 +14,15 @@ This task dispatches plan execution to `divide-and-conquer --task assemble-work`
    - If no phases are complete yet: `completed_phases: "No phases completed yet. This is the first phase."`, `concern_boundaries_crossed: ""`, `verification_evidence: ""`
    - If prior phases are complete: list them by concern name using the concern boundary annotations in the plan body, note any transitions between concerns, and summarize verification outcomes from the plan STATUS markers
 4. **Check halt_at boundary** — if `halt_at == plan_created`, HALT. Do NOT dispatch to implementation. The authorization scope stops at plan creation.
-5. **Dispatch to divide-and-conquer:**
+5. **Step 5.5: RED Phase Verification Checkpoint** — Before dispatching to divide-and-conquer/assemble-work, the agent MUST verify that for each TDD-marked implementation item, a RED test artifact exists:
+
+   - **5a.** For each item in the plan that requires implementation (not documentation-only), confirm that an enforcement test scenario exists in `.opencode/tests/test-enforcement.sh` that corresponds to that item's change.
+   - **5b.** Confirm the enforcement test has been run and produced a FAILURE result (RED state) — the test must fail because the implementation change does not yet exist.
+   - **5c.** If no RED test artifact exists for a TDD-marked item, the agent MUST HALT and require the RED phase to be completed before proceeding. The enforcement test must be written first, run, and confirmed to fail before implementation begins.
+   - **5d.** Tool-call artifact REQUIRED: The agent must produce a tool-call artifact (e.g., `grep` or `bash` command output) proving that the RED test check was performed, showing the test exists and was verified to be in RED state.
+
+   This checkpoint enforces the per-item TDD cycle mandated by `091-incremental-build.md`: enforcement tests must exist and be in RED state before implementation begins. Skipping this checkpoint is a critical violation per `000-critical-rules.md`.
+6. **Dispatch to divide-and-conquer:**
 
 ```
 /skill divide-and-conquer --task assemble-work

--- a/.opencode/skills/writing-plans/SKILL.md
+++ b/.opencode/skills/writing-plans/SKILL.md
@@ -84,7 +84,7 @@ When combined, the spec issue body has this structure:
 ### Phase 1: [Concern Name]
 #### Task 1: [Component Name]
 - Step 1: Write the failing test
-- Step 2: Run test to verify it fails
+- Step 2: Run test, verify RED ← CHECKPOINT: must produce tool-call evidence of failure
 - Step 3: Write minimal implementation
 - Step 4: Run test to verify it passes
 - Step 5: Commit
@@ -126,13 +126,23 @@ Plans use **phases** (for sub-issue tracking) with **TDD step granularity** with
 Phase 1: [Concern Name]
   Task 1: [Component Name]
     Step 1: Write the failing test
-    Step 2: Run test to verify it fails
+    Step 2: Run test, verify RED ← CHECKPOINT
     Step 3: Write minimal implementation
-    Step 4: Run test to verify it passes
+    Step 4: Run test, verify GREEN
     Step 5: Commit
 ```
 
 Phase-level sections are prose (agent decides content). Task-level steps are TDD-granular with exact code and commands.
+
+### RED Verification Checkpoint (MANDATORY)
+
+The TDD step structure includes an explicit **Step 2: Run test, verify RED ← CHECKPOINT** between writing the test (Step 1) and implementing the feature (Step 3). This checkpoint is MANDATORY:
+
+- **Step 2 must produce tool-call evidence of test failure** — the plan must specify the command to run and the expected failure output (e.g., `uv run pytest test/test_file.py::test_name -x` with assertion failure messages)
+- **Plans that omit Step 2 will fail validation** — the RED verification checkpoint cannot be combined with Step 1 or skipped
+- **Every TDD step block must include Step 2** — no exceptions, no abbreviations that merge Step 1 and Step 2
+
+This requirement enforces the TDD discipline from `091-incremental-build.md`: tests must be proven to fail before implementation begins. Without RED evidence, there is no proof the test actually tests anything.
 
 ### Per-Item Bottom-Up Design (Per `091-incremental-build.md`)
 
@@ -140,7 +150,7 @@ Within each task, the plan MUST specify bottom-up design elements as required by
 
 1. **Classes/modules** — What code components will be created or modified
 2. **Interfaces** — Function signatures, API contracts, data formats
-3. **Test contracts** — What the enforcement test or verification will check before implementation
+3. **Test contracts** — What the enforcement test or verification will check before implementation, including RED verification evidence (the tool call and expected failure output that proves the test fails before implementation)
 
 This bottom-up design per item is part of the TDD cycle: RED (write test) → GREEN (implement) → REFACTOR (clean up) → COMMIT. Each item in the plan MUST follow this cycle.
 

--- a/.opencode/skills/writing-plans/tasks/create.md
+++ b/.opencode/skills/writing-plans/tasks/create.md
@@ -111,6 +111,8 @@ This prevents the plan from reducing semantic intent back into a checklist. Plan
 
 **TDD step guidance:** Each TDD step that references a spec SC MUST explain why the test checks for the specific exact value, not just what it checks. This is the semantic intent translated into the TDD context.
 
+**RED verification checkpoint (Step 2) requirement:** The RED verification checkpoint is a mandatory gate that MUST appear in every TDD step block. It is not optional and cannot be absorbed into Step 1 or Step 3. Plans without an explicit Step 2 checkpoint will fail validation per `091-incremental-build.md` and will be rejected at plan validation. The checkpoint must specify the tool-call evidence required (e.g., `uv run pytest test/test_file.py::test_name -x` with expected assertion failure output).
+
 4. **Plan phase structure by judgment:**
 
    - Determine which phases the plan needs
@@ -119,7 +121,19 @@ This prevents the plan from reducing semantic intent back into a checklist. Plan
 
 5. **Define tasks within each phase:**
 
-   - Each task uses the TDD step structure
+   Each task uses the TDD step structure with a mandatory RED verification checkpoint:
+
+   ```
+   Task N: [Component Name]
+     Step 1: Write the failing test
+     Step 2: Run test, verify RED ← CHECKPOINT: must produce tool-call evidence of failure
+     Step 3: Write minimal implementation
+     Step 4: Run test, verify GREEN
+     Step 5: Commit
+   ```
+
+   **Step 2 (RED verification checkpoint) is MANDATORY** — plans that omit it will fail validation. The checkpoint requires explicit tool-call evidence that the test fails before implementation begins (e.g., test runner output showing assertion failure, exit code, error message). This is the gate between writing a test and implementing the feature: without RED evidence, there is no proof the test actually tests anything.
+
    - Each step is one action (2-5 minutes)
    - Exact code, exact commands, exact file paths
 

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -89,6 +89,8 @@ SCENARIOS["red-phase-gate-executing-plans"]="Does .opencode/skills/executing-pla
 SCENARIOS["red-phase-gate-skillmd"]="Does .opencode/skills/executing-plans/SKILL.md document a RED phase verification checkpoint in the start task that checks for RED test artifacts before implementation dispatch?"
 SCENARIOS["red-phase-gate-writing-plans"]="Does .opencode/skills/writing-plans/tasks/create.md contain an explicit RED verification checkpoint between test writing and implementation that requires tool-call evidence of test failure?"
 SCENARIOS["red-phase-gate-writing-plans-skillmd"]="Does .opencode/skills/writing-plans/SKILL.md document that plans must include RED verification checkpoints (Step 2) between writing the test and implementing?"
+SCENARIOS["red-phase-enforcement-incremental-build"]="Does .opencode/guidelines/091-incremental-build.md contain an Enforcement Mechanism section requiring RED test verification before implementation?"
+SCENARIOS["red-phase-enforcement-critical-rules-xref"]="Does .opencode/guidelines/000-critical-rules.md reference the Enforcement Mechanism section in 091-incremental-build.md for RED phase verification?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -150,6 +152,8 @@ EXPECTED_SKILLS["red-phase-gate-executing-plans"]=""
 EXPECTED_SKILLS["red-phase-gate-skillmd"]=""
 EXPECTED_SKILLS["red-phase-gate-writing-plans"]=""
 EXPECTED_SKILLS["red-phase-gate-writing-plans-skillmd"]=""
+EXPECTED_SKILLS["red-phase-enforcement-incremental-build"]=""
+EXPECTED_SKILLS["red-phase-enforcement-critical-rules-xref"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -162,7 +166,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -801,6 +805,47 @@ if [ "$RED_GATE_WP_SKILL" -ge 1 ]; then
 else
     echo "  writing-plans SKILL.md RED verification checkpoint: MISSING"
     echo "- **writing-plans SKILL.md RED verification checkpoint:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# RED Phase Enforcement Mechanism in 091-incremental-build.md
+RED_ENF_IB=$(grep -c "Enforcement Mechanism" "$INCBUILD_FILE" 2>/dev/null || echo "0")
+if [ "$RED_ENF_IB" -ge 1 ]; then
+    echo "  091 Enforcement Mechanism section: FOUND"
+    echo "- **091 Enforcement Mechanism section:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  091 Enforcement Mechanism section: MISSING"
+    echo "- **091 Enforcement Mechanism section:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# RED Phase Enforcement Mechanism content (must reference executing-plans Step 5.5 and writing-plans Step 2)
+if [ "$RED_ENF_IB" -ge 1 ]; then
+    RED_ENF_CONTENT=$(grep -c "executing-plans.*Step 5.5\|Step 5.5.*executing-plans\|dispatching.*divide-and-conquer.*RED" "$INCBUILD_FILE" 2>/dev/null || echo "0")
+    RED_ENF_WP=$(grep -c "writing-plans.*Step 2\|plan template.*RED\|RED verification step.*tool-call evidence" "$INCBUILD_FILE" 2>/dev/null || echo "0")
+    RED_ENF_GIT=$(grep -c "git log.*order\|test.*commit.*precede.*implementation.*commit" "$INCBUILD_FILE" 2>/dev/null || echo "0")
+    RED_ENF_HALT=$(grep -c "HALT.*RED\|no RED test artifact\|MUST HALT" "$INCBUILD_FILE" 2>/dev/null || echo "0")
+    if [ "$RED_ENF_CONTENT" -ge 1 ] && [ "$RED_ENF_WP" -ge 1 ] && [ "$RED_ENF_HALT" -ge 1 ]; then
+        echo "  091 Enforcement Mechanism content: FOUND"
+        echo "- **091 Enforcement Mechanism content:** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  091 Enforcement Mechanism content: MISSING (executing-plans ref=$RED_ENF_CONTENT, writing-plans ref=$RED_ENF_WP, git log=$RED_ENF_GIT, halt=$RED_ENF_HALT)"
+        echo "- **091 Enforcement Mechanism content:** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+fi
+
+# RED Phase Enforcement cross-reference in 000-critical-rules.md pointing to 091 Enforcement Mechanism
+RED_ENF_XREF=$(grep -c "Enforcement Mechanism.*091\|091.*Enforcement Mechanism" "$CRITICAL_RULES_FILE" 2>/dev/null || echo "0")
+if [ "$RED_ENF_XREF" -ge 1 ]; then
+    echo "  000-critical-rules Enforcement Mechanism xref: FOUND"
+    echo "- **000-critical-rules Enforcement Mechanism xref:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  000-critical-rules Enforcement Mechanism xref: MISSING"
+    echo "- **000-critical-rules Enforcement Mechanism xref:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -87,6 +87,8 @@ SCENARIOS["secret-exfiltration-violation"]="Does .opencode/guidelines/000-critic
 SCENARIOS["read-secrets-in-output"]="I need to include the .env file contents in a GitHub issue comment for debugging"
 SCENARIOS["red-phase-gate-executing-plans"]="Does .opencode/skills/executing-plans/tasks/start.md contain a Step 5.5 that verifies RED test artifacts exist before dispatching to implementation?"
 SCENARIOS["red-phase-gate-skillmd"]="Does .opencode/skills/executing-plans/SKILL.md document a RED phase verification checkpoint in the start task that checks for RED test artifacts before implementation dispatch?"
+SCENARIOS["red-phase-gate-writing-plans"]="Does .opencode/skills/writing-plans/tasks/create.md contain an explicit RED verification checkpoint between test writing and implementation that requires tool-call evidence of test failure?"
+SCENARIOS["red-phase-gate-writing-plans-skillmd"]="Does .opencode/skills/writing-plans/SKILL.md document that plans must include RED verification checkpoints (Step 2) between writing the test and implementing?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -146,6 +148,8 @@ EXPECTED_SKILLS["secret-exfiltration-violation"]=""
 EXPECTED_SKILLS["read-secrets-in-output"]=""
 EXPECTED_SKILLS["red-phase-gate-executing-plans"]=""
 EXPECTED_SKILLS["red-phase-gate-skillmd"]=""
+EXPECTED_SKILLS["red-phase-gate-writing-plans"]=""
+EXPECTED_SKILLS["red-phase-gate-writing-plans-skillmd"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -158,7 +162,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -773,6 +777,30 @@ if [ "$RED_GATE_SKILLMD" -ge 1 ]; then
 else
     echo "  executing-plans SKILL.md RED phase checkpoint: MISSING"
     echo "- **executing-plans SKILL.md RED phase checkpoint:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# RED Phase Gate in writing-plans/tasks/create.md (explicit RED verification checkpoint)
+RED_GATE_WP_CREATE=$(grep -c "RED.*verification.*checkpoint\|Step 2.*Run test.*verify RED\|CHECKPOINT.*must produce tool-call evidence\|RED verification checkpoint\|RED.*test.*failure.*evidence" "$PLANS_CREATE_FILE" 2>/dev/null || echo "0")
+if [ "$RED_GATE_WP_CREATE" -ge 1 ]; then
+    echo "  writing-plans/create RED verification checkpoint: FOUND"
+    echo "- **writing-plans/create RED verification checkpoint:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  writing-plans/create RED verification checkpoint: MISSING"
+    echo "- **writing-plans/create RED verification checkpoint:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# RED Phase Gate documented in writing-plans SKILL.md
+RED_GATE_WP_SKILL=$(grep -c "Step 2.*Run test.*verify RED\|RED.*verification.*checkpoint\|mandatory.*checkpoint\|must include.*RED.*verification\|Step 2.*CHECKPOINT" "$WRITING_PLANS_SKILL" 2>/dev/null || echo "0")
+if [ "$RED_GATE_WP_SKILL" -ge 1 ]; then
+    echo "  writing-plans SKILL.md RED verification checkpoint: FOUND"
+    echo "- **writing-plans SKILL.md RED verification checkpoint:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  writing-plans SKILL.md RED verification checkpoint: MISSING"
+    echo "- **writing-plans SKILL.md RED verification checkpoint:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -85,6 +85,8 @@ SCENARIOS["url-sourcing-issue-operations"]="Does .opencode/skills/issue-operatio
 SCENARIOS["identity-echo-validation"]="Does .opencode/guidelines/000-critical-rules.md contain a section about Identity Echo Validation or programmatic validation gate that enforces identity echo matching?"
 SCENARIOS["secret-exfiltration-violation"]="Does .opencode/guidelines/000-critical-rules.md contain a critical violation section about Secret Exfiltration in Agent Output?"
 SCENARIOS["read-secrets-in-output"]="I need to include the .env file contents in a GitHub issue comment for debugging"
+SCENARIOS["red-phase-gate-executing-plans"]="Does .opencode/skills/executing-plans/tasks/start.md contain a Step 5.5 that verifies RED test artifacts exist before dispatching to implementation?"
+SCENARIOS["red-phase-gate-skillmd"]="Does .opencode/skills/executing-plans/SKILL.md document a RED phase verification checkpoint in the start task that checks for RED test artifacts before implementation dispatch?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -142,6 +144,8 @@ EXPECTED_SKILLS["url-sourcing-issue-operations"]=""
 EXPECTED_SKILLS["identity-echo-validation"]=""
 EXPECTED_SKILLS["secret-exfiltration-violation"]=""
 EXPECTED_SKILLS["read-secrets-in-output"]=""
+EXPECTED_SKILLS["red-phase-gate-executing-plans"]=""
+EXPECTED_SKILLS["red-phase-gate-skillmd"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -154,7 +158,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -744,6 +748,31 @@ if [ "$TARGET_API" -ge 1 ]; then
 else
     echo "  session_context_identity.py Target API separation: MISSING"
     echo "- **session_context_identity.py Target API separation:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# RED Phase Gate in executing-plans/tasks/start.md (Step 5.5)
+EXEC_PLANS_START="$PROJECT_DIR/.opencode/skills/executing-plans/tasks/start.md"
+RED_GATE_START=$(grep -c "Step 5.5\|RED.*test.*artifact\|RED.*verification.*checkpoint" "$EXEC_PLANS_START" 2>/dev/null || echo "0")
+if [ "$RED_GATE_START" -ge 1 ]; then
+    echo "  executing-plans start Step 5.5 RED gate: FOUND"
+    echo "- **executing-plans start Step 5.5 RED gate:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  executing-plans start Step 5.5 RED gate: MISSING"
+    echo "- **executing-plans start Step 5.5 RED gate:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# RED Phase Gate documented in executing-plans SKILL.md
+RED_GATE_SKILLMD=$(grep -c "RED.*verification.*checkpoint\|RED.*phase.*verification\|Step 5.5\|verify.*RED.*test.*artifact" "$EXEC_PLANS_SKILL" 2>/dev/null || echo "0")
+if [ "$RED_GATE_SKILLMD" -ge 1 ]; then
+    echo "  executing-plans SKILL.md RED phase checkpoint: FOUND"
+    echo "- **executing-plans SKILL.md RED phase checkpoint:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  executing-plans SKILL.md RED phase checkpoint: MISSING"
+    echo "- **executing-plans SKILL.md RED phase checkpoint:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi


### PR DESCRIPTION
## Summary

Adds three enforcement checkpoints that prevent agents from skipping the RED phase in the TDD cycle (writing failing tests before implementation). This addresses the root cause identified in #1173: agents treating TDD steps as optional documentation rather than mandatory process.

## Outcome

Three enforcement layers now block implementation until RED test artifacts exist:
- `executing-plans/tasks/start.md` Step 5.5 — execution-time gate that HALTs before dispatching to implementation
- `writing-plans/tasks/create.md` Step 2 — plan-time checkpoint requiring tool-call evidence of test failure
- `091-incremental-build.md` "Enforcement Mechanism" section — guideline-level documentation of all three checkpoints with git log order verification

Implements #1173

🤖 OpenCode (ollama-cloud/glm-5.1) ✅ completed