### PR TITLE
feat: Phase-completion guards, 1% rule removal, TDD discipline enforcement

### DIFF
--- a/.opencode/guidelines/000-critical-rules.md
+++ b/.opencode/guidelines/000-critical-rules.md
@@ -893,6 +893,39 @@ When the `todowrite` tool is used during a session, the agent MUST maintain the 
 
 **See `060-tool-usage.md` §7 for the complete todowrite lifecycle rules (CREATE/UPDATE/CLEAR).** **AUTHORITY: `060-tool-usage.md` §7** (this line is a reference only)
 
+## Critical Violation: Session-Verified State Trust — Re-Reading Without State-Change Trigger
+
+**⚠️ Re-reading a resource in the same session without a state-change trigger is a CRITICAL GUIDELINE VIOLATION.**
+
+After a resource (issue, PR, file, comment set) is read and its state confirmed in this session, that state is TRUSTED until a state-change trigger occurs.
+
+| Rule | Text |
+| -- | -- |
+| Define | After a resource is read and its state confirmed in this session, that state is TRUSTED until a state-change trigger occurs |
+| Re-read forbidden | Re-reading the same resource in the same session without a state-change trigger is a CRITICAL GUIDELINE VIOLATION |
+| Counter allowed | A running tally of reads per resource is maintained; reading the same resource 3+ times triggers mandatory self-correction |
+| Context preserved | Trusting session-verified state DOES NOT violate `065-verification-honesty.md` — that rule governs claims ABOUT state, not the state's own persistence within a session |
+
+**State-change triggers (exhaustive list):**
+1. User explicitly says something changed
+2. API response indicates change (e.g., issue reopened)
+3. 5+ minutes elapsed with other agents active
+4. Session boundary
+5. The resource was modified by the agent itself since last read
+
+## Critical Violation: Verification Deduplication
+
+**⚠️ Re-verifying a resource that was already verified by a prior skill in the same session is a CRITICAL GUIDELINE VIOLATION.**
+
+If a verification gate from one skill has already produced evidence for a resource in this session, a subsequent skill requiring verification of the SAME resource may skip re-verification and cite the prior skill's evidence artifact.
+
+| Skill | Evidence artifact | Reusable by |
+| -- | -- | -- |
+| `verification-enforcement --task verify` | Section evidence table | `spec-auditor`, `spec-creation`, `correspondence` |
+| `approval-gate --task verify-authorization` | Authorization status, scope, halt_at | `git-workflow`, `divide-and-conquer`, `executing-plans` |
+| `git-workflow --task pre-work` | Branch state, worktree.path | `divide-and-conquer`, `finishing-a-development-branch` |
+| `verification-before-completion --task verify` | Per-SC evidence table | No skip — this is the final gate |
+
 ## Critical Violation: Pushing Agent Intelligence Decisions to the User
 
 **⚠️ Asking the user to make structural classification decisions that the agent should resolve autonomously is a CRITICAL GUIDELINE VIOLATION.**

--- a/.opencode/guidelines/065-verification-honesty.md
+++ b/.opencode/guidelines/065-verification-honesty.md
@@ -78,13 +78,11 @@ When the agent performs verification, it MUST show evidence:
 
 ## Single Exchange Window
 
-The ONLY exception: if a tool was called in the **immediately preceding exchange** (the last assistant turn in the same conversation), the agent MAY reference that result without re-calling. Any earlier reference requires re-verification.
+The ONLY exception: if a resource was read and its state confirmed within the current session, and no state-change trigger has occurred, the agent MAY reference that state without re-reading. Any earlier reference requires re-verification.
 
-This means:
+State-change triggers: user explicitly says something changed, API response indicates change, 5+ minutes elapsed with other agents active, session boundary, resource modified by the agent itself.
 
-- If the agent just ran `git status` in the previous turn → MAY reference the result
-- If the agent ran `git status` two turns ago → MUST re-run before reporting status
-- If the agent ran `git status` in a previous session → MUST re-run (always)
+This is consistent with the Session-Verified State Trust rule in `000-critical-rules.md`.
 
 ## Relationship to Other Guidelines
 

--- a/.opencode/guidelines/067-context-completeness.md
+++ b/.opencode/guidelines/067-context-completeness.md
@@ -84,6 +84,18 @@ The staleness rule is NOT about time estimation. It is about **action significan
 5. Revising a spec
 6. Creating sub-issues
 
+### De Minimis Bound
+
+If the resource was read in the same session and no state-change trigger has occurred, re-reading comments before a subsequent action on the SAME resource is OPTIONAL, not mandatory. The staleness rule applies to resources NOT read in the current session, or where a state-change trigger has occurred.
+
+**Examples:**
+| Action | Resource last read | State-change trigger? | Re-read required? |
+| -- | -- | -- | -- |
+| Check authorization | 2 exchanges ago | No | No — session-verified |
+| Create PR | Comments read 1 exchange ago | No | No — still within session |
+| Revise spec | User just posted new comment | Yes | Yes — state changed |
+| Close issue | Session started 10 min ago, no prior read | N/A | Yes — staleness rule applies |
+
 ## Single Exchange Window
 
 If comments were read in the **immediately preceding exchange** (the last assistant turn in the same conversation), the agent MAY reference those results without re-reading. Any earlier reference requires re-checking for new comments.

