### PR TITLE
feat(#1189): Add TDD Red/Green enforcement gates to content-creating skills

### DIFF
--- a/.opencode/guidelines/091-incremental-build.md
+++ b/.opencode/guidelines/091-incremental-build.md
@@ -80,6 +80,8 @@ These anti-patterns are also documented as the "Monolithic Implementation" criti
 
 The RED phase is enforced at multiple checkpoints to prevent GREEN-without-RED violations. Each enforcement point requires tool-call evidence that the test was verified to fail before implementation proceeds.
 
+**Checkpoint 0 — Spec Creation RED Gate:** Before a spec is approved, enforcement test assertions for each spec success criterion MUST exist and be in RED state (failing) in `test-enforcement.sh`. This is enforced by `spec-creation/tasks/write.md` Step 0.5 and `issue-review/tasks/analyze-and-spec.md` Step 4.1. The approval gate verifies this at Step 4.6 — enforcement test assertions for spec SCs must have been written before the spec was approved, not just before implementation.
+
 **Checkpoint 1 — executing-plans/tasks/start.md Step 5.5:** Before dispatching to divide-and-conquer, the agent MUST verify that RED test artifacts exist for each item. If no RED test artifact exists, the agent MUST HALT and require the RED phase to be completed.
 
 **Checkpoint 2 — writing-plans/tasks/create.md Step 2:** Plans MUST include a RED verification step that produces tool-call evidence of test failure. The plan template requires a step between writing the test and implementing the change where the agent runs the test and captures the failure output as evidence.

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -265,12 +265,16 @@ if not has_tdd_steps:
 
 ### Step 4.6: Verify SC-to-Test Traceability and RED-Phase Ordering
 
-**Before implementation proceeds, verify that the corresponding spec's success criteria have enforcement test assertions and that RED-phase ordering was followed.**
+**Before implementation proceeds, verify that the corresponding spec's success criteria have enforcement test assertions and that RED-phase ordering was followed.** This gate applies at TWO checkpoints:
+
+1. **Spec creation RED gate** — When the spec was created (via `spec-creation` or `analyze-and-spec`), enforcement test assertions for each SC MUST have been written and verified in RED state BEFORE the spec was approved. This is enforced by the Step 0.5 RED gate in `spec-creation/tasks/write.md` and Step 4.1 in `issue-review/tasks/analyze-and-spec.md`.
+2. **Implementation RED gate** — Each enforcement test assertion was written BEFORE the implementation commit for its corresponding item (the test was in RED state — exists and fails — before implementation began).
 
 **Verification checks:**
 
-1. **SC-to-test traceability exists** — For each success criterion in the corresponding spec, at least one enforcement test assertion references the SC ID (per `080-code-standards.md` SC-to-Test Traceability requirement)
-2. **RED-phase ordering confirmed** — Each enforcement test assertion was written BEFORE the implementation commit for its corresponding item (the test was in RED state — exists and fails — before implementation began)
+1. **Spec-creation RED gate was followed** — The spec's success criteria had enforcement test assertions written and verified in RED state before the spec was approved (not just before implementation). Evidence: `test-enforcement.sh` contains assertions referencing SC IDs from the spec, and those assertions were verified in RED state during spec creation.
+2. **SC-to-test traceability exists** — For each success criterion in the corresponding spec, at least one enforcement test assertion references the SC ID (per `080-code-standards.md` SC-to-Test Traceability requirement)
+3. **RED-phase ordering confirmed** — Each enforcement test assertion was written BEFORE the implementation commit for its corresponding item (the test was in RED state — exists and fails — before implementation began)
 
 **Procedure:**
 
@@ -281,6 +285,18 @@ spec_body = spec_issue["body"]
 
 # Parse success criteria from spec
 success_criteria = parse_success_criteria(spec_body)
+
+# 0. Verify spec-creation RED gate was followed
+# Check that enforcement test assertions for each SC were written before spec approval
+for sc in success_criteria:
+    # Spec-creation RED gate: test assertions must exist and have been verified RED
+    # during spec creation (Step 0.5 of spec-creation/tasks/write.md)
+    has_spec_red_evidence = check_spec_creation_red_gate_evidence(sc["id"])
+    if not has_spec_red_evidence:
+        # VERIFICATION-GAP: No evidence that SC test assertions were verified RED during spec creation
+        finding = f"SC {sc['id']}: no evidence that enforcement test assertions were verified in RED state during spec creation"
+        action = "BLOCK; require spec-creation RED gate to be completed"
+        severity = "VERIFICATION-GAP"
 
 # For each SC, verify:
 for sc in success_criteria:
@@ -305,7 +321,7 @@ for sc in success_criteria:
 
 **Exemption:** Existing SCs that were implemented before this mandate took effect are flagged but not blocked. RED-phase ordering is prospective (per `140-planning-spec-creation.md` constraints).
 
-**Cross-reference:** See `080-code-standards.md` "SC-to-Test Traceability" and "RED-Phase Ordering" sections for the mandate. See `091-incremental-build.md` for the per-item TDD cycle extended to SCs.
+**Cross-reference:** See `080-code-standards.md` "SC-to-Test Traceability" and "RED-Phase Ordering" sections for the mandate. See `091-incremental-build.md` for the per-item TDD cycle extended to SCs. See `spec-creation/tasks/write.md` Step 0.5 and `issue-review/tasks/analyze-and-spec.md` Step 4.1 for the content-creation RED gates that ensure enforcement test assertions exist before spec approval.
 
 ### Step 5: Verify Sub-Issue Structure (for Plan Approval)
 

--- a/.opencode/skills/issue-review/tasks/analyze-and-spec.md
+++ b/.opencode/skills/issue-review/tasks/analyze-and-spec.md
@@ -75,6 +75,37 @@ Create a fix spec using the `issue-operations` skill. The fix spec must include:
    - **Affected Files**: Files that need modification
    - **Risk Assessment**: Potential regression areas
 
+#### Step 4.1: RED Gate — Fix Spec Enforcement Test Assertions (MANDATORY)
+
+**🚫 CRITICAL: This sub-step MUST execute BEFORE the fix spec sub-issue is created in Step 6. Skipping this step is a CRITICAL GUIDELINE VIOLATION.**
+
+Before creating the fix spec sub-issue, enforcement test assertions MUST be written for each success criterion in the fix spec.
+
+**Procedure:**
+
+1. **Write enforcement test assertions** — For each success criterion in the fix spec, write an enforcement test assertion in `test-enforcement.sh` that verifies the SC's requirement. Use the format: `# SC-N: <brief description>` as a comment above the assertion, followed by a grep/check that will FAIL before the fix is implemented and PASS after
+2. **Verify RED state** — Run the newly written assertions and confirm they are in RED state (failing). The assertions MUST fail because the fix spec content they verify does not exist yet
+3. **Produce tool-call evidence** — Record the RED state verification output as a tool-call artifact
+4. **Include test assertion references in fix spec body** — Add a `Test Assertions` section to the fix spec body listing the SC IDs and their corresponding enforcement test scenario names in `test-enforcement.sh`
+
+**Evidence artifact format:**
+
+```
+RED Gate: analyze-and-spec fix spec enforcement test assertions
+Assertions written: [count]
+RED state verified: [true/false]
+Test output: [pasted failure output]
+SC-to-test mapping: [
+  SC-1 -> <test scenario name>,
+  SC-2 -> <test scenario name>,
+  ...
+]
+```
+
+**If RED state is NOT confirmed:** HALT. Do NOT create the fix spec sub-issue. The enforcement test assertions MUST exist and fail before the fix spec is persisted.
+
+**Cross-reference:** See `091-incremental-build.md` → Per-Item TDD Cycle → RED phase, and `080-code-standards.md` → SC-to-Test Traceability and RED-Phase Ordering.
+
 **Root Cause Anti-Patterns (FORBIDDEN):**
 
 | Anti-Pattern | Root Cause Fix (REQUIRED) | Symptom-Only Patch (FORBIDDEN) |

--- a/.opencode/skills/spec-creation/tasks/write.md
+++ b/.opencode/skills/spec-creation/tasks/write.md
@@ -23,6 +23,38 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
 Before assembling the spec, invoke `verification-enforcement --task verify`. This gate dispatches section-based sub-agents to collect evidence artifacts for the factual claims the spec will make — file references, API signatures, configuration fields, code behavior, and environment details. Evidence artifacts collected here ensure that the spec's claims are grounded in live sources. Claims that cannot be verified at this stage are marked with `⚠️ UNVERIFIED` for resolution in the post-generation revisit pass.
 
+### Step 0.5: RED Gate — Enforcement Test Assertions (MANDATORY)
+
+**🚫 CRITICAL: This step MUST execute BEFORE spec assembly. Skipping this step is a CRITICAL GUIDELINE VIOLATION.**
+
+Before assembling the spec, enforcement test assertions MUST be written for each success criterion that the spec will define. This ensures the TDD RED phase is satisfied before the spec is even created — the test assertions exist and are in RED state (failing) before the spec content they verify exists.
+
+**Procedure:**
+
+1. **Enumerate anticipated success criteria** — Based on the requirements extraction and analysis from prerequisite tasks, list the expected success criteria the spec will define
+2. **Write enforcement test assertions** — For each anticipated SC, write an enforcement test assertion in `test-enforcement.sh` that verifies the SC's requirement. Use the format: `# SC-N: <brief description>` as a comment above the assertion, followed by a grep/check that will FAIL before the spec exists and PASS after the spec is created
+3. **Verify RED state** — Run the newly written assertions and confirm they are in RED state (failing). The assertions MUST fail because the spec content they verify does not exist yet
+4. **Produce tool-call evidence** — Record the RED state verification output as a tool-call artifact. The evidence MUST show:
+   - The test assertions written (with SC ID comments)
+   - The test run output showing failure (RED state)
+   - The timestamp of when the RED verification was performed
+
+**Evidence artifact format:**
+
+```
+RED Gate: spec-creation enforcement test assertions
+Assertions written: [count]
+RED state verified: [true/false]
+Test output: [pasted failure output]
+Timestamp: [ISO 8601]
+```
+
+**If RED state is NOT confirmed:** HALT. Do NOT proceed to spec assembly. The enforcement test assertions MUST exist and fail before the spec is created. This is a CRITICAL VIOLATION of the per-item TDD cycle per `091-incremental-build.md`.
+
+**Exemption:** Simple specs with only 1-2 success criteria that are purely administrative (label changes, status updates) may use a simplified assertion. The RED gate still applies, but the assertion may be a single check for the spec file's existence rather than per-SC assertions.
+
+**Cross-reference:** See `091-incremental-build.md` → Per-Item TDD Cycle → RED phase, and `080-code-standards.md` → SC-to-Test Traceability and RED-Phase Ordering.
+
 ### Step 1: Assemble Spec
 
 Combine outputs from prerequisite tasks into a coherent spec. The spec should address the following content areas — the agent decides which sections to use and how to organize them:

--- a/.opencode/skills/ui-engineer/tasks/implement.md
+++ b/.opencode/skills/ui-engineer/tasks/implement.md
@@ -7,6 +7,7 @@ Produce a complete framework-specific UI implementation from design artifacts (i
 ## Entry Criteria
 
 - Design artifacts exist in the worktree (interaction-spec.yaml is REQUIRED; mockup.html, screenshot.png, wireframe.svg are recommended/reference).
+- `test-ui` task has been completed (UI test specifications exist in the worktree — MANDATORY prerequisite).
 - `worktree.path` is set and verified.
 - Target framework is known (Streamlit by default, or configured via `framework-config` task).
 - Spec or context document is available and has been read.
@@ -22,9 +23,49 @@ Produce a complete framework-specific UI implementation from design artifacts (i
 
 ## Procedure
 
+### Step 0.5: RED Gate — UI Enforcement Test Assertions (MANDATORY)
+
+**🚫 CRITICAL: This step MUST execute BEFORE any UI implementation. Skipping this step is a CRITICAL GUIDELINE VIOLATION.**
+
+Before writing any implementation code, enforcement test assertions for UI behavior MUST be written and verified to be in RED state.
+
+**Prerequisites:**
+- `test-ui` task MUST have been completed (invoke `/skill ui-engineer --task test-ui` if UI test specifications do not yet exist)
+- Interaction spec YAML is available in the worktree
+- `worktree.path` is set and verified
+
+**Procedure:**
+
+1. **Invoke `test-ui` task** — If UI test specifications do not yet exist in the worktree, invoke the `test-ui` task to generate them. The `test-ui` task produces test specification files that define expected UI behavior
+2. **Write enforcement test assertions** — For each success criterion in the spec that applies to UI behavior, write an enforcement test assertion in `test-enforcement.sh` that verifies the UI meets the SC's requirement. Use the format: `# SC-N: <brief UI description>` as a comment above the assertion
+3. **Verify RED state** — Run the newly written assertions and confirm they are in RED state (failing). The assertions MUST fail because the UI implementation does not exist yet
+4. **Produce tool-call evidence** — Record the RED state verification output as a tool-call artifact showing:
+   - The test assertions written (with SC ID comments)
+   - The test run output showing failure (RED state)
+   - The timestamp of when the RED verification was performed
+
+**Evidence artifact format:**
+
+```
+RED Gate: ui-engineer enforcement test assertions
+Assertions written: [count]
+RED state verified: [true/false]
+Test output: [pasted failure output]
+Timestamp: [ISO 8601]
+```
+
+**If RED state is NOT confirmed:** HALT. Do NOT proceed to implementation. The enforcement test assertions MUST exist and fail before any UI code is written.
+
+**Cross-reference:** See `091-incremental-build.md` → Per-Item TDD Cycle → RED phase, and `080-code-standards.md` → SC-to-Test Traceability and RED-Phase Ordering.
+
+### Step 1: Read Design Artifacts
+
 1. Read the interaction spec YAML file from the worktree.
 2. Read the mockup HTML and/or wireframe SVG for layout reference.
 3. Read `docs/ui-guidelines.md` for project UI conventions.
+
+### Step 2: Map Components and Implement
+
 4. Copy `templates/streamlit_template.py` as the starting point for each page/view.
 5. Map interaction spec components to Streamlit widgets:
    - `navigation_list` → `st.sidebar` navigation with `st.radio` or `st.sidebar.selectbox`
@@ -41,5 +82,8 @@ Produce a complete framework-specific UI implementation from design artifacts (i
    - Screen reader announcements via `st.status` or `st.toast`.
 9. Implement per-record controls inline with data, not in global toolbars.
 10. Use `st.status()` or `st.toast()` for feedback — no `st.error()` for advisory validation.
+
+### Step 3: Completion
+
 11. Invoke `completion` subtask.
 12. Return result contract.

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -96,6 +96,9 @@ SCENARIOS["dispatch-artifact-requirements"]="Does .opencode/guidelines/000-criti
 SCENARIOS["review-prep-format-self-check"]="Does .opencode/skills/git-workflow/tasks/review-prep.md contain a Format verification section that requires checking URL label context, URL format context, and element ordering before sending chat output?"
 SCENARIOS["checklist-chat-output-format"]="Does .opencode/skills/finishing-a-development-branch/tasks/checklist.md contain a Chat Output Format section that requires verifying executive summary, outcome, URL label, URL presence, AI byline, and correct ordering?"
 SCENARIOS["dispatch-checkpoint-live-verification"]="Does .opencode/skills/approval-gate/SKILL.md contain an evidence requirement that mandates tool-call artifact evidence for each dispatch chain verification gate?"
+SCENARIOS["spec-creation-red-gate"]="Does .opencode/skills/spec-creation/tasks/write.md contain a Step 0.5 RED Gate requiring enforcement test assertions verified in RED state before spec assembly?"
+SCENARIOS["analyze-and-spec-red-gate"]="Does .opencode/skills/issue-review/tasks/analyze-and-spec.md contain a Step 4.1 RED Gate requiring enforcement test assertions verified in RED state before fix spec sub-issue creation?"
+SCENARIOS["ui-engineer-red-gate"]="Does .opencode/skills/ui-engineer/tasks/implement.md contain a Step 0.5 RED Gate requiring enforcement test assertions verified in RED state before UI implementation?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -164,6 +167,9 @@ EXPECTED_SKILLS["dispatch-artifact-requirements"]=""
 EXPECTED_SKILLS["review-prep-format-self-check"]=""
 EXPECTED_SKILLS["checklist-chat-output-format"]=""
 EXPECTED_SKILLS["dispatch-checkpoint-live-verification"]=""
+EXPECTED_SKILLS["spec-creation-red-gate"]=""
+EXPECTED_SKILLS["analyze-and-spec-red-gate"]=""
+EXPECTED_SKILLS["ui-engineer-red-gate"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -176,7 +182,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref dispatch-chain-enforcement-gate dispatch-artifact-requirements review-prep-format-self-check checklist-chat-output-format dispatch-checkpoint-live-verification; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref dispatch-chain-enforcement-gate dispatch-artifact-requirements review-prep-format-self-check checklist-chat-output-format dispatch-checkpoint-live-verification spec-creation-red-gate analyze-and-spec-red-gate ui-engineer-red-gate; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -919,6 +925,44 @@ if [ "$AG_EVIDENCE" -ge 1 ]; then
 else
     echo "  dispatch chain evidence requirement: MISSING"
     echo "- **dispatch chain evidence requirement:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# spec-creation RED Gate in write.md
+SPEC_WRITE_RED=$(grep -c "Step 0.5.*RED Gate\|RED Gate.*Enforcement Test\|enforcement test assertions.*RED state.*before spec" "$SPEC_WRITE_FILE" 2>/dev/null || echo "0")
+if [ "$SPEC_WRITE_RED" -ge 1 ]; then
+    echo "  spec-creation/write RED Gate: FOUND"
+    echo "- **spec-creation/write RED Gate:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  spec-creation/write RED Gate: MISSING"
+    echo "- **spec-creation/write RED Gate:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# analyze-and-spec RED Gate in analyze-and-spec.md
+ANALYZE_SPEC_FILE="$PROJECT_DIR/.opencode/skills/issue-review/tasks/analyze-and-spec.md"
+ANALYZE_SPEC_RED=$(grep -c "Step 4.1.*RED Gate\|RED Gate.*Fix Spec.*Enforcement Test\|enforcement test assertions.*RED state.*before.*fix spec" "$ANALYZE_SPEC_FILE" 2>/dev/null || echo "0")
+if [ "$ANALYZE_SPEC_RED" -ge 1 ]; then
+    echo "  analyze-and-spec RED Gate: FOUND"
+    echo "- **analyze-and-spec RED Gate:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  analyze-and-spec RED Gate: MISSING"
+    echo "- **analyze-and-spec RED Gate:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# ui-engineer RED Gate in implement.md
+UI_IMPL_FILE="$PROJECT_DIR/.opencode/skills/ui-engineer/tasks/implement.md"
+UI_ENGINEER_RED=$(grep -c "Step 0.5.*RED Gate\|RED Gate.*UI.*Enforcement Test\|enforcement test assertions.*RED state.*before.*UI\|test-ui.*mandatory prerequisite\|test-ui.*MANDATORY prerequisite" "$UI_IMPL_FILE" 2>/dev/null || echo "0")
+if [ "$UI_ENGINEER_RED" -ge 1 ]; then
+    echo "  ui-engineer/implement RED Gate: FOUND"
+    echo "- **ui-engineer/implement RED Gate:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  ui-engineer/implement RED Gate: MISSING"
+    echo "- **ui-engineer/implement RED Gate:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi


### PR DESCRIPTION
## Summary

Adds mandatory TDD RED phase enforcement gates to three content-creating skills (spec-creation, issue-review/analyze-and-spec, ui-engineer) that were creating success criteria without requiring enforcement test assertions to be written first. Introduces Checkpoint 0 to the incremental-build enforcement model and updates approval-gate Step 4.6 to validate spec-creation RED gates before spec approval.

## Outcome

3 skill tasks now have mandatory RED gate steps requiring enforcement test assertions to be written and verified in RED state before content artifacts are created. Approval-gate Step 4.6 and incremental-build now enforce this at the spec-creation boundary (Checkpoint 0), closing the process gap where success criteria were unverifiable until implementation began.

Fixes #1189

🤖 OpenCode (ollama-cloud/glm-5.1) ✅ completed