### PR TITLE
Fix #1208 #1212 #1214: Auto-triage stale stashes, release PR routing, SC verification enforcement

### DIFF
--- a/.opencode/guidelines/117-session-trigger-behavior.md
+++ b/.opencode/guidelines/117-session-trigger-behavior.md
@@ -47,16 +47,9 @@ When the `protected_branch_with_changes` or `on_main_branch` trigger fires, the 
 
 ## Stash Analysis Protocol
 
-When the `stale_stash` trigger fires, the agent MUST:
+The `stale_stash` trigger payload includes embedded triage instructions when stashes exist. The agent MUST follow the embedded directive — auto-resolve OBSOLETE and RESUMABLE stashes, only escalate AMBIGUOUS stashes to the developer.
 
-1. Run `git stash show -p stash@{N}` for each stale stash to analyze contents
-2. Classify each stash as one of:
-   - **Resumable**: Contains meaningful, unmerged work with an issue reference → suggest resuming with `git stash pop` and entering pair mode for that issue
-   - **Obsolete**: Contains changes already merged or no longer relevant → suggest dropping with `git stash drop stash@{N}`
-   - **Ambiguous**: Cannot determine relevance → offer to create an issue for tracking
-3. Extract issue references from stash messages (e.g., "WIP: #931 ..." → issue #931)
-4. Present brief analysis, not raw stash list
-5. Example: "Stash `stash@{0}` contains work for #931 (spec-auditor ground-truth changes) that hasn't been merged. Want to resume this work?"
+When no stale stashes exist, no triage instructions are injected and no stash action is needed.
 
 ## Pair Mode Suggestion Protocol
 

--- a/.opencode/scripts/session_context_triggers.py
+++ b/.opencode/scripts/session_context_triggers.py
@@ -313,7 +313,7 @@ def build_uncommitted_work_warning(changed_files: list[str]) -> str:
 
 def build_stale_stash_warning(stashes: list[str]) -> str:
     lines = [
-        "## Stale Stash Found",
+        "## Stale Stash — Auto-Triage Required",
     ]
     stash_analyses = get_stash_analysis()
     for analysis in stash_analyses[:3]:
@@ -327,7 +327,26 @@ def build_stale_stash_warning(stashes: list[str]) -> str:
                 lines.append(f"  {fs_line}")
     if len(stashes) > 3:
         lines.append(f"- ... and {len(stashes) - 3} more")
-    lines.append("- Stash analysis available: review contents to recommend resume/drop/issue")
+    triage_directive = (
+        "STALE STASH TRIAGE REQUIRED (do not skip):\n"
+        "For each stash below, you MUST analyze and act autonomously:\n"
+        "1. Run `git stash show -p <stash_ref>` to inspect contents\n"
+        '2. Run `git log --oneline --grep="<issue_ref>" | head -5` to check if work was already merged\n'
+        "3. If issue ref exists: check issue status with "
+        "`github_issue_read` — closed issues mean the work is done or superseded\n"
+        "4. Classify and ACT:\n"
+        "   - OBSOLETE (issue closed OR changes already merged OR only lockfile bumps):\n"
+        "     → Auto-execute: `git stash drop <stash_ref>` immediately\n"
+        '     → Report: "Dropped <stash_ref> (<reason>)"\n'
+        "   - RESUMABLE (open issue + meaningful unmerged work):\n"
+        "     → Auto-execute: `git stash pop <stash_ref>` and create a pair-mode branch\n"
+        '     → Report: "Resumed <stash_ref> on pair-<branch> branch"\n'
+        "   - AMBIGUOUS (no issue ref, cannot determine relevance):\n"
+        "     → Preserve: do NOT drop the stash\n"
+        '     → Report: "Stash <stash_ref> unclear — contains <summary>. Need dev decision."\n'
+        "5. Only escalate to dev for AMBIGUOUS stashes. OBSOLETE and RESUMABLE are auto-resolved."
+    )
+    lines.append(triage_directive)
     return "\n".join(lines)
 
 

--- a/.opencode/skills/approval-gate/enforcement/closed-issue-verification.md
+++ b/.opencode/skills/approval-gate/enforcement/closed-issue-verification.md
@@ -26,9 +26,43 @@ Before treating a closed issue as resolved (skipping implementation, auto-closin
 | `duplicate` | Target issue exists and is resolved | Low — verify target issue state |
 | (null/missing) | Treat as unknown | None — re-verify from scratch |
 
+## Success Criteria Verification (Step 7)
+
+### SC Verification Is MANDATORY
+
+Step 7 of `verify-closed-issue` is MANDATORY with ZERO TOLERANCE. Skipping SC verification after confirming a merged PR exists is a CRITICAL GUIDELINE VIOLATION.
+
+A merged PR proves code was merged, NOT that success criteria are met. Every success criterion MUST be verified against the live codebase with a tool-call artifact as evidence.
+
+### SC Verification Procedure
+
+1. Extract success criteria from the issue body (parse `- [ ]` or `- [x]` checklist items under "Success Criteria" heading)
+2. If no success criteria found: result remains `VERIFIED_CLOSED` with note `SC_VERIFICATION_NOT_PERFORMED`
+3. If success criteria found: verify EACH criterion against the live codebase using `read`, `grep`, `srclight_get_symbol`, `github_pull_request_read`, or test execution
+4. Produce a per-SC pass/fail table with columns: SC ID, criterion text, verification tool used, evidence detail, PASS/FAIL
+
+### Downgrade Path
+
+| SC Verification Result | Original Result | Downgraded Result |
+|------------------------|-----------------|-------------------|
+| All SCs pass | VERIFIED_CLOSED | VERIFIED_CLOSED (no change) |
+| Some SCs pass | VERIFIED_CLOSED | PARTIALLY_IMPLEMENTED |
+| No SCs pass | VERIFIED_CLOSED | NOT_IMPLEMENTED_DESPITE_CLOSURE |
+| No SCs found | VERIFIED_CLOSED | VERIFIED_CLOSED (note: SC_VERIFICATION_NOT_PERFORMED) |
+
+### ZERO TOLERANCE Enforcement
+
+- Reporting a downgraded result as VERIFIED_CLOSED is a CRITICAL GUIDELINE VIOLATION
+- Stating "I checked" without a tool-call artifact is a CRITICAL GUIDELINE VIOLATION per `065-verification-honesty.md`
+- Each SC MUST produce a tool-call artifact as evidence
+- The default comparison mode is `exact` — character-for-character match
+- `semantic` comparison requires explicit per-field justification
+
 ## Auto-Close Rules
 
 - NEVER auto-close parents while children are still open
 - NEVER auto-close based solely on `state: "closed"` without merged PR evidence
+- NEVER treat a closed issue as verified without confirming success criteria pass (Step 7)
+- NEVER skip Step 7 SC verification and report VERIFIED_CLOSED
 - Use `approval-gate --task verify-closed-issue` for verification before any autoclose
 - Use `approval-gate --task reconcile-issue-graph` for batch graph reconciliation

--- a/.opencode/skills/git-workflow/SKILL.md
+++ b/.opencode/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Use when creating a branch, committing changes, pushing work, or creating a PR. Also use when git rebase/merge produces conflicts — invoke conflict-resolution skill for classification. Also use when user says "check pr" or "check prs" to trigger PR state verification and cleanup if merged. Triggers on: branch, commit, push, PR, pull request, pre-work, review-prep, feature branch, dev branch, squash, conflict, merge conflict, rebase conflict, check pr, check prs, check pull request, check pull requests.
+description: Use when creating a branch, committing changes, pushing work, or creating a PR. Also use when git rebase/merge produces conflicts — invoke conflict-resolution skill for classification. Also use when user says "check pr" or "check prs" to trigger PR state verification and cleanup if merged. Also use when user says "release PR", "promote to main", or "dev to main" — invokes release-promotion task for dev → main promotion. Triggers on: branch, commit, push, PR, pull request, pre-work, review-prep, feature branch, dev branch, squash, conflict, merge conflict, rebase conflict, check pr, check prs, check pull request, check pull requests, release PR, release pr, promote to main, dev to main, release promotion.
 type: discipline-enforcing
 license: MIT
 compatibility: opencode
@@ -35,6 +35,13 @@ You are a Git Workflow Enforcer. Your sole focus is ensuring all git operations 
 | `pair-pr-creation` | Squash + PR with [pair-mode] trailers targeting dev | ≈300 |
 | `pair-cleanup` | Branch deletion after merge, stash cleanup | ≈350 |
 | `pair-mode-resume` | Detect and report on pair-* branch at session start | ≈300 |
+
+## Routing: Feature PR vs Release PR
+
+| Request Type | Target Skill | Branch Pattern |
+|---|---|---|
+| Feature PR (feature/* → dev) | `pr-creation-workflow` | Feature branch to `dev` |
+| Release PR (dev → main) | `git-workflow --task release-promotion` | `dev` to `main` |
 
 ## Invocation
 

--- a/.opencode/skills/pr-creation-workflow/SKILL.md
+++ b/.opencode/skills/pr-creation-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creation-workflow
-description: Use when asking about when to create a PR or whether PR creation is authorized. Triggers on: create PR, make PR, pull request, PR timing, when to PR, PR authorized.
+description: Use when asking about when to create a PR or whether PR creation is authorized. Triggers on: create PR, make PR, pull request, PR timing, when to PR, PR authorized. This skill covers feature branch PRs targeting dev only. Release PRs (dev → main promotion) are handled by git-workflow --task release-promotion. Do NOT invoke this skill for release promotion requests.
 type: technique
 license: MIT
 compatibility: opencode
@@ -11,6 +11,15 @@ compatibility: opencode
 ## Overview
 
 PR creation is a DISTINCT phase requiring EXPLICIT instruction — it is NOT automatic after implementation. "Approved" and "go" authorize implementation ONLY, not PR creation. The developer MUST explicitly say "create a PR" or equivalent.
+
+## Exclusions
+
+This skill covers **feature branch PRs targeting `dev`** only. Release PRs (dev → main promotion) are handled by `git-workflow --task release-promotion`. The routing decision boundary:
+
+- Feature PR (feature/* → dev) → `pr-creation-workflow` skill
+- Release PR (dev → main) → `git-workflow --task release-promotion`
+
+Do NOT invoke this skill for release promotion requests.
 
 ## Tasks
 

--- a/.opencode/tests/test-enforcement.sh
+++ b/.opencode/tests/test-enforcement.sh
@@ -144,6 +144,14 @@ SCENARIOS["cleanup-sc-verification-gate"]="Does .opencode/skills/git-workflow/ta
 SCENARIOS["cleanup-phase-completion-gate"]="Does .opencode/skills/git-workflow/tasks/cleanup.md contain a Step 2.6.5 Phase-Completion Gate that prevents closing multi-phase specs after partial merges?"
 SCENARIOS["scope-next-phase-resolution"]="Does .opencode/skills/approval-gate/enforcement/scope-parsing.md contain a Next Phase Resolution section with resolve_next_phase logic?"
 SCENARIOS["scope-phase-n-resolution"]="Does .opencode/skills/approval-gate/enforcement/scope-parsing.md contain an Approved for Phase N Resolution section with resolve_phase_n logic?"
+SCENARIOS["stash-triage-directive"]="Does .opencode/scripts/session_context_triggers.py build_stale_stash_warning() output contain STALE STASH TRIAGE REQUIRED with auto-resolve instructions for OBSOLETE and RESUMABLE classifications?"
+SCENARIOS["stash-trigger-guideline-reference"]="Does .opencode/guidelines/117-session-trigger-behavior.md Stash Analysis Protocol section reference embedded triage instructions in the trigger payload?"
+SCENARIOS["release-pr-routing"]="Does .opencode/skills/git-workflow/SKILL.md frontmatter description contain the trigger phrase 'release PR'?"
+SCENARIOS["release-promotion-trigger"]="Does .opencode/skills/git-workflow/SKILL.md frontmatter description contain the trigger phrase 'promote to main'?"
+SCENARIOS["pr-creation-exclusion"]="Does .opencode/skills/pr-creation-workflow/SKILL.md frontmatter description contain an exclusion clause stating that release PRs are handled by git-workflow release-promotion?"
+SCENARIOS["git-workflow-routing-section"]="Does .opencode/skills/git-workflow/SKILL.md body contain a Routing section that distinguishes Feature PR from Release PR?"
+SCENARIOS["verify-closed-issue-step7"]="Does .opencode/skills/approval-gate/tasks/verify-closed-issue.md contain a Step 7 with MANDATORY ZERO TOLERANCE language and SC verification downgrade paths for PARTIALLY_IMPLEMENTED and NOT_IMPLEMENTED_DESPITE_CLOSURE?"
+SCENARIOS["closed-issue-enforcement-sc"]="Does .opencode/skills/approval-gate/enforcement/closed-issue-verification.md contain a Success Criteria Verification section with ZERO TOLERANCE enforcement and the downgrade path table?"
 
 # Tags per scenario for --tag filtering
 declare -A SCENARIO_TAGS
@@ -224,6 +232,14 @@ SCENARIO_TAGS["cleanup-sc-verification-gate"]="content-verification git-workflow
 SCENARIO_TAGS["cleanup-phase-completion-gate"]="content-verification git-workflow"
 SCENARIO_TAGS["scope-next-phase-resolution"]="content-verification approval"
 SCENARIO_TAGS["scope-phase-n-resolution"]="content-verification approval"
+SCENARIO_TAGS["stash-triage-directive"]="content-verification session-enforcement"
+SCENARIO_TAGS["stash-trigger-guideline-reference"]="content-verification session-enforcement"
+SCENARIO_TAGS["release-pr-routing"]="content-verification git-workflow"
+SCENARIO_TAGS["release-promotion-trigger"]="content-verification git-workflow"
+SCENARIO_TAGS["pr-creation-exclusion"]="content-verification pr-creation-workflow"
+SCENARIO_TAGS["git-workflow-routing-section"]="content-verification git-workflow"
+SCENARIO_TAGS["verify-closed-issue-step7"]="content-verification approval"
+SCENARIO_TAGS["closed-issue-enforcement-sc"]="content-verification enforcement-module"
 SCENARIO_TAGS["enforcement-module-adversarial"]="content-verification enforcement-module"
 SCENARIO_TAGS["enforcement-module-scope-parsing"]="content-verification enforcement-module"
 SCENARIO_TAGS["enforcement-module-auto-dispatch"]="content-verification enforcement-module"
@@ -244,12 +260,12 @@ declare -A FILE_SCENARIO_MAP
 FILE_SCENARIO_MAP[".opencode/guidelines/091-incremental-build.md"]="incremental-build-guideline monolithic-implementation-violation item-decomposition-step sc-assertion-tdd-cycle red-state-before-implementation red-phase-enforcement-incremental-build red-phase-enforcement-critical-rules-xref"
 FILE_SCENARIO_MAP[".opencode/guidelines/000-critical-rules.md"]="scope-auto-resolve-guideline monolithic-implementation-violation identity-echo-validation secret-exfiltration-violation url-sourcing-guideline-rules dispatch-artifact-requirements red-phase-enforcement-critical-rules-xref"
 FILE_SCENARIO_MAP[".opencode/guidelines/020-go-prohibitions.md"]="scope-auto-resolve-guideline pipeline-scoped-halt"
-FILE_SCENARIO_MAP[".opencode/skills/approval-gate/"]="item-decomposition-step scope-auto-resolve-step approval-gate-sc-traceability approval-gate-red-phase dispatch-chain-enforcement-gate dispatch-artifact-requirements dispatch-checkpoint-live-verification gap-fill-precedence-principle gap-fill-precedence-for-pr gap-fill-precedence-standard-scope screen-issue-gap-fill-awareness gap-fill-precedence-before-step5c task-file-enforcement-refs scope-next-phase-resolution scope-phase-n-resolution enforcement-module-adversarial enforcement-module-scope-parsing enforcement-module-auto-dispatch enforcement-module-closed-issue enforcement-module-sub-issue"
+FILE_SCENARIO_MAP[".opencode/skills/approval-gate/"]="item-decomposition-step scope-auto-resolve-step approval-gate-sc-traceability approval-gate-red-phase dispatch-chain-enforcement-gate dispatch-artifact-requirements dispatch-checkpoint-live-verification gap-fill-precedence-principle gap-fill-precedence-for-pr gap-fill-precedence-standard-scope screen-issue-gap-fill-awareness gap-fill-precedence-before-step5c task-file-enforcement-refs scope-next-phase-resolution scope-phase-n-resolution enforcement-module-adversarial enforcement-module-scope-parsing enforcement-module-auto-dispatch enforcement-module-closed-issue enforcement-module-sub-issue verify-closed-issue-step7 closed-issue-enforcement-sc"
 FILE_SCENARIO_MAP[".opencode/skills/brainstorming/"]="brainstorming-top-down verification-mechanics-brainstorming"
 FILE_SCENARIO_MAP[".opencode/skills/writing-plans/"]="writing-plans-bottom-up validate-executable-verification semantic-intent-writing-plans why-specific-value-tdd red-phase-gate-writing-plans red-phase-gate-writing-plans-skillmd"
 FILE_SCENARIO_MAP[".opencode/skills/executing-plans/"]="executing-plans-tdd red-phase-gate-executing-plans red-phase-gate-skillmd"
 FILE_SCENARIO_MAP[".opencode/skills/divide-and-conquer/"]="divide-conquer-tdd enforcement-module-completion enforcement-module-result-validation enforcement-module-overflow enforcement-module-work-state"
-FILE_SCENARIO_MAP[".opencode/skills/git-workflow/"]="worktree-handoff-step cleanup-sc-verification-gate cleanup-phase-completion-gate review-prep-format-self-check url-sourcing-rule1-review-prep url-sourcing-rule1-pr url-sourcing-rule2-character-match"
+FILE_SCENARIO_MAP[".opencode/skills/git-workflow/"]="worktree-handoff-step cleanup-sc-verification-gate cleanup-phase-completion-gate review-prep-format-self-check url-sourcing-rule1-review-prep url-sourcing-rule1-pr url-sourcing-rule2-character-match release-pr-routing release-promotion-trigger git-workflow-routing-section"
 FILE_SCENARIO_MAP[".opencode/skills/verification-before-completion/"]="per-sc-evidence-table vbc-per-sc-evidence-skill"
 FILE_SCENARIO_MAP[".opencode/skills/finishing-a-development-branch/"]="finishing-sc-verification checklist-chat-output-format"
 FILE_SCENARIO_MAP[".opencode/guidelines/080-code-standards.md"]="sc-to-test-traceability red-phase-ordering sc-traceability-example"
@@ -257,12 +273,14 @@ FILE_SCENARIO_MAP[".opencode/guidelines/140-planning-spec-creation.md"]="executa
 FILE_SCENARIO_MAP[".opencode/skills/spec-creation/"]="semantic-intent-spec-creation narrow-sc-table-exemption spec-creation-red-gate"
 FILE_SCENARIO_MAP[".opencode/skills/spec-auditor/"]="sc-precision-audit"
 FILE_SCENARIO_MAP[".opencode/skills/issue-operations/"]="sub-issue-structure url-sourcing-issue-operations"
+FILE_SCENARIO_MAP[".opencode/skills/pr-creation-workflow/"]="pr-creation-exclusion"
 FILE_SCENARIO_MAP[".opencode/skills/issue-review/"]="analyze-and-spec-red-gate"
 FILE_SCENARIO_MAP[".opencode/skills/ui-engineer/"]="ui-engineer-red-gate"
 FILE_SCENARIO_MAP[".opencode/skills/session-enforcement.ts"]="identity-echo-validation secret-exfiltration-violation read-secrets-in-output dev-edit-guard-plugin dev-edit-guard-pair-mode"
 FILE_SCENARIO_MAP[".opencode/plugins/session-enforcement.ts"]="identity-echo-validation secret-exfiltration-violation dev-edit-guard-plugin dev-edit-guard-pair-mode"
 FILE_SCENARIO_MAP[".opencode/scripts/session_context_identity.py"]="identity-echo-validation"
-FILE_SCENARIO_MAP[".opencode/scripts/session_context_triggers.py"]="dev-edit-guard-trigger"
+FILE_SCENARIO_MAP[".opencode/scripts/session_context_triggers.py"]="dev-edit-guard-trigger stash-triage-directive"
+FILE_SCENARIO_MAP[".opencode/guidelines/117-session-trigger-behavior.md"]="stash-trigger-guideline-reference"
 FILE_SCENARIO_MAP["AGENTS.md"]="agents-md-incremental"
 
 # --list: print scenario names and exit
@@ -470,6 +488,8 @@ EXPECTED_SKILLS["cleanup-sc-verification-gate"]=""
 EXPECTED_SKILLS["cleanup-phase-completion-gate"]=""
 EXPECTED_SKILLS["scope-next-phase-resolution"]=""
 EXPECTED_SKILLS["scope-phase-n-resolution"]=""
+EXPECTED_SKILLS["stash-triage-directive"]=""
+EXPECTED_SKILLS["stash-trigger-guideline-reference"]=""
 EXPECTED_SKILLS["enforcement-module-adversarial"]=""
 EXPECTED_SKILLS["enforcement-module-scope-parsing"]=""
 EXPECTED_SKILLS["enforcement-module-auto-dispatch"]=""
@@ -483,6 +503,12 @@ EXPECTED_SKILLS["task-file-enforcement-refs"]=""
 EXPECTED_SKILLS["dev-edit-guard-plugin"]=""
 EXPECTED_SKILLS["dev-edit-guard-trigger"]=""
 EXPECTED_SKILLS["dev-edit-guard-pair-mode"]=""
+EXPECTED_SKILLS["release-pr-routing"]="git-workflow"
+EXPECTED_SKILLS["release-promotion-trigger"]="git-workflow"
+EXPECTED_SKILLS["pr-creation-exclusion"]=""
+EXPECTED_SKILLS["git-workflow-routing-section"]=""
+EXPECTED_SKILLS["verify-closed-issue-step7"]=""
+EXPECTED_SKILLS["closed-issue-enforcement-sc"]=""
 
 RESULTS_FILE="$LOGDIR/results.md"
 
@@ -1401,6 +1427,114 @@ if [ "$PHASE_N" -ge 1 ]; then
 else
     echo "  scope-parsing Phase N Resolution: MISSING"
     echo "- **scope-parsing Phase N Resolution:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Stash triage directive in session_context_triggers.py
+TRIGGERS_FILE="$PROJECT_DIR/.opencode/scripts/session_context_triggers.py"
+if [ -f "$TRIGGERS_FILE" ]; then
+    TRIAGE_DIRECTIVE=$(grep -c "STALE STASH TRIAGE REQUIRED" "$TRIGGERS_FILE" 2>/dev/null || echo "0")
+    if [ "$TRIAGE_DIRECTIVE" -ge 1 ]; then
+        echo "  stash-triage-directive (STALE STASH TRIAGE REQUIRED): FOUND"
+        echo "- **stash-triage-directive (STALE STASH TRIAGE REQUIRED):** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  stash-triage-directive (STALE STASH TRIAGE REQUIRED): MISSING"
+        echo "- **stash-triage-directive (STALE STASH TRIAGE REQUIRED):** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+    OBSOLETE_CLASSIFY=$(grep -c "OBSOLETE.*issue closed\|OBSOLETE.*changes already merged\|OBSOLETE.*lockfile bumps" "$TRIGGERS_FILE" 2>/dev/null || echo "0")
+    if [ "$OBSOLETE_CLASSIFY" -ge 1 ]; then
+        echo "  stash-triage-directive (OBSOLETE classification): FOUND"
+        echo "- **stash-triage-directive (OBSOLETE classification):** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  stash-triage-directive (OBSOLETE classification): MISSING"
+        echo "- **stash-triage-directive (OBSOLETE classification):** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+    RESUMABLE_CLASSIFY=$(grep -c "RESUMABLE.*open issue\|RESUMABLE.*meaningful unmerged\|RESUMABLE.*pair-mode" "$TRIGGERS_FILE" 2>/dev/null || echo "0")
+    if [ "$RESUMABLE_CLASSIFY" -ge 1 ]; then
+        echo "  stash-triage-directive (RESUMABLE classification): FOUND"
+        echo "- **stash-triage-directive (RESUMABLE classification):** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  stash-triage-directive (RESUMABLE classification): MISSING"
+        echo "- **stash-triage-directive (RESUMABLE classification):** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+    AUTO_DROP=$(grep -c "git stash drop" "$TRIGGERS_FILE" 2>/dev/null || echo "0")
+    if [ "$AUTO_DROP" -ge 1 ]; then
+        echo "  stash-triage-directive (auto-drop obsolete): FOUND"
+        echo "- **stash-triage-directive (auto-drop obsolete):** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  stash-triage-directive (auto-drop obsolete): MISSING"
+        echo "- **stash-triage-directive (auto-drop obsolete):** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  session_context_triggers.py: MISSING"
+    echo "- **session_context_triggers.py:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Stash trigger guideline reference in 117-session-trigger-behavior.md
+TRIGGER_BEHAVIOR_FILE="$PROJECT_DIR/.opencode/guidelines/117-session-trigger-behavior.md"
+if [ -f "$TRIGGER_BEHAVIOR_FILE" ]; then
+    GUIDELINE_REF=$(grep -c "embedded triage instructions\|embedded directive" "$TRIGGER_BEHAVIOR_FILE" 2>/dev/null || echo "0")
+    if [ "$GUIDELINE_REF" -ge 1 ]; then
+        echo "  stash-trigger-guideline-reference (embedded triage reference): FOUND"
+        echo "- **stash-trigger-guideline-reference (embedded triage reference):** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  stash-trigger-guideline-reference (embedded triage reference): MISSING"
+        echo "- **stash-trigger-guideline-reference (embedded triage reference):** MISSING" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+    NO_PASSIVE=$(grep -c "Stash analysis available" "$TRIGGER_BEHAVIOR_FILE" 2>/dev/null || echo "0")
+    if [ "$NO_PASSIVE" -eq 0 ]; then
+        echo "  stash-trigger-guideline-reference (no passive suggest language): FOUND"
+        echo "- **stash-trigger-guideline-reference (no passive suggest language):** FOUND" >> "$RESULTS_FILE"
+    else
+        echo "  stash-trigger-guideline-reference (no passive suggest language): MISSING (still contains passive language)"
+        echo "- **stash-trigger-guideline-reference (no passive suggest language):** MISSING (still contains passive language)" >> "$RESULTS_FILE"
+        GUIDELINE_PASS=false
+        OVERALL_PASS=false
+    fi
+else
+    echo "  117-session-trigger-behavior.md: MISSING"
+    echo "- **117-session-trigger-behavior.md:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify verify-closed-issue Step 7 SC verification
+VERIFY_CLOSED_ISSUE_FILE="$PROJECT_DIR/.opencode/skills/approval-gate/tasks/verify-closed-issue.md"
+STEP7_MANDATORY=$(grep -c "Step 7.*MANDATORY\|Step 7.*ZERO TOLERANCE" "$VERIFY_CLOSED_ISSUE_FILE" 2>/dev/null || echo "0")
+STEP7_DOWNGRADE=$(grep -c "PARTIALLY_IMPLEMENTED\|NOT_IMPLEMENTED_DESPITE_CLOSURE" "$VERIFY_CLOSED_ISSUE_FILE" 2>/dev/null || echo "0")
+if [ "$STEP7_MANDATORY" -ge 1 ] && [ "$STEP7_DOWNGRADE" -ge 1 ]; then
+    echo "  verify-closed-issue Step 7 SC verification: FOUND"
+    echo "- **verify-closed-issue Step 7 SC verification:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  verify-closed-issue Step 7 SC verification: MISSING (mandatory=$STEP7_MANDATORY, downgrade=$STEP7_DOWNGRADE)"
+    echo "- **verify-closed-issue Step 7 SC verification:** MISSING" >> "$RESULTS_FILE"
+    GUIDELINE_PASS=false
+    OVERALL_PASS=false
+fi
+
+# Verify closed-issue-verification enforcement module covers SC verification
+CLOSED_ISSUE_ENFORCEMENT_FILE="$PROJECT_DIR/.opencode/skills/approval-gate/enforcement/closed-issue-verification.md"
+CIV_SC_VERIFY=$(grep -c "Success Criteria Verification\|SC Verification Is MANDATORY\|ZERO TOLERANCE" "$CLOSED_ISSUE_ENFORCEMENT_FILE" 2>/dev/null || echo "0")
+CIV_DOWNGRADE=$(grep -c "PARTIALLY_IMPLEMENTED\|NOT_IMPLEMENTED_DESPITE_CLOSURE" "$CLOSED_ISSUE_ENFORCEMENT_FILE" 2>/dev/null || echo "0")
+if [ "$CIV_SC_VERIFY" -ge 1 ] && [ "$CIV_DOWNGRADE" -ge 1 ]; then
+    echo "  closed-issue-verification enforcement SC verification: FOUND"
+    echo "- **closed-issue-verification enforcement SC verification:** FOUND" >> "$RESULTS_FILE"
+else
+    echo "  closed-issue-verification enforcement SC verification: MISSING (sc_verify=$CIV_SC_VERIFY, downgrade=$CIV_DOWNGRADE)"
+    echo "- **closed-issue-verification enforcement SC verification:** MISSING" >> "$RESULTS_FILE"
     GUIDELINE_PASS=false
     OVERALL_PASS=false
 fi


### PR DESCRIPTION
## Summary

Three bug fixes addressing agent behavior gaps in enforcement, routing, and trigger handling:

1. **#1208 — Stash triage auto-resolve**: Replaced passive "Stash analysis available" output with an embedded auto-triage directive in `session_context_triggers.py`. Agents now auto-resolve OBSOLETE stashes (drop) and RESUMABLE stashes (pop + create pair-mode branch), only escalating AMBIGUOUS stashes to the developer. Simplified `117-session-trigger-behavior.md` to reference embedded instructions.

2. **#1212 — Release PR trigger routing**: Added "release PR", "promote to main", "dev to main" trigger phrases to `git-workflow` SKILL.md. Added exclusion clause to `pr-creation-workflow` SKILL.md documenting that it covers feature PRs only (not release PRs). Added routing decision boundary table.

3. **#1214 — Enforcement test for SC verification**: Added enforcement test scenarios (`verify-closed-issue-step7`, `closed-issue-enforcement-sc`) for the mandatory SC verification step in `verify-closed-issue.md`. Updated `closed-issue-verification.md` enforcement module with SC verification, downgrade paths (PARTIALLY_IMPLEMENTED, NOT_IMPLEMENTED_DESPITE_CLOSURE), and ZERO TOLERANCE enforcement.

## Outcome

- Agents auto-triage stale stashes instead of echoing trigger data
- "Release PR" correctly routes to `git-workflow --task release-promotion`
- Mandatory SC verification step has enforcement test coverage

Fixes #1208
Fixes #1212
Fixes #1214