### PR TITLE
chore: sync uv.lock version to 0.3.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1267,7 +1267,7 @@ wheels = [
 
 [[package]]
 name = "snea-shoebox-editor"
-version = "0.2.0"
+version = "0.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "pgvector" },


### PR DESCRIPTION
Syncs `uv.lock` version string from `0.2.0` to `0.3.1` to match `pyproject.toml` after the v0.3.1 release.

1 file changed — `uv.lock` version field only.