### PR TITLE
Phase 2: Backend Indexing Logic — HeadwordSearchEntry & GlossSearchEntry Population

### DIFF
--- a/src/mdf/parser.py
+++ b/src/mdf/parser.py
@@ -52,6 +52,7 @@ def _process_block_into_record(lines_buffer):
         "record_id": None,
         "lg": [],
         "va": [],
+        "primary_va": [],
         "se": [],
         "cf": [],
         "ve": [],
@@ -66,6 +67,11 @@ def _process_block_into_record(lines_buffer):
             or _extract_tag(line, "va") is not None
             or _extract_tag(line, "xv") is not None
         ):
+            # Capture \va values before in_headword is set to False
+            if in_headword:
+                val = _extract_tag(line, "va")
+                if val is not None:
+                    record["primary_va"].append(val)
             in_headword = False
 
         val = _extract_tag(line, "lx")

--- a/src/mdf/parser.py
+++ b/src/mdf/parser.py
@@ -64,15 +64,13 @@ def _process_block_into_record(lines_buffer):
         if (
             _extract_tag(line, "se") is not None
             or _extract_tag(line, "sn") is not None
-            or _extract_tag(line, "va") is not None
             or _extract_tag(line, "xv") is not None
         ):
-            # Capture \va values before in_headword is set to False
-            if in_headword:
-                val = _extract_tag(line, "va")
-                if val is not None:
-                    record["primary_va"].append(val)
             in_headword = False
+
+        val = _extract_tag(line, "va")
+        if val is not None and in_headword:
+            record["primary_va"].append(val)
 
         val = _extract_tag(line, "lx")
         if val is not None and not record["lx"]:

--- a/src/services/upload_service.py
+++ b/src/services/upload_service.py
@@ -1757,6 +1757,7 @@ class UploadService:
             total = 0
             # Check once whether fts_entries table exists (migration guard)
             from sqlalchemy import inspect as sa_inspect
+
             _fts_table_exists = sa_inspect(session.get_bind()).has_table("fts_entries")
 
             for rid in record_ids:

--- a/src/services/upload_service.py
+++ b/src/services/upload_service.py
@@ -1774,7 +1774,10 @@ class UploadService:
                 # Re-parse MDF to extract searchable fields
                 from src.mdf.parser import parse_mdf as _parse
 
-                parsed = _parse(record.mdf_data)
+                try:
+                    parsed = _parse(record.mdf_data)
+                except ValueError:
+                    continue
                 if not parsed:
                     continue
                 entry = parsed[0]
@@ -1801,7 +1804,7 @@ class UploadService:
                     norm = LinguisticService.generate_sort_lx(term)
                     session.add(HeadwordSearchEntry(record_id=rid, entry_type="lx", term=term, normalized_term=norm))
                     total += 1
-                for val in entry.get("va", []):
+                for val in entry.get("primary_va", []):
                     if val:
                         norm = LinguisticService.generate_sort_lx(val)
                         session.add(HeadwordSearchEntry(record_id=rid, entry_type="va", term=val, normalized_term=norm))

--- a/test/test_parser_headword_block.py
+++ b/test/test_parser_headword_block.py
@@ -1,0 +1,60 @@
+"""Tests for headword-block state in MDF parser output.
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+"""
+import pytest
+
+from src.mdf.parser import parse_mdf
+
+
+def make_mdf_with_nested_va():
+    """Create MDF data with both headword-block \\va and nested \\va (inside \\se subentry)."""
+    return """\\lx wampum
+\\va wampu-
+\\ps N
+\\ge ball
+\\se
+\\va wampum
+\\ge sphere
+\\nt Record: 1"""
+
+
+class TestPrimaryVaField:
+    """RED-phase tests for SC-P1-1: primary_va field in parsed record."""
+
+    def test_primary_va_field_exists(self):
+        """SC-P1-1: Assert 'primary_va' in record — MUST FAIL because field doesn't exist yet."""
+        mdf_data = make_mdf_with_nested_va()
+        records = parse_mdf(mdf_data)
+        assert len(records) == 1
+        record = records[0]
+        assert "primary_va" in record, (
+            "RED: 'primary_va' key should exist in parsed record. "
+            "This MUST FAIL until _process_block_into_record() adds 'primary_va' to the record dict."
+        )
+
+    def test_primary_va_contains_only_headword_values(self):
+        """SC-P1-1: Assert primary_va has only headword-block \\va values — MUST FAIL."""
+        mdf_data = make_mdf_with_nested_va()
+        records = parse_mdf(mdf_data)
+        record = records[0]
+        assert "primary_va" in record
+        assert record["primary_va"] == ["wampu-"], (
+            "RED: 'primary_va' should contain only headword-block \\va values (before \\se). "
+            "This MUST FAIL until _process_block_into_record() captures \\va before in_headword=False."
+        )
+
+
+class TestExistingVaBehavior:
+    """RED-phase tests for SC-P1-2: existing va list unchanged."""
+
+    def test_va_still_contains_all_values(self):
+        """SC-P1-2: Assert va list still has ALL \\va values — should PASS even before change."""
+        mdf_data = make_mdf_with_nested_va()
+        records = parse_mdf(mdf_data)
+        record = records[0]
+        assert "va" in record
+        assert record["va"] == ["wampu-", "wampum"], (
+            "Existing 'va' list must contain ALL \\va values (headword + nested). "
+            "This should PASS even before the change."
+        )

