### PR TITLE
System Event Logging — persistent event table, service, and integration hooks

### DIFF
--- a/.issues/1332/spec.md
+++ b/.issues/1332/spec.md
@@ -1,0 +1,160 @@
+STATUS: DRAFT
+CREATED: 2026-06-17
+
+---
+
+## Executive Summary
+
+Add persistent system event logging to a SQL table for offline analysis of exceptions, migration lifecycle events, application lifecycle events, and infrastructure notifications. A single `system_event_log` table with an `event_type` discriminator captures all non-user-activity system events with structured context (severity, source, JSONB details). This replaces the narrower exception-only scope of the prior spec and provides a unified foundation for observability.
+
+---
+
+## Context
+
+### Current State
+
+The application has two logging paths:
+
+1. **stderr logging** via `get_logger()` — used throughout the codebase (e.g., `src/database/migrations.py` `log_migration_start()`, `log_migration_error()`; `src/frontend/ui_utils.py` `handle_ui_error()`). Logs are ephemeral — they disappear after rotation and are inaccessible in Streamlit Cloud production.
+
+2. **User activity logging** via `UserActivityLog` model (`src/database/models/identity.py:68`) and `AuditService.log_activity()` (`src/services/audit_service.py:21`). This tracks user-initiated actions (login, sync, edits) and is intentionally separate from system events.
+
+### Existing Patterns
+
+- **Model pattern**: `UserActivityLog` in `src/database/models/identity.py` — `TIMESTAMP(timezone=True)`, `__table_args__ = {"extend_existing": True}`, `autoincrement=True` primary key
+- **Service pattern**: `AuditService.log_activity()` in `src/services/audit_service.py` — static method, optional session injection, error-safe commit with rollback on failure, never suppresses the caller's exception
+- **Migration pattern**: `MigrationManager._MIGRATIONS` list in `src/database/migrations.py` — timestamp-based version format `YYYYMMDDHHMMSS`, each entry is `(version, method_name, description)`
+- **Model file pattern**: Separate files per concern in `src/database/models/` (e.g., `identity.py`, `core.py`, `meta.py`, `search.py`)
+- **Import convention**: `src/database/models/__init__.py` is docstring-only — no re-exports, no `__all__`
+- **Base**: `declarative_base()` from `src/database/base.py`
+
+---
+
+## Problem Statement
+
+System events that are critical for post-mortem analysis and operational awareness are currently written only to stderr logs, which:
+
+- Disappear after log rotation
+- Cannot be queried or aggregated for pattern analysis
+- Are inaccessible in Streamlit Cloud production
+- Lack structured context (severity, event type, JSONB details) for programmatic analysis
+- Require manual grep-based correlation across disparate log lines
+
+**Use Cases:**
+
+1. A developer MUST be able to review all exceptions that occurred overnight, grouped by exception type and frequency
+2. Migration failures MUST be persisted so that deployment issues can be diagnosed without access to ephemeral build logs
+3. Application startup and shutdown events MUST be recorded to establish a timeline of service availability
+4. Infrastructure events (DB connectivity loss, DNS resolution failures) MUST be logged to correlate application errors with underlying infrastructure problems
+5. A user reporting "the app crashed yesterday" MUST be supportable by querying persisted events for that time window
+
+---
+
+## Requirements
+
+The system MUST:
+
+1. **REQ-1: Unified event table** — A single `system_event_log` table with an `event_type` string discriminator, shared across all event categories. No separate tables per event type.
+
+2. **REQ-2: Event type support** — The following event types MUST be supported:
+   - `exception` — exceptions caught by error handlers
+   - `migration_start`, `migration_skip`, `migration_complete`, `migration_error` — migration lifecycle
+   - `system_startup`, `system_shutdown` — application lifecycle
+   - `infrastructure` — DB connectivity, DNS, other infra events
+
+3. **REQ-3: Common fields** — Every event MUST include: `id` (auto-increment PK), `event_type` (string discriminator), `severity` (e.g., `info`, `warning`, `error`, `critical`), `message` (human-readable summary), `source` (module or component name), `details` (JSONB for structured context), `created_at` (TIMESTAMP with timezone).
+
+4. **REQ-4: Unified logging entry point** — A single `EventLogService.log_event()` method that accepts event type, severity, message, source, and optional details dict. This MUST follow the `AuditService.log_activity()` pattern: static method, optional session injection, error-safe commit, never suppresses the caller's exception.
+
+5. **REQ-5: Exception-specific helper** — A convenience method `EventLogService.log_exception()` that extracts exception type, message, and stack trace from an `Exception` object and calls `log_event()` with `event_type="exception"`.
+
+6. **REQ-6: Migration integration** — The existing `log_migration_start()`, `log_migration_skip()`, `log_migration_complete()`, and `log_migration_error()` functions in `src/database/migrations.py` MUST also call `EventLogService.log_event()` in addition to their current stderr logging. The stderr logging MUST NOT be removed.
+
+7. **REQ-7: `handle_ui_error()` integration** — The existing `handle_ui_error()` in `src/frontend/ui_utils.py` MUST call `EventLogService.log_exception()` in addition to its current stderr logging. The stderr logging MUST NOT be removed. The function signature MUST remain backward-compatible.
+
+8. **REQ-8: DB write resilience** — A failure to write to the `system_event_log` table MUST NOT suppress the original event or exception. The service MUST catch DB exceptions, log them to stderr, and allow the caller to proceed.
+
+9. **REQ-9: Log from now on** — No backfill of existing migration history or past exceptions. Only events occurring after deployment of this feature are recorded.
+
+10. **REQ-10: Separation from user activity** — System events MUST use the `system_event_log` table, NOT the `user_activity_log` table. These are different concerns with different retention and query patterns.
+
+---
+
+## Non-Goals
+
+- **User activity logging** — Already handled by `UserActivityLog` + `AuditService`. System events are a separate concern.
+- **Real-time alerting or notification** — This spec addresses persistent storage only, not push notifications.
+- **Log rotation or purging** — Retention policy is a follow-up concern.
+- **Admin UI for viewing events** — A query API (`get_events()`) is in scope; a Streamlit admin page is not.
+- **Third-party monitoring integration** — Sentry, Datadog, etc. are not addressed here.
+- **Backfill of existing events** — Only events after deployment are recorded.
+
+---
+
+## Key Decisions
+
+| DEC-ID | Decision | Rationale |
+|--------|----------|-----------|
+| DEC-A | Single `system_event_log` table with `event_type` discriminator | Avoids schema proliferation (one table per event type would create 8+ nearly identical tables). The discriminator pattern is well-suited to events that share most fields and differ only in `details` content. |
+| DEC-B | Keep separate from `UserActivityLog` | User actions and system events have different retention requirements, query patterns, and consumers. Mixing them would complicate both. |
+| DEC-C | Log from now on only; no backfill | Backfilling migration history from stderr logs is unreliable (logs may have rotated) and adds complexity with no user-facing benefit. |
+| DEC-D | New model file `src/database/models/event_log.py` | Follows the existing convention of one file per concern (`identity.py`, `core.py`, `meta.py`, `search.py`). Keeps the model discoverable. |
+| DEC-E | `EventLogService.log_event()` as unified entry point | Follows the `AuditService.log_activity()` pattern established in `src/services/audit_service.py`. A single entry point ensures consistent field population and error handling. |
+| DEC-F | Replace prior exception-only spec entirely | The exception-only scope was too narrow. A unified system event table covers more use cases with less total complexity than multiple single-purpose tables. |
+
+---
+
+## Success Criteria
+
+| ID | Criterion | Evidence Type |
+|----|-----------|---------------|
+| SC-1 | `system_event_log` table exists with all common fields (id, event_type, severity, message, source, details JSONB, created_at TIMESTAMP with timezone) after migration | behavioral |
+| SC-2 | `EventLogService.log_event()` writes a record to `system_event_log` with correct field values | behavioral |
+| SC-3 | `EventLogService.log_exception()` extracts exception type, message, and stack trace and writes an `exception`-type event | behavioral |
+| SC-4 | Migration lifecycle events (`migration_start`, `migration_skip`, `migration_complete`, `migration_error`) are written to `system_event_log` when migrations run | behavioral |
+| SC-5 | `handle_ui_error()` calls `EventLogService.log_exception()` and an `exception`-type event appears in `system_event_log` | behavioral |
+| SC-6 | Existing stderr logging in `handle_ui_error()` and migration log functions is preserved (DB logging is additive) | behavioral |
+| SC-7 | When DB write fails during `log_event()`, the original exception or event is not suppressed — the caller proceeds normally | behavioral |
+| SC-8 | `handle_ui_error()` signature remains backward-compatible — callers passing only `(e, user_message)` continue to work | behavioral |
+| SC-9 | `EventLogService.get_events()` returns events ordered by `created_at` descending, with optional filters for event_type, severity, and date range | behavioral |
+| SC-10 | The `__init__.py` in `src/database/models/` remains docstring-only — no re-exports added | structural |
+
+---
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `src/database/models/event_log.py` | **New file** — `SystemEventLog` model |
+| `src/database/migrations.py` | Add migration entry + `_migrate_create_system_event_log()` method; update `log_migration_*()` functions to call `EventLogService.log_event()` |
+| `src/services/event_log_service.py` | **New file** — `EventLogService` with `log_event()`, `log_exception()`, `get_events()` |
+| `src/frontend/ui_utils.py` | Update `handle_ui_error()` to call `EventLogService.log_exception()` |
+
+---
+
+## Risk Traceability
+
+| RISK-ID | Risk Description | Likelihood | Impact | Mitigation | Verifying SC |
+|---------|-----------------|------------|--------|------------|--------------|
+| RISK-1 | DB write failure during event logging suppresses the original event | Low | High | Catch DB exceptions in `log_event()`, log to stderr, never suppress caller's exception | SC-7 |
+| RISK-2 | JSONB `details` column grows unboundedly | Medium | Low | Details are caller-provided; no automatic expansion. Retention policy is a follow-up concern. | — |
+| RISK-3 | Migration integration breaks existing migration behavior | Low | High | Stderr logging is preserved (SC-6); DB logging is additive. Migration functions continue to work if DB is unavailable. | SC-4, SC-6 |
+| RISK-4 | `handle_ui_error()` signature change breaks callers | Low | High | Signature MUST remain backward-compatible (SC-8). New parameter is optional with default. | SC-8 |
+
+---
+
+## Security Considerations
+
+| Concern | Mitigation |
+|---------|------------|
+| Sensitive data in exception details | `log_exception()` SHOULD NOT include local variables or request context by default. If added in the future, sensitive value filtering (per prior spec's `_filter_locals()` pattern) MUST be applied. |
+| JSONB injection | The `details` field is populated programmatically, not from user input. No injection vector. |
+| Information disclosure via event log | Event messages and details MUST NOT contain secrets, tokens, or PII. Callers are responsible for sanitizing their own event data. |
+
+---
+
+## Dependencies
+
+This spec replaces and supersedes issue #51. No other dependencies.
+
+🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)

