### PR TITLE
[#1316] Add migration for sequences + conftest for integration test migrations + fix #1313

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # AGENTS.md — Repository Guidelines for Coding Agents
 
+## Regression Test Protocol
+
+Before every regression test cycle, the local database MUST be re-synced from production:
+
+```bash
+bash scripts/sync_prod_to_local.sh
+```
+
+This ensures the test runs against a fresh exact replica of production data. The sync script MUST be the one from the feature branch under test, not from `dev` or `main`. Running against stale or branch-mismatched data produces invalid test results.
+
 ## Research Catalog
 
 Before making changes to search infrastructure, text normalization, FTS configuration, or regex processing linguistic data, consult `docs/lessons-learned/` for relevant research findings and design decisions.

--- a/scripts/sync_prod_to_local.py
+++ b/scripts/sync_prod_to_local.py
@@ -2,14 +2,25 @@
 """
 sync_prod_to_local.py — Production-to-local database sync script.
 
-Creates an exact schema+data replica of the production PostgreSQL database (Aiven)
-in the local development database (pgserver), replacing all local data.
+MANDATE: FAITHFUL EXACT COPY ONLY
+==================================
+This script MUST produce an EXACT schema+data replica of the production
+PostgreSQL database. NO "fixing", "adjustments", "optimizations", or any
+other modifications to the production schema or data are permitted.
+
+The production database is the single source of truth. The local copy
+must match it byte-for-byte in schema and row-for-row in data. Any
+deviation makes migration testing unreliable.
+
+If the local database needs schema changes that production does not
+have (e.g., sequences for ORM autoincrement), those changes MUST be
+handled by the migration system (MigrationManager), NOT by this script.
 
 Strategy
 --------
-Introspects production's actual schema via pg_catalog and replicates it faithfully —
-including generated columns, all indexes — then copies production data while
-skipping generated columns in INSERT statements.
+Introspects production's actual schema via pg_catalog and replicates it
+faithfully — including generated columns, all indexes — then copies
+production data while skipping generated columns in INSERT statements.
 """
 
 import os

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -1020,6 +1020,9 @@ class MigrationManager:
         Session = sessionmaker(bind=self._engine)
         session = Session()
         try:
+            # Truncate first to ensure idempotency — migration may be re-run
+            # against a database that already has fts_entries (e.g. after sync).
+            session.execute(text("TRUNCATE fts_entries"))
             records = session.query(Record).filter(Record.is_deleted == False).all()
             logger.info(f"Populating fts_entries for {len(records)} records...")
             for record in records:

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -115,6 +115,11 @@ class MigrationManager:
             "Add entry_type index and CHECK constraint to headword_search_entries",
         ),
         (
+            20260415000000,
+            "_migrate_ensure_sequences",
+            "Create sequences for tables missing autoincrement to match ORM expectations",
+        ),
+        (
             20260511000001,
             "_migrate_dedup_search_entries",
             "Deduplicate search_entries: keep one row per (record_id, term, entry_type), add unique index",
@@ -912,6 +917,41 @@ class MigrationManager:
                     "ALTER TABLE headword_search_entries ADD CONSTRAINT chk_headword_entry_type CHECK (entry_type IN ('lx', 'va'));"
                 )
             )