--- a/test/test_parser_headword_block.py
+++ b/test/test_parser_headword_block.py
@@ -2,7 +2,6 @@
 
 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
 """
-import pytest
 
 from src.mdf.parser import parse_mdf
 
@@ -57,4 +56,28 @@ class TestExistingVaBehavior:
         assert record["va"] == ["wampu-", "wampum"], (
             "Existing 'va' list must contain ALL \\va values (headword + nested). "
             "This should PASS even before the change."
+        )
+
+
+class TestMultipleHeadwordVa:
+    """Edge case: multiple \\va values in headword block before any structural branching tag."""
+
+    def test_multiple_headword_va_captured(self):
+        """SC-P1-1: Multiple headword \\va values all captured in primary_va."""
+        mdf_data = """\\lx wampum
+\\va wampu-
+\\va wamp-
+\\ps N
+\\ge ball
+\\se
+\\va wampum
+\\ge sphere
+\\nt Record: 1"""
+        records = parse_mdf(mdf_data)
+        record = records[0]
+        assert record["primary_va"] == ["wampu-", "wamp-"], (
+            "All headword-block \\va values must be captured, not just the first."
+        )
+        assert record["va"] == ["wampu-", "wamp-", "wampum"], (
+            "Existing va list must still contain all values."
         )

--- a/test/test_upload_search_entries.py
+++ b/test/test_upload_search_entries.py
@@ -19,6 +19,7 @@ class TestUploadSearchEntriesRED(unittest.TestCase):
             cls.test_db_path = Path("tmp/test_upload_search_entries_red_db")
             if cls.test_db_path.exists():
                 import shutil
+
                 shutil.rmtree(cls.test_db_path)
             cls.test_db_path.mkdir(parents=True, exist_ok=True)
 
@@ -33,7 +34,7 @@ class TestUploadSearchEntriesRED(unittest.TestCase):
             Base.metadata.create_all(cls.engine)
             cls.Session = sessionmaker(bind=cls.engine)
         except ImportError:
-            raise unittest.SkipTest("pgserver not available")
+            raise unittest.SkipTest("pgserver not available") from None
 
     @classmethod
     def tearDownClass(cls):
@@ -41,6 +42,7 @@ class TestUploadSearchEntriesRED(unittest.TestCase):
             cls.pg_server.cleanup()
         if hasattr(cls, "test_db_path") and cls.test_db_path.exists():
             import shutil
+
             shutil.rmtree(cls.test_db_path)
 
     def setUp(self):
@@ -81,10 +83,14 @@ class TestUploadSearchEntriesRED(unittest.TestCase):
         from src.database.models.search import HeadwordSearchEntry
 
         rec = self._add_and_populate(
-            r"\lx wampuw" "\n"
-            r"\va wampu-" "\n"
-            r"\ge round object" "\n"
-            r"\se wampuw-" "\n"
+            r"\lx wampuw"
+            "\n"
+            r"\va wampu-"
+            "\n"
+            r"\ge round object"
+            "\n"
+            r"\se wampuw-"
+            "\n"
             r"  \va wampum"
         )
         entries = self.session.query(HeadwordSearchEntry).filter_by(record_id=rec.id).all()
@@ -98,9 +104,12 @@ class TestUploadSearchEntriesRED(unittest.TestCase):
         from src.database.models.search import GlossSearchEntry
 
         rec = self._add_and_populate(
-            r"\lx wampuw" "\n"
-            r"\ge ball" "\n"
-            r"\se wampuw-" "\n"
+            r"\lx wampuw"
+            "\n"
+            r"\ge ball"
+            "\n"
+            r"\se wampuw-"
+            "\n"
             r"  \ge sphere"
         )
         entries = self.session.query(GlossSearchEntry).filter_by(record_id=rec.id).all()
@@ -128,19 +137,21 @@ class TestUploadSearchEntriesRED(unittest.TestCase):
         from src.database.models.search import SearchEntry
 
         rec = self._add_and_populate(
-            r"\lx wampuw" "\n"
-            r"\va wampu-" "\n"
-            r"\ge round" "\n"
-            r"\se wampuw-" "\n"
-            r"\cf wampuch" "\n"
+            r"\lx wampuw"
+            "\n"
+            r"\va wampu-"
+            "\n"
+            r"\ge round"
+            "\n"
+            r"\se wampuw-"
+            "\n"
+            r"\cf wampuch"
+            "\n"
             r"\ve fire"
         )
         entries = self.session.query(SearchEntry).filter_by(record_id=rec.id).all()
         types = sorted([e.entry_type for e in entries])
-        self.assertEqual(
-            types, ["cf", "lx", "se", "va", "ve"],
-            "SearchEntry must contain ALL entry types (unchanged)"
-        )
+        self.assertEqual(types, ["cf", "lx", "se", "va", "ve"], "SearchEntry must contain ALL entry types (unchanged)")
 
 
 if __name__ == "__main__":

--- a/test/test_upload_search_entries.py
+++ b/test/test_upload_search_entries.py
@@ -1,0 +1,147 @@
+import unittest
+from pathlib import Path
+
+from src.services.upload_service import UploadService
+
+
+class TestUploadSearchEntriesRED(unittest.TestCase):
+    """RED-phase tests for Phase 2: headword-block state for search entry population."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import pgserver
+            from sqlalchemy import create_engine, text
+            from sqlalchemy.orm import sessionmaker
+
+            from src.database.base import Base
+
+            cls.test_db_path = Path("tmp/test_upload_search_entries_red_db")
+            if cls.test_db_path.exists():
+                import shutil
+                shutil.rmtree(cls.test_db_path)
+            cls.test_db_path.mkdir(parents=True, exist_ok=True)
+
+            cls.pg_server = pgserver.get_server(str(cls.test_db_path))
+            cls.db_url = cls.pg_server.get_uri()
+            cls.engine = create_engine(cls.db_url)
+
+            with cls.engine.connect() as conn:
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+                conn.commit()
+
+            Base.metadata.create_all(cls.engine)
+            cls.Session = sessionmaker(bind=cls.engine)
+        except ImportError:
+            raise unittest.SkipTest("pgserver not available")
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "pg_server"):
+            cls.pg_server.cleanup()
+        if hasattr(cls, "test_db_path") and cls.test_db_path.exists():
+            import shutil
+            shutil.rmtree(cls.test_db_path)
+
+    def setUp(self):
+        from src.database.models.core import Language, Record, Source
+        from src.database.models.identity import User
+        from src.database.models.search import GlossSearchEntry, HeadwordSearchEntry, SearchEntry
+
+        self.session = self.Session()
+        self.session.query(GlossSearchEntry).delete()
+        self.session.query(HeadwordSearchEntry).delete()
+        self.session.query(SearchEntry).delete()
+        self.session.query(Record).delete()
+
+        if not self.session.query(User).filter_by(email="test@example.com").first():
+            self.session.add(User(email="test@example.com", username="tester", github_id=1))
+        if not self.session.query(Source).filter_by(name="Test Source").first():
+            self.session.add(Source(name="Test Source"))
+        if not self.session.query(Language).filter_by(code="alg").first():
+            self.session.add(Language(code="alg", name="Algonquian"))
+        self.session.commit()
+        self.source_id = self.session.query(Source).filter_by(name="Test Source").first().id
+
+    def tearDown(self):
+        self.session.close()
+
+    def _add_and_populate(self, mdf_data):
+        from src.database.models.core import Record
+
+        rec = Record(lx="entry", source_id=self.source_id, mdf_data=mdf_data)
+        self.session.add(rec)
+        self.session.commit()
+        UploadService.populate_search_entries([rec.id], session=self.session)
+        return rec
+
+    # --- Item 2.1: HeadwordSearchEntry uses primary_va (SC-3) ---
+    def test_headword_va_excludes_nested_va(self):
+        """SC-3: HeadwordSearchEntry va must use primary_va, excluding nested va values."""
+        from src.database.models.search import HeadwordSearchEntry
+
+        rec = self._add_and_populate(
+            r"\lx wampuw" "\n"
+            r"\va wampu-" "\n"
+            r"\ge round object" "\n"
+            r"\se wampuw-" "\n"
+            r"  \va wampum"
+        )
+        entries = self.session.query(HeadwordSearchEntry).filter_by(record_id=rec.id).all()
+        terms = [e.term for e in entries]
+        self.assertIn("wampu-", terms, "Primary headword va should be in HeadwordSearchEntry")
+        self.assertNotIn("wampum", terms, "Nested subentry va must NOT be in HeadwordSearchEntry")
+
+    # --- Item 2.2: GlossSearchEntry uses in_headword_block state (SC-5, SC-23) ---
+    def test_gloss_ge_excludes_nested_ge(self):
+        """SC-5, SC-23: GlossSearchEntry ge must use headword-block ge, excluding nested ge values."""
+        from src.database.models.search import GlossSearchEntry
+
+        rec = self._add_and_populate(
+            r"\lx wampuw" "\n"
+            r"\ge ball" "\n"
+            r"\se wampuw-" "\n"
+            r"  \ge sphere"
+        )
+        entries = self.session.query(GlossSearchEntry).filter_by(record_id=rec.id).all()
+        terms = [e.term for e in entries]
+        self.assertIn("ball", terms, "Primary headword ge should be in GlossSearchEntry")
+        self.assertNotIn("sphere", terms, "Nested subentry ge must NOT be in GlossSearchEntry")
+
+    # --- Item 2.3: Skip records missing \lx for HeadwordSearchEntry (SC-26) ---
+    def test_no_lx_no_headword_entry(self):
+        """SC-26: Record without lx must not create HeadwordSearchEntry."""
+        from src.database.models.core import Record
+        from src.database.models.search import HeadwordSearchEntry
+
+        mdf_data = r"\ge orphan gloss" "\n" r"\ps n"
+        rec = Record(lx="", source_id=self.source_id, mdf_data=mdf_data)
+        self.session.add(rec)
+        self.session.commit()
+        UploadService.populate_search_entries([rec.id], session=self.session)
+        count = self.session.query(HeadwordSearchEntry).filter_by(record_id=rec.id).count()
+        self.assertEqual(count, 0, "Record without lx must not create HeadwordSearchEntry")
+
+    # --- Item 2.4: SearchEntry population is unchanged (SC-4) ---
+    def test_search_entry_unchanged(self):
+        """SC-4: SearchEntry must still contain ALL values including nested ones."""
+        from src.database.models.search import SearchEntry
+
+        rec = self._add_and_populate(
+            r"\lx wampuw" "\n"
+            r"\va wampu-" "\n"
+            r"\ge round" "\n"
+            r"\se wampuw-" "\n"
+            r"\cf wampuch" "\n"
+            r"\ve fire"
+        )
+        entries = self.session.query(SearchEntry).filter_by(record_id=rec.id).all()
+        types = sorted([e.entry_type for e in entries])
+        self.assertEqual(
+            types, ["cf", "lx", "se", "va", "ve"],
+            "SearchEntry must contain ALL entry types (unchanged)"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 2 implementation for #400 — Backend Indexing Logic for Headword and Gloss Search Modes.

## Changes

**Phase 1: Parser (`src/mdf/parser.py`)**
- Add `primary_va` field to parsed record — captures only headword-block `\va` values (before structural branching tags `\se`, `\sn`, `\xv`)
- Existing `va` list unchanged (still contains ALL `\va` values including nested)

**Phase 2: Upload Service (`src/services/upload_service.py`)**
- `populate_search_entries()` uses `entry.get("primary_va", [])` for HeadwordSearchEntry `\va` population (SC-3)
- Wraps `parse_mdf()` in try/except ValueError to gracefully skip records without `\lx` (SC-26)
- GlossSearchEntry already indexed only first `\ge` via existing parser behavior (SC-5, SC-23)

**Tests**
- `test/test_parser_headword_block.py` — 4 tests for parser `primary_va` field
- `test/test_upload_search_entries.py` — 4 tests for search entry population

## Success Criteria

| SC | Criterion | Status |
|----|-----------|--------|
| SC-3 | Headword excludes nested va — "wampu-" returns 0 records | ✅ PASS |
| SC-5 | Gloss excludes nested ge — "ball" returns 0 records | ✅ PASS |
| SC-23 | Gloss indexes only first ge at headword level | ✅ PASS |
| SC-26 | Records missing \lx excluded from headword results | ✅ PASS |

## Pipeline

Full 16-step implementation pipeline executed for both phases: coherence gate → pre-red-baseline → RED → GREEN → structural checks → VbC → dual-auditor adversarial audit (2/2 consensus PASS) → cross-validate → regression checks.

---

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)