--- a/.issues/1332/tests/test_migration_system_event_log.py
+++ b/.issues/1332/tests/test_migration_system_event_log.py
@@ -1,0 +1,107 @@
+"""Test for Phase 1: system_event_log table creation migration.
+
+SC-1: system_event_log table exists with correct schema after migration.
+RED phase: this test must FAIL because _migrate_create_system_event_log() does not exist yet.
+"""
+
+import unittest
+from pathlib import Path
+
+import pgserver
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import sessionmaker
+
+from src.database.base import Base
+from src.database.migrations import MigrationManager
+
+
+class TestMigrationSystemEventLog(unittest.TestCase):
+    """RED-phase test: system_event_log table does not exist before migration."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_db_path = Path("tmp/test_system_event_log_db")
+        if cls.test_db_path.exists():
+            import shutil
+
+            shutil.rmtree(cls.test_db_path)
+        cls.test_db_path.mkdir(parents=True, exist_ok=True)
+
+        cls.pg_server = pgserver.get_server(str(cls.test_db_path))
+        cls.db_url = cls.pg_server.get_uri()
+        cls.engine = create_engine(cls.db_url)
+
+        with cls.engine.connect() as conn:
+            conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+            conn.commit()
+
+        # Import models to ensure base metadata is populated
+        from src.database.models.core import Language, Record, Source  # noqa: F401
+        from src.database.models.identity import User, UserActivityLog  # noqa: F401
+        from src.database.models.search import (  # noqa: F401
+            FTSEntry,
+            GlossSearchEntry,
+            HeadwordSearchEntry,
+            SearchEntry,
+        )
+        from src.database.models.workflow import EditHistory, MatchupQueue  # noqa: F401
+        from src.database.models.meta import SchemaVersion  # noqa: F401
+
+        Base.metadata.create_all(cls.engine)
+        cls.Session = sessionmaker(bind=cls.engine)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "pg_server"):
+            cls.pg_server.cleanup()
+        if hasattr(cls, "test_db_path") and cls.test_db_path.exists():
+            import shutil
+
+            shutil.rmtree(cls.test_db_path)
+
+    def setUp(self):
+        self.session = self.Session()
+
+    def tearDown(self):
+        self.session.close()
+
+    def test_migration_creates_system_event_log(self):
+        """SC-1: _migrate_create_system_event_log() creates the system_event_log table.
+
+        RED phase: this FAILS because the migration method does not exist yet.
+        GREEN phase: this PASSES after the method is implemented.
+        """
+        # Given: the table does not exist yet
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+        self.assertNotIn("system_event_log", table_names, "system_event_log should not exist before migration")
+
+        # When: the migration runs (this will AttributeError — method doesn't exist yet)
+        mgr = MigrationManager(self.engine)
+        mgr._migrate_create_system_event_log()
+
+        # Then: the table should exist with correct schema
+        inspector = inspect(self.engine)
+        table_names = inspector.get_table_names()
+        self.assertIn("system_event_log", table_names, "system_event_log should exist after migration")
+
+        columns = {col["name"]: col for col in inspector.get_columns("system_event_log")}
+
+        expected_columns = {
+            "id": {"type": "INTEGER", "nullable": False},
+            "event_type": {"type": "VARCHAR", "nullable": False},
+            "severity": {"type": "VARCHAR", "nullable": False},
+            "message": {"type": "VARCHAR" if "TEXT" else "VARCHAR", "nullable": False},
+            "source": {"type": "VARCHAR", "nullable": False},
+            "details": {"type": "JSONB" if "JSONB" else "JSON", "nullable": True},
+            "created_at": {"type": "TIMESTAMP", "nullable": False},
+        }
+
+        for col_name, expected in expected_columns.items():
+            self.assertIn(
+                col_name, columns, f"Column '{col_name}' should exist in system_event_log"
+            )
+            self.assertFalse(
+                columns[col_name]["nullable"],
+                f"Column '{col_name}' should be NOT NULL",
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "streamlit-cookies-controller>=0.0.4",
     "tqdm>=4.67.1",
     "rapidfuzz>=3.14.5",
+    "pgserver>=0.1.4",
 ]
 
 

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -22,6 +22,15 @@ def log_migration_start(version: int, description: str) -> None:
     logger.info("=" * 60)
     logger.info("MIGRATION START: v%s - %s", version, description)
     logger.info("=" * 60)
+    from src.services.event_log_service import EventLogService
+
+    EventLogService.log_event(
+        event_type="migration_start",
+        severity="info",
+        message=f"Migration started: v{version} - {description}",
+        source="snea.migrations",
+        details={"version": version, "description": description},
+    )
 
 
 def log_migration_skip(version: int, description: str, reason: str) -> None:
@@ -30,6 +39,15 @@ def log_migration_skip(version: int, description: str, reason: str) -> None:
     logger.info("MIGRATION SKIP: v%s - %s", version, description)
     logger.info("  Reason: %s", reason)
     logger.info("-" * 60)
+    from src.services.event_log_service import EventLogService
+
+    EventLogService.log_event(
+        event_type="migration_skip",
+        severity="info",
+        message=f"Migration skipped: v{version} - {description}",
+        source="snea.migrations",
+        details={"version": version, "description": description, "reason": reason},
+    )
 
 
 def log_migration_complete(version: int, description: str, duration_seconds: float | None = None) -> None:
@@ -45,6 +63,18 @@ def log_migration_complete(version: int, description: str, duration_seconds: flo
     else:
         logger.info("MIGRATION COMPLETE: v%s - %s", version, description)
     logger.info("=" * 60)
+    from src.services.event_log_service import EventLogService
+
+    details = {"version": version, "description": description}
+    if duration_seconds is not None:
+        details["duration_seconds"] = duration_seconds
+    EventLogService.log_event(
+        event_type="migration_complete",
+        severity="info",
+        message=f"Migration completed: v{version} - {description}",
+        source="snea.migrations",
+        details=details,
+    )
 
 
 def log_migration_error(version: int, description: str, error: Exception) -> None:
@@ -53,6 +83,20 @@ def log_migration_error(version: int, description: str, error: Exception) -> Non
     logger.error("MIGRATION FAILED: v%s - %s", version, description)
     logger.error("  Error: %s: %s", type(error).__name__, str(error))
     logger.error("=" * 60)
+    from src.services.event_log_service import EventLogService
+
+    EventLogService.log_event(
+        event_type="migration_error",
+        severity="error",
+        message=f"Migration failed: v{version} - {description}",
+        source="snea.migrations",
+        details={
+            "version": version,
+            "description": description,
+            "error_type": type(error).__name__,
+            "error_message": str(error),
+        },
+    )
 
 
 class MigrationManager:
@@ -133,6 +177,11 @@ class MigrationManager:
             20260615125509,
             "_migrate_backfill_search_entries",
             "Backfill HeadwordSearchEntry and GlossSearchEntry for existing records",
+        ),
+        (
+            2026061876990,
+            "_migrate_create_system_event_log",
+            "Create system_event_log table for persistent system event tracking",
         ),
     ]
 
@@ -702,6 +751,34 @@ class MigrationManager:
             raise
         finally:
             session.close()
+
+    def _migrate_create_system_event_log(self):
+        """Migration 2026061876990: Create system_event_log table."""
+        with self._engine.connect() as conn:
+            conn.execute(
+                text("""
+                CREATE TABLE IF NOT EXISTS system_event_log (
+                    id SERIAL PRIMARY KEY,
+                    event_type VARCHAR NOT NULL,
+                    severity VARCHAR NOT NULL,
+                    message VARCHAR NOT NULL,
+                    source VARCHAR NOT NULL,
+                    details JSONB NOT NULL DEFAULT '{}',
+                    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+                );
+            """)
+            )
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS idx_system_event_log_event_type ON system_event_log (event_type);"
+                )
+            )
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS idx_system_event_log_created_at ON system_event_log (created_at);"
+                )
+            )
+            conn.commit()
 
     def _seed_default_sources(self):
         """Seed default sources if table is empty or missing specific entries."""

--- a/src/database/models/event_log.py
+++ b/src/database/models/event_log.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+"""
+SystemEventLog model for persistent system event logging.
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+"""
+from sqlalchemy import TIMESTAMP, Column, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import func
+
+from ..base import Base
+
+
+class SystemEventLog(Base):
+    """
+    Persistent log of system-level events for offline analysis.
+    Uses event_type as a discriminator for different event categories.
+    """
+
+    __tablename__ = "system_event_log"
+    __table_args__ = {"extend_existing": True}
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_type = Column(String, nullable=False)
+    severity = Column(String, nullable=False)
+    message = Column(String, nullable=False)
+    source = Column(String, nullable=False)
+    details = Column(JSONB, nullable=False, server_default="{}")
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)

--- a/src/frontend/ui_utils.py
+++ b/src/frontend/ui_utils.py
@@ -26,10 +26,12 @@ def handle_ui_error(e: Exception, user_message: str = "An unexpected error occur
     """
     from src.database.connection import is_production
     from src.logging_config import get_logger
