### PR TITLE
Convert .opencode from git submodule to untracked local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ docker.app/
 /opencode-guidelines-export.zip
 .srclight/
 
+/.issues/
+/.tools/
+/.opencode/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "opencode-config"]
-	path = .opencode
-	url = https://github.com/michael-conrad/.opencode.git
-	branch = dev
-	update = rebase


### PR DESCRIPTION
## Summary

Convert `.opencode/` from a git submodule (tracked via `.gitmodules` + gitlink to `michael-conrad/.opencode`) to a locally-managed untracked directory.

## Changes

| File | Change |
|------|--------|
| `.gitmodules` | Remove `[submodule "opencode-config"]` section (5 lines) |
| `.opencode` (gitlink) | Delete submodule pointer (160000 mode) |
| `.gitignore` | Add `/.opencode/`, `/.issues/`, `/.tools/` entries |

## Why

- Submodule updates require explicit `git submodule update --init` after every clone/checkout
- The submodule tracks a remote repo that may diverge from local needs
- `.opencode/` contains project-specific AI agent configuration that should be managed locally
- The directory is now ignored by git, preventing accidental commits

## Verification

- [x] `.gitmodules` has no opencode submodule entry
- [x] `git ls-files .opencode` returns empty
- [x] `.gitignore` contains all three new entries
- [x] `git status` shows no `.opencode/` changes

Fixes #1295

---

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)