### PR TITLE
[#1305] Phase 4 — Backend Search Logic: Strategy-Dispatch for Headword/Gloss Modes

### DIFF
--- a/src/services/linguistic_service.py
+++ b/src/services/linguistic_service.py
@@ -569,42 +569,10 @@ class LinguisticService:
                             query = query.filter(Record.source_id == source_id)
 
                         if search_term:
-                            if search_mode == "Lexeme":
-                                # Normalize search term for punctuation, case, diacritics, and quotes
-                                norm_search = LinguisticService.generate_sort_lx(search_term)
-
-                                # If search term exists but normalizes to nothing (e.g. "10"),
-                                # we should return no results instead of matching everything.
-                                if search_term.strip() and not norm_search:
-                                    query = query.filter(Record.id == -1)
-                                else:
-                                    # Infix matching for better discovery (contains)
-                                    query = (
-                                        query.join(Record.search_entries)
-                                        .filter(SearchEntry.normalized_term.ilike(f"%{norm_search}%"))
-                                        .distinct()
-                                    )
-                            else:
-                                from sqlalchemy import text
-
-                                if search_term.startswith("#") and search_term[1:].isdigit():
-                                    query = query.filter(Record.id == int(search_term[1:]))
-                                else:
-                                    norm_search = LinguisticService.generate_sort_lx(search_term)
-                                    words = [
-                                        clean
-                                        for w in norm_search.split()
-                                        if (clean := _TSQUERY_UNSAFE.sub("", w).strip())
-                                    ]
-                                    if words:
-                                        fts_query = " & ".join([f"{w}:*" for w in words])
-                                        query = (
-                                            query.join(Record.fts_entry)
-                                            .filter(text("fts_entries.fts_vector @@ to_tsquery('simple', :fts_term)"))
-                                            .params(fts_term=fts_query)
-                                        )
-                                    else:
-                                        query = query.filter(Record.id == -1)
+                            strategy = _search_strategies.get(search_mode)
+                            if strategy is None:
+                                raise ValueError(f"Unknown search mode: {search_mode}")
+                            query = strategy(query, search_term)
 
                     query = query.order_by(Record.source_id, Record.sort_lx, Record.hm)
 

--- a/src/services/linguistic_service.py
+++ b/src/services/linguistic_service.py
@@ -46,9 +46,11 @@ def _search_fts(query, search_term: str):
     words = [clean for w in norm_search.split() if (clean := _TSQUERY_UNSAFE.sub("", w).strip())]
     if words:
         fts_query = " & ".join([f"{w}:*" for w in words])
-        return query.join(Record.fts_entry).filter(
-            text("fts_entries.fts_vector @@ to_tsquery('simple', :fts_term)")
-        ).params(fts_term=fts_query)
+        return (
+            query.join(Record.fts_entry)
+            .filter(text("fts_entries.fts_vector @@ to_tsquery('simple', :fts_term)"))
+            .params(fts_term=fts_query)
+        )
     return query.filter(Record.id == -1)
 
 
@@ -511,37 +513,10 @@ class LinguisticService:
                     query = query.filter(Record.source_id == source_id)
 
                 if search_term:
-                    if search_mode == "Lexeme":
-                        # Normalize search term for punctuation, case, diacritics, and quotes
-                        norm_search = LinguisticService.generate_sort_lx(search_term)
-
-                        # If search term exists but normalizes to nothing (e.g. "10"),
-                        # we should return no results instead of matching everything.
-                        if search_term.strip() and not norm_search:
-                            query = query.filter(Record.id == -1)
-                        else:
-                            # We need to join SearchEntry but we want to keep the column projection
-                            # Infix matching for better discovery (contains)
-                            query = (
-                                query.join(Record.search_entries)
-                                .filter(SearchEntry.normalized_term.ilike(f"%{norm_search}%"))
-                                .distinct()
-                            )
-                    else:
-                        from sqlalchemy import text
-
-                        if search_term.startswith("#") and search_term[1:].isdigit():
-                            query = query.filter(Record.id == int(search_term[1:]))
-                        else:
-                            norm_search = LinguisticService.generate_sort_lx(search_term)
-                            words = [clean for w in norm_search.split() if (clean := _TSQUERY_UNSAFE.sub("", w).strip())]
-                            if words:
-                                fts_query = " & ".join([f"{w}:*" for w in words])
-                                query = query.join(Record.fts_entry).filter(
-                                    text("fts_entries.fts_vector @@ to_tsquery('simple', :fts_term)")
-                                ).params(fts_term=fts_query)
-                            else:
-                                query = query.filter(Record.id == -1)
+                    strategy = _search_strategies.get(search_mode)
+                    if strategy is None:
+                        raise ValueError(f"Unknown search mode: {search_mode}")
+                    query = strategy(query, search_term)
 
             # Efficient Sorting: source_id, sort_lx (NFD/No-Punct), hm, ps, ge
             query = query.order_by(Record.source_id, Record.sort_lx, Record.hm)
@@ -616,12 +591,18 @@ class LinguisticService:
                                     query = query.filter(Record.id == int(search_term[1:]))
                                 else:
                                     norm_search = LinguisticService.generate_sort_lx(search_term)
-                                    words = [clean for w in norm_search.split() if (clean := _TSQUERY_UNSAFE.sub("", w).strip())]
+                                    words = [
+                                        clean
+                                        for w in norm_search.split()
+                                        if (clean := _TSQUERY_UNSAFE.sub("", w).strip())
+                                    ]
                                     if words:
                                         fts_query = " & ".join([f"{w}:*" for w in words])
-                                        query = query.join(Record.fts_entry).filter(
-                                            text("fts_entries.fts_vector @@ to_tsquery('simple', :fts_term)")
-                                        ).params(fts_term=fts_query)
+                                        query = (
+                                            query.join(Record.fts_entry)
+                                            .filter(text("fts_entries.fts_vector @@ to_tsquery('simple', :fts_term)"))
+                                            .params(fts_term=fts_query)
+                                        )
                                     else:
                                         query = query.filter(Record.id == -1)
 

--- a/tests/services/test_linguistic_service.py
+++ b/tests/services/test_linguistic_service.py
@@ -179,6 +179,7 @@ class TestLinguisticService(unittest.TestCase):
 
     def test_search_records_fts(self):
         from sqlalchemy import func
+
         from src.database.models.search import FTSEntry
 
         r1 = Record(lx="dog", ge="canine", source_id=self.source_id, mdf_data="\\lx dog\n\\nt some note")
@@ -186,7 +187,7 @@ class TestLinguisticService(unittest.TestCase):
         self.session.commit()
 
         norm_mdf = LinguisticService.generate_sort_lx(r1.mdf_data)
-        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector('simple', norm_mdf)))
+        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector("simple", norm_mdf)))
         self.session.commit()
 
         with self._patch_session():
