### PR TITLE
fix(approval-gate): encode gap-fill precedence principle for bug report spec requirements

### DIFF
--- a/.opencode/skills/approval-gate/tasks/screen-issue.md
+++ b/.opencode/skills/approval-gate/tasks/screen-issue.md
@@ -385,6 +385,8 @@ concerns:
 ```yaml
 issue_number: <N>
 work_peers: [<list of other issue numbers in work set>]
+authorization_scope:   # From verify-authorization Step 2.0
+gap_fill_actions: []  # Derived from authorization_scope
 session_vars:
   github.owner: <from-session>
   github.repo: <from-session>
@@ -457,5 +459,29 @@ Screening sub-agents produce result contracts that feed into `pre-implementation
 1. **Screening results are data, not decisions.** The result contract is consumed by `pre-implementation-analysis` which auto-dispatches to `assemble-work`. No human review of screening results is required unless `requires_developer: true`.
 2. **Individual screen-issue sub-agents MUST NOT halt the orchestrator.** They return result contracts and terminate. The orchestrator processes all contracts before any action.
 3. **The orchestrator assembles results and proceeds.** Presentation of assembled results is informational — not a gate, not a decision point, not a halt point. See `pre-implementation-analysis.md` §"Post-Analysis Dispatch (MANDATORY)" for enforcement.
+
+### Gap-Fill Override for Screening Sub-Agents
+
+**When `authorization_scope` is passed via dispatch context and its gap-fill actions include `auto_create_spec`, screening sub-agents MUST NOT block on missing spec artifacts (including the fix-spec requirement for bug reports).** The missing spec is a gap-fill trigger handled by `verify-authorization` Step 5c, not a screening blocking condition.
+
+Screening sub-agents classify issues (include/exclude/reduce-scope). They do NOT enforce artifact requirements that are covered by the authorization scope's gap-fill cascade. A bug report without a fix-spec is classified normally (e.g., "included") — the fix-spec creation is deferred to the gap-fill cascade.
+
+**Procedure:**
+
+```python
+# When evaluating a bug report during screening:
+if is_bug_report and not has_fix_spec:
+    if "auto_create_spec" in dispatch_context.get("gap_fill_actions", []):
+        # Do NOT flag as blocking — gap-fill handles this
+        # Classify normally (include/reduce-scope/etc.)
+        pass
+    else:
+        # No gap-fill coverage — flag in result contract
+        result_contract["concerns"].append(
+            "Bug report lacks fix-spec; scope has no auto_create_spec gap-fill"
+        )
+```
+
+**The `gap_fill_actions` field MUST be passed in the dispatch context** when `authorization_scope >= for_implementation`. See `verify-authorization.md` Step 2.0 for the `GAP_FILL` mapping.
 
 - Produce the result contract as the final output of this task

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -734,6 +734,56 @@ elif not plan_issues:
 
 **Evidence artifact:** `github_search_issues` response showing plan issues referencing the spec, and `github_issue_write` response confirming label removal and comment posting.
 
