### PR TITLE
fix: remove undocumented file extension filter from MDF uploader (#1334)

### DIFF
--- a/src/frontend/pages/upload_mdf.py
+++ b/src/frontend/pages/upload_mdf.py
@@ -48,8 +48,8 @@ def upload_mdf():
         # C-3: File uploader
         uploaded_file = st.file_uploader(
             "Upload MDF File",
-            type=["txt", "mdf"],
-            help="Select a .txt or .mdf file containing MDF-formatted dictionary entries.",
+            help="Select an MDF file (.txt, .mdf, .db, or other extension) "
+                 "containing MDF-formatted dictionary entries.",
             disabled=staging_in_progress,
         )
 

--- a/tests/frontend/test_upload_mdf_page.py
+++ b/tests/frontend/test_upload_mdf_page.py
@@ -129,7 +129,7 @@ class TestUploadMdfFileUploader(unittest.TestCase):
         upload_mdf()
 
         kwargs = mock_uploader.call_args
-        self.assertEqual(kwargs[1]["type"], ["txt", "mdf"])
+        self.assertNotIn("type", kwargs[1])
 
 
 class TestUploadMdfParseSummary(unittest.TestCase):


### PR DESCRIPTION
## Summary

Removed the undocumented `type=["txt", "mdf"]` restriction from `st.file_uploader` in the MDF upload page. This restriction was never specified in any spec or plan — the plan said "accept .txt and .mdf files" (permissive), not "only accept these" (restrictive). The AI agent incorrectly interpreted this as a whitelist.

## Changes

- **`src/frontend/pages/upload_mdf.py`**: Removed `type=["txt", "mdf"]` from `st.file_uploader` call; updated help text to list common MDF extensions informatively
- **`tests/frontend/test_upload_mdf_page.py`**: Updated test to assert `type` parameter is absent

## Outcome

Users can now upload any file type. The help text still guides them toward `.txt` and `.mdf` files without enforcing a restriction.

Fixes #1334

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)