@@ -589,9 +590,7 @@ class TestLinguisticService(unittest.TestCase):
 
     def test_search_records_headword_finds_primary_lx(self):
         """SC-1: Headword search finds primary lx — 'wampuw' returns exactly 1 record."""
-        r1 = Record(
-            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
-        )
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
         self.session.add(r1)
         self.session.commit()
 
@@ -652,9 +651,7 @@ class TestLinguisticService(unittest.TestCase):
 
     def test_search_records_gloss_finds_primary_ge(self):
         """SC-4: Gloss search finds primary ge — 'round object' returns exactly 1 record."""
-        r1 = Record(
-            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
-        )
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
         self.session.add(r1)
         self.session.commit()
 
@@ -690,9 +687,7 @@ class TestLinguisticService(unittest.TestCase):
 
     def test_search_records_gloss_excludes_headword(self):
         """SC-6: Gloss excludes headword — 'wampuw' returns 0 records."""
-        r1 = Record(
-            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
-        )
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
         self.session.add(r1)
         self.session.commit()
 
@@ -708,9 +703,7 @@ class TestLinguisticService(unittest.TestCase):
 
     def test_search_records_lexeme_mode_unchanged(self):
         """SC-7: Lexeme mode UNCHANGED — all variants returned, no entry_type filter."""
-        r1 = Record(
-            lx="run", ge="to move fast", source_id=self.source_id, mdf_data="\\lx run\n\\va ran"
-        )
+        r1 = Record(lx="run", ge="to move fast", source_id=self.source_id, mdf_data="\\lx run\n\\va ran")
         self.session.add(r1)
         self.session.commit()
 
@@ -728,6 +721,7 @@ class TestLinguisticService(unittest.TestCase):
     def test_search_records_fts_mode_unchanged(self):
         """SC-8: FTS mode UNCHANGED — no changes to FTS logic."""
         from sqlalchemy import func
+
         from src.database.models.search import FTSEntry
 
         r1 = Record(lx="dog", ge="canine", source_id=self.source_id, mdf_data="\\lx dog\n\\nt some note")
