### PR TITLE
chore: dev-to-main — ISO 639-3 language identification + AGENTS.md docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,18 @@ When creating a release PR that includes a version bump, the agent MUST discover
 
 **Prohibited:** Maintaining a hardcoded list of version locations in AGENTS.md or any other file. Drift between the static list and the actual project structure produces silent version mismatches. Every release PR must re-discover.
 
-**Rationale:** Files get renamed, moved, added, or removed between releases. A static list from a previous release is stale by definition on the next release. Live discovery is the only reliable mechanism. |
+**Rationale:** Files get renamed, moved, added, or removed between releases. A static list from a previous release is stale by definition on the next release. Live discovery is the only reliable mechanism.
+
+## Release PR Body — No Auto-Closing Keywords for Stakeholder Issues
+
+Release PR bodies MUST NOT include auto-closing keywords (`Closes`, `Fixes`, `Resolves`) that reference stakeholder-facing issues. Feature requests from stakeholders must be closed manually after the stakeholder has had an opportunity to verify the release and confirm the work meets their needs.
+
+**Correct:** Describe the feature in release notes without auto-closing syntax.
+
+```
+Closes #N
+```
+
+Instead, close the stakeholder issue manually after deployment and stakeholder verification.
+
+**Exception:** Feature PRs merging to `dev` may use `Closes #N` for internal spec/plan issues where no stakeholder verification is needed. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,72 @@ For AI agent infrastructure changes (`.opencode/` directory), see
 - **sync_prod_to_local Rewrite** (#1299) — Rewrote the production-to-local sync script to use `pg_catalog` introspection for true schema replication, ensuring the local database schema matches production exactly.
 - **3 New Tests + 2 Fixed FTS Tests** (#1299) — Added tests for FTS normalization, infinity symbol handling (`∞` maps to `oozzz`), and no-ILIKE-fallback path. Fixed two existing FTS tests to search `mdf_data` content (not `ge`) and to use punctuation-only terms that `tsvector` does not index, plus 15+ fixup commits resolving autoflush PK collisions, indentation issues, and deduplication edge cases.
 
+### feature/1339-iso-639-3-language-identification
+
+- **ISO 639-3 Language Identification** (#1339) — Replaced previous free-text language lookup with ISO 639-3 three-letter code-based identification. Added JaroWinkler plausibility check for ambiguous language assignments. Language identification is now deterministic and standards-based.
+
+### feature/1334-remove-extension-filter
+
+- **Remove Undocumented MDF Uploader Extension Filter** (#1334) — Removed `type=["txt", "mdf"]` from `st.file_uploader` in `upload_mdf.py` so any file extension is accepted. Updated help text to document common MDF extensions without implying server-side restriction. Updated existing test assertion to verify the type parameter is absent.
+
+### feature/1330-release-pr-no-closing-keywords
+
+- **Release PR Body No Auto-Closing Keywords** (#1330) — Release PR bodies must not use auto-closing keywords (`Closes`, `Fixes`, `Resolves`) for stakeholder issues. Feature PRs merging to `dev` may still use `Closes #N` for internal spec/plan issues. Documented in `AGENTS.md` under Release PR Body section.
+
+### feature/1327-release-pr-version-bump-protocol
+
+- **Release PR Version Bump Protocol** (#1327) — Added mandatory live-discovery version bump protocol to `AGENTS.md`. Every release PR must re-discover all version-bearing locations via grep for `__version__`, `version =`, `"version":`, `version=` across all file types. Prohibits static/hardcoded lists.
+
+### feature/1324-1323-records-lint-pyright
+
+- **Ruff Lint + Pyright Type Fixes in records.py** (#1323, #1324) — Fixed 12 ruff lint errors (unused logger/search_query, ambiguous `l` vars, long lines, set comprehension, `list()` in `sorted()`) and 3 pyright type errors (`str|None` → `int()`, `str|None` → `json.loads`, unused logger import removal).
+
+### feature/401-filter-ux
+
+- **Records View Filter UX Improvements** (#401) — Series of UX improvements to the records view left panel: clear search now immediately empties the input field via dynamic widget key; FTS mode disables language selectbox and role radio with explanatory tooltips; search controls handle Unicode characters without crashing; filter state persists across headword/gloss/lexeme mode switches; empty search returns all records without error.
+
+### feature/1321-search-caption
+
+- **Dynamic Search Mode Caption** (#1321) — Replaced static `── Focused ──` / `── Broad ──` group labels and dense help-text block with a single dynamic caption below the search-mode radio group. Caption updates to explain the currently selected mode in plain language.
+
+### feature/1126-search-mode-ui
+
+- **Search Mode UI — Vertical Radio with Grouping** (#1126 Phase 5) — Replaced horizontal toggle with vertical radio button group organized into two logical groups (Lexeme/FTS and Headword/Gloss). Headword set as default mode. Added mode name header, help text per mode, and improved button reflow layout.
+
+### feature/1305-search-dispatch-strategy
+
+- **Backend Strategy-Dispatch for Headword/Gloss Modes** (#1305 Phase 4) — Refactored `get_all_records_for_export()` and `stream_records_to_temp_file()` to use `_search_strategies` dictionary dispatch, matching the pattern already used by `search_records()`. All four strategy functions (`_search_lexeme`, `_search_fts`, `_search_headword`, `_search_gloss`) are now consistently dispatched across all query paths.
+
+### feature/1316-ensure-sequences
+
+- **Sequences Migration + Integration Test Setup** (#1316, #1313, #1319) — Created migration `20260415000000` that generates sequences for all 14 tables with integer id columns but no associated sequence, setting the column default to `nextval()`. Added `conftest.py` for integration tests that runs migrations before any test connects. Fixed ISO import ordering in `test_language_assignment.py`. Made FTS migration idempotent by adding `TRUNCATE fts_entries` before the insert loop.
+
+### feature/1310-purge-cross-repo-contaminations
+
+- **Purge Cross-Repo Contaminations** (#1310) — Deleted files that integrated with the `.opencode/` submodule from the main application repo: `src/security/` (3 files, agent infrastructure), and 8 test files that referenced `.opencode/` paths, guidelines, scripts, or hooks. The `.opencode/` repo is independent — the main repo must not test it.
+
+### feature/1306-backfill-migration
+
+- **Backfill Migration for Headword/Gloss Search Entries** (#1306 Phase 3) — Added `_migrate_backfill_search_entries()` method to `MigrationManager` with migration version `20260615125509`. Populates `HeadwordSearchEntry` and `GlossSearchEntry` tables for existing records. Test file with 4 tests covering initial empty state, population, rollback safety, and registry presence. Removed cross-repo tests (`pair_mode`, `secret_redaction`) that asserted against `.opencode/` submodule.
+
+### feature/1304-headword-gloss-indexing
+
+- **Backend Indexing for Headword/Gloss Search** (#1304 Phase 2, Phase 1) — Added `primary_va` field to MDF parser capturing headword-block `\va` values. HeadwordSearchEntry uses `primary_va` (not full `va` list) for headword results. GlossSearchEntry indexes only the first `\ge` at headword level. Records missing `\lx` are gracefully excluded from headword results. Added 4 tests covering SC-3, SC-5, SC-23, SC-26, and SearchEntry regression guard.
+
+### feature/1300-autoflush-pk-collision-fix
+
+- **Autoflush PK Collision Fix** (#1300) — Fixed primary key collision in `reprocess_all_records()` and migration session routing. `populate_search_entries()` uses `session.flush()` after ORM deletes; `_update_record_languages()` uses raw SQL DELETE for immediate execution; `reprocess_all_records()` uses per-record commit with optional session parameter.
+
+### Changed
+
+- **AGENTS.md Regression Test Protocol** — Added mandatory `bash scripts/sync_prod_to_local.sh` before every regression test cycle, to re-sync local database from production. The sync script must be from the feature branch under test, not from `dev` or `main`.
+
+- **Version Bump to 0.3.1** — Bumped project version to 0.3.1.
+
+- **uv.lock Sync to 0.3.1** — Synced `uv.lock` to match version 0.3.1 dependency resolution.
+
+- **Dev Sync with Main** — Synced `dev` branch with `main` following the v0.3.1 release.
+
 ## [0.2.0] - Unreleased
 
 ### feature/1197-phase4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "streamlit-oauth>=0.1.11",
     "streamlit-cookies-controller>=0.0.4",
     "tqdm>=4.67.1",
+    "rapidfuzz>=3.14.5",
 ]
 
 

--- a/src/services/upload_service.py
+++ b/src/services/upload_service.py
@@ -11,6 +11,7 @@ import uuid
 from collections import defaultdict
 from collections.abc import Callable
 
+from rapidfuzz.distance import JaroWinkler
 from sqlalchemy import func, text
 
 from src.database.connection import get_session
@@ -1223,15 +1224,21 @@ class UploadService:
                     continue
 
                 iso_entry = session.query(ISO639_3).filter_by(id=lg_code).first()
-                if not iso_entry or iso_entry.ref_name != lg_name:
-                    # Both code and ref name must match ISO 639-3 exactly
+                if not iso_entry:
+                    # Code must exist in ISO 639-3 reference table
+                    continue
+
+                # Jaro-Winkler plausibility check: name should resemble the canonical ref_name.
+                # Catches wrong-code entries like French [mjy] (JW=0.437) while passing
+                # legitimate variants like Mohican→Mahican (JW=0.914).
+                if JaroWinkler.normalized_similarity(lg_name, iso_entry.ref_name) < 0.75:
                     continue
 
                 # Find by code first (canonical)
                 lang = session.query(Language).filter_by(code=lg_code).first()
 
                 if not lang:
-                    lang = Language(name=lg_name, code=lg_code)
+                    lang = Language(name=iso_entry.ref_name, code=lg_code)
                     session.add(lang)
                     session.flush()
 

--- a/tests/integration/test_language_assignment.py
+++ b/tests/integration/test_language_assignment.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import sessionmaker
 from src.database.base import Base
 from src.database.models.core import Language, Record, RecordLanguage, Source
 from src.database.models.identity import User
-from src.database.models.iso639 import ISO639_3
 from src.database.models.workflow import MatchupQueue
 from src.services.upload_service import UploadService
 
@@ -66,8 +65,8 @@ class TestLanguageAssignment(unittest.TestCase):
                     )
                     _sess.commit()
             _sess.close()
-        except ImportError:
-            raise unittest.SkipTest("pgserver not installed")
+        except ImportError as err:
+            raise unittest.SkipTest("pgserver not installed") from err
 
     @classmethod
     def tearDownClass(cls):
@@ -84,7 +83,9 @@ class TestLanguageAssignment(unittest.TestCase):
         with self.engine.connect() as conn:
             conn.execute(
                 text(
-                    "TRUNCATE user_activity_log, record_languages, edit_history, search_entries, records, languages, matchup_queue, users, sources RESTART IDENTITY CASCADE;"
+                    "TRUNCATE user_activity_log, record_languages, edit_history, "
+                    "search_entries, records, languages, matchup_queue, users, sources "
+                    "RESTART IDENTITY CASCADE;"
                 )
             )
             conn.commit()
@@ -161,7 +162,7 @@ class TestLanguageAssignment(unittest.TestCase):
         self.assertEqual(lang2.code, "eng")
 
     def test_scenario_3_subentry_so_only(self):
-        r"""3) headwords does not have \so, subentries have \so = record does not have a primary language and has secondary languages"""
+        r"""3) headwords without \so, subentries with \so = no primary, secondary languages only"""
         mdf_data = "\\lx test3\n\\ge test gloss\n\\se subentry\n\\so Mohegan-Pequot [xpq]\n\\ge subgloss"
         record = self._commit_mdf("test3", mdf_data)
 
@@ -179,6 +180,70 @@ class TestLanguageAssignment(unittest.TestCase):
 
         record_langs = self.session.query(RecordLanguage).filter_by(record_id=record.id).all()
         self.assertEqual(len(record_langs), 0)
+
+
+# ── RED-phase tests for ISO 639-3 language identification (issue #1339) ──
+
+    def test_mohican_mjy_creates_correct_language(self):
+        r"""SC-1 (MUST FAIL currently): Mohican [mjy] creates Language(code=mjy, name="Mahican").
+
+        Currently fails because "Mohican != Mahican" hits the ref_name != lg_name guard.
+        After fix, JaroWinkler("Mohican", "Mahican") >= 0.75 passes and the Language is created.
+        """
+        mdf_data = "\\lx mohican_test\n\\so Mohican [mjy]\n\\ge test gloss"
+        record = self._commit_mdf("mohican_test", mdf_data)
+
+        record_langs = self.session.query(RecordLanguage).filter_by(record_id=record.id).all()
+        self.assertEqual(len(record_langs), 1)
+
+        lang = self.session.get(Language, record_langs[0].language_id)
+        self.assertEqual(lang.code, "mjy")
+        self.assertEqual(lang.name, "Mahican")
+
+    def test_english_eng_still_works(self):
+        r"""SC-2 (MUST PASS currently): English [eng] still creates RecordLanguage.
+
+        Regression guard — "English == English" passes the guard today and must
+        continue to work after the fix.
+        """
+        mdf_data = "\\lx english_test\n\\so English [eng]\n\\ge test gloss"
+        record = self._commit_mdf("english_test", mdf_data)
+
+        record_langs = self.session.query(RecordLanguage).filter_by(record_id=record.id).all()
+        self.assertEqual(len(record_langs), 1)
+
+        lang = self.session.get(Language, record_langs[0].language_id)
+        self.assertEqual(lang.code, "eng")
+
+    def test_unknown_zzz_skipped(self):
+        r"""SC-3 (MUST PASS currently): Unknown [zzz] is skipped — code not in ISO 639-3.
+
+        Regression guard — unknown codes must never produce Language rows.
+        """
+        mdf_data = "\\lx unknown_test\n\\so Unknown [zzz]\n\\ge test gloss"
+        record = self._commit_mdf("unknown_test", mdf_data)
+
+        record_langs = self.session.query(RecordLanguage).filter_by(record_id=record.id).all()
+        self.assertEqual(len(record_langs), 0)
+
+        lang = self.session.query(Language).filter_by(code="zzz").first()
+        self.assertIsNone(lang)
+
+    def test_french_mjy_skipped(self):
+        r"""SC-4 (MUST PASS currently AND after fix): French [mjy] is skipped.
+
+        Currently passes because "French != Mahican" hits the ref_name != lg_name guard.
+        After fix, JaroWinkler("French", "Mahican") < 0.75 blocks it instead.
+        This is a regression guard — it must pass before AND after.
+        """
+        mdf_data = "\\lx french_mjy_test\n\\so French [mjy]\n\\ge test gloss"
+        record = self._commit_mdf("french_mjy_test", mdf_data)
+
+        record_langs = self.session.query(RecordLanguage).filter_by(record_id=record.id).all()
+        self.assertEqual(len(record_langs), 0)
+
+        lang = self.session.query(Language).filter_by(code="mjy").first()
+        self.assertIsNone(lang)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1034,6 +1034,25 @@ wheels = [
 ]
 
 [[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1267,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "snea-shoebox-editor"
-version = "0.2.0"
+version = "0.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "pgvector" },
@@ -1275,6 +1294,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pygithub" },
     { name = "python-dotenv" },
+    { name = "rapidfuzz" },
     { name = "sqlalchemy" },
     { name = "streamlit" },
     { name = "streamlit-cookies-controller" },
@@ -1305,6 +1325,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pygithub", specifier = ">=2.8.1" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
     { name = "streamlit", specifier = ">=1.53.1" },
     { name = "streamlit-cookies-controller", specifier = ">=0.0.4" },


### PR DESCRIPTION
## Summary

Sync remaining `dev` changes to `main`.

## Changes (6 files, +184/−10)

### Core: ISO 639-3 Language Identification (#1339)
- **`src/services/upload_service.py`** — Replaced exact name+code match with ISO 639-3 code lookup + Jaro-Winkler plausibility check (0.75 threshold). Code must exist in ISO 639-3 table; language name must resemble the canonical `ref_name`. Catches wrong-code entries (e.g. French labeled [mjy], JW=0.437) while passing legitimate variants (e.g. Mohican→Mahican, JW=0.914).
- **`pyproject.toml`** — Added `rapidfuzz>=3.14.5` dependency for Jaro-Winkler implementation.
- **`uv.lock`** — Synced for rapidfuzz.

### Tests
- **`tests/integration/test_language_assignment.py`** — Added 4 RED-phase tests: Mohican→Mahican variant acceptance, English regression guard, unknown-code skip, wrong-code rejection (French [mjy]).

### Documentation
- **`AGENTS.md`** — Added Release PR Body No Auto-Closing Keywords section. Release PRs must not use `Closes`/`Fixes`/`Resolves` for stakeholder-facing issues.
- **`CHANGELOG.md`** — Added entries for all accumulated feature work.

🤖 Co-authored with AI: OpenCode (deepseek-v4-flash-free)