### PR TITLE
fix: update opencode-config submodule to track dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "opencode-config"]
 	path = .opencode
 	url = https://github.com/michael-conrad/opencode-config.git
-	branch = main
+	branch = dev
 	update = rebase


### PR DESCRIPTION
## Summary

Fixes `.gitmodules` to track `dev` branch for the `opencode-config` submodule instead of `main`.

## Problem

The submodule migration (PR #1271) configured `.gitmodules` with `branch = main`. Following the migration, all development in `opencode-config` moved to the `dev` branch. Since then, every clone/refresh of the submodule checks out `main` (or a detached HEAD), causing agents and developers to operate on stale code.

## Fix

Change `branch = main` → `branch = dev` in `.gitmodules`.

This is a post-migration fixup that should have been included in the original migration but was overlooked.

## Verification

- ✅ `git submodule update --init --remote` now pulls `origin/dev`
- ✅ Submodule no longer enters detached HEAD state on update

🤖 Co-authored with AI: OpenCode (kimi-k2.6:cloud)

Compare URL: https://github.com/Brothertown-Language/snea-shoebox-editor/compare/dev...feature/fix-gitmodules-branch