@@ -735,7 +729,7 @@ class TestLinguisticService(unittest.TestCase):
         self.session.commit()
 
         norm_mdf = LinguisticService.generate_sort_lx(r1.mdf_data)
-        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector('simple', norm_mdf)))
+        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector("simple", norm_mdf)))
         self.session.commit()
 
         with self._patch_session():
@@ -747,9 +741,7 @@ class TestLinguisticService(unittest.TestCase):
         """SC-14: Search performance < 500ms for all modes."""
         import time
 
-        r1 = Record(
-            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
-        )
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
         self.session.add(r1)
         self.session.commit()
 
@@ -769,9 +761,7 @@ class TestLinguisticService(unittest.TestCase):
 
     def test_search_records_empty_input(self):
         """SC-24: Empty search input returns all records without error/crash."""
-        r1 = Record(
-            lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object"
-        )
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
         self.session.add(r1)
         self.session.commit()
 
@@ -810,6 +800,72 @@ class TestLinguisticService(unittest.TestCase):
         for doc in expected_docs:
             self.assertIn(doc, agents_content, f"AGENTS.md missing link to {doc}")
 
+    def test_export_headword_mode(self):
+        """SC-28: get_all_records_for_export() Headword mode returns correct results."""
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
+        self.session.add(r1)
+        self.session.commit()
+
+        hse_lx = HeadwordSearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        hse_va = HeadwordSearchEntry(record_id=r1.id, term="wampu", normalized_term="wampu", entry_type="va")
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        self.session.add_all([hse_lx, hse_va, gse])
+        self.session.commit()
+
+        with self._patch_session():
+            records = LinguisticService.get_all_records_for_export(search_term="wampuw", search_mode="Headword")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["lx"], "wampuw")
+
+    def test_export_gloss_mode(self):
+        """SC-29: get_all_records_for_export() Gloss mode returns correct results."""
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
+        self.session.add(r1)
+        self.session.commit()
+
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        self.session.add(gse)
+        self.session.commit()
+
+        with self._patch_session():
+            records = LinguisticService.get_all_records_for_export(search_term="round object", search_mode="Gloss")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["lx"], "wampuw")
+
+    def test_export_lexeme_mode_unchanged(self):
+        """SC-32: get_all_records_for_export() Lexeme mode UNCHANGED — regression guard."""
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
+        self.session.add(r1)
+        self.session.commit()
+
+        se = SearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        self.session.add(se)
+        self.session.commit()
+
+        with self._patch_session():
+            records = LinguisticService.get_all_records_for_export(search_term="wampuw", search_mode="Lexeme")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["lx"], "wampuw")
+
+    def test_export_fts_mode_unchanged(self):
+        """SC-34: get_all_records_for_export() FTS mode UNCHANGED — regression guard."""
+        from sqlalchemy import func
+
+        from src.database.models.search import FTSEntry
+
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
+        self.session.add(r1)
+        self.session.commit()
+
+        norm_mdf = LinguisticService.generate_sort_lx(r1.mdf_data)
+        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector("simple", norm_mdf)))
+        self.session.commit()
+
+        with self._patch_session():
+            records = LinguisticService.get_all_records_for_export(search_term="wampuw", search_mode="FTS")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["lx"], "wampuw")
+
     def test_search_records_special_characters(self):
         """SC-25: Special characters no crash or SQL injection."""
         r1 = Record(lx="safe", ge="test", source_id=self.source_id, mdf_data="\\lx safe")
@@ -835,8 +891,9 @@ class TestLinguisticService(unittest.TestCase):
     def test_ftsentry_model_schema(self):
         """Phase 2: Verify FTSEntry model exists with correct schema."""
         from sqlalchemy.inspection import inspect
-        from src.database.models.search import FTSEntry
+
         from src.database.models.core import Record
+        from src.database.models.search import FTSEntry
 
         self.assertEqual(FTSEntry.__tablename__, "fts_entries")
 
@@ -883,15 +940,15 @@ class TestLinguisticService(unittest.TestCase):
     def test_search_records_fts_normalized(self):
         """SC-8: FTS with normalized text — diacritics in mdf_data, search normalized form."""
         from sqlalchemy import func
+
         from src.database.models.search import FTSEntry
 
