### PR TITLE
feat(#1197): Phase 2 — condense SKILL.md, convert verify-authorization.md to routing

### DIFF
--- a/.opencode/skills/approval-gate/SKILL.md
+++ b/.opencode/skills/approval-gate/SKILL.md
@@ -304,145 +304,22 @@ When `halt_at < pr_created`, no PR is created — the agent halts before reachin
 
 ### Result Contracts (Sub-Agent Tasks)
 
-#### screen-issue
+Result contracts define the structured YAML output each sub-agent task must return. Full schemas are in the `enforcement/` directory when applicable; key fields are listed below for orchestration reference.
 
-```yaml
-status: DONE | DONE_WITH_CONCERNS | BLOCKED | OVERFLOW
-task: screen-issue
-issue_number: <N>
-classification: included | excluded | scope-reduced
-category: <already-implemented|superseded|moot|partially-implemented|meta-non-code|null>
-exclude_reason: <reason|null>
-reduce_reason: <reason|null>
-reduced_scope: {completed_phases: [], remaining_phases: []}
-flat_items: [{issue: <N>, title: <str>, phase: <str>}]
-gate_evidence: {gate1_called: bool, gate1_sub_issues_verified: bool, gate1_closure_legitimacy: bool, gate2_criteria_extracted: bool, gate2_criteria_verified: bool, final_classification: <str>}
-requires_developer: bool
-developer_reason: <reason|null>
-file_references: [<path>]
-symbol_references: [<name>]
-concerns: [<str>]
-```
+#### Key Result Contract Fields
 
-#### verify-authorization
-
-```yaml
-status: DONE | BLOCKED
-task: verify-authorization
-issue_number: <N>
-authorization_result: authorized | unauthorized | needs_approval
-cascade_applied: bool
-sub_issues_verified: bool
-gates_passed: [gate_name]
-blocking_reason: <reason|null>
-cascade_type: plan_cascade | output_lineage_cascade | none
-cascade_parent: <issue_number | null>
-authorization_scope: standard | for_spec | for_plan | for_implementation | for_code_review | for_pr | pr_only | review_only
-scope_source: parsed | default
-halt_at: <pipeline_stage>
-pr_strategy: stacked | individual | none
-gap_fill_actions: [<action_list>]
-```
-
-#### verify-qa-mode
-
-```yaml
-status: DONE
-task: verify-qa-mode
-mode: qa_mode | implementation_mode
-spec_found: bool
-spec_candidates: [<issue_number>]
-routing: <next_task|null>
-```
-
-#### verify-already-implemented
-
-```yaml
-status: DONE
-task: verify-already-implemented
-issue_number: <N>
-classification: already_implemented | partially_implemented | not_implemented
-evidence_summary: <str>
-auto_close_performed: bool
-```
-
-#### verify-closed-issue
-
-```yaml
-status: DONE
-task: verify-closed-issue
-issue_number: <N>
-legitimate: bool
-state_reason: <str>
-merged_pr_evidence: <url|null>
-action: none | reopen | flag
-```
-
-#### verify-sub-issues
-
-```yaml
-status: DONE
-task: verify-sub-issues
-parent_issue: <N>
-sub_issues_count: <int>
-all_verified: bool
-missing_sub_issues: [<phase>]
-auto_created: bool
-```
-
-#### post-implementation
-
-```yaml
-status: DONE
-task: post-implementation
-branch_pushed: bool
-compare_url: <url>
-issues_reported: [<N>]
-```
-
-#### pre-implementation-analysis
-
-```yaml
-status: DONE | BLOCKED
-task: pre-implementation-analysis
-screening_results_count: <int>
-included: [<issue_number>]
-excluded: [{issue: <N>, reason: <str>}]
-scope_reduced: [{issue: <N>, remaining_phases: []}]
-dependency_graph: {serial: [<N>], parallel_groups: [[<N>]]}
-execution_plan_presented: bool
-requires_developer: bool
-developer_reason: <str|null>
-work_state_file: <path>
-authorization_scope: <scope_value>
-halt_at: <pipeline_stage>
-pr_strategy: stacked | individual | none
-per_issue_gap_fill: [{issue: <N>, gap_fill: [<action>]}]
-```
-
-#### verify-fix-spec
-
-```yaml
-status: DONE
-task: verify-fix-spec
-bug_report: <N>
-fix_spec_exists: bool
-fix_spec_issue: <N|null>
-action: none | create_fix_spec
-```
-
-#### reconcile-issue-graph
-
-```yaml
-status: DONE | DONE_WITH_UNCERTAIN
-task: reconcile-issue-graph
-root_issue: <N>
-auto_closed: [<N>]
-reopened: [<N>]
-no_action: [<N>]
-requires_dev_action: [{issue: <N>, current: <state>, needed: <state>, reason: <str>}]
-nodes_visited: <N>
-```
+| Task | Status Values | Key Fields |
+|------|--------------|------------|
+| `screen-issue` | DONE, DONE_WITH_CONCERNS, BLOCKED, OVERFLOW | classification, category, flat_items, gate_evidence, requires_developer |
+| `verify-authorization` | DONE, BLOCKED | authorization_result, cascade_applied, sub_issues_verified, authorization_scope, halt_at, pr_strategy, gap_fill_actions |
+| `verify-qa-mode` | DONE | mode, spec_found, spec_candidates, routing |
+| `verify-already-implemented` | DONE | issue_number, classification, evidence_summary, auto_close_performed |
+| `verify-closed-issue` | DONE | issue_number, legitimate, state_reason, merged_pr_evidence, action |
+| `verify-sub-issues` | DONE | parent_issue, sub_issues_count, all_verified, missing_sub_issues, auto_created |
+| `post-implementation` | DONE | branch_pushed, compare_url, issues_reported |
+| `pre-implementation-analysis` | DONE, BLOCKED | included, excluded, scope_reduced, dependency_graph, requires_developer, work_state_file, authorization_scope, halt_at, pr_strategy |
+| `verify-fix-spec` | DONE | bug_report, fix_spec_exists, fix_spec_issue, action |
+| `reconcile-issue-graph` | DONE, DONE_WITH_UNCERTAIN | root_issue, auto_closed, reopened, no_action, requires_dev_action, nodes_visited |
 
 ### Dispatch Context Schema (All Sub-Agent Tasks)
 
@@ -462,44 +339,11 @@ session_vars:
 
 ## Adversarial Verification Requirements
 
-Every task in this skill that reads a metadata claim (label, comment, STATUS marker, sub-issue state, authorization history) MUST verify that claim against actual state before trusting it for workflow decisions. This extends the `065-verification-honesty.md` principle from code verification to metadata verification.
+Every task that reads a metadata claim (label, comment, STATUS marker, sub-issue state, authorization history) MUST verify that claim against actual GitHub state before trusting it for workflow decisions. This extends `065-verification-honesty.md` from code verification to metadata verification.
 
-### Verification Table
+**Evidence format and finding classification:** See `enforcement/adversarial-verification.md` for the complete evidence format, three-tier finding classification (auto-fix, conditional, flag-for-review), and problem class taxonomy. Every verification check MUST produce an evidence artifact via tool call — assertions without tool call evidence are verification honesty violations.
 
-| Metadata Claim | Verification Action | Tool Call | Problem Class |
-|----------------|-------------------|-----------|---------------|
-| `needs-approval` label present | Check issue comments for explicit authorization ("approved"/"go") from a developer | `github_issue_read(method=get_comments)` | MISSING-ELEMENT |
-| `needs-approval` label absent | Verify no pending authorization is needed (issue state is actually authorized) | `github_issue_read(method=get_labels)` | STRUCTURE-VIOLATION |
-| Authorization comment exists | Verify author is a developer (not bot/agent); verify scope matches current issue; verify comment is not superseded by revision | `github_issue_read(method=get_comments)` → filter by author association | CONFLICTING |
-| STATUS marker value | Compare STATUS against actual content maturity per ground-truth classification | `github_issue_read(method=get)` → parse body content | STRUCTURE-VIOLATION |
-| Authorization currency | Verify spec has not been revised after most recent authorization comment | `github_issue_read(method=get_comments)` → compare revision timestamps | STRUCTURE-VIOLATION |
-| Sub-issue state (open/closed) | Verify sub-issue state via GitHub API, not from cached or claimed state | `github_issue_read(method=get, issue_number=N)` → check `state` field | VERIFICATION-GAP |
-| Fix spec existence | Verify fix spec sub-issue exists and has correct labels/STATUS for its maturity | `github_issue_read(method=get_sub_issues)` → verify each child | MISSING-TRACEABILITY |
-| Work screening dispatch | Verify `screen-issue` sub-agents were dispatched for EVERY approved issue — no count threshold | Check for `task(subagent_type="general")` dispatch calls per issue | STRUCTURE-VIOLATION |
-
-### Evidence Artifacts
-
-Every adversarial verification check MUST produce an evidence artifact — a tool call result that demonstrates the verification was performed. Assertions without tool call evidence are verification honesty violations per `065-verification-honesty.md`.
-
-**Evidence format:**
-
-```
-Check: [what was verified]
-Tool: [tool call and parameters]
-Result: [actual state found]
-Classification: [STRUCTURE-VIOLATION|MISSING-ELEMENT|CONFLICTING|VERIFICATION-GAP|MISSING-TRACEABILITY]
-Action: [auto-fix|conditional|flag-for-review]
-```
-
-### Finding Classification
-
-Findings from adversarial verification follow the same three-tier model as `spec-auditor` ground-truth:
-
-| Classification | When | Action |
-|----------------|------|--------|
-| auto-fix | Safe, mechanical corrections (stale label, mismatched STATUS) | Apply fix, note in evidence |
-| conditional | Requires scope/safety check before applying (authorization claim vs actual) | Verify scope, then apply if safe |
-| flag-for-review | Requires domain judgment (conflicting authorization, ambiguous state) | Report in findings, do not apply |
+Key verification checks: `needs-approval` label status, authorization comment author/scope/currency, STATUS marker maturity, sub-issue open/closed state, fix spec existence, and screen-issue dispatch completeness.
 
 ## Cross-References
 

--- a/.opencode/skills/approval-gate/tasks/verify-authorization.md
+++ b/.opencode/skills/approval-gate/tasks/verify-authorization.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Check for explicit authorization and needs-approval label status before implementation.
+Check for explicit authorization and needs-approval label status before implementation. This task orchestrates the atomized sub-tasks in `verify-authorization/` for fine-grained, low-context verification.
 
 ## Entry Criteria
 
@@ -16,274 +16,61 @@ Check for explicit authorization and needs-approval label status before implemen
 - Git state verified (worktree environment ready)
 - Authorization recorded for scope tracking
 
-## Procedure
+## Sub-Task Dispatch Order
 
-### Step 0: Sub-Agent Result Guard
+This task delegates to atomic sub-tasks. Each sub-task reads inputs from the work state file and writes results back. Invoke in sequence:
 
-When `verify-authorization` is executed inline after a sub-agent dispatch returns an empty result, this step provides the fallback path.
+| Step | Sub-Task | Purpose |
+|------|----------|---------|
+| 0 | Inline fallback guard | If sub-agent returns empty, execute Steps 1-6 inline |
+| 0.5 | `verify-authorization/scope-auto-resolve` | Parse authorization text, resolve scope/halt_at/pr_strategy/gap_fill |
+| 1 | `verify-authorization/verify-explicit-authorization` | Check for "approved"/"go" + author identity + currency |
+| 2 | Label check (inline) | Check needs-approval label status, handle explicit auth override |
+| 3 | Authorization decision (inline) | Route based on authorization result |
+| 4.5 | `verify-authorization/item-decomposition-check` | Verify item enumeration, dependency ordering, TDD steps |
+| 4.6 | `verify-authorization/sc-traceability-check` | Verify SC-to-test traceability, RED-phase ordering |
+| 5 | `verify-authorization/sub-issue-verification` | Sub-issue phase count, adversarial verification, closed-issue check |
+| 5b | `verify-authorization/spec-to-plan-cascade` | Spec-to-plan approval cascade |
+| 5b.5+5c | `verify-authorization/gap-fill-cascade` | Gap-fill precedence and cascade execution |
+| 6 | `verify-authorization/auto-dispatch` | Scope-aware auto-dispatch + output lineage |
 
-**Trigger condition:** After dispatching a `screen-issue` or other sub-agent via `task()`, if the result is empty or whitespace-only:
+## Sub-Agent Result Guard
 
-```python
-if not result or not result.strip():
-    # Sub-agent returned empty — perform inline verification
-    report_warning("Sub-agent for verify-authorization returned empty result, performing inline")
-    # Execute Steps 1-6 of this verify-authorization procedure inline
-    # Continue the dispatch chain as if verify-authorization completed normally
-```
+When `verify-authorization` is dispatched as a sub-agent and returns empty or whitespace-only:
 
-**Fallback execution:** When this guard activates, the agent executes the full verify-authorization procedure (Steps 1-6) inline using direct tool calls rather than dispatching another sub-agent. The inline execution follows the same steps and produces the same result contract format.
+1. Report: `"Sub-agent for verify-authorization returned empty result, performing inline"`
+2. Execute Steps 0.5–6 inline using direct tool calls
+3. Produce the same result contract format
 
 **Double-failure protocol:** If inline verification also fails:
-
 1. Report: `"Sub-agent and inline verification both failed for verify-authorization"`
 2. Invoke `--task completion` on the `approval-gate` skill
 3. HALT with status message + byline
-
-**No regression:** When sub-agent returns a valid result, this guard is not triggered — Steps 1-6 execute normally from the sub-agent's result.
-
-### Step 0.5: Scope Auto-Resolve (MANDATORY BEFORE ANY HUMAN-FACING OUTPUT)
-
-**This step MUST execute before Step 1, Step 2.0, and before any screen-issue dispatch.**
-
-Parse the authorization text to determine scope horizon and gap-fill actions. Scope detection is NEVER ambiguous — the parsing table is deterministic. The agent MUST NOT ask the user to classify scope.
-
-→ **Full procedure:** See `tasks/verify-authorization/scope-auto-resolve.md`
-
-### Step 1: Verify Git State (MANDATORY FIRST)
-
-**🚫 CRITICAL: This check MUST happen BEFORE any other work.**
-
-```bash
-git branch --show-current
-git status
-```
-
-**If on `main` or `dev`:** This is expected — feature branches are created in worktrees, not by switching branches in the main tree. Proceed to Step 2.
-
-**If on a feature branch already:** Verify you're in the correct worktree. Check `worktree.path` environment variable.
-
-**🚫 CRITICAL: Do NOT create branches directly in verify-authorization.** Branch creation is DELEGATED to `git-workflow --task pre-work`, which creates worktrees via the `using-git-worktrees` skill. Creating branches here bypasses worktree isolation — a CRITICAL VIOLATION.
-
-**After git state verification:**
-
-1. Record that git state is verified
-2. Proceed to Step 2 (authorization verification)
-3. After ALL verification steps, invoke `git-workflow --task pre-work` for worktree creation
-4. `pre-work` will handle: sync with `dev`, worktree creation, and environment variable setup
-
-### Step 2: Verify Authorization Is Explicit
-
-Check that authorization is:
-
-- From user (not agent)
-- Explicit ("approved", "go", "approved: N.M")
-- for the CURRENT issue (not old session)
-
-#### Step 2.0: Authorization Scope Parsing
-
-Parse the authorization phrase to determine scope horizon and gap-fill actions.
-
-→ **Scope detection regex and values:** See `enforcement/scope-parsing.md`
-→ **Auto-dispatch routing:** See `enforcement/auto-dispatch-table.md`
-
-Authorization phrases carry implicit scope — the pipeline stage the developer expects work to reach. The scope horizon determines where the agent MUST stop, and what intermediate artifacts are gap-filled.
-
-**Evidence artifact:** The parsed authorization text, matched regex pattern, and resulting scope fields MUST be recorded in the verification report.
-
-#### Step 2.1: Authorization Cascade by Output Lineage
-
-→ **Full procedure:** See `tasks/verify-authorization/auto-dispatch.md` → "Authorization Cascade by Output Lineage"
-
-### Step 2.5: Adversarial Verification — Verify Authorization Against Actual State
-
-**🚫 CRITICAL: Before trusting any authorization claim, verify it against actual GitHub state. Do NOT rely on cached values, assumed labels, or claimed authorization without direct evidence.**
-
-→ **Evidence format and three-tier classification:** See `enforcement/adversarial-verification.md`
-
-#### 2.5.1 Verify Author Identity
-
-```
-comments = github_issue_read(method="get_comments", issue_number=N)
-
-For each comment claiming "approved", "go", or "approved: X.Y":
-  - Verify comment author is a developer (not bot/agent)
-  - Check author_association: "MEMBER", "OWNER", or "COLLABORATOR" = human developer
-  - Check author_association: "FIRST_TIME_CONTRIBUTOR", "NONE" = not authorized
-  - Bot/agent comments (login contains "[bot]") are NOT authorization
-```
-
-**Evidence artifact:** `github_issue_read(method=get_comments)` response showing author details for the authorization comment.
-
-#### 2.5.2 Verify Authorization Scope
-
-```
-For each valid authorization comment found:
-  - Does the comment scope match the current issue number?
-  - "approved #N" where N ≠ current issue → NOT scoped to this issue
-  - "approved" without issue number → scoped to the issue where it appears
-  - "go" without issue number → scoped to the issue where it appears
-```
-
-**Evidence artifact:** Comment text and issue number showing scope match or mismatch.
-
-#### 2.5.3 Verify Authorization Currency
-
-```
-comments = github_issue_read(method="get_comments", issue_number=N)
-
-For each authorization comment:
-  - Compare comment timestamp against spec revision history
-  - If spec body was edited AFTER the authorization comment → authorization may be stale
-  - Check for "REVISED - NEEDS APPROVAL" in spec body → authorization is revoked
-  - If authorization comment is the most recent relevant comment → current
-```
-
-**Evidence artifact:** Comparison of authorization comment timestamp vs spec update timestamp.
-
-#### 2.5.4 Verify Sub-Issue State
-
-```
-For plan issues (detected in Step 5):
-  sub_issues = github_issue_read(method="get_sub_issues", issue_number=N)
-  
-  For each sub-issue:
-    - Verify state matches claimed state (open/closed) via API
-    - Do NOT trust cached or previously-read sub-issue state
-    - If sub-issue state is "closed" but no merged PR → VERIFICATION-GAP (flag-for-review)
-```
-
-**Evidence artifact:** `github_issue_read(method=get_sub_issues)` response showing actual state of each sub-issue.
-
-#### Finding Classification for Authorization Verification
-
-| Finding | Problem Class | Classification | Action |
-| -- | -- | -- | -- |
-| Authorization from bot/agent | CONFLICTING | flag-for-review | Reject as authorization source |
-| Authorization scoped to different issue | CONFLICTING | flag-for-review | Reject — not scoped to current issue |
-| Authorization superseded by revision | STRUCTURE-VIOLATION | auto-fix | Mark authorization as stale, require re-approval |
-
-### Step 3: Check needs-approval Label
-
-```python
-# Get issue labels
-issue = github_issue_read(method="get", issue_number=N)
-has_label = "needs-approval" in [l["name"] for l in issue["labels"]]
-
-if has_label and explicit_authorization:
-    # Label is informational, NOT blocking
-    # Proceed with implementation
-    # Optionally note: "needs-approval label can be removed"
-```
-
-## Critical: Explicit Authorization Priority
-
-When user provides explicit authorization, it **OVERRIDES** the needs-approval label.
-
-| Scenario | Action |
-| -- | -- |
-| "approved" AND label present | PROCEED - explicit auth wins |
-| "approved" AND no label | PROCEED |
-| NO auth AND label present | HALT - wait for authorization |
-| NO auth AND no label | Check other blockers |
-
-### Step 4: Record Authorization Scope
-
-Authorization applies to:
-
-- Specific issue only
-- Current phase/task only
-- This session only (no carryover)
-
-### Step 4.5: Verify Item Decomposition and Behavioral Test Coverage
-
-Before implementation proceeds, verify that the plan includes item-level decomposition AND that items which change agent behavior (rule/guideline changes) have behavioral enforcement test coverage.
-
-→ **Full procedure:** See `tasks/verify-authorization/item-decomposition-check.md`
-
-In addition to the decomposition checks in the sub-task file, this step verifies:
-
-- **For each plan item that changes a rule governing agent behavior** (guideline text, skill enforcement, critical violation, agent behavior rule): The item's TDD cycle MUST include a behavioral enforcement test in the RED phase, not just a content-verification test. A plan item for a rule change that only specifies a content-verification grep test in its TDD cycle is INCOMPLETE — it must also specify a behavioral test that verifies the agent actually follows the changed rule.
-- **Behavioral test coverage check:** For each rule-changing item in the plan, confirm that the TDD step block includes a behavioral RED phase (write behavioral test expecting agent NOT to follow rule) and a behavioral GREEN phase (make rule change, verify agent NOW follows rule). Items missing behavioral TDD for rule changes are flagged as STRUCTURE-VIOLATION.
-
-### Step 4.6: Verify SC-to-Test Traceability, Behavioral Test Assertions, and RED-Phase Ordering
-
-Before implementation proceeds, verify that the corresponding spec's success criteria have enforcement test assertions (BOTH content-verification AND behavioral where applicable) and that RED-phase ordering was followed.
-
-→ **Full procedure:** See `tasks/verify-authorization/sc-traceability-check.md`
-
-In addition to the content-verification checks in the sub-task file, this step verifies:
-
-- **For each SC that changes agent behavior** (rule-changing, enforcement, behavioral SCs): The spec's success criteria MUST include at least one behavioral assertion describing the RED state (agent behavior without the rule) and GREEN state (agent behavior with the rule). SCs that only have content-verification grep commands are INCOMPLETE for behavioral rule changes.
-- **Behavioral test assertions distinguish content from behavior:** A content-verification assertion checks that text exists in a file (e.g., `grep -c 'pattern' file.md`). A behavioral assertion checks that the agent actually follows the rule (e.g., `assert_tool_calls_made` to verify the agent makes verification calls, or `assert_forbidden_pattern_absent` to verify the agent does not bypass a gate). For rule-changing SCs, behavioral assertions are PRIMARY — content-verification is secondary.
-- **Behavioral RED state confirmation:** For each rule-changing SC, confirm that a behavioral enforcement test exists in `.opencode/tests/behaviors/` that was verified in RED state (test sends a prompt and confirms the agent does NOT follow the new rule yet). If only content-verification (grep) tests exist for a behavioral SC, flag as MISSING-TRACEABILITY.
-
-### Step 5: Verify Sub-Issue Structure (for Plan Approval)
-
-**This gate is the SINGLE AUTHORITATIVE verification point for sub-issue readiness.** The `issue-operations` `link-sub-issue` task's verification logic is superseded — all sub-issue verification logic lives here.
-
-→ **Full procedure:** See `tasks/verify-authorization/sub-issue-verification.md`
-
-→ **Phase-count cross-reference algorithm:** See `enforcement/sub-issue-graph-traversal.md`
-→ **Closed-issue verification procedure:** See `enforcement/closed-issue-verification.md`
-
-### Step 5b: Spec-to-Plan Approval Cascade
-
-When a spec is approved and a plan already exists for that spec, the plan inherits the spec's approval status.
-
-→ **Full procedure:** See `tasks/verify-authorization/spec-to-plan-cascade.md`
-
-### Step 5b.5: Gap-Fill Precedence Principle
-
-**Before evaluating any blocking gate in Steps 5 through 5c, the agent MUST apply this precedence principle:**
-
-> When `authorization_scope`'s gap-fill actions cover a missing artifact requirement, that requirement is a gap-fill trigger, not a blocking gate. Hard gates only apply to artifacts outside the scope's gap-fill coverage.
-
-→ **Full gap-fill procedure and precedence examples:** See `tasks/verify-authorization/gap-fill-cascade.md`
-
-### Step 5c: Scope-Aware Gap-Fill Cascade
-
-When `authorization_scope` from Step 2.0 is >= `for_plan`, missing intermediate artifacts are gap-filled automatically.
-
-→ **Full procedure including PR strategy derivation:** See `tasks/verify-authorization/gap-fill-cascade.md`
-
-→ **Scope-dependent routing table:** See `enforcement/auto-dispatch-table.md`
-
-### Step 6: Scope-Aware Auto-Dispatch After Successful Verification
-
-**🚫 CRITICAL: This step runs ONLY when ALL prior verification gates (Steps 1-5) pass. If ANY gate fails, HALT — do NOT dispatch.**
-
-→ **Full procedure including auto-dispatch context differentiation, spec revision revocation detection, and edge cases:** See `tasks/verify-authorization/auto-dispatch.md`
-
-**🚫 HARD HALT AT SCOPE BOUNDARY:** The agent MUST NOT proceed past the pipeline stage specified by `halt_at`. If the dispatch chain reaches the `halt_at` stage, the agent reports completion and STOPS. Proceeding past `halt_at` without re-authorization is a CRITICAL GUIDELINE VIOLATION.
-
-## Context Required
-
-- Related tasks: `verify-sub-issues` (delegated sub-issue verification detail), `verify-codebase`
-- Sub-issue verification gate: This task (Step 5) is the SINGLE AUTHORITATIVE verification point. `issue-operations` `link-sub-issue` verification logic is superseded by this gate.
-- Auto-dispatch targets: `writing-plans` (spec approval), `executing-plans` (plan approval)
-- Dispatch context for plan approval: pass `plan_issue=#N` and `spec_issue=#M` (extracted from plan body)
-- Label state machine: `141-planning-status-tracking.md §10` (remove `needs-approval`, add `in-progress` on approval)
-- Adversarial verification model: `spec-auditor --task ground-truth` (finding classification and evidence artifacts)
-
-## Sub-Task Files
-
-This task delegates detailed procedures to sub-task files:
-
-| Sub-Task File | Purpose |
-| -- | -- |
-| `verify-authorization/scope-auto-resolve.md` | Step 0.5: Scope auto-resolve from authorization phrase |
-| `verify-authorization/item-decomposition-check.md` | Step 4.5: Verify item decomposition in plan |
-| `verify-authorization/sc-traceability-check.md` | Step 4.6: SC-to-test traceability and RED-phase ordering |
-| `verify-authorization/sub-issue-verification.md` | Step 5: Verify sub-issue structure (authoritative gate) |
-| `verify-authorization/spec-to-plan-cascade.md` | Step 5b: Spec-to-plan approval cascade |
-| `verify-authorization/gap-fill-cascade.md` | Step 5b.5 + 5c: Gap-fill precedence and cascade execution |
-| `verify-authorization/auto-dispatch.md` | Step 6: Scope-aware auto-dispatch after verification |
 
 ## Enforcement References
 
 - Evidence format + finding classification: see `enforcement/adversarial-verification.md`
 - Scope parsing: see `enforcement/scope-parsing.md`
-- Auto-dispatch routing: see `enforcement/auto-dispatch-table.md`
+- Dispatch routing: see `enforcement/auto-dispatch-table.md`
 - Closed-issue verification: see `enforcement/closed-issue-verification.md`
 - Sub-issue graph traversal: see `enforcement/sub-issue-graph-traversal.md`
+
+## Result Contract
+
+```yaml
+status: DONE | BLOCKED
+task: verify-authorization
+issue_number: <N>
+authorization_result: authorized | unauthorized | needs_approval
+cascade_applied: bool
+sub_issues_verified: bool
+gates_passed: [gate_name]
+blocking_reason: <reason|null>
+cascade_type: plan_cascade | output_lineage_cascade | none
+cascade_parent: <issue_number | null>
+authorization_scope: standard | for_spec | for_plan | for_implementation | for_code_review | for_pr | pr_only | review_only
+scope_source: parsed | default
+halt_at: <pipeline_stage>
+pr_strategy: stacked | individual | none
+gap_fill_actions: [<action_list>]
+```

--- a/.opencode/tests/test-enforcement-phase2-scoped.sh
+++ b/.opencode/tests/test-enforcement-phase2-scoped.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# Phase 2: Decompose verify-authorization — Scoped Content-Verification Tests
+#
+# Tests that Phase 2 decomposition changes are correct:
+# - Atomic tasks exist and are ≤3,000 words each
+# - SKILL.md is ≤4,000 words (routing document)
+# - Old monolithic verify-authorization.md is a routing file (≤500 words)
+# - SKILL.md references new atomic tasks in its task list
+#
+# Follows #1236 principle: each phase tests only what it changes.
+# Phase 2 does NOT test Phase 3/4/5 deliverables (pre-impl-analysis, 
+# screen-issue, chain-of-responsibility, remaining SKILL.md condensation).
+#
+# Usage:  bash .opencode/tests/test-enforcement-phase2-scoped.sh
+#         bash .opencode/tests/test-enforcement-phase2-scoped.sh --scenario SC-1
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILLS_DIR="$PROJECT_DIR/.opencode/skills"
+
+SCENARIO_FILTER=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scenario)
+            SCENARIO_FILTER+=("$2")
+            shift 2
+            ;;
+        --list)
+            echo "SC-1: verify-authorization atomic tasks exist and are ≤3,000 words"
+            echo "SC-1-naming: Atomic task files match spec naming"
+            echo "SC-6: approval-gate SKILL.md ≤4,000 words"
+            echo "SC-routing: Old verify-authorization.md is routing file (≤500 words)"
+            echo "SC-skill-refs: SKILL.md references atomic tasks in task list"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: bash .opencode/tests/test-enforcement-phase2-scoped.sh [--scenario NAME]... [--list]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+PASS=0
+FAIL=0
+RESULTS=()
+
+report() {
+    local scenario="$1"
+    local status="$2"
+    local detail="$3"
+    RESULTS+=("$scenario | $status | $detail")
+    if [ "$status" = "PASS" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+should_run() {
+    local scenario="$1"
+    if [ ${#SCENARIO_FILTER[@]} -eq 0 ]; then
+        return 0
+    fi
+    for f in "${SCENARIO_FILTER[@]}"; do
+        if [ "$f" = "$scenario" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ── SC-1: verify-authorization atomic tasks exist and are ≤3,000 words ──────
+
+if should_run "SC-1"; then
+    echo "=== SC-1: verify-authorization atomic tasks exist and are ≤3,000 words ==="
+
+    ATOMIC_DIR="$SKILLS_DIR/approval-gate/tasks/verify-authorization"
+    ATOMIC_TASKS=(
+        "scope-auto-resolve.md"
+        "item-decomposition-check.md"
+        "sc-traceability-check.md"
+        "sub-issue-verification.md"
+        "spec-to-plan-cascade.md"
+        "gap-fill-cascade.md"
+        "auto-dispatch.md"
+    )
+
+    ALL_EXIST=true
+    ALL_WITHIN_LIMIT=true
+
+    for f in "${ATOMIC_TASKS[@]}"; do
+        FILE="$ATOMIC_DIR/$f"
+        if [ ! -f "$FILE" ]; then
+            report "SC-1" "FAIL" "Atomic task missing: $f"
+            ALL_EXIST=false
+        else
+            WORDS=$(wc -w < "$FILE")
+            if [ "$WORDS" -gt 3000 ]; then
+                report "SC-1" "FAIL" "$f has $WORDS words (max 3,000)"
+                ALL_WITHIN_LIMIT=false
+            else
+                echo "  $f: $WORDS words (≤3,000) ✓"
+            fi
+        fi
+    done
+
+    if [ "$ALL_EXIST" = true ] && [ "$ALL_WITHIN_LIMIT" = true ]; then
+        report "SC-1" "PASS" "All 7 atomic tasks exist and are ≤3,000 words"
+    fi
+fi
+
+# ── SC-1-naming: Atomic task files match spec naming ──────────────────────
+
+if should_run "SC-1-naming"; then
+    echo "=== SC-1-naming: Atomic task files match spec naming ==="
+
+    ATOMIC_DIR="$SKILLS_DIR/approval-gate/tasks/verify-authorization"
+    SPEC_NAMES=(
+        "scope-auto-resolve"
+        "item-decomposition-check"
+        "sc-traceability-check"
+        "sub-issue-verification"
+        "spec-to-plan-cascade"
+        "gap-fill-cascade"
+        "auto-dispatch"
+    )
+
+    ALL_MATCH=true
+    for name in "${SPEC_NAMES[@]}"; do
+        if [ ! -f "$ATOMIC_DIR/$name.md" ]; then
+            report "SC-1-naming" "FAIL" "Missing atomic task file: $name.md"
+            ALL_MATCH=false
+        else
+            echo "  $name.md exists ✓"
+        fi
+    done
+
+    if [ "$ALL_MATCH" = true ]; then
+        report "SC-1-naming" "PASS" "All atomic task files match spec naming"
+    fi
+fi
+
+# ── SC-6: approval-gate SKILL.md ≤4,000 words ──────────────────────────
+
+if should_run "SC-6"; then
+    echo "=== SC-6: approval-gate SKILL.md ≤4,000 words ==="
+
+    SKILL_FILE="$SKILLS_DIR/approval-gate/SKILL.md"
+    if [ ! -f "$SKILL_FILE" ]; then
+        report "SC-6" "FAIL" "SKILL.md not found: $SKILL_FILE"
+    else
+        WORDS=$(wc -w < "$SKILL_FILE")
+        if [ "$WORDS" -gt 4000 ]; then
+            report "SC-6" "FAIL" "SKILL.md has $WORDS words (max 4,000)"
+        else
+            report "SC-6" "PASS" "SKILL.md has $WORDS words (≤4,000)"
+        fi
+    fi
+fi
+
+# ── SC-routing: Old verify-authorization.md is routing file (≤500 words) ──
+
+if should_run "SC-routing"; then
+    echo "=== SC-routing: verify-authorization.md is routing file (≤500 words) ==="
+
+    ROUTING_FILE="$SKILLS_DIR/approval-gate/tasks/verify-authorization.md"
+    if [ ! -f "$ROUTING_FILE" ]; then
+        report "SC-routing" "FAIL" "Routing file not found: $ROUTING_FILE"
+    else
+        WORDS=$(wc -w < "$ROUTING_FILE")
+        if [ "$WORDS" -gt 500 ]; then
+            report "SC-routing" "FAIL" "Routing file has $WORDS words (max 500 for routing-only)"
+        else
+            # Also verify it delegates to sub-tasks
+            if grep -q "scope-auto-resolve\|item-decomposition-check\|sub-issue-verification" "$ROUTING_FILE"; then
+                report "SC-routing" "PASS" "Routing file has $WORDS words and delegates to atomic tasks"
+            else
+                report "SC-routing" "FAIL" "Routing file has $WORDS words but does not delegate to atomic tasks"
+            fi
+        fi
+    fi
+fi
+
+# ── SC-skill-refs: SKILL.md references atomic tasks in task list ────────
+
+if should_run "SC-skill-refs"; then
+    echo "=== SC-skill-refs: SKILL.md references atomic tasks in task list ==="
+
+    SKILL_FILE="$SKILLS_DIR/approval-gate/SKILL.md"
+    ATOMIC_REFS=(
+        "scope-auto-resolve"
+        "item-decomposition-check"
+        "sc-traceability-check"
+        "sub-issue-verification"
+        "spec-to-plan-cascade"
+        "gap-fill-cascade"
+        "auto-dispatch"
+    )
+
+    ALL_REFERENCED=true
+    for ref in "${ATOMIC_REFS[@]}"; do
+        if ! grep -q "$ref" "$SKILL_FILE" 2>/dev/null; then
+            report "SC-skill-refs" "FAIL" "SKILL.md does not reference atomic task: $ref"
+            ALL_REFERENCED=false
+        else
+            echo "  SKILL.md references $ref ✓"
+        fi
+    done
+
+    if [ "$ALL_REFERENCED" = true ]; then
+        report "SC-skill-refs" "PASS" "SKILL.md references all atomic tasks"
+    fi
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Phase 2 Enforcement Test Results ==="
+for result in "${RESULTS[@]}"; do
+    echo "$result"
+done
+echo ""
+echo "Passed: $PASS | Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Completes Phase 2 of #1197 by condensing `approval-gate/SKILL.md` to a routing document and converting `verify-authorization.md` from a monolithic task file to a routing file that delegates to the 7 atomic sub-tasks created in PR #1209. Adds phase-scoped enforcement tests per #1236.

## Outcome

- `SKILL.md` reduced from 4,245 → 3,794 words (SC-6: ≤4,000 ✅)
- `verify-authorization.md` converted from 2,010-word monolith → 419-word routing file delegating to atomic sub-tasks
- Phase-scoped enforcement tests (`test-enforcement-phase2-scoped.sh`) added with 5 scenarios, all passing
- Phase 1 tests verified passing (no regression)

Implements #1197 Phase 2 items 2.9, 2.10, 2.11