### PR TITLE
fix: test cleanup for HeadwordSearchEntry/GlossSearchEntry FK violations, expire_all→expunge_all, and populate_search_entries duplicate loop

### DIFF
--- a/src/services/linguistic_service.py
+++ b/src/services/linguistic_service.py
@@ -904,6 +904,10 @@ class LinguisticService:
 
         with get_session() as session:
             try:
+                # 0. Check if record exists
+                if not session.get(Record, record_id):
+                    return False
+
                 # 1. Delete history first
                 session.query(EditHistory).filter(EditHistory.record_id == record_id).delete()
 

--- a/src/services/upload_service.py
+++ b/src/services/upload_service.py
@@ -1804,13 +1804,6 @@ class UploadService:
                     norm = LinguisticService.generate_sort_lx(term)
                     session.add(GlossSearchEntry(record_id=rid, term=term, normalized_term=norm))
                     total += 1
-                # Insert va, se, cf, ve lists
-                for field in ("va", "se", "cf", "ve"):
-                    for val in entry.get(field, []):
-                        if val:
-                            norm = LinguisticService.generate_sort_lx(val)
-                            session.add(SearchEntry(record_id=rid, term=val, normalized_term=norm, entry_type=field))
-                            total += 1
 
             if not _provided_session:
                 session.commit()

--- a/tests/services/test_linguistic_service.py
+++ b/tests/services/test_linguistic_service.py
@@ -286,7 +286,7 @@ class TestLinguisticService(unittest.TestCase):
             record_id = LinguisticService.create_record(**fields)
 
         self.assertIsNotNone(record_id)
-        self.session.expire_all()
+        self.session.expunge_all()
         db_record = self.session.query(Record).filter_by(id=record_id).first()
         self.assertEqual(db_record.lx, "test")
 
@@ -301,7 +301,7 @@ class TestLinguisticService(unittest.TestCase):
             )
 
         self.assertTrue(success)
-        self.session.expire_all()
+        self.session.expunge_all()
         db_record = self.session.query(Record).filter_by(id=record.id).first()
         self.assertEqual(db_record.lx, "new")
         self.assertEqual(db_record.status, "approved")
@@ -354,7 +354,7 @@ class TestLinguisticService(unittest.TestCase):
             success = LinguisticService.soft_delete_record(record.id, "editor@example.com")
 
         self.assertTrue(success)
-        self.session.expire_all()
+        self.session.expunge_all()
         db_record = self.session.query(Record).filter_by(id=record.id).first()
         self.assertTrue(db_record.is_deleted)
 
@@ -363,7 +363,7 @@ class TestLinguisticService(unittest.TestCase):
             success = LinguisticService.update_source(self.source_id, name="New Name")
 
         self.assertTrue(success)
-        self.session.expire_all()
+        self.session.expunge_all()
         db_source = self.session.query(Source).filter_by(id=self.source_id).first()
         self.assertEqual(db_source.name, "New Name")
 
@@ -381,8 +381,9 @@ class TestLinguisticService(unittest.TestCase):
             count = LinguisticService.reassign_records(self.source_id, source_b_id)
 
         self.assertEqual(count, 1)
-        self.session.expire_all()
-        db_record = self.session.query(Record).filter_by(id=r1.id).first()
+        r1_id = r1.id
+        self.session.expunge_all()
+        db_record = self.session.query(Record).filter_by(id=r1_id).first()
         self.assertEqual(db_record.source_id, source_b_id)
 
     def test_delete_source(self):
@@ -395,7 +396,7 @@ class TestLinguisticService(unittest.TestCase):
         with self._patch_session():
             success = LinguisticService.delete_source(source_c_id)
         self.assertTrue(success)
-        self.session.expire_all()
+        self.session.expunge_all()
         self.assertIsNone(self.session.query(Source).filter_by(id=source_c_id).first())
 
         # Cannot delete source with records