+            conn.commit()
+
+    def _migrate_ensure_sequences(self):
+        """Migration 20260415000000: Create sequences for tables missing autoincrement.
+
+        Production DDL uses plain integer NOT NULL for id columns on most tables
+        (no SERIAL, no IDENTITY, no DEFAULT nextval). The ORM models declare
+        autoincrement=True. This migration creates sequences for all tables that
+        have an integer id column but no associated sequence, and sets the column
+        default to nextval().
+        """
+        with self._engine.connect() as conn:
+            tables = [
+                r[0]
+                for r in conn.execute(
+                    text("SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname='public'")
+                ).fetchall()
+            ]
+            for tname in tables:
+                seq = conn.execute(text("SELECT pg_get_serial_sequence(:t, 'id')"), {"t": tname}).scalar()
+                if seq:
+                    continue
+                has_int_id = conn.execute(
+                    text(
+                        "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+                        "WHERE table_name = :t AND column_name = 'id' AND data_type = 'integer')"
+                    ),
+                    {"t": tname},
+                ).scalar()
+                if has_int_id:
+                    seq_name = f"{tname}_id_seq"
+                    conn.execute(text(f"CREATE SEQUENCE IF NOT EXISTS {seq_name}"))
+                    max_id = conn.execute(text(f"SELECT COALESCE(MAX(id), 0) FROM {tname}")).scalar()
+                    conn.execute(text(f"ALTER SEQUENCE {seq_name} RESTART WITH {max_id + 1}"))
+                    conn.execute(text(f"ALTER TABLE {tname} ALTER COLUMN id SET DEFAULT nextval('{seq_name}')"))
             conn.commit()
 
     def _migrate_create_gloss_search_entries(self):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,16 @@
+"""Session-scoped conftest: run pending migrations before any integration test."""
+
+import pytest
+from sqlalchemy import create_engine
+
+from src.database.connection import _get_local_db_path, _start_pgserver_core
+from src.database.migrations import MigrationManager
+
+
+@pytest.fixture(scope="session", autouse=True)
+def run_migrations():
+    """Run all pending migrations before any integration test connects."""
+    db_path = _get_local_db_path()
+    uri = _start_pgserver_core(db_path)
+    engine = create_engine(uri)
+    MigrationManager(engine).run_all()

--- a/tests/integration/test_language_assignment.py
+++ b/tests/integration/test_language_assignment.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import sessionmaker
 from src.database.base import Base
 from src.database.models.core import Language, Record, RecordLanguage, Source
 from src.database.models.identity import User
+from src.database.models.iso639 import ISO639_3
 from src.database.models.workflow import MatchupQueue
 from src.services.upload_service import UploadService
 


### PR DESCRIPTION
## Summary

Four stacked fixes to make the integration test suite a reliable PR gate:

1. **Migration `20260415000000`** — Creates sequences for all 14 tables with `id integer NOT NULL` that lack one. Production DDL uses plain integer IDs (no SERIAL/IDENTITY), but the ORM declares `autoincrement=True`. The migration bridges this gap so ORM inserts work after syncing from production.

2. **`tests/integration/conftest.py`** — Session-scoped autouse fixture that runs `MigrationManager.run_all()` before any integration test connects. Previously, tests connected to the synced database at production schema version without applying pending dev migrations.

3. **Fix #1313** — Move `ISO639_3` import to top of `test_language_assignment.py` so the table is created by `Base.metadata.create_all()`.

4. **Fix #1319** — Add `TRUNCATE fts_entries` to `_migrate_replace_fts_vector` so the migration is idempotent when re-run against a database that already has fts_entries.

5. **Sync script mandate** — Header comment explicitly prohibiting any "fixing", "adjustments", or "optimizations" — the script must produce an exact copy only.

6. **AGENTS.md** — Regression Test Protocol requiring re-sync from production before every test cycle, using the feature branch's sync script.

## Changes

| File | Change |
|------|--------|
| `src/database/migrations.py` | Add `_migrate_ensure_sequences()` at version `20260415000000`; add TRUNCATE to `_migrate_replace_fts_vector` |
| `scripts/sync_prod_to_local.py` | Add FAITHFUL EXACT COPY ONLY mandate header |
| `tests/integration/conftest.py` | NEW — session-scoped migration runner |
| `tests/integration/test_language_assignment.py` | Fix #1313: ISO import order |
| `AGENTS.md` | Add Regression Test Protocol |

## Verification

- 9/9 integration tests pass (first time ever)
- Migration is idempotent (verified by running twice)
- fts_entries migration is idempotent (TRUNCATE before INSERT)
- All 330 unit tests pass

Fixes #1316, #1313, #1317, #1319

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)