### PR TITLE
[SPEC] Remove dead fts_vector column check from sync_prod_to_local.py

### DIFF
--- a/scripts/sync_prod_to_local.py
+++ b/scripts/sync_prod_to_local.py
@@ -334,9 +334,6 @@ def sync_data():
             with SessionLocal() as s:
                 cnt = s.execute(text(f"SELECT count(*) FROM {t}")).scalar()
                 log_message(f"  {t}: {cnt} rows")
-                if t == 'records':
-                    cols = [c['name'] for c in ins.get_columns(t)]
-                    log_message(f"    fts_vector present: {'fts_vector' in cols}")
 
     from src.database.models.meta import SchemaVersion
     with SessionLocal() as s:


### PR DESCRIPTION
**Summary:**

Removes a dead code check in sync_prod_to_local.py that always prints False, eliminating a confusing log line that could mislead future debugging.

**Outcome:** Developers will no longer see a misleading "fts_vector present: False" output during database sync, reducing noise in sync logs.

**Verification Attestation:** All success criteria verified PASS — exact-match against live evidence. This is a pure dead code removal with zero functional impact. The 3-line deletion was verified via diff review against the target branch.

**Detail: VbC Table**

| ID | Criterion | Test | Result |
|----|-----------|------|--------|
| SC-1 | Dead fts_vector check removed from sync_prod_to_local.py | structural: diff shows 3 lines removed, no other changes | PASS |
| SC-2 | No other production code references records.fts_vector | structural: grep confirms no remaining references | PASS |

**Detail: Spec-Card-Mapped Commits**

| Commit | Issue | Spec Card | Description |
|--------|-------|-----------|-------------|
| dc1de04 | #1358 | SC-1, SC-2 | Remove dead fts_vector column check from sync script |

🤖 Co-authored with AI: OpenCode (opencode/mimo-v2-free)
Co-authored-by: Michael Conrad <m.conrad.202@gmail.com>

Fixes #1358