### PR TITLE
Release v0.3.1: promote dev → main

### DIFF
--- a/src/frontend/pages/upload_mdf.py
+++ b/src/frontend/pages/upload_mdf.py
@@ -48,8 +48,7 @@ def upload_mdf():
         # C-3: File uploader
         uploaded_file = st.file_uploader(
             "Upload MDF File",
-            type=["txt", "mdf"],
-            help="Select a .txt or .mdf file containing MDF-formatted dictionary entries.",
+            help="Select an MDF file (.txt, .mdf, .db, or other) containing MDF-formatted dictionary entries.",
             disabled=staging_in_progress,
         )
 

--- a/tests/frontend/test_upload_mdf_page.py
+++ b/tests/frontend/test_upload_mdf_page.py
@@ -129,7 +129,7 @@ class TestUploadMdfFileUploader(unittest.TestCase):
         upload_mdf()
 
         kwargs = mock_uploader.call_args
-        self.assertEqual(kwargs[1]["type"], ["txt", "mdf"])
+        self.assertNotIn("type", kwargs[1])
 
 
 class TestUploadMdfParseSummary(unittest.TestCase):


### PR DESCRIPTION
## Summary

Promote dev to main. The actual diff from main is the MDF extension filter removal (#1334).

## Changes vs main

- **#1334** — Remove undocumented file extension filter from MDF uploader (`upload_mdf.py`, `test_upload_mdf_page.py`)

## Files Changed vs main

```
2 files changed, 2 insertions(+), 3 deletions(-)
```

## Version

`main` is at `v0.3.0`. This PR does not include a version bump — the release branch version (`0.2.0`) is stale and needs a bump to `0.3.1` before merge.