-        r1 = Record(lx="akitusu-", ge="test", source_id=self.source_id,
-                    mdf_data="\\lx akitusu-\n\\ge test")
+        r1 = Record(lx="akitusu-", ge="test", source_id=self.source_id, mdf_data="\\lx akitusu-\n\\ge test")
         self.session.add(r1)
         self.session.commit()
 
         norm_mdf = LinguisticService.generate_sort_lx(r1.mdf_data)
-        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector('simple', norm_mdf)))
+        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector("simple", norm_mdf)))
         self.session.commit()
 
         with self._patch_session():
@@ -902,15 +959,15 @@ class TestLinguisticService(unittest.TestCase):
     def test_search_records_fts_infinity_symbol(self):
         """SC-8: FTS with infinity symbol in mdf_data, search via pooy prefix."""
         from sqlalchemy import func
+
         from src.database.models.search import FTSEntry
 
-        r1 = Record(lx="pooy∞", ge="test", source_id=self.source_id,
-                    mdf_data="\\lx pooy∞\\ge test")
+        r1 = Record(lx="pooy∞", ge="test", source_id=self.source_id, mdf_data="\\lx pooy∞\\ge test")
         self.session.add(r1)
         self.session.commit()
 
         norm_mdf = LinguisticService.generate_sort_lx(r1.mdf_data)
-        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector('simple', norm_mdf)))
+        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector("simple", norm_mdf)))
         self.session.commit()
 
         with self._patch_session():
@@ -928,18 +985,20 @@ class TestLinguisticService(unittest.TestCase):
         # to "99problems" which matches via tsquery prefix match.
         # Instead, use a term that to_tsvector('simple') does NOT index as a lexeme:
         # punctuation-only strings like "!!!" are not word tokens.
-        r1 = Record(lx="secret", ge="hidden", source_id=self.source_id,
-                    mdf_data="\\lx secret\n\\nt some text !!!")
+        r1 = Record(lx="secret", ge="hidden", source_id=self.source_id, mdf_data="\\lx secret\n\\nt some text !!!")
         self.session.add(r1)
         self.session.commit()
 
         norm_mdf = LinguisticService.generate_sort_lx(r1.mdf_data)
         from sqlalchemy import func
-        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector('simple', norm_mdf)))
+
+        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector("simple", norm_mdf)))
         self.session.commit()
 
         with self._patch_session():
             # "!!!" is not a tsvector token, so FTS returns no results.
             # The old code had an ILIKE fallback that would match "!!!" in raw mdf_data.
             result = LinguisticService.search_records(search_term="!!!", search_mode="FTS")
-        self.assertEqual(len(result.records), 0, "Punctuation-only term should not match via FTS without ILIKE fallback")
+        self.assertEqual(
+            len(result.records), 0, "Punctuation-only term should not match via FTS without ILIKE fallback"
+        )

--- a/tests/services/test_linguistic_service.py
+++ b/tests/services/test_linguistic_service.py
@@ -866,6 +866,102 @@ class TestLinguisticService(unittest.TestCase):
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["lx"], "wampuw")
 