--- a/.opencode/guidelines/091-incremental-build.md
+++ b/.opencode/guidelines/091-incremental-build.md
@@ -151,6 +151,12 @@ Over-verification creates two failure modes:
 | Single test verifies all SCs across all phases | Split into N phase-scoped tests, each verifying its phase's SCs only |
 | Shell check reads skill card content to guess AI behavior | Behavioral test sends prompt and verifies agent response pattern |
 
+### Trust Prior Phase Verification
+
+Phase N tests trusting Phase M verification (M < N) is REQUIRED, not optional. This trust is consistent with `000-critical-rules.md` Session-Verified State Trust.
+
+**Anti-pattern:** Re-verifying a prior phase's deliverable in a later phase's test is over-verification, not honest verification, and is a STRUCTURE-VIOLATION.
+
 ## Cross-References
 
 - `000-critical-rules.md` → "Monolithic Implementation" critical violation section (authoritative enforcement)

--- a/.opencode/plugins/session-enforcement.ts
+++ b/.opencode/plugins/session-enforcement.ts
@@ -743,11 +743,13 @@ Critical rules:
  * Adapted from obra/superpowers skill enforcement pattern:
  * https://github.com/obra/superpowers/blob/main/.opencode/plugins/superpowers.js
  *
- * Key principle: "If you think there is even a 1% chance a skill might apply,
- * you ABSOLUTELY MUST invoke the skill." — from obra/superpowers using-superpowers
+ * Key principle: removed per spec #1249/#1248.
+ * Skill dispatch now follows the deterministic chain-of-responsibility
+ * table in approval-gate/SKILL.md. Invoke ONLY the skill(s) mapped
+ * to the current pipeline stage. Do NOT load skills speculatively.
  */
 function buildEnforcementContent(skillDescriptions: Array<{ name: string; description: string }>): string {
-  // Process skills first, implementation skills second (adapted from superpowers priority)
+  // Process skills first, implementation skills second
   const processSkills = skillDescriptions.filter(s =>
     ["approval-gate", "brainstorming", "spec-creation", "writing-plans", "executing-plans",
      "verification-before-completion", "finishing-a-development-branch",
@@ -762,12 +764,10 @@ function buildEnforcementContent(skillDescriptions: Array<{ name: string; descri
     .map(s => `- **${s.name}**: ${s.description}`)
     .join("\n");
 
-  // Red-flags rationalization table adapted from obra/superpowers writing-skills SKILL.md
-  // https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md
   return `<EXTREMELY_IMPORTANT>
 You have access to mandatory workflow skills. Skill invocation is NOT optional when a skill applies.
 
-**The 1% Rule:** If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+**Deterministic Dispatch:** Skill dispatch follows the chain-of-responsibility table in approval-gate/SKILL.md. Invoke ONLY the skill(s) deterministically mapped to the current pipeline stage. Do NOT load skills speculatively. Never invoke a skill "just in case."
 
 IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
 
@@ -816,7 +816,7 @@ ${skillLines}
 
 Use the OpenCode skill tool: \`/skill <skill-name>\` or \`/skill <skill-name> --task <task-name>\`
 
-Invoke relevant skills BEFORE any response or action. Even a 1% chance means invoke it to check.
+Invoke relevant skills BEFORE any response or action, per the deterministic dispatch table.
 </EXTREMELY_IMPORTANT>`;
 }
 

--- a/.opencode/skills/executing-plans/tasks/start.md
+++ b/.opencode/skills/executing-plans/tasks/start.md
@@ -26,6 +26,13 @@ This task dispatches plan execution to `divide-and-conquer --task assemble-work`
    - **5e.** Tool-call artifact REQUIRED: The agent must produce a tool-call artifact (e.g., `grep` or `bash` command output) proving that the RED test check was performed, showing the test exists and was verified to be in RED state.
 
    This checkpoint enforces the per-item TDD cycle mandated by `091-incremental-build.md`. For rule items, it enforces the behavioral TDD variant — behavioral tests must exist and be in RED state before implementation begins. Content-verification tests are secondary for rule changes. Skipping this checkpoint is a critical violation per `000-critical-rules.md`.
+
+#### Step 5.5a — Verify Behavioral Enforcement Test Files Exist (Missing-Test Recovery)
+
+**5.5a.** Before dispatching, verify behavioral enforcement test files exist for each TDD-marked item. If absent, create them from the spec's Success Criteria test mandate. If present, run them and confirm they fail (RED). If they pass, HALT.
+
+This makes the implementation phase resilient to branch switching, worktree recreation, and developer context-switching.
+
 6. **Dispatch to divide-and-conquer:**
 
 ```

--- a/.opencode/skills/git-workflow/tasks/cleanup/issue-closure.md
+++ b/.opencode/skills/git-workflow/tasks/cleanup/issue-closure.md
@@ -17,17 +17,17 @@ Hierarchical issue closure after PR merge verification. Handles plan→spec upwa
 
 ## Procedure
 
-### Step 1: Collect Referenced Issues from PR Body
+### Step 1: Collect Referenced Issues from PR Body with Keyword Classification
 
-Parse the PR body for all issue reference patterns:
+Parse the PR body for all issue reference patterns. **Each issue is classified by the keyword that introduced it.**
 
-| Pattern | Matches | Purpose |
-| -- | -- | -- |
-| `Spec:\s*#(\d+)` | `Spec: #959` | Plan→Spec upward |
-| `Plan:\s*#(\d+)` | `Plan: #960` | Spec→Plan downward |
-| `Fixes\s*#(\d+)` | `Fixes #968` | Cross-reference |
-| `Implements\s*#(\d+)` | `Implements #866` | Informational reference |
-| `Related\s*#(\d+)` | `Related #100` | Weak reference (evaluate only) |
+| Pattern | Matches | Purpose | Semantic Classification |
+| -- | -- | -- | -- |
+| `Spec:\s*#(\d+)` | `Spec: #959` | Plan→Spec upward | `spec_ref` |
+| `Plan:\s*#(\d+)` | `Plan: #960` | Spec→Plan downward | `plan_ref` |
+| `Fixes\s*#(\d+)` | `Fixes #968` | Cross-reference | `fixes` → unconditional close (subject to spec checks) |
+| `Implements\s*#(\d+)` | `Implements #866` | Partial implementation | `implements` → completeness check required before close |
+| `Related\s*#(\d+)` | `Related #100` | Weak reference (evaluate only) | `related` → never auto-close |
 
 ```python
 patterns = {
@@ -38,12 +38,24 @@ patterns = {
     "related": r"Related\s*#(\d+)",
 }
 
-closure_candidates = set()
+closure_candidates = {}
 for pattern_name, pattern in patterns.items():
     for match in re.finditer(pattern, pr_body):
         issue_num = int(match.group(1))
-        closure_candidates.add(issue_num)
+        closure_candidates[issue_num] = pattern_name
 ```
+
+**Keyword → Closure Behavior Dispatch Table:**
+
+| Keyword | Closure Behavior |
+|---|---|
+| `fixes` | Proceed to phase/completeness check → close if ALL checks pass |
+| `implements` | Proceed to phase/completeness check → do NOT close if ANY phases/SCs remain incomplete |
+| `related` | Evaluate only — never auto-close |
+| `spec_ref` | Follow spec closure path (Step 4) |
+| `plan_ref` | Follow plan closure path (Step 3) |
+
+**CRITICAL: `Implements` does NOT unconditionally close the issue.** A PR that "implements" an issue may only cover a subset of phases or SCs. The completeness check (Step 4a) determines whether the issue can be closed.
 
 ### Step 2: Classify Each Issue
 
@@ -66,6 +78,69 @@ for pattern_name, pattern in patterns.items():
 **Deliverable check:** Verify each sub-issue's deliverables (file paths, descriptions) against the merged PR's file list.
 
 ### Step 4: Spec Closure Path
+
+#### Step 4a: Phase-Completion Verification (MANDATORY FIRST)
+
+Before closing any spec, verify ALL phases in the spec body are marked complete. This check prevents premature closure of multi-phase specs after partial implementation.
+
+**Procedure:**
+
+1. Fetch the spec issue body via `github_issue_read(method="get", issue_number=spec_num)`
+2. Parse the body for phase markers:
+   - Markdown headings: `## Phase N:`, `### Phase N:`, `#### Phase N:`
+   - Checkbox markers: `☐`, `☑`, `✅ Done`, `⬜ Not Done`
+   - Inline lists: `- [ ]`, `- [x]`
+3. Extract all phases and their completion status
+4. **If ANY phase is incomplete (☐, ⬜ Not Done, or - [ ]):**
+   - Do NOT close this issue
+   - Post a comment: `Partially implemented by PR #N. Remaining phases: [list of incomplete phases]. Next phase continuation pending.`
+   - Skip to next closure candidate
+5. **If ALL phases are complete (☑, ✅ Done, or - [x]) OR no phase markers exist:**
+   - Proceed to Step 4b (plan reference check)
+
+**Phase marker regex patterns:**
+```python
+phase_patterns = [
+    r"^(#{1,4}\s*Phase\s+\d+[:.]?\s*.*)$",  # ## Phase 1: Title
+    r"^\s*[☐☑]\s*Phase\s+\d+[:.]?\s*.*$",  # ☑ Phase 1: Title
+    r"^\s*-\s+\[([ x])\]\s*Phase\s+\d+[:.]?\s*.*$",  # - [x] Phase 1: Title
+]
+
+completion_patterns = [
+    r"☑\s*Phase\s+\d+",
+    r"✅\s*Done",
+    r"- \[x\]",
+    r"Phase\s+\d+[:.]?\s*✅\s*Done",
+    r"Phase\s+\d+[:.]?\s*merged",
+]
+
+incomplete_patterns = [
+    r"☐\s*Phase\s+\d+",
+    r"⬜\s*Not\s*Done",
+    r"- \[ \]",
+    r"Phase\s+\d+[:.]?\s*(?:(?!✅|merged|Done).)*$",
+]
+```
+
+**SC Checklist Coverage Check (for [SPEC-FIX] and [Bug] issues):**
+
+For issues with `[SPEC-FIX]` or `[Bug]` labels/title prefixes, also verify:
+1. Extract the "Success Criteria" or "Checklist" section from the issue body
+2. Check ALL checkbox items (`- [ ]` or `☐`) are marked complete (`- [x]` or `☑`)
+3. If ANY SC/checkbox is incomplete → do NOT close
+
+**Classification of incomplete findings:**
+
+| Finding | Action |
+|---|---|
+| Phase incomplete | Skip closure, post partial-implementation comment |
+| SC checklist incomplete | Skip closure, post partial-implementation comment |
+| No phase markers | Skip check, proceed to Step 4b |
+| Single-phase spec (1 phase found, complete) | Proceed to Step 4b |
+
+#### Step 4b: Plan Reference Check
+
+After passing phase-completion verification:
 
 1. Search for plans referencing this spec: `github_search_issues(query="Spec: #<N> repo:<owner>/<repo>")`
 2. For each plan found, verify it is closed

--- a/.opencode/skills/spec-auditor/SKILL.md
+++ b/.opencode/skills/spec-auditor/SKILL.md
@@ -149,7 +149,7 @@ One of `--issue`, `--file`, or `--url` is mandatory (except for overview mode). 
 
 | Document Type | Baseline Subtasks | Why These |
 |---------------|-------------------|-----------|
-| Spec | `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles`, `sc-precision` | Every spec must be self-contained, properly structured, faithful to its problem, metadata-verified, principle-compliant, and have precise SCs with executable verification commands and semantic intent |
+| Spec | `fresh-start`, `structure`, `fidelity`, `ground-truth`, `principles`, `sc-precision` | Every spec must be self-contained, properly structured, faithful to its problem, metadata-verified, principle-compliant, have precise SCs with executable verification commands and semantic intent, and mandate TDD discipline (behavioral enforcement tests before implementation) |
 | Plan | `fresh-start`, `structure`, `ground-truth`, `principles` | Plans need self-containment, structure, metadata verification, and principle compliance; `fidelity` applies only to specs |
 | Process Flow | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | Flows need self-containment, adapted structure checks, metadata verification, and principle compliance |
 | Runbook/SOP | `fresh-start`, `structure` (adapted), `ground-truth`, `principles` | Runbooks need self-containment, adapted structure checks, metadata verification, and principle compliance |

--- a/.opencode/skills/spec-auditor/tasks/content-quality.md
+++ b/.opencode/skills/spec-auditor/tasks/content-quality.md
@@ -18,6 +18,7 @@ Check architectural reasoning, ambiguity, conflicts, and scope creep in a spec.
 | Superseded closure | SUPERSEDED-CLOSURE-VIOLATION | Does closing language claim future action without execution? |
 | Plan bleed | PLAN-BLEED | Does the spec contain implementation details (code, DDL, algorithms) that belong in the plan? |
 | Plan bleed (ambiguous) | PLAN-BLEED-AMBIGUOUS | Could content be either a requirement or implementation detail? Requires domain judgment |
+| TDD discipline | TDD-DISCIPLINE-GAP | Does the spec mandate behavioral enforcement tests before implementation, including a recovery clause for missing tests? Do plan phases have RED checkpoints that handle the missing-test scenario? |
 
 ## Procedure
 
@@ -81,5 +82,6 @@ Severity: [HIGH|MEDIUM|LOW]
 | ARCHITECTURAL-REASONING-GAP | flag-for-review | Requires understanding design tradeoffs |
 | PLAN-BLEED | auto-fix | Replace code/DDL/algorithms with requirements tables; note moved content for plan |
 | PLAN-BLEED-AMBIGUOUS | flag-for-review | Content could be requirement or implementation detail; requires domain judgment |
+| TDD-DISCIPLINE-GAP | conditional | Missing behavioral test mandate or RED checkpoint |
 
 Co-authored with AI: <AgentName> (<ModelId>)

--- a/.opencode/skills/spec-auditor/tasks/fidelity.md
+++ b/.opencode/skills/spec-auditor/tasks/fidelity.md
@@ -42,6 +42,14 @@ Compare clean-room plan against existing spec at three levels:
 | Step-level | Missing steps, extra steps, step ordering | Clean-room covers edge case not in original |
 | Content-level | Different approaches, wrong assumptions | Clean-room uses different strategy |
 
+### Step 3.5: TDD Step Structure Check
+
+During clean-room comparison, verify that the clean-room plan includes TDD step structure (RED checkpoint with missing-test handling) if the spec's problem statement implies code/rule changes.
+
+| Finding | Classification | Action |
+| -- | -- | -- |
+| MISSING-TDD-CHECKPOINT | conditional | Flag for review if TDD structure is absent |
+
 ### Step 4: Semantic Matching
 
 Before reporting differences, attempt semantic matching:

--- a/.opencode/skills/spec-auditor/tasks/sc-precision.md
+++ b/.opencode/skills/spec-auditor/tasks/sc-precision.md
@@ -9,6 +9,8 @@ Verify that every success criterion in the audited spec includes executable veri
 1. **Executable verification command** — Each SC has a shell command or test assertion with exact expected value (per `140-planning-spec-creation.md` mandate)
 2. **Semantic intent** — Each SC has a prose annotation explaining why the exact value matters and what semantic distinction it represents (per `spec-creation/tasks/write.md` Step 3)
 3. **No vague verification methods** — No SC uses "check exit code" without specifying the expected code, "validate JSON schema" without listing required fields, etc.
+4. **TDD discipline check** — For rule-changing specs, verify that at least one SC mandates behavioral enforcement test creation in `.opencode/tests/behaviors/` before implementation, including a missing-test recovery clause. Findings: `MISSING-BEHAVIORAL-RED`.
+5. **RED checkpoint check** — For plans, verify each phase/task includes a Step 2 RED checkpoint ("Run test, verify RED") that handles the missing-test scenario. Findings: `MISSING-TDD-CHECKPOINT`.
 
 ## Classification Rules
 
@@ -17,12 +19,14 @@ Verify that every success criterion in the audited spec includes executable veri
 | Missing semantic intent where the intent is unambiguous from context | **Auto-fix** | Agent can add a brief "why" explanation safely — the distinction is clear from the criterion text |
 | Vague verification method where the exact expected value is inferable | **Conditional** | Agent rewrites with executable command, but must confirm the inferred exact value is correct |
 | Ambiguous semantic distinction between specified value and similar value | **Flag-for-review** | Developer judgment required — agent cannot determine the correct value without domain context |
+| Missing behavioral test mandate with recovery clause | **Conditional** | Requires agent judgment on test framework |
+| Missing RED checkpoint in plan | **Conditional** | Requires agent judgment on test scope |
 
 ## Finding Format
 
 ```
 Subtask: sc-precision
-Finding: [VAGUE-VERIFICATION|MISSING-SEMANTIC-INTENT|VAGUE-VERIFICATION-AMBIGUOUS] - [SC ID and summary]
+Finding: [VAGUE-VERIFICATION|MISSING-SEMANTIC-INTENT|VAGUE-VERIFICATION-AMBIGUOUS|TDD-DISCIPLINE-GAP] - [SC ID and summary]
 Location: Success criteria table, row [SC ID]
 Context: [why this matters for this specific spec]
 Classification: [auto-fix|conditional|flag-for-review]

--- a/.opencode/skills/spec-creation/tasks/write.md
+++ b/.opencode/skills/spec-creation/tasks/write.md
@@ -23,39 +23,15 @@ Assemble the final spec with acceptance criteria, ambiguity elimination, and del
 
 Before assembling the spec, invoke `verification-enforcement --task verify`. This gate dispatches section-based sub-agents to collect evidence artifacts for the factual claims the spec will make — file references, API signatures, configuration fields, code behavior, and environment details. Evidence artifacts collected here ensure that the spec's claims are grounded in live sources. Claims that cannot be verified at this stage are marked with `⚠️ UNVERIFIED` for resolution in the post-generation revisit pass.
 
-### Step 0.5: RED Gate — Enforcement Test Assertions (MANDATORY)
+### Step 0.5: Behavioral Test Mandate in Success Criteria (MANDATORY)
 
-**🚫 CRITICAL: This step MUST execute BEFORE spec assembly. Skipping this step is a CRITICAL GUIDELINE VIOLATION.**
+**Behavioral enforcement tests are NOT written during spec creation.** They are written during implementation, per the post-approval spec mandate. However, the spec MUST include a Success Criterion mandating behavioral test creation before implementation.
 
-Before assembling the spec, enforcement test assertions MUST be written for each success criterion that the spec will define. This ensures the TDD RED phase is satisfied before the spec is even created — the test assertions exist and are in RED state (failing) before the spec content they verify exists.
+**For rule-changing specs** (guidelines, skills, critical violations): Include a success criterion that mandates "Before any implementation, write behavioral enforcement tests in `.opencode/tests/behaviors/` that verify the new rule; confirm RED state (test fails before change). If the tests are missing from the working tree when implementation begins, they must be re-created before any source changes."
 
-**Procedure:**
-
-1. **Enumerate anticipated success criteria** — Based on the requirements extraction and analysis from prerequisite tasks, list the expected success criteria the spec will define
-2. **Write enforcement test assertions** — For each anticipated SC, write an enforcement test assertion in `test-enforcement.sh` that verifies the SC's requirement. Use the format: `# SC-N: <brief description>` as a comment above the assertion, followed by a grep/check that will FAIL before the spec exists and PASS after the spec is created
-3. **Verify RED state** — Run the newly written assertions and confirm they are in RED state (failing). The assertions MUST fail because the spec content they verify does not exist yet
-4. **Produce tool-call evidence** — Record the RED state verification output as a tool-call artifact. The evidence MUST show:
-   - The test assertions written (with SC ID comments)
-   - The test run output showing failure (RED state)
-   - The timestamp of when the RED verification was performed
-
-**Evidence artifact format:**
-
-```
-RED Gate: spec-creation enforcement test assertions
-Assertions written: [count]
-RED state verified: [true/false]
-Test output: [pasted failure output]
-Timestamp: [ISO 8601]
-```
-
-**If RED state is NOT confirmed:** HALT. Do NOT proceed to spec assembly. The enforcement test assertions MUST exist and fail before the spec is created. This is a CRITICAL VIOLATION of the per-item TDD cycle per `091-incremental-build.md`.
-
-**Exemption:** Simple specs with only 1-2 success criteria that are purely administrative (label changes, status updates) may use a simplified assertion. The RED gate still applies, but the assertion may be a single check for the spec file's existence rather than per-SC assertions.
+**For code-changing specs**: Include a success criterion that mandates "Before any implementation, write unit or integration tests that verify the changed behavior; confirm RED state (test fails before change). If the tests are missing from the working tree when implementation begins, they must be re-created before any source changes."
 
 **Cross-reference:** See `091-incremental-build.md` → Per-Item TDD Cycle → RED phase, `080-code-standards.md` → SC-to-Test Traceability and RED-Phase Ordering, and `080-code-standards.md` → Behavioral Enforcement Tests (PRIMARY) for the behavioral RED/GREEN gate.
-
-**Behavioral RED/GREEN gate for rule-changing specs:** When the spec changes a rule that governs agent behavior (guideline, skill enforcement, critical violation), the enforcement test assertions in Step 0.5 MUST include behavioral assertions — not just content-verification grep patterns. A behavioral assertion describes the agent's expected behavior (what tool calls it makes, what it declines, what it outputs) rather than just checking for text presence. If a spec SC changes agent behavior and the Step 0.5 test assertions only contain content-verification (grep) checks, the RED gate is incomplete — the agent could pass content-verification while still violating the behavioral rule in practice (see Bug #1217).
 
 ### Step 1: Assemble Spec
 

--- a/.opencode/tests/behaviors/issue-closure-phase-completion.sh
+++ b/.opencode/tests/behaviors/issue-closure-phase-completion.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Issue Closure Phase Completion
+#
+# Verifies that issue-closure.md correctly maps "Implements" keyword to
+# completeness-check-required behavior and does NOT close issues with
+# incomplete phases.
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+# helpers.sh computes PROJECT_DIR from the main repo. For worktree tests,
+# we need the worktree root (three levels up from behaviors/).
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+SCENARIO_NAME="issue-closure-phase-completion"
+SCENARIO_PROMPT="When processing a PR body with 'Implements #N' where the spec #N has incomplete phases, the cleanup/issue-closure task must NOT close #N. Instead, it must require a completeness check first."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+# For this content-verification behavioral test, we inspect the worktree file directly.
+ISSUE_CLOSURE_FILE=".opencode/skills/git-workflow/tasks/cleanup/issue-closure.md"
+WORKTREE_FILE="$WORKTREE_ROOT/$ISSUE_CLOSURE_FILE"
+
+if [ ! -f "$WORKTREE_FILE" ]; then
+    echo "FAIL: $SCENARIO_NAME — $ISSUE_CLOSURE_FILE not found"
+    exit 1
+fi
+
+OVERALL_RESULT=0
+
+# Verify 1: Keyword classification table contains "Implements" mapped to "completeness check required"
+if ! grep -q 'Implements\s*#.*completeness check required' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — 'Implements' keyword not mapped to 'completeness check required' in classification table"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — 'Implements' keyword maps to 'completeness check required'"
+fi
+
+# Verify 2: Closure behavior table shows "implements" → "do NOT close if ANY phases/SCs remain incomplete"
+if ! grep -q 'implements.*do NOT close if ANY phases' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — closure behavior table does NOT show 'implements' → 'do NOT close if ANY phases remain incomplete'"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — closure behavior table correctly prevents closing incomplete implements issues"
+fi
+
+# Verify 3: Step 4a contains Phase-Completion Verification (MANDATORY FIRST)
+if ! grep -q 'Phase-Completion Verification (MANDATORY FIRST)' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — Step 4a Phase-Completion Verification heading missing"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — Step 4a Phase-Completion Verification heading present"
+fi
+
+# Verify 4: Step 4a explicitly says incomplete phases must skip closure
+if ! grep -q 'If ANY phase is incomplete' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — Step 4a does not explicitly check for incomplete phases"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — Step 4a explicitly checks for incomplete phases"
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/.opencode/tests/behaviors/session-enforcement-no-1pct.sh
+++ b/.opencode/tests/behaviors/session-enforcement-no-1pct.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Session Enforcement No 1% Rule
+#
+# Verifies that session-enforcement.ts does NOT contain the old "1% Rule"
+# or "1% chance" heuristic, and instead contains "Deterministic Dispatch".
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+# helpers.sh computes PROJECT_DIR from the main repo. For worktree tests,
+# we need the worktree root (three levels up from behaviors/).
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+SCENARIO_NAME="session-enforcement-no-1pct"
+SCENARIO_PROMPT="The session-enforcement.ts plugin output must not reference '1% Rule' or '1% chance'. It must use 'Deterministic Dispatch' instead."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+SESSION_FILE=".opencode/plugins/session-enforcement.ts"
+WORKTREE_FILE="$WORKTREE_ROOT/$SESSION_FILE"
+
+if [ ! -f "$WORKTREE_FILE" ]; then
+    echo "FAIL: $SCENARIO_NAME — $SESSION_FILE not found"
+    exit 1
+fi
+
+OVERALL_RESULT=0
+
+# Verify 1: "1% Rule" is ABSENT from the file
+if grep -qi '1% Rule' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — forbidden pattern '1% Rule' found in session-enforcement.ts"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — '1% Rule' is absent from session-enforcement.ts"
+fi
+
+# Verify 2: "1% chance" is ABSENT from the file
+if grep -qi '1% chance' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — forbidden pattern '1% chance' found in session-enforcement.ts"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — '1% chance' is absent from session-enforcement.ts"
+fi
+
+# Verify 3: "Deterministic Dispatch" is PRESENT in the file
+if ! grep -qi 'Deterministic Dispatch' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — required pattern 'Deterministic Dispatch' missing from session-enforcement.ts"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — 'Deterministic Dispatch' is present in session-enforcement.ts"
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/.opencode/tests/behaviors/spec-auditor-tdd-discipline.sh
+++ b/.opencode/tests/behaviors/spec-auditor-tdd-discipline.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Spec Auditor TDD Discipline
+#
+# Verifies that spec-auditor task files include TDD discipline checks:
+# - sc-precision.md includes behavioral test mandate verification
+# - content-quality.md includes TDD-DISCIPLINE-GAP
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+# helpers.sh computes PROJECT_DIR from the main repo. For worktree tests,
+# we need the worktree root (three levels up from behaviors/).
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+SCENARIO_NAME="spec-auditor-tdd-discipline"
+SCENARIO_PROMPT="The spec-auditor must include TDD discipline checks: sc-precision.md must verify behavioral test mandates, and content-quality.md must flag TDD-DISCIPLINE-GAP."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+SC_PRECISION_FILE=".opencode/skills/spec-auditor/tasks/sc-precision.md"
+CONTENT_QUALITY_FILE=".opencode/skills/spec-auditor/tasks/content-quality.md"
+WORKTREE_SC="$WORKTREE_ROOT/$SC_PRECISION_FILE"
+WORKTREE_CQ="$WORKTREE_ROOT/$CONTENT_QUALITY_FILE"
+
+if [ ! -f "$WORKTREE_SC" ]; then
+    echo "FAIL: $SCENARIO_NAME — $SC_PRECISION_FILE not found"
+    exit 1
+fi
+if [ ! -f "$WORKTREE_CQ" ]; then
+    echo "FAIL: $SCENARIO_NAME — $CONTENT_QUALITY_FILE not found"
+    exit 1
+fi
+
+OVERALL_RESULT=0
+
+# Verify 1: sc-precision.md has a TDD discipline check (behavioral test mandate verification)
+if ! grep -qi 'TDD discipline check' "$WORKTREE_SC"; then
+    echo "FAIL: $SCENARIO_NAME — sc-precision.md missing 'TDD discipline check' heading"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — sc-precision.md contains 'TDD discipline check'"
+fi
+
+if ! grep -qi 'behavioral enforcement test' "$WORKTREE_SC"; then
+    echo "FAIL: $SCENARIO_NAME — sc-precision.md missing behavioral enforcement test mandate verification"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — sc-precision.md verifies behavioral enforcement test mandate"
+fi
+
+# Verify 2: sc-precision.md finding format includes TDD-DISCIPLINE-GAP
+if ! grep -q 'TDD-DISCIPLINE-GAP' "$WORKTREE_SC"; then
+    echo "FAIL: $SCENARIO_NAME — sc-precision.md finding format missing TDD-DISCIPLINE-GAP"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — sc-precision.md finding format includes TDD-DISCIPLINE-GAP"
+fi
+
+# Verify 3: content-quality.md checks table includes TDD-DISCIPLINE-GAP
+if ! grep -q 'TDD-DISCIPLINE-GAP' "$WORKTREE_CQ"; then
+    echo "FAIL: $SCENARIO_NAME — content-quality.md missing TDD-DISCIPLINE-GAP in checks table"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — content-quality.md checks table includes TDD-DISCIPLINE-GAP"
+fi
+
+# Verify 4: content-quality.md auto-fix classification table includes TDD-DISCIPLINE-GAP
+if ! grep -q 'TDD discipline' "$WORKTREE_CQ"; then
+    echo "FAIL: $SCENARIO_NAME — content-quality.md missing 'TDD discipline' row in checks table"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — content-quality.md contains 'TDD discipline' check row"
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT

--- a/.opencode/tests/behaviors/spec-creation-red-gate-removal.sh
+++ b/.opencode/tests/behaviors/spec-creation-red-gate-removal.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Behavioral Enforcement Test: Spec Creation RED Gate Removal
+#
+# Verifies that spec-creation/tasks/write.md does NOT have the old Step 0.5
+# RED gate, and instead includes behavioral test mandate language for
+# Success Criteria.
+#
+# Co-authored with AI: OpenCode (ollama-cloud/glm-5)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/helpers.sh"
+
+# helpers.sh computes PROJECT_DIR from the main repo. For worktree tests,
+# we need the worktree root (three levels up from behaviors/).
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+SCENARIO_NAME="spec-creation-red-gate-removal"
+SCENARIO_PROMPT="The spec-creation write task must no longer contain the Step 0.5 RED gate. Instead it must mandate behavioral test inclusion in Success Criteria."
+
+echo "=== Behavioral Test: $SCENARIO_NAME ==="
+
+WRITE_FILE=".opencode/skills/spec-creation/tasks/write.md"
+WORKTREE_FILE="$WORKTREE_ROOT/$WRITE_FILE"
+
+if [ ! -f "$WORKTREE_FILE" ]; then
+    echo "FAIL: $SCENARIO_NAME — $WRITE_FILE not found"
+    exit 1
+fi
+
+OVERALL_RESULT=0
+
+# Verify 1: Step 0.5 RED Gate heading is ABSENT
+if grep -q '### Step 0\.5.*RED Gate' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — forbidden Step 0.5 RED Gate heading still present in write.md"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — Step 0.5 RED Gate heading is absent"
+fi
+
+# Verify 2: Step 0.5 Behavioral Test Mandate heading is PRESENT
+if ! grep -q '### Step 0\.5.*Behavioral Test Mandate' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — required Step 0.5 Behavioral Test Mandate heading missing"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — Step 0.5 Behavioral Test Mandate heading present"
+fi
+
+# Verify 3: Behavioral test mandate language for Success Criteria exists
+if ! grep -qi 'behavioral enforcement tests' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — behavioral enforcement test mandate language missing"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — behavioral enforcement test mandate language present"
+fi
+
+# Verify 4: RED state (test fails before change) language exists in SC context
+if ! grep -qi 'RED state' "$WORKTREE_FILE"; then
+    echo "FAIL: $SCENARIO_NAME — RED state language missing in Success Criteria section"
+    OVERALL_RESULT=1
+else
+    echo "PASS: $SCENARIO_NAME — RED state language present in Success Criteria section"
+fi
+
+echo ""
+if [ "$OVERALL_RESULT" -eq 0 ]; then
+    echo "PASS: $SCENARIO_NAME"
+else
+    echo "FAIL: $SCENARIO_NAME"
+fi
+
+exit $OVERALL_RESULT


### PR DESCRIPTION
## Summary

Phase-completion guards prevent premature spec/phase closure; 1% speculative skill loading removed; TDD discipline now enforced at audit time.

## Outcome

- **Issue-closure**: keyword classification + phase-check before closing specs
- **Session enforcement**: 1% Rule removed → deterministic chain-of-responsibility dispatch
- **Guidelines**: Session-Verified State Trust + Verification Deduplication rules added
- **Spec creation**: RED gate removed → behavioral test mandate embedded inSuccess Criteria
- **Spec auditor**: TDD discipline checks + MISSING-TDD-CHECKPOINT findings
- **Executing plans**: missing-test recovery handling added

## Fixes

Fixes #1245, Fixes #1246, Implements #1247, Implements #1248, Implements #1249, Implements #1251, Implements #1252

🤖 OpenCode (ollama-cloud/kimi-k2.6:cloud)