@@ -406,7 +407,7 @@ class TestLinguisticService(unittest.TestCase):
         with self._patch_session():
             success = LinguisticService.delete_source(self.source_id)
         self.assertFalse(success)
-        self.session.expire_all()
+        self.session.expunge_all()
         self.assertIsNotNone(self.session.query(Source).filter_by(id=self.source_id).first())
 
     def _patch_stats_session(self):
@@ -476,7 +477,7 @@ class TestLinguisticService(unittest.TestCase):
             result = LinguisticService.hard_delete_record(record.id)
 
         self.assertTrue(result)
-        self.session.expire_all()
+        self.session.expunge_all()
         self.assertIsNone(self.session.query(Record).filter_by(id=record.id).first())
         self.assertEqual(self.session.query(SearchEntry).filter_by(record_id=record.id).count(), 0)
         self.assertEqual(self.session.query(HeadwordSearchEntry).filter_by(record_id=record.id).count(), 0)
@@ -510,7 +511,7 @@ class TestLinguisticService(unittest.TestCase):
             result = LinguisticService.hard_delete_record(record.id)
 
         self.assertTrue(result)
-        self.session.expire_all()
+        self.session.expunge_all()
         self.assertIsNone(self.session.query(Record).filter_by(id=record.id).first())
         self.assertEqual(self.session.query(EditHistory).filter_by(record_id=record.id).count(), 0)
 
@@ -539,7 +540,7 @@ class TestLinguisticService(unittest.TestCase):
             result = LinguisticService.hard_delete_record(record.id)
 
         self.assertTrue(result)
-        self.session.expire_all()
+        self.session.expunge_all()
         self.assertIsNone(self.session.query(Record).filter_by(id=record.id).first())
         self.assertEqual(self.session.query(HeadwordSearchEntry).filter_by(record_id=record.id).count(), 0)
         self.assertEqual(self.session.query(GlossSearchEntry).filter_by(record_id=record.id).count(), 0)
@@ -559,18 +560,21 @@ class TestLinguisticService(unittest.TestCase):
             lx="word",
             mdf_data="\\lx word",
             suggested_record_id=record2.id,
+            user_email="editor@example.com",
+            source_id=self.source_id,
             batch_id="test-batch",
             status="pending",
         )
         self.session.add(queue_entry)
         self.session.commit()
+        queue_id = queue_entry.id
 
         with self._patch_session():
             result = LinguisticService.hard_delete_record(record2.id)
 
         self.assertTrue(result)
-        self.session.expire_all()
+        self.session.expunge_all()
         self.assertIsNone(self.session.query(Record).filter_by(id=record2.id).first())
-        updated_queue = self.session.query(MatchupQueue).filter_by(id=queue_entry.id).first()
+        updated_queue = self.session.query(MatchupQueue).filter_by(id=queue_id).first()
         self.assertIsNotNone(updated_queue)
         self.assertIsNone(updated_queue.suggested_record_id)

--- a/tests/services/test_rollback.py
+++ b/tests/services/test_rollback.py
@@ -6,7 +6,7 @@ from datetime import UTC
 from src.database.connection import get_session, init_db
 from src.database.models.core import Language, Record, Source
 from src.database.models.identity import User
-from src.database.models.search import SearchEntry
+from src.database.models.search import GlossSearchEntry, HeadwordSearchEntry, SearchEntry
 from src.database.models.workflow import EditHistory
 from src.services.upload_service import UploadService
 
@@ -42,6 +42,8 @@ class TestRollbackService(unittest.TestCase):
 
     def setUp(self):
         # Clear existing records and history to isolate tests
+        self.session.query(HeadwordSearchEntry).delete()
+        self.session.query(GlossSearchEntry).delete()
         self.session.query(SearchEntry).delete()
         self.session.query(EditHistory).delete()
         self.session.query(Record).delete()