+    def test_stream_headword_mode(self):
+        """SC-30: stream_records_to_temp_file() Headword mode returns correct results."""
+        import os
+
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
+        self.session.add(r1)
+        self.session.commit()
+
+        hse_lx = HeadwordSearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        hse_va = HeadwordSearchEntry(record_id=r1.id, term="wampu", normalized_term="wampu", entry_type="va")
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        self.session.add_all([hse_lx, hse_va, gse])
+        self.session.commit()
+
+        with self._patch_session():
+            temp_path = LinguisticService.stream_records_to_temp_file(search_term="wampuw", search_mode="Headword")
+            try:
+                self.assertTrue(os.path.exists(temp_path))
+                with open(temp_path, encoding="utf-8") as f:
+                    content = f.read()
+                self.assertIn("\\lx wampuw", content)
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+
+    def test_stream_gloss_mode(self):
+        """SC-31: stream_records_to_temp_file() Gloss mode returns correct results."""
+        import os
+
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
+        self.session.add(r1)
+        self.session.commit()
+
+        gse = GlossSearchEntry(record_id=r1.id, term="round object", normalized_term="round object")
+        self.session.add(gse)
+        self.session.commit()
+
+        with self._patch_session():
+            temp_path = LinguisticService.stream_records_to_temp_file(search_term="round object", search_mode="Gloss")
+            try:
+                self.assertTrue(os.path.exists(temp_path))
+                with open(temp_path, encoding="utf-8") as f:
+                    content = f.read()
+                self.assertIn("\\lx wampuw", content)
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+
+    def test_stream_lexeme_mode_unchanged(self):
+        """SC-33: stream_records_to_temp_file() Lexeme mode UNCHANGED — regression guard."""
+        import os
+
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
+        self.session.add(r1)
+        self.session.commit()
+
+        se = SearchEntry(record_id=r1.id, term="wampuw", normalized_term="wampuw", entry_type="lx")
+        self.session.add(se)
+        self.session.commit()
+
+        with self._patch_session():
+            temp_path = LinguisticService.stream_records_to_temp_file(search_term="wampuw", search_mode="Lexeme")
+            try:
+                self.assertTrue(os.path.exists(temp_path))
+                with open(temp_path, encoding="utf-8") as f:
+                    content = f.read()
+                self.assertIn("\\lx wampuw", content)
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+
+    def test_stream_fts_mode_unchanged(self):
+        """SC-35: stream_records_to_temp_file() FTS mode UNCHANGED — regression guard."""
+        import os
+        from sqlalchemy import func
+        from src.database.models.search import FTSEntry
+
+        r1 = Record(lx="wampuw", ge="round object", source_id=self.source_id, mdf_data="\\lx wampuw\n\\ge round object")
+        self.session.add(r1)
+        self.session.commit()
+
+        norm_mdf = LinguisticService.generate_sort_lx(r1.mdf_data)
+        self.session.add(FTSEntry(record_id=r1.id, fts_vector=func.to_tsvector("simple", norm_mdf)))
+        self.session.commit()
+
+        with self._patch_session():
+            temp_path = LinguisticService.stream_records_to_temp_file(search_term="wampuw", search_mode="FTS")
+            try:
+                self.assertTrue(os.path.exists(temp_path))
+                with open(temp_path, encoding="utf-8") as f:
+                    content = f.read()
+                self.assertIn("\\lx wampuw", content)
+            finally:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+
     def test_search_records_special_characters(self):
         """SC-25: Special characters no crash or SQL injection."""
         r1 = Record(lx="safe", ge="test", source_id=self.source_id, mdf_data="\\lx safe")


### PR DESCRIPTION
## Summary

Refactor `get_all_records_for_export()` and `stream_records_to_temp_file()` to use the same `_search_strategies` dictionary dispatch pattern already used by `search_records()`. Both methods had inline `if/else` branching that only handled Lexeme and FTS — Headword and Gloss modes silently fell through to the FTS branch, producing incorrect results.

## Outcome

| Method | Before | After |
|--------|--------|-------|
| `search_records()` | ✅ `_search_strategies` dispatch | ✅ Unchanged |
| `get_all_records_for_export()` | ❌ Inline `if/else` (Lexeme/FTS only) | ✅ `_search_strategies` dispatch |
| `stream_records_to_temp_file()` | ❌ Inline `if/else` (Lexeme/FTS only) | ✅ `_search_strategies` dispatch |

## SCs Addressed

| SC | Criterion | Status |
|----|-----------|--------|
| SC-28 | `get_all_records_for_export()` Headword mode | ✅ PASS |
| SC-29 | `get_all_records_for_export()` Gloss mode | ✅ PASS |
| SC-30 | `stream_records_to_temp_file()` Headword mode | ✅ PASS |
| SC-31 | `stream_records_to_temp_file()` Gloss mode | ✅ PASS |
| SC-32 | `get_all_records_for_export()` Lexeme UNCHANGED | ✅ PASS |
| SC-33 | `stream_records_to_temp_file()` Lexeme UNCHANGED | ✅ PASS |
| SC-34 | `get_all_records_for_export()` FTS UNCHANGED | ✅ PASS |
| SC-35 | `stream_records_to_temp_file()` FTS UNCHANGED | ✅ PASS |

## Changes

- `src/services/linguistic_service.py`: 77 lines removed (inline if/else replaced with 6-line dispatch block in each method)
- `tests/services/test_linguistic_service.py`: 8 new test functions (4 export, 4 stream) + existing test updates
- No changes to strategy functions (lines 31-74), dispatch dict (lines 77-82), column projection, or `yield_per(1000)`

## Verification

- 49/49 tests pass in `test_linguistic_service.py`
- Dual-family adversarial audit (qwen3.5 + deepseek-flash): PASS
- Checkpoint tag: `snea-shoebox-editor/checkpoint/1305/phase-4-snea-shoebox-editor`

Fixes #1305

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)