+### Step 5b.5: Gap-Fill Precedence Principle
+
+**Before evaluating any blocking gate in Steps 5 through 5c, the agent MUST apply this precedence principle:**
+
+> When `authorization_scope`'s gap-fill actions cover a missing artifact requirement, that requirement is a gap-fill trigger, not a blocking gate. Hard gates only apply to artifacts outside the scope's gap-fill coverage.
+
+**Application to Bug Reports:**
+
+The critical rule "Bug Reports Without Fix Spec" requires a fix-spec sub-issue before implementation. When `authorization_scope >= for_implementation` (which includes `for_implementation`, `for_code_review`, and `for_pr`), the gap-fill actions include `auto_create_spec`. This means:
+
+- **Missing fix-spec for a bug report + `for_pr` authorization** → Gap-fill trigger: proceed to Step 5c, which dispatches `brainstorming --task explore` to create the fix-spec. NOT a blocking gate.
+- **Missing fix-spec for a bug report + `for_implementation` authorization** → Gap-fill trigger: same as above. NOT a blocking gate.
+- **Missing fix-spec for a bug report + `for_code_review` authorization** → Gap-fill trigger: same as above. NOT a blocking gate.
+- **Missing fix-spec for a bug report + `for_plan` authorization** → Gap-fill trigger: `for_plan` includes `auto_create_spec`. NOT a blocking gate.
+- **Missing fix-spec for a bug report + `for_spec` authorization** → Gap-fill trigger: `for_spec` targets spec creation. NOT a blocking gate.
+- **Missing fix-spec for a bug report + `standard` authorization** → Blocking gate: `standard` scope has NO gap-fill actions, so the fix-spec must already exist. HALT and report missing fix-spec. Standard scope without auto_create_spec means missing spec artifacts remain blocking gates, not gap-fill triggers.
+
+**Procedure:**
+
+```python
+# At the start of Step 5, before evaluating any blocking gate:
+scope = verification_result["authorization_scope"]
+gap_fill_actions = GAP_FILL.get(scope, [])
+
+# For ANY blocking gate that checks for a missing artifact:
+# If the missing artifact would be created by a gap-fill action,
+# the gate is OVERRIDDEN — proceed to Step 5c gap-fill cascade.
+
+# Example: Bug report without fix-spec
+missing_fix_spec = is_bug_report and not has_fix_spec_sub_issue
+if missing_fix_spec:
+    if "auto_create_spec" in gap_fill_actions:
+        # Gap-fill covers this — NOT a blocking gate
+        # Proceed to Step 5c to create the spec
+        pass
+    else:
+        # No gap-fill coverage — this IS a blocking gate
+        # HALT and report missing fix-spec
+        findings.append({
+            "finding": "Bug report requires fix-spec but scope has no auto_create_spec",
+            "problem_class": "MISSING-ELEMENT",
+            "classification": "flag-for-review",
+            "action": "block"
+        })
+```
+
+**This principle applies universally**, not just to bug reports. Any blocking gate that checks for a missing artifact MUST be evaluated against the gap-fill actions for the current scope. If the gap-fill covers the artifact, the gate is bypassed.
+
+**Evidence artifact:** The agent's verification report MUST note when a blocking gate was overridden by the Gap-Fill Precedence Principle, citing the specific gate, the missing artifact, and the covering gap-fill action.
+
 ### Step 5c: Scope-Aware Gap-Fill Cascade
 
 **When `authorization_scope` from Step 2.0 is >= `for_plan`, missing intermediate artifacts are gap-filled automatically.** This eliminates the "catch-22" where pipeline authorization says "go to PR" but the plan doesn't exist yet — the scope horizon authorizes its creation.

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -99,6 +99,11 @@ SCENARIOS["dispatch-checkpoint-live-verification"]="Does .opencode/skills/approv
 SCENARIOS["spec-creation-red-gate"]="Does .opencode/skills/spec-creation/tasks/write.md contain a Step 0.5 RED Gate requiring enforcement test assertions verified in RED state before spec assembly?"
 SCENARIOS["analyze-and-spec-red-gate"]="Does .opencode/skills/issue-review/tasks/analyze-and-spec.md contain a Step 4.1 RED Gate requiring enforcement test assertions verified in RED state before fix spec sub-issue creation?"
 SCENARIOS["ui-engineer-red-gate"]="Does .opencode/skills/ui-engineer/tasks/implement.md contain a Step 0.5 RED Gate requiring enforcement test assertions verified in RED state before UI implementation?"