--- a/tests/services/test_upload_service.py
+++ b/tests/services/test_upload_service.py
@@ -338,11 +338,13 @@ class TestMatchAndCommitOperations(unittest.TestCase):
     def setUp(self):
         from src.database.models.core import Language, Record, Source
         from src.database.models.identity import User
-        from src.database.models.search import SearchEntry
+        from src.database.models.search import GlossSearchEntry, HeadwordSearchEntry, SearchEntry
         from src.database.models.workflow import EditHistory, MatchupQueue
 
         self.session = self.Session()
         # Clean all test data
+        self.session.query(HeadwordSearchEntry).delete()
+        self.session.query(GlossSearchEntry).delete()
         self.session.query(SearchEntry).delete()
         self.session.query(EditHistory).delete()
         self.session.query(MatchupQueue).delete()
@@ -1040,7 +1042,7 @@ class TestMatchAndCommitOperations(unittest.TestCase):
         rec = self._add_record("esh", "\\lx esh\n\\va ēsh\n\\se eshkw\n\\cf nane\n\\ve fire\n\\ps n\n\\ge fire")
         with self._patch_session():
             count = UploadService.populate_search_entries([rec.id])
-        self.assertEqual(count, 5)  # lx + va + se + cf + ve
+        self.assertEqual(count, 8)  # 5 SearchEntry + 2 HeadwordSearchEntry + 1 GlossSearchEntry
         from src.database.models.search import SearchEntry
 
         entries = self.session.query(SearchEntry).filter_by(record_id=rec.id).all()
@@ -1055,7 +1057,7 @@ class TestMatchAndCommitOperations(unittest.TestCase):
         self.session.commit()
         with self._patch_session():
             count = UploadService.populate_search_entries([rec.id])
-        self.assertEqual(count, 1)
+        self.assertEqual(count, 3)  # 1 SearchEntry + 1 HeadwordSearchEntry + 1 GlossSearchEntry
         entries = self.session.query(SearchEntry).filter_by(record_id=rec.id).all()
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].term, "esh")


### PR DESCRIPTION
## Summary

Fixes test FK violations from missing HeadwordSearchEntry/GlossSearchEntry cleanup, ObjectDeletedError from expire_all(), and a production code bug with a duplicated loop in populate_search_entries.

### Issues Fixed

- **#1281** — TestRollbackService.setUp() missing HeadwordSearchEntry/GlossSearchEntry cleanup
- **#1282** — test_linguistic_service.py hard_delete tests failing with ObjectDeletedError (expire_all→expunge_all)
- **#1283** — TestMatchAndCommitOperations.setUp() missing HeadwordSearchEntry/GlossSearchEntry cleanup

### Changes

| File | Change |
|------|--------|
| `src/services/linguistic_service.py` | Added record existence check in `hard_delete_record()` |
| `src/services/upload_service.py` | Removed duplicate `va/se/cf/ve` SearchEntry insertion loop in `populate_search_entries()` |
| `tests/services/test_linguistic_service.py` | Replaced `expire_all()`→`expunge_all()` (11x), fixed missing MatchupQueue fields, captured IDs before expunge |
| `tests/services/test_rollback.py` | Added HeadwordSearchEntry/GlossSearchEntry cleanup and imports in setUp() |
| `tests/services/test_upload_service.py` | Added HeadwordSearchEntry/GlossSearchEntry cleanup and imports in setUp(); updated populate test expectations |

### Triage Findings

All 92 tests pass (23 linguistic + 9 rollback + 60 upload).

Bug #1282 report was incomplete — investigation revealed 3 distinct root causes for the 5 failing hard_delete tests:
1. `expire_all()` → `ObjectDeletedError` (3 tests)
2. Missing record existence check in `hard_delete_record()` (1 test)
3. Missing required MatchupQueue fields + detached object access (1 test)

During #1283 triage, a production code bug was found: a duplicated `va/se/cf/ve` SearchEntry loop in `populate_search_entries()` caused double-insertion. The live database has duplicate rows for every processed record.

A deduplication migration may be warranted for the live DB.