### PR TITLE
feat(records): replace Focused/Broad labels with dynamic search mode caption

### DIFF
--- a/src/frontend/pages/records.py
+++ b/src/frontend/pages/records.py
@@ -195,8 +195,13 @@ def records():
             on_change=on_search_change,
         )
 
-        # Search Mode: Vertical Radio with Focused/Broad Grouping
-        st.markdown("**── Focused ──**")
+        # Search Mode: Vertical Radio with Dynamic Caption
+        SEARCH_MODE_CAPTIONS = {
+            "Headword": "Algonquian headwords and variants (\\lx, \\va)",
+            "Gloss": "Primary English glosses (\\ge)",
+            "Lexeme": "All Algonquian terms",
+            "FTS": "Every field",
+        }
         st.radio(
             "Search Mode",
             ["Headword", "Gloss", "Lexeme", "FTS"],
@@ -205,10 +210,7 @@ def records():
             label_visibility="collapsed",
             on_change=on_mode_change,
         )
-        st.markdown("**── Broad ──**")
-        st.markdown(
-            "HW: \\lx+\\va (primary) | Gloss: \\ge (primary) | LX: all markers | FTS: all fields",
-        )
+        st.caption(SEARCH_MODE_CAPTIONS.get(st.session_state.search_mode, ""))
         if st.button("", icon="🔍", key="search_trigger", help="Execute Search", use_container_width=True):
             on_search_change()
             st.rerun()


### PR DESCRIPTION
Replace static "── Focused ──" / "── Broad ──" group labels and dense help-text block with a single dynamic caption below the search-mode radio group.

**Before:**
- "── Focused ──" label above Headword/Gloss
- "── Broad ──" label above Lexeme/FTS  
- Dense help text: `HW: \lx+\va (primary) | Gloss: \ge (primary) | LX: all markers | FTS: all fields`

**After:**
- Clean vertical radio list (no group labels)
- Dynamic `st.caption()` that updates based on selected mode:
  - **Headword**: Algonquian headwords and variants (\lx, \va)
  - **Gloss**: Primary English glosses (\ge)
  - **Lexeme**: All Algonquian terms
  - **FTS**: Every field

**Verification:**
- ✅ SC-1: "Focused" label removed
- ✅ SC-2: "Broad" label and help-text removed
- ✅ SC-3: Dynamic caption appears below radio group
- ✅ SC-4: Caption text matches approved table
- ✅ SC-5: Search/Clear buttons remain functional

Fixes #1321

🤖 Co-authored with AI: OpenCode (ollama-cloud/kimi-k2.6)