+    from src.services.event_log_service import EventLogService
 
     # 1. Server-side logging (Full trace)
     log = get_logger(logger_name or "ui_error_handler")
     log.error(f"{user_message} Detail: {str(e)}", exc_info=True)
+    EventLogService.log_exception(e)
 
     # 2. UI Display (Sanitized)
     st.error(user_message)

--- a/src/services/event_log_service.py
+++ b/src/services/event_log_service.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 Brothertown Language
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+# <!-- CRITICAL: NO EDITS WITHOUT APPROVED PLAN (Wait for "Go", "Proceed", or "Approved") -->
+"""
+Event Log Service for persisting system-level events to the system_event_log table.
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+"""
+
+import traceback
+
+from sqlalchemy import and_, desc
+from sqlalchemy.exc import ProgrammingError
+
+from src.database.connection import get_session
+from src.database.models.event_log import SystemEventLog
+from src.logging_config import get_logger
+
+logger = get_logger("snea.event_log")
+
+
+class EventLogService:
+    """
+    Service for persisting system-level events (exceptions, migration lifecycle,
+    application lifecycle, infrastructure notifications) to the system_event_log table.
+    """
+
+    @staticmethod
+    def log_event(
+        event_type: str,
+        severity: str,
+        message: str,
+        source: str,
+        details: dict | None = None,
+        session=None,
+    ) -> None:
+        """
+        Write a system event to the system_event_log table.
+
+        Args:
+            event_type: Discriminator for the event category.
+            severity: Severity level ('info', 'warning', 'error', 'critical').
+            message: Human-readable summary of the event.
+            source: Module or component name that generated the event.
+            details: Optional structured context as a dict (stored as JSONB).
+            session: Optional existing database session.
+        """
+        _provided_session = session is not None
+        if not _provided_session:
+            session = get_session()
+        try:
+            log = SystemEventLog(
+                event_type=event_type,
+                severity=severity,
+                message=message,
+                source=source,
+                details=details or {},
+            )
+            session.add(log)
+            if not _provided_session:
+                session.commit()
+        except ProgrammingError:
+            # Table doesn't exist yet (called from a migration that predates
+            # the system_event_log table). Rollback to clear session state
+            # but don't suppress the caller's exception.
+            session.rollback()
+            logger.warning("system_event_log table not available yet — event not persisted")
+        except Exception as e:
+            if not _provided_session:
+                session.rollback()
+            logger.error("Failed to log system event: %s", e)
+        finally:
+            if not _provided_session:
+                session.close()
+
+    @staticmethod
+    def log_exception(e: Exception, source: str | None = None, session=None) -> None:
+        """
+        Log an exception as a system event.
+
+        Extracts the exception type, message, and stack trace from the exception
+        and writes an 'exception'-type event via log_event().
+
+        Args:
+            e: The exception to log.
+            source: Optional source component name.
+            session: Optional existing database session.
+        """
+        details = {
+            "exception_type": type(e).__name__,
+            "exception_message": str(e),
+            "stack_trace": traceback.format_exc(),
+        }
+        EventLogService.log_event(
+            event_type="exception",
+            severity="error",
+            message=f"{type(e).__name__}: {str(e)}",
+            source=source or "exception_handler",
+            details=details,
+            session=session,
+        )
+
+    @staticmethod
+    def get_events(
+        event_type: str | None = None,
+        severity: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        limit: int = 100,
+        session=None,
+    ) -> list[SystemEventLog]:
+        """
+        Retrieve system events ordered by created_at descending.
+
+        Args:
+            event_type: Optional filter by event type.
+            severity: Optional filter by severity level.
+            date_from: Optional filter for events on or after this date (ISO 8601).
+            date_to: Optional filter for events on or before this date (ISO 8601).
+            limit: Maximum number of events to return (default 100).
+            session: Optional existing database session.
+
+        Returns:
+            List of SystemEventLog instances ordered by created_at descending.
+        """
+        _provided_session = session is not None
+        if not _provided_session:
+            session = get_session()
+        try:
+            query = session.query(SystemEventLog)
+
+            filters = []
+            if event_type is not None:
+                filters.append(SystemEventLog.event_type == event_type)
+            if severity is not None:
+                filters.append(SystemEventLog.severity == severity)
+            if date_from is not None:
+                filters.append(SystemEventLog.created_at >= date_from)
+            if date_to is not None:
+                filters.append(SystemEventLog.created_at <= date_to)
+
+            if filters:
+                query = query.filter(and_(*filters))
+
+            return query.order_by(desc(SystemEventLog.created_at)).limit(limit).all()
+        finally:
+            if not _provided_session:
+                session.close()

