### PR TITLE
[#400] Phase 4: Add Headword and Gloss search dispatch modes

### DIFF
--- a/src/services/linguistic_service.py
+++ b/src/services/linguistic_service.py
@@ -59,7 +59,11 @@ def _search_headword(query, search_term: str):
     norm_search = LinguisticService.generate_sort_lx(search_term)
     if search_term.strip() and not norm_search:
         return query.filter(Record.id == -1)
-    return query.join(Record.headword_entries).filter(HeadwordSearchEntry.normalized_term.ilike(f"%{norm_search}%")).distinct()
+    return (
+        query.join(Record.headword_entries)
+        .filter(HeadwordSearchEntry.normalized_term.ilike(f"%{norm_search}%"))
+        .distinct()
+    )
 
 
 def _search_gloss(query, search_term: str):
@@ -67,7 +71,9 @@ def _search_gloss(query, search_term: str):
     norm_search = LinguisticService.generate_sort_lx(search_term)
     if search_term.strip() and not norm_search:
         return query.filter(Record.id == -1)
-    return query.join(Record.gloss_entries).filter(GlossSearchEntry.normalized_term.ilike(f"%{norm_search}%")).distinct()
+    return (
+        query.join(Record.gloss_entries).filter(GlossSearchEntry.normalized_term.ilike(f"%{norm_search}%")).distinct()
+    )
 
 
 _search_strategies: dict[str, callable] = {

--- a/src/services/linguistic_service.py
+++ b/src/services/linguistic_service.py
@@ -9,7 +9,7 @@ import re
 import tempfile
 import unicodedata
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from sqlalchemy import func
 
@@ -22,7 +22,60 @@ from src.logging_config import get_logger
 
 logger = get_logger("snea.linguistic_service")
 
-_TSQUERY_UNSAFE = re.compile(r"[|&!()]+")
+_TSQUERY_UNSAFE = re.compile(r"[^a-zA-Z0-9]+")
+
+# Search mode literal type
+SearchMode = Literal["Lexeme", "FTS", "Headword", "Gloss"]
+
+
+def _search_lexeme(query, search_term: str):
+    """Lexeme mode: join SearchEntry, match on normalized_term."""
+    norm_search = LinguisticService.generate_sort_lx(search_term)
+    if search_term.strip() and not norm_search:
+        return query.filter(Record.id == -1)
+    return query.join(Record.search_entries).filter(SearchEntry.normalized_term.ilike(f"%{norm_search}%")).distinct()
+
+
+def _search_fts(query, search_term: str):
+    """FTS mode: full-text search on fts_vector + mdf_data ILIKE fallback."""
+    from sqlalchemy import or_, text
+
+    if search_term.startswith("#") and search_term[1:].isdigit():
+        return query.filter(Record.id == int(search_term[1:]))
+    words = [clean for w in search_term.split() if (clean := _TSQUERY_UNSAFE.sub("", w).strip())]
+    if words:
+        fts_query = " & ".join([f"{w}:*" for w in words])
+        return query.filter(
+            or_(
+                text("records.fts_vector @@ to_tsquery('english', :fts_term)"),
+                Record.mdf_data.ilike(f"%{search_term}%"),
+            )
+        ).params(fts_term=fts_query)
+    return query.filter(Record.mdf_data.ilike(f"%{search_term}%"))
+
+
+def _search_headword(query, search_term: str):
+    """Headword mode: join HeadwordSearchEntry, match on normalized_term."""
+    norm_search = LinguisticService.generate_sort_lx(search_term)
+    if search_term.strip() and not norm_search:
+        return query.filter(Record.id == -1)
+    return query.join(Record.headword_entries).filter(HeadwordSearchEntry.normalized_term.ilike(f"%{norm_search}%")).distinct()
+
+
+def _search_gloss(query, search_term: str):
+    """Gloss mode: join GlossSearchEntry, match on normalized_term."""
+    norm_search = LinguisticService.generate_sort_lx(search_term)
+    if search_term.strip() and not norm_search:
+        return query.filter(Record.id == -1)
+    return query.join(Record.gloss_entries).filter(GlossSearchEntry.normalized_term.ilike(f"%{norm_search}%")).distinct()
+
+
+_search_strategies: dict[str, callable] = {
+    "Lexeme": _search_lexeme,
+    "FTS": _search_fts,
+    "Headword": _search_headword,
+    "Gloss": _search_gloss,
+}
 
 
 @dataclass
@@ -329,14 +382,15 @@ class LinguisticService:
         status: str | None = None,
         is_locked: bool | None = None,
         search_term: str | None = None,
-        search_mode: str = "Lexeme",
+        search_mode: SearchMode = "Lexeme",
         record_ids: list[int] | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> RecordSearchResult:
         """
         Search records with optional filters.
-        Supports 'Lexeme' mode (via search_entries) and 'FTS' mode.
+        Supports 'Lexeme' mode (via search_entries), 'FTS' mode,
+        'Headword' mode (via headword_search_entries), and 'Gloss' mode (via gloss_search_entries).
         If record_ids is provided, other filters are ignored except for is_deleted.
         """
         with get_session() as session:
@@ -381,53 +435,10 @@ class LinguisticService:
                     query = query.filter(Record.is_locked == is_locked)
 
                 if search_term:
-                    if search_mode == "Lexeme":
-                        # Normalize search term for punctuation, case, diacritics, and quotes
-                        norm_search = LinguisticService.generate_sort_lx(search_term)
-
-                        # If search term exists but normalizes to nothing (e.g. "10"),
-                        # we should return no results instead of matching everything.
-                        if search_term.strip() and not norm_search:
-                            # We can't easily return empty results here without modifying the whole query flow,
-                            # but we can force a filter that matches nothing.
-                            query = query.filter(Record.id == -1)
-                        else:
-                            # Join with search_entries to find matches in lx, va, se, etc.
-                            # Infix matching for better discovery (contains)
-                            query = (
-                                query.join(Record.search_entries)
-                                .filter(SearchEntry.normalized_term.ilike(f"%{norm_search}%"))
-                                .distinct()
-                            )
-                    else:
-                        # Native Full-Text Search (Roadmap Phase 6b)
-                        # Supported by the pgserver envelope.
-                        # Uses fts_vector column and GIN index via Migration 8
-                        from sqlalchemy import text
-
-                        # Support for specific record ID search via #<id>
-                        if search_term.startswith("#") and search_term[1:].isdigit():
-                            query = query.filter(Record.id == int(search_term[1:]))
-                        else:
-                            # FTS support for multiple words + prefix matching for partials
-                            # We join words with ' & ' and add ':*' for prefix matching
-                            # We also use ILIKE on mdf_data to support infix search (consistency with Lexeme)
-                            from sqlalchemy import or_
-
-                            words = [
-                                clean for w in search_term.split() if (clean := _TSQUERY_UNSAFE.sub("", w).strip())
-                            ]
-                            if words:
-                                fts_query = " & ".join([f"{w}:*" for w in words])
-                                query = query.filter(
-                                    or_(
-                                        text("records.fts_vector @@ to_tsquery('english', :fts_term)"),
-                                        Record.mdf_data.ilike(f"%{search_term}%"),
-                                    )
-                                ).params(fts_term=fts_query)
-                            else:
-                                # Handle cases like empty or just punctuation search
-                                query = query.filter(Record.mdf_data.ilike(f"%{search_term}%"))
+                    strategy = _search_strategies.get(search_mode)
+                    if strategy is None:
+                        raise ValueError(f"Unknown search mode: {search_mode}")
+                    query = strategy(query, search_term)
 
             # Efficient Sorting: sort_lx (NFD/No-Punct), hm, ps, primary_lang, ge
             query = query.order_by(Record.sort_lx, Record.hm, Record.ps, primary_lang.c.lang_name, Record.ge)

--- a/tests/services/test_linguistic_service.py
+++ b/tests/services/test_linguistic_service.py
@@ -578,3 +578,209 @@ class TestLinguisticService(unittest.TestCase):
         updated_queue = self.session.query(MatchupQueue).filter_by(id=queue_id).first()
         self.assertIsNotNone(updated_queue)
         self.assertIsNone(updated_queue.suggested_record_id)
+
+    def test_search_records_headword_finds_primary_lx(self):
+        """SC-1: Headword search finds primary lx — 'wampuw' returns exactly 1 record."""
+        r1 = Record(
+            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        hse_lx = HeadwordSearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        hse_va = HeadwordSearchEntry(record_id=r1.id, term="wampu", normalized_term="wampu", entry_type="va")
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        self.session.add_all([hse_lx, hse_va, gse])
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.search_records(search_term="wampuw", search_mode="Headword")
+        self.assertEqual(len(result.records), 1)
+        self.assertEqual(result.records[0]["lx"], "wampuw")
+        self.assertEqual(result.total_count, 1)
+
+    def test_search_records_headword_finds_primary_va(self):
+        """SC-2: Headword search finds primary va — 'wampu' returns exactly 1 record."""
+        r1 = Record(
+            lx="wampuw",
+            ge="round object",
+            source_id=self.source_id,
+            mdf_data="\\lx wampuw\n\\va wampu\n\\ge round object",
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        hse_lx = HeadwordSearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        hse_va = HeadwordSearchEntry(record_id=r1.id, term="wampu", normalized_term="wampu", entry_type="va")
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        self.session.add_all([hse_lx, hse_va, gse])
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.search_records(search_term="wampu", search_mode="Headword")
+        self.assertEqual(len(result.records), 1)
+        self.assertEqual(result.records[0]["lx"], "wampuw")
+        self.assertEqual(result.total_count, 1)
+
+    def test_search_records_headword_excludes_nested_va(self):
+        """SC-3: Headword excludes nested va — 'wampu-' returns 0 records."""
+        r1 = Record(
+            lx="other",
+            ge="something",
+            source_id=self.source_id,
+            mdf_data="\\lx other\n\\va wampu-\n\\ge something",
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        hse = HeadwordSearchEntry(record_id=r1.id, term="other", normalized_term="other", entry_type="lx")
+        self.session.add(hse)
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.search_records(search_term="wampu-", search_mode="Headword")
+        self.assertEqual(len(result.records), 0)
+        self.assertEqual(result.total_count, 0)
+
+    def test_search_records_gloss_finds_primary_ge(self):
+        """SC-4: Gloss search finds primary ge — 'round object' returns exactly 1 record."""
+        r1 = Record(
+            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        self.session.add(gse)
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.search_records(search_term="round object", search_mode="Gloss")
+        self.assertEqual(len(result.records), 1)
+        self.assertEqual(result.records[0]["lx"], "wampuw")
+        self.assertEqual(result.total_count, 1)
+
+    def test_search_records_gloss_excludes_nested_ge(self):
+        """SC-5: Gloss excludes nested ge — 'ball' returns 0 records."""
+        r1 = Record(
+            lx="other",
+            ge="something",
+            source_id=self.source_id,
+            mdf_data="\\lx other\n\\ge something\n\\ge ball",
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        gse = GlossSearchEntry(record_id=r1.id, term="something", normalized_term="something")
+        self.session.add(gse)
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.search_records(search_term="ball", search_mode="Gloss")
+        self.assertEqual(len(result.records), 0)
+        self.assertEqual(result.total_count, 0)
+
+    def test_search_records_gloss_excludes_headword(self):
+        """SC-6: Gloss excludes headword — 'wampuw' returns 0 records."""
+        r1 = Record(
+            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        hse = HeadwordSearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        self.session.add_all([hse, gse])
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.search_records(search_term="wampuw", search_mode="Gloss")
+        self.assertEqual(len(result.records), 0)
+        self.assertEqual(result.total_count, 0)
+
+    def test_search_records_lexeme_mode_unchanged(self):
+        """SC-7: Lexeme mode UNCHANGED — all variants returned, no entry_type filter."""
+        r1 = Record(
+            lx="run", ge="to move fast", source_id=self.source_id, mdf_data="\\lx run\n\\va ran"
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        se1 = SearchEntry(record_id=r1.id, term="run", normalized_term="run", entry_type="lx")
+        se2 = SearchEntry(record_id=r1.id, term="ran", normalized_term="ran", entry_type="va")
+        self.session.add_all([se1, se2])
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.search_records(search_term="ran", search_mode="Lexeme")
+        self.assertEqual(len(result.records), 1)
+        self.assertEqual(result.records[0]["lx"], "run")
+        self.assertEqual(result.total_count, 1)
+
+    def test_search_records_fts_mode_unchanged(self):
+        """SC-8: FTS mode UNCHANGED — no changes to FTS logic."""
+        r1 = Record(lx="dog", ge="canine", source_id=self.source_id, mdf_data="\\lx dog\n\\nt some note")
+        self.session.add(r1)
+        self.session.commit()
+
+        with self._patch_session():
+            result = LinguisticService.search_records(search_term="canine", search_mode="FTS")
+        self.assertEqual(len(result.records), 1)
+        self.assertEqual(result.total_count, 1)
+
+    def test_search_records_performance(self):
+        """SC-14: Search performance < 500ms for all modes."""
+        import time
+
+        r1 = Record(
+            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        hse_lx = HeadwordSearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        hse_va = HeadwordSearchEntry(record_id=r1.id, term="wampu", normalized_term="wampu", entry_type="va")
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        se = SearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        self.session.add_all([hse_lx, hse_va, gse, se])
+        self.session.commit()
+
+        with self._patch_session():
+            for mode in ["Lexeme", "FTS", "Headword", "Gloss"]:
+                start = time.perf_counter()
+                result = LinguisticService.search_records(search_term="wampuw", search_mode=mode)
+                elapsed = (time.perf_counter() - start) * 1000
+                self.assertLess(elapsed, 500, f"{mode} mode took {elapsed:.0f}ms")
+
+    def test_search_records_empty_input(self):
+        """SC-24: Empty search input returns all records without error/crash."""
+        r1 = Record(
+            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
+        )
+        self.session.add(r1)
+        self.session.commit()
+
+        with self._patch_session():
+            for mode in ["Lexeme", "FTS", "Headword", "Gloss"]:
+                result = LinguisticService.search_records(search_term="", search_mode=mode)
+                self.assertIsNotNone(result)
+                self.assertIsInstance(result.records, list)
+
+    def test_search_records_special_characters(self):
+        """SC-25: Special characters no crash or SQL injection."""
+        r1 = Record(lx="safe", ge="test", source_id=self.source_id, mdf_data="\\lx safe")
+        self.session.add(r1)
+        self.session.commit()
+
+        payloads = [
+            "'; DROP TABLE records; --",
+            "1; SELECT * FROM users",
+            "<script>alert('xss')</script>",
+            "\\' OR '1'='1",
+        ]
+        with self._patch_session():
+            for mode in ["Lexeme", "FTS", "Headword", "Gloss"]:
+                for payload in payloads:
+                    result = LinguisticService.search_records(search_term=payload, search_mode=mode)
+                    self.assertIsNotNone(result)
+                    self.assertIsInstance(result.records, list)

--- a/tests/services/test_linguistic_service.py
+++ b/tests/services/test_linguistic_service.py
@@ -748,7 +748,7 @@ class TestLinguisticService(unittest.TestCase):
         with self._patch_session():
             for mode in ["Lexeme", "FTS", "Headword", "Gloss"]:
                 start = time.perf_counter()
-                result = LinguisticService.search_records(search_term="wampuw", search_mode=mode)
+                LinguisticService.search_records(search_term="wampuw", search_mode=mode)
                 elapsed = (time.perf_counter() - start) * 1000
                 self.assertLess(elapsed, 500, f"{mode} mode took {elapsed:.0f}ms")
 


### PR DESCRIPTION
## Summary

Phase 4 implementation for spec #400 — strategy-dispatch for Headword and Gloss search modes in the backend search layer.

## Changes

1. **Strategy-dispatch refactor** — extracted Lexeme/FTS into standalone strategy functions (`_search_lexeme`, `_search_fts`), added `_search_headword` (joins `Record.headword_entries` → ILIKE on `normalized_term`) and `_search_gloss` (joins `Record.gloss_entries` → ILIKE on `normalized_term`). Dispatch via `_search_strategies` dict (per DEC-2).
2. **SearchMode type alias** — `Literal["Lexeme", "FTS", "Headword", "Gloss"]` for the `search_mode` parameter.
3. **FTS sanitization fix** — `_TSQUERY_UNSAFE` regex changed from `[|&!()]+` to `[^a-zA-Z0-9]+` (pre-existing bug exposed by special characters test).
4. **11 behavioral tests** — covering SC-1 through SC-8, SC-14, SC-24, SC-25.

## Verification

- 34/34 tests pass in `tests/services/test_linguistic_service.py`
- 324/324 project-wide tests pass (full regression clean)
- All 11 Phase 4 SCs verified PASS (adversarial audit + cross-validate)
- Lint/format clean (zero new violations)

## Files Changed

| File | Change |
|------|--------|
| `src/services/linguistic_service.py` | Strategy-dispatch refactor (+113/-51) |
| `tests/services/test_linguistic_service.py` | 11 behavioral tests (+206) |

## Out of Scope

- Phase 5 (UI) is tracked in #1126
- `populate_search_entries` indexing logic unchanged (Phase 2 already complete)

Fixes: #400 (Phase 4)