### PR TITLE
chore: update submodule URL to renamed repo (.opencode)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "opencode-config"]
 	path = .opencode
-	url = https://github.com/michael-conrad/opencode-config.git
+	url = https://github.com/michael-conrad/.opencode.git
 	branch = dev
 	update = rebase


### PR DESCRIPTION
## Summary

- Update `.gitmodules` URL from `michael-conrad/opencode-config.git` → `michael-conrad/.opencode.git` (repo was renamed)
- Bump `.opencode` submodule pointer to dev tip (`5bc401d`)