--- a/test/test_event_log_behavioral.py
+++ b/test/test_event_log_behavioral.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+"""Behavioral tests for EventLogService — Phase 2 of issue #1332.
+
+These tests verify actual DB behavior: writing records, extracting exceptions,
+handling DB failures, and querying with filters.
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+"""
+import unittest
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+class TestEventLogServiceBehavioral(unittest.TestCase):
+    """Behavioral tests for EventLogService."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import pgserver
+
+            from src.database.base import Base
+
+            cls.test_db_path = Path("tmp/test_event_log_behavioral_db")
+            if cls.test_db_path.exists():
+                import shutil
+                shutil.rmtree(cls.test_db_path)
+            cls.test_db_path.mkdir(parents=True, exist_ok=True)
+
+            cls.pg_server = pgserver.get_server(str(cls.test_db_path))
+            cls.db_url = cls.pg_server.get_uri()
+            cls.engine = create_engine(cls.db_url)
+
+            with cls.engine.connect() as conn:
+                conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+                conn.commit()
+
+            from src.database.models.core import Language, Record, Source  # noqa: F401
+            from src.database.models.identity import User  # noqa: F401
+            from src.database.models.search import (  # noqa: F401
+                FTSEntry,
+                GlossSearchEntry,
+                HeadwordSearchEntry,
+                SearchEntry,
+            )
+            from src.database.models.workflow import EditHistory, MatchupQueue  # noqa: F401
+            from src.database.models.event_log import SystemEventLog  # noqa: F401
+
+            Base.metadata.create_all(cls.engine)
+            cls.Session = sessionmaker(bind=cls.engine)
+        except ImportError:
+            raise unittest.SkipTest("pgserver not available") from None
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "pg_server"):
+            cls.pg_server.cleanup()
+        if hasattr(cls, "test_db_path") and cls.test_db_path.exists():
+            import shutil
+            shutil.rmtree(cls.test_db_path)
+
+    def setUp(self):
+        from src.database.models.event_log import SystemEventLog
+
+        self.session = self.Session()
+        self.session.query(SystemEventLog).delete()
+        self.session.commit()
+
+    def tearDown(self):
+        self.session.close()
+
+    def test_log_event_writes_record(self):
+        """SC-2: log_event() writes a record to system_event_log with correct field values."""
+        from src.services.event_log_service import EventLogService
+
+        EventLogService.log_event(
+            event_type="test_type",
+            severity="info",
+            message="test message",
+            source="test_module",
+            details={"key": "value"},
+            session=self.session,
+        )
+
+        from src.database.models.event_log import SystemEventLog
+
+        record = self.session.query(SystemEventLog).first()
+        self.assertIsNotNone(record, "A record should exist after log_event()")
+        self.assertEqual(record.event_type, "test_type")
+        self.assertEqual(record.severity, "info")
+        self.assertEqual(record.message, "test message")
+        self.assertEqual(record.source, "test_module")
+        self.assertIsNotNone(record.details)
+        self.assertEqual(record.details.get("key"), "value")
+        self.assertIsNotNone(record.created_at)
+
+    def test_log_exception_extracts_exception(self):
+        """SC-3: log_exception() extracts exception type, message, and stack trace."""
+        from src.services.event_log_service import EventLogService
+
+        try:
+            raise ValueError("test error detail")
+        except ValueError as e:
+            EventLogService.log_exception(e, session=self.session)
+
+        from src.database.models.event_log import SystemEventLog
+
+        record = self.session.query(SystemEventLog).first()
+        self.assertIsNotNone(record, "A record should exist after log_exception()")
+        self.assertEqual(record.event_type, "exception")
+        self.assertEqual(record.severity, "error")
+        self.assertIn("ValueError", record.message)
+        self.assertIsNotNone(record.details)
+        self.assertEqual(record.details.get("exception_type"), "ValueError")
+        self.assertEqual(record.details.get("exception_message"), "test error detail")
+        self.assertIsNotNone(record.details.get("stack_trace"))
+
+    def test_db_write_failure_does_not_suppress_caller(self):
+        """SC-7: DB write failure during log_event() does not suppress the original exception."""
+        from src.services.event_log_service import EventLogService
+
+        # Close the session to force a DB write failure
+        self.session.close()
+
+        # This should not raise — log_event catches DB errors
+        try:
+            EventLogService.log_event(
+                event_type="test",
+                severity="info",
+                message="should fail silently",
+                source="test",
+                session=self.session,
+            )
+        except Exception:
+            self.fail("log_event() should not raise when DB write fails")
+
+    def test_get_events_returns_ordered_with_filters(self):
+        """SC-9: get_events() returns events ordered by created_at desc with optional filters."""
+        from src.services.event_log_service import EventLogService
+
+        # Insert events with different types
+        EventLogService.log_event(
+            event_type="type_a", severity="info", message="first",
+            source="test", details={"seq": 1}, session=self.session,
+        )
+        EventLogService.log_event(
+            event_type="type_b", severity="warning", message="second",
+            source="test", details={"seq": 2}, session=self.session,
+        )
+        EventLogService.log_event(
+            event_type="type_a", severity="error", message="third",
+            source="test", details={"seq": 3}, session=self.session,
+        )
+
+        # Test unfiltered — should return all 3 events
+        all_events = EventLogService.get_events(session=self.session)
+        self.assertEqual(len(all_events), 3)
+
+        # Test event_type filter
+        type_a_events = EventLogService.get_events(
+            event_type="type_a", session=self.session,
+        )
+        self.assertEqual(len(type_a_events), 2)
+        for e in type_a_events:
+            self.assertEqual(e.event_type, "type_a")
+
+        # Test severity filter
+        error_events = EventLogService.get_events(
+            severity="error", session=self.session,
+        )
+        self.assertEqual(len(error_events), 1)
+        self.assertEqual(error_events[0].severity, "error")
+
+        # Test date range filter
+        from datetime import datetime, timezone, timedelta
+        _now = datetime.now(timezone.utc)
+        recent_events = EventLogService.get_events(
+            date_from=(_now - timedelta(hours=1)).isoformat(),
+            date_to=(_now + timedelta(hours=1)).isoformat(),
+            session=self.session,
+        )
+        self.assertEqual(len(recent_events), 3)

--- a/test/test_event_log_integration_red.py
+++ b/test/test_event_log_integration_red.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+"""RED tests for Phase 3 integration hooks — issue #1332.
+
+These tests fail because migration log functions and handle_ui_error()
+do not yet call EventLogService.
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+"""
+
+import unittest
+from unittest.mock import patch
+
+
+class TestMigrationIntegrationRED(unittest.TestCase):
+    """RED tests: migration log functions don't call EventLogService yet."""
+
+    def test_migration_start_calls_log_event(self):
+        """SC-4: log_migration_start should call EventLogService.log_event()."""
+        from src.database.migrations import log_migration_start
+        from src.services.event_log_service import EventLogService
+
+        with patch.object(EventLogService, "log_event") as mock_log:
+            log_migration_start("test_version", "test_desc")
+            mock_log.assert_called_once()
+
+    def test_migration_skip_calls_log_event(self):
+        """SC-4: log_migration_skip should call EventLogService.log_event()."""
+        from src.database.migrations import log_migration_skip
+        from src.services.event_log_service import EventLogService
+
+        with patch.object(EventLogService, "log_event") as mock_log:
+            log_migration_skip("test_version", "test_desc", "test_reason")
+            mock_log.assert_called_once()
+
+    def test_migration_complete_calls_log_event(self):
+        """SC-4: log_migration_complete should call EventLogService.log_event()."""
+        from src.database.migrations import log_migration_complete
+        from src.services.event_log_service import EventLogService
+
+        with patch.object(EventLogService, "log_event") as mock_log:
+            log_migration_complete("test_version", "test_desc")
+            mock_log.assert_called_once()
+
+    def test_migration_error_calls_log_event(self):
+        """SC-4: log_migration_error should call EventLogService.log_event()."""
+        from src.database.migrations import log_migration_error
+        from src.services.event_log_service import EventLogService
+
+        with patch.object(EventLogService, "log_event") as mock_log:
+            log_migration_error("test_version", "test_desc", "test_error")
+            mock_log.assert_called_once()
+
+    def test_handle_ui_error_calls_log_exception(self):
+        """SC-5: handle_ui_error should call EventLogService.log_exception()."""
+        from src.frontend.ui_utils import handle_ui_error
+        from src.services.event_log_service import EventLogService
+
+        with patch.object(EventLogService, "log_exception") as mock_log:
+            handle_ui_error(Exception("test"), "user message")
+            mock_log.assert_called_once()
+
+    def test_stderr_logging_preserved(self):
+        """SC-6: Stderr logging still happens after integration."""
+        from src.database.migrations import log_migration_start
+        from src.database.migrations import logger as migration_logger
+
+        with patch.object(migration_logger, "info") as mock_info:
+            log_migration_start("test_version", "test_desc")
+            mock_info.assert_called()
+
+    def test_handle_ui_error_signature_backward_compat(self):
+        """SC-8: handle_ui_error accepts (Exception, str) without new required params."""
+        import inspect
+
+        from src.frontend.ui_utils import handle_ui_error
+
+        sig = inspect.signature(handle_ui_error)
+        params = list(sig.parameters.keys())
+        # Must accept at minimum e and user_message
+        self.assertIn("e", params)
+        self.assertIn("user_message", params)

--- a/test/test_event_log_red.py
+++ b/test/test_event_log_red.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Michael Conrad
+# SPDX-License-Identifier: MIT
+# Provenance: AI-generated
+"""RED tests for EventLogService — Phase 2 of issue #1332.
+
+These tests fail because EventLogService doesn't exist yet.
+
+Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)
+"""
+import unittest
+
+
+class TestEventLogServiceRED(unittest.TestCase):
+    """RED tests: EventLogService does not exist yet."""
+
+    def test_log_event_writes_record(self):
+        """SC-2: EventLogService.log_event() should exist."""
+        from src.services.event_log_service import EventLogService  # noqa: F811
+
+        self.assertTrue(hasattr(EventLogService, "log_event"))
+
+    def test_log_exception_extracts_exception(self):
+        """SC-3: EventLogService.log_exception() should exist."""
+        from src.services.event_log_service import EventLogService  # noqa: F811
+
+        self.assertTrue(hasattr(EventLogService, "log_exception"))
+
+    def test_log_event_has_error_safe_session_pattern(self):
+        """SC-7: log_event should accept optional session parameter."""
+        from src.services.event_log_service import EventLogService  # noqa: F811
+
+        import inspect
+
+        sig = inspect.signature(EventLogService.log_event)
+        self.assertIn("session", sig.parameters)
+
+    def test_get_events_exists(self):
+        """SC-9: EventLogService.get_events() should exist."""
+        from src.services.event_log_service import EventLogService  # noqa: F811
+
+        self.assertTrue(hasattr(EventLogService, "get_events"))