+SCENARIOS["gap-fill-precedence-principle"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md contain a Gap-Fill Precedence Principle section stating that when authorization_scope gap-fill actions cover a missing artifact requirement it is a gap-fill trigger not a blocking gate?"
+SCENARIOS["gap-fill-precedence-for-pr"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md Gap-Fill Precedence Principle section explicitly state that for_pr scope with auto_create_spec means a bug report missing fix spec is a gap-fill trigger not a blocking gate?"
+SCENARIOS["gap-fill-precedence-standard-scope"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md Gap-Fill Precedence Principle section state that standard scope without auto_create_spec means a bug report missing fix spec remains a blocking gate?"
+SCENARIOS["screen-issue-gap-fill-awareness"]="Does .opencode/skills/approval-gate/tasks/screen-issue.md contain a note that screening sub-agents must not block on missing specs when authorization_scope gap-fill actions include auto_create_spec?"
+SCENARIOS["gap-fill-precedence-before-step5c"]="Does .opencode/skills/approval-gate/tasks/verify-authorization.md place the Gap-Fill Precedence Principle before Step 5c so it is evaluated before blocking gates?"
 
 # Expected skill invocations per scenario (empty = no specific skill expected)
 declare -A EXPECTED_SKILLS
@@ -170,6 +175,11 @@ EXPECTED_SKILLS["dispatch-checkpoint-live-verification"]=""
 EXPECTED_SKILLS["spec-creation-red-gate"]=""
 EXPECTED_SKILLS["analyze-and-spec-red-gate"]=""
 EXPECTED_SKILLS["ui-engineer-red-gate"]=""
+EXPECTED_SKILLS["gap-fill-precedence-principle"]=""
+EXPECTED_SKILLS["gap-fill-precedence-for-pr"]=""
+EXPECTED_SKILLS["gap-fill-precedence-standard-scope"]=""
+EXPECTED_SKILLS["screen-issue-gap-fill-awareness"]=""
+EXPECTED_SKILLS["gap-fill-precedence-before-step5c"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -182,7 +192,7 @@ echo "" >> "$RESULTS_FILE"
 
 OVERALL_PASS=true
 
-for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref dispatch-chain-enforcement-gate dispatch-artifact-requirements review-prep-format-self-check checklist-chat-output-format dispatch-checkpoint-live-verification spec-creation-red-gate analyze-and-spec-red-gate ui-engineer-red-gate; do
+for scenario_name in bug-report create-spec simple-question implement-request post-merge-cleanup symptom-patch incremental-build-guideline monolithic-implementation-violation item-decomposition-step brainstorming-top-down writing-plans-bottom-up executing-plans-tdd divide-conquer-tdd agents-md-incremental worktree-handoff-step scope-auto-resolve-guideline scope-auto-resolve-step worktree-mandate offer-to-edit-bypass bug-discovery-no-auth confirmation-not-auth pipeline-scoped-halt silent-halt-with-search pr-creation-guard post-implementation-format sub-issue-structure read-comments-before-action per-sc-evidence-table vbc-per-sc-evidence-skill finishing-sc-verification sc-to-test-traceability red-phase-ordering sc-traceability-example approval-gate-sc-traceability approval-gate-red-phase executable-verification-commands vague-verification-antipattern sc-assertion-tdd-cycle red-state-before-implementation validate-executable-verification semantic-intent-spec-creation narrow-sc-table-exemption semantic-intent-writing-plans why-specific-value-tdd verification-mechanics-brainstorming sc-precision-audit url-sourcing-rule1-pr url-sourcing-rule1-review-prep url-sourcing-rule2-character-match url-sourcing-guideline-rules url-sourcing-issue-operations identity-echo-validation secret-exfiltration-violation read-secrets-in-output red-phase-gate-executing-plans red-phase-gate-skillmd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref dispatch-chain-enforcement-gate dispatch-artifact-requirements review-prep-format-self-check checklist-chat-output-format dispatch-checkpoint-live-verification spec-creation-red-gate analyze-and-spec-red-gate ui-engineer-red-gate gap-fill-precedence-principle gap-fill-precedence-for-pr gap-fill-precedence-standard-scope screen-issue-gap-fill-awareness gap-fill-precedence-before-step5c; do
     MESSAGE="${SCENARIOS[$scenario_name]}"
     EXPECTED="${EXPECTED_SKILLS[$scenario_name]}"
     SCENARIO_LOG="$LOGDIR/${scenario_name}.log"
@@ -970,6 +980,69 @@ fi
 echo ""
 echo "" >> "$RESULTS_FILE"
 echo "" >> "$RESULTS_FILE"
+
+# Gap-Fill Precedence Principle in verify-authorization.md
+VERIFY_AUTH_FILE="$PROJECT_DIR/.opencode/skills/approval-gate/tasks/verify-authorization.md"
+GAP_FILL_PRECEDENCE=$(grep -c "Gap-Fill Precedence Principle\|gap-fill trigger.*not a blocking gate\|gap-fill actions cover.*missing artifact" "$VERIFY_AUTH_FILE" 2>/dev/null || echo "0")
+if [ "$GAP_FILL_PRECEDENCE" -ge 1 ]; then
+    echo "  verify-authorization Gap-Fill Precedence Principle: FOUND"
+    echo "- **verify-authorization Gap-Fill Precedence Principle:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  verify-authorization Gap-Fill Precedence Principle: MISSING"
+    echo "- **verify-authorization Gap-Fill Precedence Principle:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Gap-Fill Precedence Principle explicit for_pr reference
+GAP_FILL_FORPR=$(grep -c "for_pr.*auto_create_spec\|bug report.*fix spec.*gap-fill\|missing fix spec.*gap-fill trigger" "$VERIFY_AUTH_FILE" 2>/dev/null || echo "0")
+if [ "$GAP_FILL_FORPR" -ge 1 ]; then
+    echo "  verify-authorization gap-fill for_pr bug report: FOUND"
+    echo "- **verify-authorization gap-fill for_pr bug report:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  verify-authorization gap-fill for_pr bug report: MISSING"
+    echo "- **verify-authorization gap-fill for_pr bug report:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Gap-Fill Precedence Principle standard scope preserves blocking
+GAP_FILL_STANDARD=$(grep -c "standard.*blocking\|scope.*without.*auto_create_spec.*blocking\|gap-fill.*does not cover.*blocking" "$VERIFY_AUTH_FILE" 2>/dev/null || echo "0")
+if [ "$GAP_FILL_STANDARD" -ge 1 ]; then
+    echo "  verify-authorization gap-fill standard scope blocking: FOUND"
+    echo "- **verify-authorization gap-fill standard scope blocking:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  verify-authorization gap-fill standard scope blocking: MISSING"
+    echo "- **verify-authorization gap-fill standard scope blocking:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# screen-issue gap-fill awareness
+SCREEN_GAP_FILL=$(grep -c "gap-fill\|auto_create_spec\|authorization_scope.*gap-fill" "$PROJECT_DIR/.opencode/skills/approval-gate/tasks/screen-issue.md" 2>/dev/null || echo "0")
+if [ "$SCREEN_GAP_FILL" -ge 1 ]; then
+    echo "  screen-issue gap-fill awareness: FOUND"
+    echo "- **screen-issue gap-fill awareness:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  screen-issue gap-fill awareness: MISSING"
+    echo "- **screen-issue gap-fill awareness:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Gap-Fill Precedence Principle placed before Step 5c
+GAP_FILL_BEFORE_5C=$(grep -n "Gap-Fill Precedence\|Step 5c" "$VERIFY_AUTH_FILE" 2>/dev/null | head -5)
+GAP_FILL_LINE=$(echo "$GAP_FILL_BEFORE_5C" | grep "Gap-Fill Precedence" | head -1 | grep -oP '^\d+' || echo "0")
+STEP5C_LINE=$(echo "$GAP_FILL_BEFORE_5C" | grep "Step 5c" | head -1 | grep -oP '^\d+' || echo "0")
+if [ "$GAP_FILL_LINE" -gt 0 ] && [ "$STEP5C_LINE" -gt 0 ] && [ "$GAP_FILL_LINE" -lt "$STEP5C_LINE" ]; then
+    echo "  verify-authorization Gap-Fill Precedence before Step 5c: FOUND"
+    echo "- **verify-authorization Gap-Fill Precedence before Step 5c:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  verify-authorization Gap-Fill Precedence before Step 5c: MISSING"
+    echo "- **verify-authorization Gap-Fill Precedence before Step 5c:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
 
 SKILL_CARD_SCRIPT="$PROJECT_DIR/.opencode/skills/skill-creator/scripts/validate_skill_cards.py"
 SKILL_CARD_PASS=true


### PR DESCRIPTION
## Summary

Encode a Gap-Fill Precedence Principle in `verify-authorization.md` so that when `authorization_scope`'s gap-fill actions cover a missing artifact requirement (including the fix-spec requirement for bug reports), that requirement is treated as a gap-fill trigger — not a blocking gate. Hard gates only apply to artifacts outside the scope's gap-fill coverage.

## Outcome

Bug reports approved with `for_pr`, `for_implementation`, `for_code_review`, `for_plan`, or `for_spec` scope now proceed through the gap-fill cascade to auto-create missing specs, instead of blocking at the fix-spec verification gate. `standard` scope blocking behavior is preserved.

Implements #1199