### PR TITLE
#1334 Remove undocumented file extension filter from MDF uploader

### DIFF
--- a/src/frontend/pages/upload_mdf.py
+++ b/src/frontend/pages/upload_mdf.py
@@ -48,8 +48,7 @@ def upload_mdf():
         # C-3: File uploader
         uploaded_file = st.file_uploader(
             "Upload MDF File",
-            type=["txt", "mdf"],
-            help="Select a .txt or .mdf file containing MDF-formatted dictionary entries.",
+            help="Select an MDF file (.txt, .mdf, .db, or other) containing MDF-formatted dictionary entries.",
             disabled=staging_in_progress,
         )
 

--- a/tests/frontend/test_upload_mdf_page.py
+++ b/tests/frontend/test_upload_mdf_page.py
@@ -129,7 +129,7 @@ class TestUploadMdfFileUploader(unittest.TestCase):
         upload_mdf()
 
         kwargs = mock_uploader.call_args
-        self.assertEqual(kwargs[1]["type"], ["txt", "mdf"])
+        self.assertNotIn("type", kwargs[1])
 
 
 class TestUploadMdfParseSummary(unittest.TestCase):


### PR DESCRIPTION
## Summary

Remove undocumented `type=["txt", "mdf"]` restriction from `st.file_uploader` in the MDF upload page so any file extension is accepted by the uploader. File content validation is handled by the MDF parser, not the uploader.

## Changes

- **`src/frontend/pages/upload_mdf.py`**: Removed `type=["txt", "mdf"]` parameter from `st.file_uploader`. Updated `help` text to document common MDF extensions without implying server-side restriction.
- **`tests/frontend/test_upload_mdf_page.py`**: Updated `test_file_uploader_accepts_txt_mdf` to assert `type` parameter is absent instead of asserting its value.

## Verification

- All 15 tests in `test_upload_mdf_page.py` pass
- All 39 tests in `tests/frontend/` pass
- Dual cross-family adversarial audit (gemma4 + mistral-large) — all 4 SCs PASS consensus
- No new lint/type errors

## Success Criteria

| ID | Criterion | Status |
|----|-----------|--------|
| SC-1 | `st.file_uploader` has no `type` parameter | ✅ |
| SC-2 | `.db` file uploadable — uploader accepts any extension | ✅ |
| SC-3 | Non-MDF file rejected by parser (not uploader) | ✅ |
| SC-4 | Existing `.txt`/`.mdf` uploads work | ✅ |

Fixes #1334

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash)