### PR TITLE
fix: release PR body must not use auto-closing keywords for stakeholder issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,18 @@ When creating a release PR that includes a version bump, the agent MUST discover
 
 **Prohibited:** Maintaining a hardcoded list of version locations in AGENTS.md or any other file. Drift between the static list and the actual project structure produces silent version mismatches. Every release PR must re-discover.
 
-**Rationale:** Files get renamed, moved, added, or removed between releases. A static list from a previous release is stale by definition on the next release. Live discovery is the only reliable mechanism. |
+**Rationale:** Files get renamed, moved, added, or removed between releases. A static list from a previous release is stale by definition on the next release. Live discovery is the only reliable mechanism.
+
+## Release PR Body — No Auto-Closing Keywords for Stakeholder Issues
+
+Release PR bodies MUST NOT include auto-closing keywords (`Closes`, `Fixes`, `Resolves`) that reference stakeholder-facing issues. Feature requests from stakeholders must be closed manually after the stakeholder has had an opportunity to verify the release and confirm the work meets their needs.
+
+**Correct:** Describe the feature in release notes without auto-closing syntax.
+
+```
+Closes #N
+```
+
+Instead, close the stakeholder issue manually after deployment and stakeholder verification.
+
+**Exception:** Feature PRs merging to `dev` may use `Closes #N` for internal spec/plan issues where no stakeholder verification is needed. |


### PR DESCRIPTION
## Summary

Release PR bodies were including `Closes #N` for stakeholder-facing issues, causing the issue to auto-close on merge before the stakeholder could verify the release. This adds a rule to AGENTS.md prohibiting auto-closing keywords for stakeholder issues in release PRs.

## Change

- **AGENTS.md**: New section "Release PR Body — No Auto-Closing Keywords for Stakeholder Issues" under the Release PR protocol section

The rule:
- Prohibits `Closes`/`Fixes`/`Resolves` for stakeholder-facing issues in release PRs
- Requires manual closure after stakeholder verification
- Exempts feature PRs merging to `dev` for internal spec/plan issues

Closes #1330