--- a/uv.lock
+++ b/uv.lock
@@ -1289,6 +1289,7 @@ name = "snea-shoebox-editor"
 version = "0.3.1"
 source = { virtual = "." }
 dependencies = [
+    { name = "pgserver" },
     { name = "pgvector" },
     { name = "psutil" },
     { name = "psycopg2-binary" },
@@ -1319,6 +1320,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "pgserver", specifier = ">=0.1.4" },
     { name = "pgserver", marker = "extra == 'local'", specifier = ">=0.1.4" },
     { name = "pgvector", specifier = ">=0.3.6" },
     { name = "psutil", specifier = ">=7.2.2" },


### PR DESCRIPTION
## Summary

Add persistent system event logging to a SQL `system_event_log` table for offline analysis of exceptions, migration lifecycle events, application lifecycle events, and infrastructure notifications.

## Changes

### Phase 1: Model + Migration
- **`src/database/models/event_log.py`** (new) — `SystemEventLog` model with fields: id, event_type, severity, message, source, details (JSONB), created_at (TIMESTAMP with timezone)
- **`src/database/migrations.py`** — Migration `2026061876990` creates the `system_event_log` table with indexes on event_type and created_at

### Phase 2: EventLogService
- **`src/services/event_log_service.py`** (new) — `EventLogService` with:
  - `log_event()` — unified entry point, follows `AuditService.log_activity()` pattern (static method, optional session, error-safe commit, never suppresses caller)
  - `log_exception()` — extracts exception type/message/stack trace, writes `exception`-type event
  - `get_events()` — query API with optional filters (event_type, severity, date range), ordered by created_at DESC

### Phase 3: Integration Hooks
- **`src/database/migrations.py`** — `log_migration_start/skip/complete/error` now call `EventLogService.log_event()` alongside existing stderr logging
- **`src/frontend/ui_utils.py`** — `handle_ui_error()` now calls `EventLogService.log_exception()` alongside existing stderr logging; signature remains backward-compatible

## Testing
- 15 event log tests (7 integration RED, 4 unit RED, 4 behavioral) — all PASS
- 0 regressions from Phase 3 changes (backfill migration regression fixed via `ProgrammingError` handling in `log_event()`)

## SC Coverage
- SC-1: `system_event_log` table exists with all common fields ✅
- SC-2: `log_event()` writes record with correct field values ✅
- SC-3: `log_exception()` extracts exception data ✅
- SC-4: Migration lifecycle events logged ✅
- SC-5: `handle_ui_error()` calls `log_exception()` ✅
- SC-6: Existing stderr logging preserved ✅
- SC-7: DB write failure does not suppress caller ✅
- SC-8: `handle_ui_error()` signature backward-compatible ✅
- SC-9: `get_events()` returns ordered with filters ✅
- SC-10: `__init__.py` remains docstring-only ✅

🤖 Co-authored with AI: OpenCode (ollama-cloud/deepseek-v4-flash)